### PR TITLE
chore: dev branch setup, branch protection docs, PR template, preview CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What this PR does
+<!-- Brief description of the change -->
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Design/UI change
+- [ ] Refactor
+- [ ] Docs
+
+## Testing
+- [ ] pnpm typecheck passes (4/4)
+- [ ] pnpm test passes (all)
+- [ ] pnpm --filter web build passes
+- [ ] Tested in browser at localhost:5173
+- [ ] Mobile typecheck passes
+
+## Notes for reviewer
+<!-- Anything specific to look at, known issues, follow-ups -->

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,42 @@
+name: Preview
+on:
+  pull_request:
+    branches: [dev]
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm typecheck
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm test
+
+  mobile-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: cd apps/mobile && npm install --legacy-peer-deps && npm run typecheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,22 @@ Thanks for showing up. OGA stays free and open because contributors make it bett
 
 See the [Quick start](./README.md#quick-start) in the README for the full sequence (`supabase start`, `pnpm install`, `pnpm dev --filter web`). Make sure `pnpm typecheck` and `pnpm test` both pass before you start touching code so you have a clean baseline.
 
+## Development workflow
+
+### Branching
+- Branch from dev: `git checkout dev && git pull && git checkout -b feature/your-feature`
+- Name branches: `feature/thing`, `fix/bug-name`, `chore/cleanup`
+- Never push directly to main or dev
+
+### Opening a PR
+1. Push your branch
+2. Open a PR against `dev` (not main)
+3. Fill out the PR template
+4. CI must pass before merging
+
+### Releases
+Maintainers periodically merge dev → main to cut a release.
+
 ## Reporting bugs
 
 Open a [GitHub issue](https://github.com/cner-smith/opengolfapp/issues). Include:

--- a/docs/vercel-dev-setup.md
+++ b/docs/vercel-dev-setup.md
@@ -1,0 +1,25 @@
+# Vercel preview environment setup
+
+## Create a dev Supabase project
+1. Go to supabase.com → New project → name it "oga-dev"
+2. Run migrations: supabase db push (linked to dev project)
+3. Run seed: paste supabase/seed.sql in SQL editor
+4. Note the dev project URL and anon key
+
+## Configure Vercel preview environment
+1. Go to vercel.com → opengolfapp project → Settings →
+   Environment Variables
+2. Add the following for "Preview" environment only
+   (not Production):
+   VITE_SUPABASE_URL = your oga-dev project URL
+   VITE_SUPABASE_ANON_KEY = your oga-dev anon key
+   VITE_MAPBOX_TOKEN = same mapbox token is fine
+3. Vercel automatically creates a preview URL for every
+   PR — it will use these preview env vars
+
+## How it works after setup
+- Every PR to dev gets a unique preview URL
+  (e.g. opengolfapp-git-feature-xyz-cner-smiths-projects.vercel.app)
+- Preview deployments use the oga-dev Supabase project
+- Production deployments (main) use the real Supabase project
+- You can share preview URLs to get feedback before merging


### PR DESCRIPTION
## What this PR does
Bootstraps the dev-branch workflow:

- `.github/PULL_REQUEST_TEMPLATE.md` — checklist for future PRs
- `.github/workflows/preview.yml` — CI on PRs to `dev` (typecheck / test / mobile-typecheck)
- `CONTRIBUTING.md` — adds a "Development workflow" section explaining branching, PRs, releases
- `docs/vercel-dev-setup.md` — manual steps for the Vercel preview env + `oga-dev` Supabase project

`.github/workflows/ci.yml` already triggers only on `main` push / PR — no change needed there.

`CLAUDE.md` is intentionally gitignored (commit \`1eb7fc2\`); the Branch strategy section was added locally per task spec but is not committed.

Direct push to \`dev\` is blocked by repo rules (2 required status checks), which is why this lands as a PR.

## Type of change
- [x] Docs
- [x] New feature (CI workflow)

## Testing
- [ ] pnpm typecheck passes (4/4)
- [ ] pnpm test passes (all)
- [ ] pnpm --filter web build passes
- [ ] Tested in browser at localhost:5173
- [ ] Mobile typecheck passes

(Workflow / docs only — no code changed; preview.yml will validate itself on this PR.)

## Notes for reviewer
- preview.yml uses pnpm v9 + plain `pnpm install` per spec; existing ci.yml is on pnpm v10 + `--frozen-lockfile`. Intentional split.
- After merge to dev, future feature branches PR against dev; dev → main only at release.