### PR TITLE
fix: quick wins — error boundaries, keyboard handling, hit slop, AppBar safe area

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -3,6 +3,7 @@ import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { ErrorBoundary } from '../../components/errors/ErrorBoundary'
 
 const ICON_SIZE = 18
 
@@ -36,6 +37,7 @@ export default function AppLayout() {
   if (profileState === 'incomplete') return <Redirect href="/(auth)/onboarding" />
 
   return (
+    <ErrorBoundary>
     <Tabs
       screenOptions={{
         headerShown: false,
@@ -116,5 +118,6 @@ export default function AppLayout() {
       <Tabs.Screen name="round/[id]/index" options={{ href: null }} />
       <Tabs.Screen name="round/[id]/hole/[number]" options={{ href: null }} />
     </Tabs>
+    </ErrorBoundary>
   )
 }

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -469,7 +469,11 @@ export default function HoleScreen() {
           justifyContent: 'space-between',
         }}
       >
-        <Pressable onPress={() => router.replace('/(app)')}>
+        <Pressable
+          onPress={() => router.replace('/(app)')}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+          style={{ padding: 6 }}
+        >
           <Text
             style={{
               ...KICKER,
@@ -602,10 +606,18 @@ export default function HoleScreen() {
                 marginBottom: 10,
               }}
             >
-              <Pressable onPress={() => setRoundState('PLACE_BALL')}>
+              <Pressable
+                onPress={() => setRoundState('PLACE_BALL')}
+                hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+                style={{ padding: 6 }}
+              >
                 <Text style={{ ...KICKER, color: '#8A8B7E' }}>← Re-place ball</Text>
               </Pressable>
-              <Pressable onPress={skipAim}>
+              <Pressable
+                onPress={skipAim}
+                hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+                style={{ padding: 6 }}
+              >
                 <Text style={{ ...KICKER, color: '#8A8B7E' }}>Skip aim</Text>
               </Pressable>
             </View>

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -455,7 +455,10 @@ function ManualCourseForm({
 
   return (
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
-      <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
+      <ScrollView
+        contentContainerStyle={{ padding: 18, paddingBottom: 40 }}
+        keyboardShouldPersistTaps="handled"
+      >
         <Text style={{ ...KICKER, marginBottom: 8 }}>Add course</Text>
         <Text
           style={{

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -1,5 +1,13 @@
 import { useState } from 'react'
-import { View, Text, TextInput, Pressable } from 'react-native'
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
 import { Link, useRouter } from 'expo-router'
 import { supabase } from '../../lib/supabase'
 
@@ -23,7 +31,19 @@ export default function Login() {
   }
 
   return (
-    <View className="flex-1 justify-center bg-oga-bg-page px-6">
+    <KeyboardAvoidingView
+      className="flex-1 bg-oga-bg-page"
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          justifyContent: 'center',
+          paddingHorizontal: 24,
+          paddingVertical: 24,
+        }}
+        keyboardShouldPersistTaps="handled"
+      >
       <View
         style={{
           backgroundColor: '#FFFFFF',
@@ -90,7 +110,8 @@ export default function Login() {
           No account? Sign up
         </Link>
       </View>
-    </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   )
 }
 

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -58,6 +58,7 @@ export default function MobileOnboarding() {
     <ScrollView
       style={{ flex: 1, backgroundColor: '#F4F4F0' }}
       contentContainerStyle={{ padding: 16, paddingTop: 48, paddingBottom: 32 }}
+      keyboardShouldPersistTaps="handled"
     >
       <Text
         style={{

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -1,5 +1,13 @@
 import { useState } from 'react'
-import { View, Text, TextInput, Pressable } from 'react-native'
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
 import { Link, useRouter } from 'expo-router'
 import { supabase } from '../../lib/supabase'
 
@@ -28,7 +36,19 @@ export default function Signup() {
   }
 
   return (
-    <View className="flex-1 justify-center bg-oga-bg-page px-6">
+    <KeyboardAvoidingView
+      className="flex-1 bg-oga-bg-page"
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          justifyContent: 'center',
+          paddingHorizontal: 24,
+          paddingVertical: 24,
+        }}
+        keyboardShouldPersistTaps="handled"
+      >
       <View
         style={{
           backgroundColor: '#FFFFFF',
@@ -102,7 +122,8 @@ export default function Signup() {
           Have an account? Sign in
         </Link>
       </View>
-    </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   )
 }
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,13 +1,16 @@
 import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { ErrorBoundary } from '../components/errors/ErrorBoundary'
 import '../global.css'
 
 export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <StatusBar style="auto" />
-      <Stack screenOptions={{ headerShown: false }} />
+      <ErrorBoundary>
+        <Stack screenOptions={{ headerShown: false }} />
+      </ErrorBoundary>
     </GestureHandlerRootView>
   )
 }

--- a/apps/mobile/components/errors/ErrorBoundary.tsx
+++ b/apps/mobile/components/errors/ErrorBoundary.tsx
@@ -1,0 +1,119 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { Pressable, ScrollView, Text, View } from 'react-native'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  override state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.error('ErrorBoundary caught:', error, info)
+    }
+  }
+
+  override render(): ReactNode {
+    if (this.state.error) {
+      return (
+        <ErrorScreen
+          error={this.state.error}
+          onReset={() => this.setState({ error: null })}
+        />
+      )
+    }
+    return this.props.children
+  }
+}
+
+function ErrorScreen({ error, onReset }: { error: Error; onReset: () => void }) {
+  return (
+    <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
+      <ScrollView
+        contentContainerStyle={{
+          flexGrow: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 28,
+        }}
+      >
+        <View style={{ maxWidth: 480 }}>
+          <Text
+            style={{
+              fontFamily: 'Fraunces-MediumItalic',
+              fontStyle: 'italic',
+              fontWeight: '500',
+              fontSize: 32,
+              color: '#1C211C',
+              textAlign: 'center',
+            }}
+          >
+            Something went wrong.
+          </Text>
+          <Text
+            style={{
+              fontFamily: 'Inter-Regular',
+              fontSize: 15,
+              color: '#5C6356',
+              textAlign: 'center',
+              marginTop: 14,
+              marginBottom: 22,
+            }}
+          >
+            The screen hit an unexpected error. Tap below to retry.
+          </Text>
+          {__DEV__ && (
+            <Text
+              style={{
+                fontFamily: 'JetBrainsMono-Regular',
+                fontSize: 11,
+                color: '#A33A2A',
+                backgroundColor: '#FBF8F1',
+                borderColor: '#D9D2BF',
+                borderWidth: 1,
+                borderRadius: 4,
+                padding: 14,
+                marginBottom: 22,
+              }}
+            >
+              {error.message}
+              {error.stack ? `\n\n${error.stack}` : ''}
+            </Text>
+          )}
+          <Pressable
+            onPress={onReset}
+            style={{
+              backgroundColor: '#1F3D2C',
+              borderRadius: 2,
+              paddingVertical: 14,
+              paddingHorizontal: 18,
+              alignSelf: 'center',
+            }}
+          >
+            <Text
+              style={{
+                fontFamily: 'Inter-SemiBold',
+                fontSize: 14,
+                fontWeight: '600',
+                letterSpacing: 0.28,
+                color: '#F2EEE5',
+              }}
+            >
+              Try again
+            </Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </View>
+  )
+}

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -1,5 +1,13 @@
 import { useEffect, useState } from 'react'
-import { Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import {
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
 import { GreenDiagram, type BreakDirection } from './GreenDiagram'
 import { useUnits } from '../../hooks/useUnits'
 
@@ -145,7 +153,8 @@ export function PuttingSheet({
   const distance = value.puttDistanceFt ?? 0
 
   return (
-    <View
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
       style={{
         backgroundColor: '#FBF8F1',
         borderTopLeftRadius: 12,
@@ -364,7 +373,7 @@ export function PuttingSheet({
           </Pressable>
         </View>
       </ScrollView>
-    </View>
+    </KeyboardAvoidingView>
   )
 }
 

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -198,12 +198,12 @@ export function PuttingSheet({
             On the green.
           </Text>
         </View>
-        <Pressable onPress={onClose}>
-          <Text
-            style={{ ...KICKER, color: '#8A8B7E', padding: 6 }}
-          >
-            Close
-          </Text>
+        <Pressable
+          onPress={onClose}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+          style={{ padding: 12 }}
+        >
+          <Text style={{ ...KICKER, color: '#8A8B7E' }}>Close</Text>
         </Pressable>
       </View>
 

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -189,7 +189,11 @@ export function ShotLogger({
                 Log it.
               </Text>
             </View>
-            <Pressable onPress={onSkip}>
+            <Pressable
+              onPress={onSkip}
+              hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+              style={{ padding: 6 }}
+            >
               <Text
                 style={{
                   ...KICKER,

--- a/apps/mobile/components/ui/AppBar.tsx
+++ b/apps/mobile/components/ui/AppBar.tsx
@@ -1,4 +1,5 @@
 import { Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 interface AppBarProps {
   eyebrow?: string
@@ -7,11 +8,12 @@ interface AppBarProps {
 }
 
 export function AppBar({ eyebrow, title, right }: AppBarProps) {
+  const insets = useSafeAreaInsets()
   return (
     <View
       style={{
         backgroundColor: '#1C211C',
-        paddingTop: 52,
+        paddingTop: insets.top + 14,
         paddingBottom: 14,
         paddingHorizontal: 18,
         flexDirection: 'row',

--- a/apps/web/src/components/errors/ErrorBoundary.tsx
+++ b/apps/web/src/components/errors/ErrorBoundary.tsx
@@ -1,0 +1,119 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { useRouteError } from 'react-router-dom'
+
+interface Props {
+  children: ReactNode
+}
+
+interface State {
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  override state: State = { error: null }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error }
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo): void {
+    if (import.meta.env.DEV) {
+      console.error('ErrorBoundary caught:', error, info)
+    }
+  }
+
+  override render(): ReactNode {
+    if (this.state.error) {
+      return <ErrorScreen error={this.state.error} />
+    }
+    return this.props.children
+  }
+}
+
+// React Router v6 routes use this — its hook gives us the thrown value, no
+// class component needed since the router catches the error itself.
+export function RouteErrorBoundary() {
+  const error = useRouteError()
+  const normalized = error instanceof Error ? error : new Error(String(error))
+  return <ErrorScreen error={normalized} />
+}
+
+function ErrorScreen({ error }: { error: Error }) {
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        backgroundColor: 'var(--caddie-bg)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 28,
+      }}
+    >
+      <div style={{ maxWidth: 520, textAlign: 'center' }}>
+        <h1
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontWeight: 500,
+            fontSize: 38,
+            color: 'var(--caddie-ink)',
+            margin: 0,
+          }}
+        >
+          Something went wrong.
+        </h1>
+        <p
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 15,
+            color: 'var(--caddie-ink-dim)',
+            marginTop: 14,
+            marginBottom: 22,
+          }}
+        >
+          The page hit an unexpected error. Reloading usually clears it.
+        </p>
+        {import.meta.env.DEV && (
+          <pre
+            style={{
+              fontFamily: 'JetBrains Mono, monospace',
+              fontSize: 12,
+              color: 'var(--caddie-neg)',
+              backgroundColor: 'var(--caddie-surface)',
+              border: '1px solid var(--caddie-line)',
+              borderRadius: 4,
+              padding: 14,
+              marginBottom: 22,
+              textAlign: 'left',
+              overflow: 'auto',
+              maxHeight: 240,
+              whiteSpace: 'pre-wrap',
+            }}
+          >
+            {error.message}
+            {error.stack ? `\n\n${error.stack}` : ''}
+          </pre>
+        )}
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 14,
+            fontWeight: 600,
+            letterSpacing: 0.28,
+            backgroundColor: 'var(--caddie-accent)',
+            color: 'var(--caddie-accent-ink)',
+            border: 'none',
+            borderRadius: 2,
+            padding: '12px 16px',
+            cursor: 'pointer',
+          }}
+        >
+          Reload page
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, Outlet, type RouteObject } from 'react-router-dom'
 import { AuthGuard } from './components/auth/AuthGuard'
 import { ProfileGuard } from './components/auth/ProfileGuard'
 import { AppShell } from './components/layout/AppShell'
+import { RouteErrorBoundary } from './components/errors/ErrorBoundary'
 import { LoginPage } from './pages/auth/LoginPage'
 import { SignupPage } from './pages/auth/SignupPage'
 import { OnboardingPage } from './pages/onboarding/OnboardingPage'
@@ -28,23 +29,30 @@ function ProtectedShell() {
   )
 }
 
+const errorElement = <RouteErrorBoundary />
+
 const routes: RouteObject[] = [
-  { path: '/login', element: <LoginPage /> },
-  { path: '/signup', element: <SignupPage /> },
-  { path: '/onboarding', element: <AuthGuard><OnboardingPage /></AuthGuard> },
+  { path: '/login', element: <LoginPage />, errorElement },
+  { path: '/signup', element: <SignupPage />, errorElement },
+  {
+    path: '/onboarding',
+    element: <AuthGuard><OnboardingPage /></AuthGuard>,
+    errorElement,
+  },
   {
     element: <ProtectedShell />,
+    errorElement,
     children: [
-      { path: '/', element: <DashboardPage /> },
-      { path: '/rounds', element: <RoundsPage /> },
-      { path: '/rounds/new', element: <NewRoundPage /> },
-      { path: '/rounds/:id', element: <RoundDetailPage /> },
-      { path: '/stats', element: <StrokesGainedPage /> },
-      { path: '/patterns', element: <ShotPatternsPage /> },
-      { path: '/practice', element: <PracticePlanPage /> },
-      { path: '/practice/drills', element: <DrillLibraryPage /> },
-      { path: '/learn', element: <LearnPage /> },
-      { path: '/settings', element: <SettingsPage /> },
+      { path: '/', element: <DashboardPage />, errorElement },
+      { path: '/rounds', element: <RoundsPage />, errorElement },
+      { path: '/rounds/new', element: <NewRoundPage />, errorElement },
+      { path: '/rounds/:id', element: <RoundDetailPage />, errorElement },
+      { path: '/stats', element: <StrokesGainedPage />, errorElement },
+      { path: '/patterns', element: <ShotPatternsPage />, errorElement },
+      { path: '/practice', element: <PracticePlanPage />, errorElement },
+      { path: '/practice/drills', element: <DrillLibraryPage />, errorElement },
+      { path: '/learn', element: <LearnPage />, errorElement },
+      { path: '/settings', element: <SettingsPage />, errorElement },
     ],
   },
 ]


### PR DESCRIPTION
## Summary

Four audit follow-ups, one commit each.

## Closes

Closes #27 — error boundaries on web + mobile
Closes #34 — KeyboardAvoidingView on auth and shot forms
Closes #35 — hit slop on critical mobile tap targets
Closes #41 — AppBar uses useSafeAreaInsets

## What changed

**#27 — Error boundaries**
- New `apps/web/src/components/errors/ErrorBoundary.tsx`: class boundary plus a `RouteErrorBoundary` that uses `useRouteError`. Paper-aesthetic error screen — Fraunces italic headline, Inter body, accent reload button, dev-only stack trace.
- `router.tsx` wires `errorElement` on every route.
- New `apps/mobile/components/errors/ErrorBoundary.tsx`. Wrapped around root `Stack` and around `Tabs` so a render throw in one tab no longer kills the whole app.

**#34 — Keyboard handling**
- `login.tsx` / `signup.tsx`: `KeyboardAvoidingView` (`padding` on iOS, `height` on Android) + `ScrollView` with `keyboardShouldPersistTaps='handled'`.
- `onboarding.tsx`, `round/new.tsx` (ManualCourseForm): `keyboardShouldPersistTaps='handled'` so chip taps register after the keyboard is open.
- `PuttingSheet.tsx` outer container becomes `KeyboardAvoidingView`.

**#35 — Hit slop**
- `ShotLogger.tsx` (Skip all), `hole/[number].tsx` (Home, Re-place ball, Skip aim), `PuttingSheet.tsx` (Close): `hitSlop={{12,12,12,12}}` plus 6–12px padding.

**#41 — AppBar safe area**
- `AppBar.tsx` swaps hardcoded `paddingTop: 52` for `insets.top + 14`. `react-native-safe-area-context` already installed; `SafeAreaProvider` is provided by the expo-router Stack/Tabs.

## Verify

- [x] `pnpm typecheck` — passes (3/3 workspaces)
- [x] `pnpm --filter web build` — passes
- [x] `cd apps/mobile && npm run typecheck` — passes
- [ ] Local smoke: throw in a route, see error screen instead of blank
- [ ] Local smoke: open Android keyboard on login, password field stays visible
- [ ] Local smoke: tap "Skip all →" — registers reliably
- [ ] Local smoke: AppBar matches status bar on a tall-notch Android device

## Notes

- Error boundary on `(app)/_layout.tsx` only catches throws inside the Tabs screens. The `_layout.tsx` (root) boundary catches everything outside that.
- Mobile boundary's "Try again" path resets local state — works for transient errors, won't recover from broken navigation state. Acceptable for v1.