### PR TITLE
fix: live round map starts on tee + putt count syncs (#8, #10)

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -102,14 +102,14 @@ export default function HoleScreen() {
       ? { lat: currentHole.tee_lat, lng: currentHole.tee_lng }
       : null
 
+  // Camera anchors on the tee box — the player's starting point. Pin/green
+  // is intentionally NOT a fallback; it would mis-frame the hole every time.
   const center: LatLng = useMemo(() => {
-    if (roundPin) return roundPin
-    if (storedPin) return storedPin
     if (tee) return tee
     if (ball) return ball
     return FALLBACK_CENTER
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [roundPin?.lat, roundPin?.lng, storedPin?.lat, storedPin?.lng, tee?.lat, tee?.lng, ball])
+  }, [tee?.lat, tee?.lng, ball])
 
   const loadAll = useCallback(async () => {
     if (!id) return

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -73,6 +73,8 @@ export default function HoleScreen() {
   const lastEndRef = useRef<LatLng | null>(null)
   const [remoteShotCount, setRemoteShotCount] = useState(0)
   const [localShotCount, setLocalShotCount] = useState(0)
+  const [remotePuttCount, setRemotePuttCount] = useState(0)
+  const [localPuttCount, setLocalPuttCount] = useState(0)
   const [loggerOpen, setLoggerOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [mapMode, setMapMode] = useState<HoleMapMode>('shot')
@@ -143,19 +145,38 @@ export default function HoleScreen() {
     loadAll()
   }, [loadAll])
 
-  // Reload remote + local shot counts whenever the active hole_score changes.
+  // Reload remote + local shot/putt counts whenever the active hole_score
+  // changes. Putts are counted as shots where club='putter' OR lie_type='green'.
   useEffect(() => {
     if (!currentHoleScore) return
     let active = true
     ;(async () => {
-      const { count } = await supabase
-        .from('shots')
-        .select('id', { count: 'exact', head: true })
-        .eq('hole_score_id', currentHoleScore.id)
-      const local = await pendingShotsForHoleScore(currentHoleScore.id)
+      const [shotRes, puttRes, local] = await Promise.all([
+        supabase
+          .from('shots')
+          .select('id', { count: 'exact', head: true })
+          .eq('hole_score_id', currentHoleScore.id),
+        supabase
+          .from('shots')
+          .select('id', { count: 'exact', head: true })
+          .eq('hole_score_id', currentHoleScore.id)
+          .or('club.eq.putter,lie_type.eq.green'),
+        pendingShotsForHoleScore(currentHoleScore.id),
+      ])
       if (!active) return
-      setRemoteShotCount(count ?? 0)
+      let localPutts = 0
+      for (const r of local) {
+        try {
+          const p = JSON.parse(r.payload) as ShotPayload
+          if (p.club === 'putter' || p.lie_type === 'green') localPutts++
+        } catch {
+          // skip malformed pending payload
+        }
+      }
+      setRemoteShotCount(shotRes.count ?? 0)
       setLocalShotCount(local.length)
+      setRemotePuttCount(puttRes.count ?? 0)
+      setLocalPuttCount(localPutts)
       lastEndRef.current = null
     })()
     return () => {
@@ -252,18 +273,31 @@ export default function HoleScreen() {
     try {
       await insertPendingShot(payload)
       lastEndRef.current = ball
+      const isPutt = payload.club === 'putter' || payload.lie_type === 'green'
       setLocalShotCount((c) => c + 1)
+      if (isPutt) setLocalPuttCount((c) => c + 1)
       setAim(null)
       setBall(null)
       setLoggerOpen(false)
       // Background sync — don't await.
       syncPendingShots().catch(() => undefined)
-      // Best-effort score update so the scorecard reflects shot count.
+      // Best-effort hole_score update so the scorecard reflects shot/putt
+      // count. shotNumber is the just-saved shot's number == new score.
+      const newPutts =
+        remotePuttCount + localPuttCount + (isPutt ? 1 : 0)
       supabase
         .from('hole_scores')
-        .update({ score: shotNumber })
+        .update({ score: shotNumber, putts: newPutts })
         .eq('id', payload.hole_score_id)
         .then(() => undefined, () => undefined)
+      // Reflect optimistically in the inline scorecard preview.
+      setHoleScores((prev) =>
+        prev.map((hs) =>
+          hs.id === payload.hole_score_id
+            ? { ...hs, score: shotNumber, putts: newPutts }
+            : hs,
+        ),
+      )
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('shot save failed', err, payload)

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -103,7 +103,8 @@ export function HoleMap({
     if (!cameraRef.current) return
     cameraRef.current.setCamera({
       centerCoordinate: toCoord(center),
-      zoomLevel: 16,
+      zoomLevel: 17,
+      pitch: 45,
       animationDuration: 400,
     })
     cameraInitialized.current = true
@@ -165,7 +166,8 @@ export function HoleMap({
             ref={cameraRef}
             defaultSettings={{
               centerCoordinate: toCoord(center),
-              zoomLevel: 16,
+              zoomLevel: 17,
+              pitch: 45,
             }}
           />
 

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -285,14 +285,19 @@ export function RoundDetailPage() {
     setSaveError(null)
     try {
       // Ensure a hole_score row exists; the score equals the placed
-      // shot count, which is what the player just confirmed.
+      // shot count, which is what the player just confirmed. Putts is
+      // derived from the rows so the scorecard reflects what was placed
+      // without needing a manual entry.
       const existing = scoresByHoleId.get(activeHole.id)
+      const puttCount = rows.filter(
+        (r) => r.lieType === 'green' || r.club === 'putter',
+      ).length
       const hsResult = await upsertHoleScore.mutateAsync({
         id: existing?.id,
         round_id: round.data.id,
         hole_id: activeHole.id,
         score: rows.length,
-        putts: existing?.putts ?? null,
+        putts: puttCount,
         fairway_hit: existing?.fairway_hit ?? null,
         gir: existing?.gir ?? null,
       })


### PR DESCRIPTION
## Summary
- **#8** — Live round map was framing the green; pin came first in the `center` fallback. Now anchors on tee box (zoom 17, 45° pitch) so the player sees where they're standing.
- **#10** — Map-saved shots updated the `shots` table but never `hole_scores.putts`. Web now derives putts from review rows and includes them in the upsert; mobile tracks remote+local putt counts and updates `score+putts` after each shot.

## Test plan
- [ ] Start a live round on mobile — map opens zoomed on tee box, not green
- [ ] Log shots including putts via map placement
- [ ] Confirm `hole_scores.putts` matches putt-club + green-lie shot count
- [ ] Web: place shots via map, "Save hole" — scorecard shows correct putts without reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)