### PR TITLE
chore: gitignore .env.development / .production / .staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@ build/
 .env
 .env.local
 .env.*.local
+.env.development
+.env.production
+.env.staging
+apps/web/.env.development
+apps/web/.env.production
+apps/mobile/.env.development
+apps/mobile/.env.production
 !.env.example
 
 # editor


### PR DESCRIPTION
## What this PR does
Adds the missing env-file patterns to the root .gitignore so they stop getting picked up by \`git add -A\`:

\`\`\`
.env.development
.env.production
.env.staging
apps/web/.env.development
apps/web/.env.production
apps/mobile/.env.development
apps/mobile/.env.production
\`\`\`

\`apps/mobile/.gitignore\` already has \`.env.*\`; the explicit mobile entries at root are redundant-but-harmless and keep root .gitignore self-documenting.

No \`git rm --cached\` was needed — only \`.env.example\` variants are tracked, and those stay (whitelisted via \`!.env.example\`).

## Type of change
- [x] Docs / chore

## Testing
- [x] \`git ls-files | grep '\\.env\\.'\` shows only \`.env.example\` files
- [x] \`git check-ignore -v\` confirms .env.development/.production now match

## Notes for reviewer
Triggered by apps/web/.env.development being auto-staged on a recent branch. No code changes.