### PR TITLE
fix(ci): install packages/supabase before mobile typecheck on preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,4 +39,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: cd apps/mobile && npm install --legacy-peer-deps && npm run typecheck
+      - name: Install supabase package deps
+        run: cd packages/supabase && npm install --legacy-peer-deps
+      - name: Mobile typecheck
+        run: cd apps/mobile && npm install --legacy-peer-deps && npm run typecheck


### PR DESCRIPTION
## What this PR does
Adds an explicit \`packages/supabase\` install step to the \`mobile-typecheck\` job in \`.github/workflows/preview.yml\`.

Without it, \`apps/mobile\`'s \`npm install\` resolves \`@oga/supabase\` via the \`file:../../packages/supabase\` link but doesn't populate \`packages/supabase/node_modules\`, so tsc can't find \`@supabase/supabase-js\` when typechecking \`packages/supabase/src/client.ts\` from the mobile project.

This mirrors what \`ci.yml\`'s mobile job already does. Split into two named steps so the CI log makes the dependency obvious.

## Type of change
- [x] Bug fix
- [x] Docs / chore (CI workflow)

## Testing
- [ ] pnpm typecheck passes (4/4) — _untouched, n/a_
- [ ] pnpm test passes (all) — _untouched, n/a_
- [ ] pnpm --filter web build passes — _untouched, n/a_
- [ ] Tested in browser at localhost:5173 — _CI-only_
- [ ] Mobile typecheck passes — _will validate on this PR_

## Notes for reviewer
PR #4 (chore/remove-unused-worklets) will be rebased on top of this so its mobile-typecheck check picks up the fix.