### PR TITLE
feat: Ko-fi + GitHub Sponsors links in sidebar and profile (#15)

### DIFF
--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from 'react'
-import { Alert, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import {
+  Alert,
+  Linking,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
 import { FACILITIES, GOALS, SKILL_LEVELS } from '@oga/core'
 import { getProfile, updateProfile } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
@@ -221,6 +229,78 @@ export default function ProfileTab() {
             {saving ? 'Saving…' : 'Save changes'}
           </Text>
         </Pressable>
+
+        <View
+          style={{
+            marginTop: 28,
+            backgroundColor: '#FBF8F1',
+            borderWidth: 1,
+            borderColor: '#D9D2BF',
+            borderRadius: 2,
+            padding: 18,
+          }}
+        >
+          <Text style={{ ...KICKER, marginBottom: 10 }}>Support OGA</Text>
+          <Text
+            style={{
+              color: '#1C211C',
+              fontSize: 14,
+              lineHeight: 20,
+              marginBottom: 14,
+            }}
+          >
+            OGA is free and open source. If it helps your game,
+            consider buying us a round.
+          </Text>
+          <View style={{ flexDirection: 'row', gap: 10 }}>
+            <Pressable
+              onPress={() => Linking.openURL('https://ko-fi.com/nartana')}
+              style={{
+                flex: 1,
+                borderWidth: 1,
+                borderColor: '#1F3D2C',
+                paddingVertical: 12,
+                alignItems: 'center',
+                borderRadius: 2,
+              }}
+            >
+              <Text
+                style={{
+                  color: '#1F3D2C',
+                  fontSize: 13,
+                  fontWeight: '600',
+                  letterSpacing: 0.3,
+                }}
+              >
+                Ko-fi ↗
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={() =>
+                Linking.openURL('https://github.com/sponsors/cner-smith')
+              }
+              style={{
+                flex: 1,
+                borderWidth: 1,
+                borderColor: '#1F3D2C',
+                paddingVertical: 12,
+                alignItems: 'center',
+                borderRadius: 2,
+              }}
+            >
+              <Text
+                style={{
+                  color: '#1F3D2C',
+                  fontSize: 13,
+                  fontWeight: '600',
+                  letterSpacing: 0.3,
+                }}
+              >
+                GitHub ↗
+              </Text>
+            </Pressable>
+          </View>
+        </View>
 
         <Pressable
           onPress={() => supabase.auth.signOut()}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -114,6 +114,39 @@ export function Sidebar() {
         />
       </nav>
 
+      <div style={{ padding: '12px 14px 6px' }}>
+        <div
+          className="font-mono uppercase text-white/30"
+          style={{
+            fontSize: 10,
+            letterSpacing: '0.14em',
+            marginBottom: 8,
+          }}
+        >
+          Support OGA
+        </div>
+        <div style={{ display: 'flex', gap: 14 }}>
+          <a
+            href="https://ko-fi.com/nartana"
+            target="_blank"
+            rel="noreferrer"
+            className="text-white/45 transition-colors hover:text-caddie-accent-ink"
+            style={{ fontSize: 12 }}
+          >
+            Ko-fi
+          </a>
+          <a
+            href="https://github.com/sponsors/cner-smith"
+            target="_blank"
+            rel="noreferrer"
+            className="text-white/45 transition-colors hover:text-caddie-accent-ink"
+            style={{ fontSize: 12 }}
+          >
+            Sponsor
+          </a>
+        </div>
+      </div>
+
       <div
         className="border-t border-white/10"
         style={{ padding: '14px 14px 18px' }}


### PR DESCRIPTION
## Summary
- **Web sidebar:** small "SUPPORT OGA" kicker above the user/sign-out block, with two muted links — "Ko-fi" and "Sponsor" — that lift to accent ink on hover and open in a new tab.
- **Mobile profile tab:** "Support OGA" card between settings and sign out. caddie-surface fill with caddie-line border, body copy ("OGA is free and open source. If it helps your game, consider buying us a round."), and two side-by-side buttons ("Ko-fi ↗" / "GitHub ↗") opening via \`Linking.openURL\`.

## Files
- \`apps/web/src/components/layout/Sidebar.tsx\`
- \`apps/mobile/app/(app)/profile.tsx\`

Links: https://ko-fi.com/nartana · https://github.com/sponsors/cner-smith

## Test plan
- [ ] Web: open the app, scroll the sidebar — section appears above user block, tapping each link opens the destination in a new tab
- [ ] Mobile: open the Profile tab — card renders between save/units and sign-out; both buttons launch the device browser

\`pnpm typecheck\`, \`pnpm --filter web build\`, and \`apps/mobile\` typecheck all green.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)