### PR TITLE
fix: data quality — input validation, async races, batch inserts

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -17,6 +17,7 @@ export default function AppLayout() {
     if (authLoading) return
     if (!user) return
 
+    let active = true
     supabase
       .from('profiles')
       .select('skill_level, goal')
@@ -24,12 +25,16 @@ export default function AppLayout() {
       .single()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then(({ data, error }: { data: any; error: any }) => {
+        if (!active) return
         if (error || !data || !data.skill_level || !data.goal) {
           setProfileState('incomplete')
         } else {
           setProfileState('complete')
         }
       })
+    return () => {
+      active = false
+    }
   }, [user, authLoading])
 
   if (authLoading || profileState === 'loading') return null

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -69,6 +69,10 @@ export default function ProfileTab() {
       Alert.alert('Handicap must be a number')
       return
     }
+    if (numericHandicap != null && (numericHandicap < -10 || numericHandicap > 54)) {
+      Alert.alert('Handicap must be between -10 and 54')
+      return
+    }
     setSaving(true)
     const { data, error } = await updateProfile(supabase, user.id, {
       username: username || null,

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -192,11 +192,18 @@ export default function HoleScreen() {
       setLocalShotCount(local.length)
       setRemotePuttCount(puttRes.count ?? 0)
       setLocalPuttCount(localPutts)
-      lastSavedShotLocalIdRef.current = null
     })()
     return () => {
       active = false
     }
+  }, [currentHoleScore?.id])
+
+  // Reset the just-saved-shot ref synchronously on hole transition. Keeping
+  // it inside the async count-load effect (above) created a race: a tap-to-
+  // mark-ball that set the ref could be wiped out when the (slower) count
+  // load resolved a moment later, leaving shot N's end_lat/end_lng unset.
+  useEffect(() => {
+    lastSavedShotLocalIdRef.current = null
   }, [currentHoleScore?.id])
 
   // Auto-place ball at current GPS position once per hole. Also keep

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -22,7 +22,6 @@ import {
   getCourseByExternalId,
   searchCourses,
   upsertCourseTees,
-  upsertHoleScore,
 } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../../lib/supabase'
@@ -153,16 +152,20 @@ export default function NewRound() {
         .order('number')
       if (holesError) throw holesError
 
-      await Promise.all(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (holes ?? []).map((h: any) =>
-          upsertHoleScore(supabase, {
-            round_id: round.id,
-            hole_id: h.id,
-            score: 0,
-          }),
-        ),
-      )
+      // Single batch insert beats 18 sequential round-trips; round was just
+      // created so there's nothing to conflict against.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const holeScoreRows = (holes ?? []).map((h: any) => ({
+        round_id: round.id,
+        hole_id: h.id,
+        score: 0,
+      }))
+      if (holeScoreRows.length > 0) {
+        const { error: hsError } = await supabase
+          .from('hole_scores')
+          .insert(holeScoreRows)
+        if (hsError) throw hsError
+      }
 
       router.replace(`/(app)/round/${round.id}/hole/1?mode=${mode}`)
     } catch (err) {

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -40,6 +40,10 @@ export default function MobileOnboarding() {
       Alert.alert('Handicap must be a number')
       return
     }
+    if (numericHandicap != null && (numericHandicap < -10 || numericHandicap > 54)) {
+      Alert.alert('Handicap must be between -10 and 54')
+      return
+    }
     setSaving(true)
     const { error } = await updateProfile(supabase, user.id, {
       skill_level: skill,

--- a/apps/mobile/lib/sync.ts
+++ b/apps/mobile/lib/sync.ts
@@ -1,8 +1,9 @@
-import { createShot } from '@oga/supabase'
 import { listPendingShots, markShotSynced, type ShotPayload } from './db'
 import { supabase } from './supabase'
 
 let inFlight = false
+
+const CHUNK_SIZE = 50
 
 export async function syncPendingShots(): Promise<{ synced: number; failed: number }> {
   if (inFlight) return { synced: 0, failed: 0 }
@@ -11,15 +12,41 @@ export async function syncPendingShots(): Promise<{ synced: number; failed: numb
   let failed = 0
   try {
     const pending = await listPendingShots()
-    for (const row of pending) {
-      const payload = JSON.parse(row.payload) as ShotPayload
-      const { data, error } = await createShot(supabase, payload)
-      if (error || !data) {
-        failed += 1
+    for (let i = 0; i < pending.length; i += CHUNK_SIZE) {
+      const chunk = pending.slice(i, i + CHUNK_SIZE)
+      const payloads: ShotPayload[] = []
+      for (const row of chunk) {
+        try {
+          payloads.push(JSON.parse(row.payload) as ShotPayload)
+        } catch {
+          // Malformed pending payload — skip; the row stays pending and
+          // will be retried (or hand-pruned) later.
+        }
+      }
+      if (payloads.length === 0) {
+        failed += chunk.length
         continue
       }
-      await markShotSynced(row.local_id, data.id)
-      synced += 1
+      const { data, error } = await supabase
+        .from('shots')
+        .insert(payloads)
+        .select('id')
+      if (error || !data || data.length !== payloads.length) {
+        failed += chunk.length
+        continue
+      }
+      // supabase-js returns inserted rows in input order, so we can map
+      // each pending local_id to its remote id by index.
+      for (let j = 0; j < chunk.length; j++) {
+        const row = chunk[j]
+        const remote = data[j]
+        if (!row || !remote) {
+          failed += 1
+          continue
+        }
+        await markShotSynced(row.local_id, remote.id)
+        synced += 1
+      }
     }
   } finally {
     inFlight = false

--- a/apps/web/src/components/auth/ProfileGuard.tsx
+++ b/apps/web/src/components/auth/ProfileGuard.tsx
@@ -13,18 +13,23 @@ export function ProfileGuard({ children }: { children: React.ReactNode }) {
     if (authLoading) return
     if (!user) return
 
+    let active = true
     supabase
       .from('profiles')
       .select('skill_level, goal')
       .eq('id', user.id)
       .single()
       .then(({ data, error }) => {
+        if (!active) return
         if (error || !data || !data.skill_level || !data.goal) {
           setProfileState('incomplete')
         } else {
           setProfileState('complete')
         }
       })
+    return () => {
+      active = false
+    }
   }, [user, authLoading])
 
   if (authLoading || profileState === 'loading') return null

--- a/apps/web/src/hooks/useCompleteRound.ts
+++ b/apps/web/src/hooks/useCompleteRound.ts
@@ -9,7 +9,6 @@ import {
   getHoleScoresForRound,
   getHolesForCourse,
   getShotsForRound,
-  updateHoleScore,
   updateProfile,
   updateRound,
 } from '@oga/supabase'
@@ -71,18 +70,33 @@ export function useCompleteRound() {
 
       const result = computeRoundSG({ holes, holeScores, shots, handicap })
 
-      const sgUpdates = Object.entries(result.perHoleScore).map(
-        ([holeScoreId, sg]) =>
-          updateHoleScore(supabase, holeScoreId, {
+      // Single batch upsert beats N sequential UPDATEs. Carry round_id /
+      // hole_id / score forward unchanged so the underlying INSERT path of
+      // upsert can satisfy the NOT NULL columns; the conflict on `id` then
+      // updates the SG fields only.
+      const holeScoresById = new Map(holeScores.map((hs) => [hs.id, hs]))
+      const sgRows = Object.entries(result.perHoleScore)
+        .map(([holeScoreId, sg]) => {
+          const existing = holeScoresById.get(holeScoreId)
+          if (!existing) return null
+          return {
+            id: holeScoreId,
+            round_id: existing.round_id,
+            hole_id: existing.hole_id,
+            score: existing.score,
             sg_off_tee: round2(sg.offTee),
             sg_approach: round2(sg.approach),
             sg_around_green: round2(sg.aroundGreen),
             sg_putting: round2(sg.putting),
-          }),
-      )
-      const sgResults = await Promise.all(sgUpdates)
-      const sgError = sgResults.find((r) => r.error)
-      if (sgError?.error) throw sgError.error
+          }
+        })
+        .filter((r): r is NonNullable<typeof r> => r != null)
+      if (sgRows.length > 0) {
+        const { error: sgError } = await supabase
+          .from('hole_scores')
+          .upsert(sgRows, { onConflict: 'id' })
+        if (sgError) throw sgError
+      }
 
       // ---- Handicap differential ------------------------------------------
       const tee =

--- a/apps/web/src/pages/onboarding/OnboardingPage.tsx
+++ b/apps/web/src/pages/onboarding/OnboardingPage.tsx
@@ -43,6 +43,10 @@ export function OnboardingPage() {
 
   async function save() {
     setError(null)
+    if (draft.handicap < -10 || draft.handicap > 54) {
+      setError('Handicap must be between -10 and 54')
+      return
+    }
     try {
       await updateProfile.mutateAsync({
         skill_level: draft.skillLevel,

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -86,6 +86,10 @@ export function SettingsPage() {
       setError('Handicap must be a number')
       return
     }
+    if (numericHandicap != null && (numericHandicap < -10 || numericHandicap > 54)) {
+      setError('Handicap must be between -10 and 54')
+      return
+    }
     try {
       await updateProfile.mutateAsync({
         username: trimmed || null,
@@ -139,8 +143,11 @@ export function SettingsPage() {
           <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
             <span className="kicker">Handicap index</span>
             <input
-              type="text"
+              type="number"
               inputMode="decimal"
+              min={-10}
+              max={54}
+              step={0.1}
               value={handicap}
               onChange={(e) => setHandicap(e.target.value)}
               style={inputStyle}

--- a/supabase/migrations/0012_input_validation.sql
+++ b/supabase/migrations/0012_input_validation.sql
@@ -1,0 +1,20 @@
+-- DB-level validation for handicap and par. Without these, a poisoned
+-- handicap (e.g. -50) flows into the SG calculation producing NaN or
+-- the wrong handicap bracket. Par values outside 3-6 are physically
+-- impossible on a real course.
+--
+-- Range note: -10 covers the lowest plus-handicaps (PGA tour scratch is
+-- around -8); 54 is the WHS maximum.
+alter table public.profiles
+  add constraint handicap_range
+  check (handicap_index is null or handicap_index between -10 and 54);
+
+-- The original `holes` table already constrains par via
+--   par int not null check (par between 3 and 6)
+-- in 0001_initial_schema.sql, so re-asserting it here is redundant but
+-- harmless and serves as documentation alongside the new profile constraint.
+alter table public.holes
+  drop constraint if exists par_range;
+alter table public.holes
+  add constraint par_range
+  check (par between 3 and 6);


### PR DESCRIPTION
## Summary

Three audit follow-ups, one commit each.

## Closes

Closes #25 — async state races (post-unmount setState)
Closes #26 — N+1 batch inserts on round start, finalize, and sync
Closes #31 — handicap and par input validation + DB constraints

## What changed

**#31 — Input validation**
- New migration `0012_input_validation.sql`: `CHECK (handicap_index BETWEEN -10 AND 54)` on `profiles`; re-asserts `CHECK (par BETWEEN 3 AND 6)` on `holes` for documentation.
- `SettingsPage` (web), mobile profile, mobile onboarding, web OnboardingPage save: reject out-of-range handicap before hitting the DB.
- `SettingsPage` input becomes `type=number` with `min={-10}`, `max={54}`, `step={0.1}`.

**#25 — Async races**
- `ProfileGuard.tsx` and mobile `(app)/_layout.tsx`: `let active = true` flag gates the `setState` after the profile fetch.
- `hole/[number].tsx`: the `lastSavedShotLocalIdRef.current = null` reset moves out of the async count-load effect into its own synchronous effect keyed on `currentHoleScore?.id`. Fixes the race where a tap-to-mark-ball that set the ref could be wiped out by a slower count load resolving later, leaving shot N's `end_lat`/`end_lng` unset.

**#26 — Batch inserts**
- `round/new.tsx` (mobile): 18 sequential `upsertHoleScore` calls become one `.insert([...18 rows])`.
- `useCompleteRound.ts` (web): per-hole SG update loop becomes one `.upsert(rows, { onConflict: 'id' })`. Carries `round_id`/`hole_id`/`score` forward unchanged so the upsert's INSERT path satisfies NOT NULL columns; conflict-on-id then updates SG fields only.
- `sync.ts` (mobile): sequential `createShot` per pending row becomes chunked `.insert([...50])` calls; inserted rows come back in input order so each `local_id` maps to its remote id by index. Malformed payloads no longer crash the loop.

## Verify

- [x] `pnpm typecheck` — passes (3/3 workspaces)
- [x] `pnpm --filter web build` — passes
- [x] `apps/mobile npm run typecheck` — passes
- [ ] `npx supabase db push --linked` to apply `0012`
- [ ] After migration: try saving handicap = -50 from Settings — should be rejected client-side and (if bypassed) server-side
- [ ] Start a new round on mobile — hole_scores rows appear in one DB round-trip
- [ ] Complete a round with shots — SG fields populate on hole_scores via single upsert
- [ ] Take 3+ shots offline, come online, run sync — chunked insert syncs all in one round-trip per chunk