### PR TITLE
feat: add lat/lng/city/state to courses table (0011)

### DIFF
--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -61,6 +61,10 @@ export interface Database {
           external_id: string | null
           created_by: string | null
           created_at: string
+          lat: number | null
+          lng: number | null
+          city: string | null
+          state: string | null
         }
         Insert: {
           id?: string
@@ -70,6 +74,10 @@ export interface Database {
           external_id?: string | null
           created_by?: string | null
           created_at?: string
+          lat?: number | null
+          lng?: number | null
+          city?: string | null
+          state?: string | null
         }
         Update: {
           id?: string
@@ -79,6 +87,10 @@ export interface Database {
           external_id?: string | null
           created_by?: string | null
           created_at?: string
+          lat?: number | null
+          lng?: number | null
+          city?: string | null
+          state?: string | null
         }
         Relationships: [
           {

--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -124,6 +124,8 @@ interface OgaListItem {
   name: string
   city?: string
   state?: string
+  lat?: number
+  lng?: number
 }
 
 interface OgaTee {
@@ -146,6 +148,8 @@ interface OgaCourseDetail {
   name: string
   city?: string
   state?: string
+  lat?: number
+  lng?: number
   holes: OgaHole[]
   tees: OgaTee[]
 }
@@ -188,6 +192,12 @@ interface RawCourse {
   holes?: RawHole[]
   scorecard?: RawHole[]
   tees?: RawTee[]
+  lat?: number | string
+  lng?: number | string
+  longitude?: number | string
+  latitude?: number | string
+  coordinates?: { lat?: number | string; lng?: number | string; longitude?: number | string; latitude?: number | string }
+  location?: { lat?: number | string; lng?: number | string; longitude?: number | string; latitude?: number | string }
 }
 
 interface OsmCourseLite {
@@ -296,16 +306,34 @@ function pickArray(payload: unknown): RawCourse[] {
   return []
 }
 
+function pickCoords(raw: RawCourse): { lat?: number; lng?: number } {
+  const sources: Array<RawCourse['coordinates']> = [
+    raw,
+    raw.coordinates,
+    raw.location && typeof raw.location === 'object' ? raw.location : undefined,
+  ]
+  for (const src of sources) {
+    if (!src) continue
+    const lat = asNumber(src.lat ?? src.latitude)
+    const lng = asNumber(src.lng ?? src.longitude)
+    if (lat != null && lng != null) return { lat, lng }
+  }
+  return {}
+}
+
 function normalizeListItem(raw: RawCourse): OgaListItem | null {
   const id = String(raw.id ?? raw.course_id ?? '')
   if (!id) return null
   const name = (raw.name ?? raw.course_name ?? '').trim()
   if (!name) return null
+  const coords = pickCoords(raw)
   return {
     id,
     name,
     city: raw.city ?? undefined,
     state: raw.state ?? raw.region ?? undefined,
+    lat: coords.lat,
+    lng: coords.lng,
   }
 }
 
@@ -368,11 +396,14 @@ function normalizeDetail(raw: RawCourse): OgaCourseDetail | null {
     holes.push(yards != null ? { number, par, yards } : { number, par })
   }
   holes.sort((a, b) => a.number - b.number)
+  const coords = pickCoords(raw)
   return {
     id,
     name,
     city: raw.city ?? undefined,
     state: raw.state ?? raw.region ?? undefined,
+    lat: coords.lat,
+    lng: coords.lng,
     holes,
     tees: normalizeTees(raw.tees),
   }
@@ -499,8 +530,20 @@ async function insertOrUpdateCourse(args: {
   externalId: string
   name: string
   location: string | null
+  city: string | null
+  state: string | null
+  lat: number | null
+  lng: number | null
   force: boolean
 }): Promise<{ id: string; isNew: boolean; skipped: boolean }> {
+  const fields = {
+    name: args.name,
+    location: args.location,
+    city: args.city,
+    state: args.state,
+    lat: args.lat,
+    lng: args.lng,
+  }
   const existing = await findCourseByExternalId(args.externalId)
   if (existing && !args.force) {
     return { id: existing, isNew: false, skipped: true }
@@ -508,7 +551,7 @@ async function insertOrUpdateCourse(args: {
   if (existing) {
     const { error } = await supabase
       .from('courses')
-      .update({ name: args.name, location: args.location })
+      .update(fields)
       .eq('id', existing)
     if (error) throw error
     return { id: existing, isNew: false, skipped: false }
@@ -516,8 +559,7 @@ async function insertOrUpdateCourse(args: {
   const { data, error } = await supabase
     .from('courses')
     .insert({
-      name: args.name,
-      location: args.location,
+      ...fields,
       external_id: args.externalId,
     })
     .select('id')
@@ -660,13 +702,17 @@ async function crawlOpenGolfApi(
             await sleep(OPENGOLFAPI_DELAY_MS)
             continue
           }
-          const location = [detail.city ?? item.city, detail.state ?? item.state ?? state]
-            .filter((s) => !!s && s.length > 0)
-            .join(', ')
+          const city = (detail.city ?? item.city ?? '').trim() || null
+          const stateCode = (detail.state ?? item.state ?? state).trim() || null
+          const location = [city, stateCode].filter((s) => !!s).join(', ') || null
           const upsert = await insertOrUpdateCourse({
             externalId,
             name: detail.name,
-            location: location || null,
+            location,
+            city,
+            state: stateCode,
+            lat: detail.lat ?? item.lat ?? null,
+            lng: detail.lng ?? item.lng ?? null,
             force,
           })
           if (!upsert.skipped) {
@@ -752,6 +798,10 @@ async function crawlOsm(
             externalId,
             name: c.name,
             location: c.state,
+            city: null,
+            state: c.state,
+            lat: c.lat,
+            lng: c.lng,
             force,
           })
           if (upsert.skipped) totalSkipped++

--- a/scripts/import-osm-course.ts
+++ b/scripts/import-osm-course.ts
@@ -348,18 +348,28 @@ function matchHoles(
 // Supabase upsert
 // ---------------------------------------------------------------------------
 
-async function upsertCourse(name: string): Promise<{ id: string; created: boolean }> {
+async function upsertCourse(
+  name: string,
+  centroid: LatLon,
+): Promise<{ id: string; created: boolean }> {
   const { data: existing, error: lookupErr } = await supabase
     .from('courses')
     .select('id')
     .eq('name', name)
     .maybeSingle()
   if (lookupErr) throw lookupErr
-  if (existing) return { id: existing.id, created: false }
+  if (existing) {
+    const { error: updateErr } = await supabase
+      .from('courses')
+      .update({ lat: centroid.lat, lng: centroid.lon })
+      .eq('id', existing.id)
+    if (updateErr) throw updateErr
+    return { id: existing.id, created: false }
+  }
 
   const { data, error } = await supabase
     .from('courses')
-    .insert({ name, mapbox_id: null })
+    .insert({ name, mapbox_id: null, lat: centroid.lat, lng: centroid.lon })
     .select('id')
     .single()
   if (error || !data) throw error ?? new Error('course insert failed')
@@ -404,7 +414,13 @@ async function main() {
     )
   }
 
-  const { id, created } = await upsertCourse(args.name)
+  // Course centroid = mean of all matched tee + pin coordinates. More
+  // robust than the query center the user passed (which is often the
+  // clubhouse, not the course).
+  const courseCentroid = centroid(
+    matched.flatMap((h) => [h.tee, h.pin]),
+  )
+  const { id, created } = await upsertCourse(args.name, courseCentroid)
   await upsertHoles(id, matched)
 
   const greenHits = matched.filter((h) => h.hasGreenMatch).length

--- a/supabase/migrations/0011_course_coordinates.sql
+++ b/supabase/migrations/0011_course_coordinates.sql
@@ -1,0 +1,20 @@
+-- Course geolocation: lat/lng for map display + nearest-course search,
+-- and city/state as discrete columns so the crawler doesn't have to round-
+-- trip through the freeform `location` string. The legacy `location`
+-- column stays for back-compat — crawler keeps it populated as
+-- "city, state" so existing UI keeps working.
+alter table public.courses
+  add column lat numeric,
+  add column lng numeric,
+  add column city text,
+  add column state text;
+
+-- Best-effort backfill from the legacy `location` text. Rows that don't
+-- match the "City, ST" pattern keep null city/state — the crawler will
+-- fill them in on next run.
+update public.courses
+set
+  city = trim(split_part(location, ',', 1)),
+  state = trim(split_part(location, ',', 2))
+where location is not null
+  and location like '%,%';


### PR DESCRIPTION
## Summary

- Migration `0011_course_coordinates.sql` adds `lat`, `lng`, `city`, `state` to `courses` and backfills city/state from the legacy `location` text where possible.
- Crawler captures OpenGolfAPI coordinates (covers `lat/lng`, `latitude/longitude`, and nested `coordinates`/`location` shapes) and writes city/state as discrete columns.
- `import-osm-course.ts` computes course centroid from matched tee + pin coords and stores on the course row.

## Why

OpenGolfAPI returns coordinates but the schema had nowhere to store them. Map UIs and nearest-course search both need lat/lng on `courses`. Discrete `city`/`state` removes the need to parse the freeform `location` string. Legacy `location` stays populated (`"city, state"`) for back-compat with existing UI.

## Verify

- [x] `pnpm typecheck` — passes
- [x] `pnpm --filter web build` — passes
- [x] `tsc --noEmit` standalone on `crawl-courses.ts` + `import-osm-course.ts` — clean
- [ ] Apply `0011` to local Supabase (`npx supabase db push`)
- [ ] `pnpm crawl:courses --source opengolfapi --states OK --limit 5 --force` — verify lat/lng/city/state populated
- [ ] `pnpm import:osm --name "Test" --lat ... --lng ... --radius ...` — verify course row has lat/lng

## Note

Generated `packages/supabase/src/types.ts` was hand-edited to mirror the new columns. When `npx supabase gen types typescript` runs next, it should produce the same shape — verify on first regen.