### PR TITLE
fix(mobile): pin react-native-worklets to 0.3.0 for RN 0.74.5

### DIFF
--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -34,7 +34,7 @@
         "react-native-svg": "15.2.0",
         "react-native-url-polyfill": "^2.0.0",
         "react-native-web": "~0.19.10",
-        "react-native-worklets": "0.4.2",
+        "react-native-worklets": "0.3.0",
         "react-native-worklets-core": "^1.6.3",
         "tailwindcss": "^3.4.7",
         "victory-native": "^36.9.2"
@@ -10966,9 +10966,9 @@
       "license": "MIT"
     },
     "node_modules/react-native-worklets": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.4.2.tgz",
-      "integrity": "sha512-02IMmU2rOL6vrF7uA6cLAeN4haXOMTBh7opmVYQbjYG8mNAb0cnhmkvkdQupmpFjBpWZRJnBGYJJa471a/9IPg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.3.0.tgz",
+      "integrity": "sha512-dmsLZ1XJdUZgbd+SVo7yL2uzOHIissjIt8SD6L7ejzfYOxrZ5lz9rlJzVLlppjKvL5AcUcASOcp1CIDu1fxC5A==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -38,7 +38,7 @@
     "react-native-svg": "15.2.0",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-web": "~0.19.10",
-    "react-native-worklets": "0.4.2",
+    "react-native-worklets": "0.3.0",
     "react-native-worklets-core": "^1.6.3",
     "tailwindcss": "^3.4.7",
     "victory-native": "^36.9.2"


### PR DESCRIPTION
## What this PR does
Pins \`react-native-worklets\` to exactly \`0.3.0\` so EAS stops resolving incompatible 0.4.x / 0.8.x lines.

## Why 0.3.0
The package's published compatibility.json (visible in 0.5.0+) maps:
- \`0.4.x\` → react-native \`['0.78','0.79','0.80','0.81']\`
- \`0.5.x\` → react-native \`['0.78','0.79','0.80','0.81']\`
- \`0.8.x\` → react-native \`'0.81 - 0.85'\` (per peer dep)

We're on RN 0.74.5 (Expo SDK 51). **No 0.4+ line supports it.** 0.3.0 predates compatibility.json and the embedded RN-version assertion, so it loads cleanly.

## What I checked
- \`npm view react-native-worklets versions\` — 0.3.0 is the only stable 0.3.x release; everything else in the line is nightlies
- \`npm view react-native-worklets@0.3.0 peerDependencies\` — open peer (\`react-native: '*'\`)
- Inspected the 0.3.0 tarball — no compat.json, no RN-version check in build.gradle
- \`npm install --legacy-peer-deps\` clean
- \`npm list react-native-worklets\` → \`react-native-worklets@0.3.0\` (no duplicate resolutions)
- \`npm run typecheck\` clean

## Type of change
- [x] Bug fix

## Testing
- [ ] pnpm typecheck passes (4/4) — _untouched, n/a_
- [ ] pnpm test passes (all) — _untouched, n/a_
- [ ] pnpm --filter web build passes — _untouched, n/a_
- [ ] Tested in browser at localhost:5173 — _mobile-only change_
- [x] Mobile typecheck passes

## Notes for reviewer
\`react-native-worklets\` is currently a top-level dep with **no imports anywhere in our code** (\`grep -r 'react-native-worklets' apps/mobile/\` only matches package.json). \`react-native-worklets-core\` is the same story. A follow-up chore could remove both entirely; for now this is the minimum-scope fix.

If EAS still trips on this version, the next step is dropping \`react-native-worklets\` from package.json altogether rather than chasing another version.