### PR TITLE
fix: flesh out web SettingsPage with profile + support sections

### DIFF
--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useProfile, useUpdateProfile } from '../../hooks/useProfile'
 
 const UNIT_OPTIONS: { value: 'yards' | 'meters'; label: string }[] = [
@@ -10,12 +10,40 @@ export function SettingsPage() {
   const { data: profile } = useProfile()
   const updateProfile = useUpdateProfile()
   const [error, setError] = useState<string | null>(null)
+  const [username, setUsername] = useState('')
+  const [handicap, setHandicap] = useState('')
+  const [saved, setSaved] = useState(false)
   const unit = profile?.distance_unit ?? 'yards'
+
+  useEffect(() => {
+    setUsername(profile?.username ?? '')
+    setHandicap(profile?.handicap_index?.toString() ?? '')
+  }, [profile?.username, profile?.handicap_index])
 
   async function setUnit(value: 'yards' | 'meters') {
     setError(null)
     try {
       await updateProfile.mutateAsync({ distance_unit: value })
+    } catch (err) {
+      setError((err as Error).message)
+    }
+  }
+
+  async function saveProfile() {
+    setError(null)
+    setSaved(false)
+    const trimmed = username.trim()
+    const numericHandicap = handicap === '' ? null : Number(handicap)
+    if (handicap !== '' && Number.isNaN(numericHandicap)) {
+      setError('Handicap must be a number')
+      return
+    }
+    try {
+      await updateProfile.mutateAsync({
+        username: trimmed || null,
+        handicap_index: numericHandicap,
+      })
+      setSaved(true)
     } catch (err) {
       setError((err as Error).message)
     }
@@ -34,6 +62,66 @@ export function SettingsPage() {
           Settings
         </h1>
       </div>
+
+      <section
+        style={{
+          borderTop: '1px solid #D9D2BF',
+          paddingTop: 18,
+          marginBottom: 28,
+        }}
+      >
+        <div className="kicker" style={{ marginBottom: 12 }}>
+          Profile
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14, maxWidth: 360 }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span className="kicker">Username</span>
+            <input
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              autoCapitalize="off"
+              autoCorrect="off"
+              style={inputStyle}
+            />
+          </label>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            <span className="kicker">Handicap index</span>
+            <input
+              type="text"
+              inputMode="decimal"
+              value={handicap}
+              onChange={(e) => setHandicap(e.target.value)}
+              style={inputStyle}
+            />
+          </label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            <button
+              type="button"
+              onClick={saveProfile}
+              disabled={updateProfile.isPending}
+              className="bg-caddie-accent text-caddie-accent-ink"
+              style={{
+                border: 'none',
+                borderRadius: 2,
+                padding: '10px 18px',
+                fontSize: 13,
+                fontWeight: 600,
+                letterSpacing: '0.02em',
+                cursor: 'pointer',
+                opacity: updateProfile.isPending ? 0.5 : 1,
+              }}
+            >
+              {updateProfile.isPending ? 'Saving…' : 'Save profile'}
+            </button>
+            {saved && (
+              <span className="text-caddie-pos" style={{ fontSize: 12 }}>
+                Saved.
+              </span>
+            )}
+          </div>
+        </div>
+      </section>
 
       <section
         style={{
@@ -79,12 +167,77 @@ export function SettingsPage() {
           Switches the display of distances throughout the app.
           Stored values stay in yards/feet — only formatting changes.
         </p>
-        {error && (
-          <p className="text-caddie-neg" style={{ fontSize: 12, marginTop: 8 }}>
-            {error}
-          </p>
-        )}
       </section>
+
+      <section
+        style={{
+          borderTop: '1px solid #D9D2BF',
+          paddingTop: 18,
+          marginBottom: 28,
+        }}
+      >
+        <div className="kicker" style={{ marginBottom: 12 }}>
+          Support OGA
+        </div>
+        <p
+          className="text-caddie-ink"
+          style={{ fontSize: 14, lineHeight: 1.55, marginBottom: 14, maxWidth: 520 }}
+        >
+          OGA is free and open source. If it helps your game,
+          consider buying us a round.
+        </p>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          <a
+            href="https://ko-fi.com/nartana"
+            target="_blank"
+            rel="noreferrer"
+            className="text-caddie-accent"
+            style={{
+              border: '1px solid #1F3D2C',
+              borderRadius: 2,
+              padding: '10px 16px',
+              fontSize: 13,
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+              textDecoration: 'none',
+            }}
+          >
+            Ko-fi ↗
+          </a>
+          <a
+            href="https://github.com/sponsors/cner-smith"
+            target="_blank"
+            rel="noreferrer"
+            className="text-caddie-accent"
+            style={{
+              border: '1px solid #1F3D2C',
+              borderRadius: 2,
+              padding: '10px 16px',
+              fontSize: 13,
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+              textDecoration: 'none',
+            }}
+          >
+            GitHub Sponsors ↗
+          </a>
+        </div>
+      </section>
+
+      {error && (
+        <p className="text-caddie-neg" style={{ fontSize: 12 }}>
+          {error}
+        </p>
+      )}
     </div>
   )
+}
+
+const inputStyle: React.CSSProperties = {
+  background: '#FBF8F1',
+  border: '1px solid #D9D2BF',
+  borderRadius: 2,
+  padding: '10px 12px',
+  fontSize: 14,
+  color: '#1C211C',
 }


### PR DESCRIPTION
## Diagnosis
The route, page, and sidebar link **all already existed** on dev:

- \`apps/web/src/router.tsx:47\` — \`{ path: '/settings', element: <SettingsPage /> }\`
- \`apps/web/src/components/layout/Sidebar.tsx:19\` — \`{ to: '/settings', label: 'Settings', section: 'resources' }\`
- \`apps/web/src/pages/settings/SettingsPage.tsx\` — present

What was missing: the page **only had the units toggle**, so it didn't surface anything a user would expect under "Settings". That's why it felt unreachable — there was nothing recognizable when you got there.

## Fix
Three sections in SettingsPage, hairline-rule separated per DESIGN.md:

1. **Profile** — username + handicap_index inputs, "Save profile" via \`useUpdateProfile\`
2. **Units** — yards / metres toggle (unchanged)
3. **Support OGA** — Ko-fi and GitHub Sponsors links, open in new tab

## Files
- \`apps/web/src/pages/settings/SettingsPage.tsx\`

## Test plan
- [ ] Open the sidebar — "Settings" link visible under Resources
- [ ] Click it — page renders with three sections
- [ ] Edit username/handicap, click "Save profile" — value persists, "Saved." flashes
- [ ] Toggle units — display flips throughout the app
- [ ] Click Ko-fi / GitHub Sponsors — open in new tab

\`pnpm typecheck\` + \`pnpm --filter web build\` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)