### PR TITLE
fix: security and reliability — RLS hardening, error handling, type safety, sync robustness

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -22,11 +22,19 @@ export default function AppLayout() {
       .from('profiles')
       .select('skill_level, goal')
       .eq('id', user.id)
-      .single()
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .then(({ data, error }: { data: any; error: any }) => {
+      .maybeSingle()
+      .then(({ data, error }) => {
         if (!active) return
-        if (error || !data || !data.skill_level || !data.goal) {
+        if (error) {
+          // eslint-disable-next-line no-console
+          console.error('[(app)/_layout]', error.message)
+          // Treat as incomplete is the wrong call for a transient error;
+          // leave the user on the loading state until the next render
+          // can retry. Setting incomplete here would punt them to
+          // onboarding and clobber their saved profile.
+          return
+        }
+        if (!data || !data.skill_level || !data.goal) {
           setProfileState('incomplete')
         } else {
           setProfileState('complete')

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -74,13 +74,23 @@ export default function Home() {
   useEffect(() => {
     if (!user) return
     let active = true
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getProfile(supabase, user.id).then(({ data }: { data: any }) => {
-      if (active && data) setProfile(data)
+    getProfile(supabase, user.id).then(({ data, error }) => {
+      if (!active) return
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.error('[home/getProfile]', error.message)
+        return
+      }
+      if (data) setProfile(data)
     })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getRecentSGData(supabase, user.id, 20).then(({ data }: { data: any }) => {
-      if (active && data) setRounds(data as RecentRound[])
+    getRecentSGData(supabase, user.id, 20).then(({ data, error }) => {
+      if (!active) return
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.error('[home/getRecentSGData]', error.message)
+        return
+      }
+      if (data) setRounds(data as RecentRound[])
     })
     return () => {
       active = false

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -56,9 +56,10 @@ export default function Home() {
 
   const handleDelete = useCallback(
     async (id: string) => {
+      if (!user) return
       setDeleting(true)
       try {
-        const { error } = await deleteRound(supabase, id)
+        const { error } = await deleteRound(supabase, id, user.id)
         if (error) throw error
         setRounds((prev) => prev.filter((r) => r.id !== id))
       } finally {
@@ -67,7 +68,7 @@ export default function Home() {
         swipeRefs.current.delete(id)
       }
     },
-    [],
+    [user],
   )
 
   useEffect(() => {

--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -87,10 +87,13 @@ export default function Patterns() {
     if (!user) return
     let active = true
     setLoading(true)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getShotsByClub(supabase, user.id, club).then(({ data }: { data: any }) => {
+    getShotsByClub(supabase, user.id, club).then(({ data, error }) => {
       if (!active) return
-      setShots((data as ShotRowMin[]) ?? [])
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.error('[patterns/getShotsByClub]', error.message)
+      }
+      setShots((data as ShotRowMin[] | null) ?? [])
       setLoading(false)
     })
     return () => {

--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -401,11 +401,11 @@ function DispersionPlot({
         AIM
       </SvgText>
 
-      {points.map((p, i) => {
+      {points.map((p) => {
         const c = pointColor(p.shotResult)
         return (
           <Circle
-            key={i}
+            key={p.id}
             cx={px(p.lateralOffsetYards)}
             cy={py(p.distanceOffsetYards)}
             r={3.5}

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -41,10 +41,11 @@ export default function ProfileTab() {
   useEffect(() => {
     if (authLoading || !user) return
     let active = true
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getProfile(supabase, user.id).then(({ data, error }: { data: any; error: any }) => {
+    getProfile(supabase, user.id).then(({ data, error }) => {
       if (!active) return
       if (error) {
+        // eslint-disable-next-line no-console
+        console.error('[profile/getProfile]', error.message)
         Alert.alert('Could not load profile', error.message)
         return
       }

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -416,10 +416,10 @@ export default function HoleScreen() {
   }
 
   async function handleDeleteRound() {
-    if (!round) return
+    if (!round || !user) return
     setDeleting(true)
     try {
-      const { error: delErr } = await deleteRound(supabase, round.id)
+      const { error: delErr } = await deleteRound(supabase, round.id, user.id)
       if (delErr) {
         Alert.alert('Delete failed', delErr.message)
         return

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -314,7 +314,12 @@ export default function HoleScreen() {
         .from('hole_scores')
         .update({ score: shotNumber, putts: newPutts })
         .eq('id', payload.hole_score_id)
-        .then(() => undefined, () => undefined)
+        .then(({ error }) => {
+          if (error) {
+            // eslint-disable-next-line no-console
+            console.warn('[hole/score-update]', error.message)
+          }
+        })
       // Reflect optimistically in the inline scorecard preview.
       setHoleScores((prev) =>
         prev.map((hs) =>
@@ -384,7 +389,12 @@ export default function HoleScreen() {
           .from('shots')
           .update({ end_lat: ballSnapshot.lat, end_lng: ballSnapshot.lng })
           .eq('id', result.remote_id)
-          .then(() => undefined, () => undefined)
+          .then(({ error }) => {
+            if (error) {
+              // eslint-disable-next-line no-console
+              console.warn('[hole/end-coord-patch]', error.message)
+            }
+          })
       }
       lastSavedShotLocalIdRef.current = null
     }

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -25,6 +25,7 @@ import {
   insertPendingShot,
   pendingShotsForHoleScore,
   setPendingShotEnd,
+  type PendingShot,
   type ShotPayload,
 } from '../../../../../lib/db'
 import { syncPendingShots } from '../../../../../lib/sync'
@@ -83,9 +84,11 @@ export default function HoleScreen() {
   // can fill in that shot's end_lat/end_lng with the new ball position.
   const lastSavedShotLocalIdRef = useRef<number | null>(null)
   const [remoteShotCount, setRemoteShotCount] = useState(0)
-  const [localShotCount, setLocalShotCount] = useState(0)
   const [remotePuttCount, setRemotePuttCount] = useState(0)
-  const [localPuttCount, setLocalPuttCount] = useState(0)
+  // Single source of truth for unsynced shots on this hole. Local counts
+  // are derived via useMemo so an optimistic save and a slow re-load can't
+  // disagree about how many shots / putts the user has logged.
+  const [pendingForHole, setPendingForHole] = useState<PendingShot[]>([])
   const [loggerOpen, setLoggerOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   // Pin placement is orthogonal to the shot phase machine. When true,
@@ -179,19 +182,9 @@ export default function HoleScreen() {
         pendingShotsForHoleScore(currentHoleScore.id),
       ])
       if (!active) return
-      let localPutts = 0
-      for (const r of local) {
-        try {
-          const p = JSON.parse(r.payload) as ShotPayload
-          if (p.club === 'putter' || p.lie_type === 'green') localPutts++
-        } catch {
-          // skip malformed pending payload
-        }
-      }
       setRemoteShotCount(shotRes.count ?? 0)
-      setLocalShotCount(local.length)
       setRemotePuttCount(puttRes.count ?? 0)
-      setLocalPuttCount(localPutts)
+      setPendingForHole(local)
     })()
     return () => {
       active = false
@@ -242,6 +235,22 @@ export default function HoleScreen() {
     return distanceYards(gpsPosition, storedPin) <= PIN_PROMPT_RADIUS_YARDS
   }, [roundPin, storedPin, gpsPosition])
 
+  // Derive local shot/putt counts from the pending array — single source
+  // of truth, never out of sync with the underlying queue. Putts are
+  // counted as shots where club='putter' OR lie_type='green'.
+  const localShotCount = pendingForHole.length
+  const localPuttCount = useMemo(() => {
+    let n = 0
+    for (const r of pendingForHole) {
+      try {
+        const p = JSON.parse(r.payload) as ShotPayload
+        if (p.club === 'putter' || p.lie_type === 'green') n++
+      } catch {
+        // skip malformed pending payload
+      }
+    }
+    return n
+  }, [pendingForHole])
   const shotNumber = remoteShotCount + localShotCount + 1
 
   function buildPayload(meta: ShotLoggerValue | null): ShotPayload | null {
@@ -298,8 +307,18 @@ export default function HoleScreen() {
       const localId = await insertPendingShot(payload)
       lastSavedShotLocalIdRef.current = localId
       const isPutt = payload.club === 'putter' || payload.lie_type === 'green'
-      setLocalShotCount((c) => c + 1)
-      if (isPutt) setLocalPuttCount((c) => c + 1)
+      // Append to the pending queue — counts derive from this so they can't
+      // drift. Status starts 'pending' until syncPendingShots flips it.
+      setPendingForHole((prev) => [
+        ...prev,
+        {
+          local_id: localId,
+          remote_id: null,
+          status: 'pending',
+          payload: JSON.stringify(payload),
+          created_at: Date.now(),
+        },
+      ])
       setAim(null)
       setBall(null)
       setLoggerOpen(false)

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -111,8 +111,14 @@ export default function NewRound() {
     setSearching(true)
     Promise.allSettled([
       searchOpenGolfApi(term, ctrl.signal),
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      searchCourses(supabase, term, 10).then((r: any) => r.data ?? []),
+      searchCourses(supabase, term, 10).then(({ data, error }) => {
+        if (error) {
+          // eslint-disable-next-line no-console
+          console.warn('[round/new searchCourses]', error.message)
+          return [] as CourseRow[]
+        }
+        return (data ?? []) as CourseRow[]
+      }),
     ])
       .then(([api, local]) => {
         if (ctrl.signal.aborted) return

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -160,8 +160,7 @@ export default function NewRound() {
 
       // Single batch insert beats 18 sequential round-trips; round was just
       // created so there's nothing to conflict against.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const holeScoreRows = (holes ?? []).map((h: any) => ({
+      const holeScoreRows = (holes ?? []).map((h) => ({
         round_id: round.id,
         hole_id: h.id,
         score: 0,

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -44,10 +44,13 @@ export default function Stats() {
     if (!user) return
     let active = true
     setLoading(true)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getRecentSGData(supabase, user.id, n).then(({ data }: { data: any }) => {
+    getRecentSGData(supabase, user.id, n).then(({ data, error }) => {
       if (!active) return
-      setRounds((data as RecentRound[]) ?? [])
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.error('[stats/getRecentSGData]', error.message)
+      }
+      setRounds((data as RecentRound[] | null) ?? [])
       setLoading(false)
     })
     return () => {

--- a/apps/mobile/hooks/useAuth.ts
+++ b/apps/mobile/hooks/useAuth.ts
@@ -9,8 +9,7 @@ export function useAuth() {
   useEffect(() => {
     let mounted = true
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    supabase.auth.getSession().then(({ data }: { data: any }) => {
+    supabase.auth.getSession().then(({ data }) => {
       if (!mounted) return
       setUser(data.session?.user ?? null)
       setLoading(false)
@@ -18,8 +17,7 @@ export function useAuth() {
 
     const {
       data: { subscription },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } = supabase.auth.onAuthStateChange((_event: any, session: any) => {
+    } = supabase.auth.onAuthStateChange((_event, session) => {
       if (!mounted) return
       setUser(session?.user ?? null)
     })

--- a/apps/mobile/hooks/useUnits.ts
+++ b/apps/mobile/hooks/useUnits.ts
@@ -15,9 +15,14 @@ export function useUnits() {
   useEffect(() => {
     if (!user) return
     let active = true
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getProfile(supabase, user.id).then(({ data }: { data: any }) => {
-      if (!active || !data) return
+    getProfile(supabase, user.id).then(({ data, error }) => {
+      if (!active) return
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.warn('[useUnits/getProfile]', error.message)
+        return
+      }
+      if (!data) return
       if (data.distance_unit === 'meters') setUnit('meters')
       else setUnit('yards')
     })

--- a/apps/mobile/lib/sync.ts
+++ b/apps/mobile/lib/sync.ts
@@ -1,13 +1,39 @@
 import { listPendingShots, markShotSynced, type ShotPayload } from './db'
 import { supabase } from './supabase'
 
+// Module-scope lock that survives a Fast Refresh and prevents two
+// concurrent syncPendingShots() calls from racing the same SQLite rows.
+// A timestamp + TTL guards against the lock getting stuck `true` after a
+// crash mid-flight: if the current process can't have been holding it
+// for that long, we know it's stale and reset.
 let inFlight = false
-
+let inFlightSince: number | null = null
+const LOCK_TTL_MS = 30_000
 const CHUNK_SIZE = 50
 
-export async function syncPendingShots(): Promise<{ synced: number; failed: number }> {
-  if (inFlight) return { synced: 0, failed: 0 }
+function acquireLock(): boolean {
+  if (inFlight) {
+    if (inFlightSince != null && Date.now() - inFlightSince > LOCK_TTL_MS) {
+      // eslint-disable-next-line no-console
+      console.warn('[sync] stale lock detected, resetting')
+      inFlight = false
+      inFlightSince = null
+    } else {
+      return false
+    }
+  }
   inFlight = true
+  inFlightSince = Date.now()
+  return true
+}
+
+function releaseLock(): void {
+  inFlight = false
+  inFlightSince = null
+}
+
+export async function syncPendingShots(): Promise<{ synced: number; failed: number }> {
+  if (!acquireLock()) return { synced: 0, failed: 0 }
   let synced = 0
   let failed = 0
   try {
@@ -49,7 +75,7 @@ export async function syncPendingShots(): Promise<{ synced: number; failed: numb
       }
     }
   } finally {
-    inFlight = false
+    releaseLock()
   }
   return { synced, failed }
 }

--- a/apps/web/src/components/auth/ProfileGuard.tsx
+++ b/apps/web/src/components/auth/ProfileGuard.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router-dom'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 
-type ProfileState = 'loading' | 'complete' | 'incomplete'
+type ProfileState = 'loading' | 'complete' | 'incomplete' | 'error'
 
 export function ProfileGuard({ children }: { children: React.ReactNode }) {
   const { user, loading: authLoading } = useAuth()
@@ -18,10 +18,19 @@ export function ProfileGuard({ children }: { children: React.ReactNode }) {
       .from('profiles')
       .select('skill_level, goal')
       .eq('id', user.id)
-      .single()
+      .maybeSingle()
       .then(({ data, error }) => {
         if (!active) return
-        if (error || !data || !data.skill_level || !data.goal) {
+        if (error) {
+          // Real failure (network, RLS misconfig). Don't punish the user
+          // by punting them to onboarding — surface the issue and stop.
+          // eslint-disable-next-line no-console
+          console.error('[ProfileGuard]', error.message)
+          setProfileState('error')
+          return
+        }
+        // No row, or row missing required onboarding fields.
+        if (!data || !data.skill_level || !data.goal) {
           setProfileState('incomplete')
         } else {
           setProfileState('complete')
@@ -32,8 +41,54 @@ export function ProfileGuard({ children }: { children: React.ReactNode }) {
     }
   }, [user, authLoading])
 
-  if (authLoading || profileState === 'loading') return null
+  if (authLoading || profileState === 'loading') {
+    return (
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'Inter, sans-serif',
+          fontSize: 13,
+          color: 'var(--caddie-ink-dim)',
+          backgroundColor: 'var(--caddie-bg)',
+        }}
+      >
+        Loading…
+      </div>
+    )
+  }
   if (!user) return <Navigate to="/login" replace />
+  if (profileState === 'error') {
+    // Soft error screen so a transient network blip doesn't redirect a
+    // fully-onboarded user to /onboarding (which would clobber their
+    // profile on save).
+    return (
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+          gap: 14,
+          fontFamily: 'Inter, sans-serif',
+          backgroundColor: 'var(--caddie-bg)',
+          color: 'var(--caddie-ink)',
+          padding: 28,
+          textAlign: 'center',
+        }}
+      >
+        <div style={{ fontFamily: 'Fraunces, serif', fontStyle: 'italic', fontSize: 22 }}>
+          Couldn't load your profile.
+        </div>
+        <div style={{ fontSize: 13, color: 'var(--caddie-ink-dim)' }}>
+          Check your connection and reload.
+        </div>
+      </div>
+    )
+  }
   if (profileState === 'incomplete') return <Navigate to="/onboarding" replace />
   return <>{children}</>
 }

--- a/apps/web/src/hooks/useCompleteRound.ts
+++ b/apps/web/src/hooks/useCompleteRound.ts
@@ -57,7 +57,11 @@ export function useCompleteRound() {
       if (holeScoresRes.error) throw holeScoresRes.error
       if (shotsRes.error) throw shotsRes.error
 
-      const holes = (holesRes.data ?? []) as HoleRow[]
+      // Plain ?? [] — the select returns the row type already, no cast
+      // needed. The holeScoreRows annotation carries the nested holes()
+      // join shape that the typed select doesn't expose; that's the one
+      // place a narrowing assertion still earns its keep.
+      const holes: HoleRow[] = holesRes.data ?? []
       const holeScoreRows = (holeScoresRes.data ?? []) as Array<
         HoleScoreRow & { holes?: HoleRow | null }
       >
@@ -66,7 +70,7 @@ export function useCompleteRound() {
         return rest
       })
       const shots = (shotsRes.data ?? []) as ShotRow[]
-      const tees = (teesRes.data ?? []) as CourseTeeRow[]
+      const tees: CourseTeeRow[] = teesRes.data ?? []
 
       const result = computeRoundSG({ holes, holeScores, shots, handicap })
 

--- a/apps/web/src/hooks/useCompleteRound.ts
+++ b/apps/web/src/hooks/useCompleteRound.ts
@@ -50,7 +50,7 @@ export function useCompleteRound() {
       const [holesRes, holeScoresRes, shotsRes, teesRes] = await Promise.all([
         getHolesForCourse(supabase, courseId),
         getHoleScoresForRound(supabase, roundId),
-        getShotsForRound(supabase, roundId),
+        getShotsForRound(supabase, roundId, userId),
         getCourseTees(supabase, courseId),
       ])
       if (holesRes.error) throw holesRes.error
@@ -128,7 +128,10 @@ export function useCompleteRound() {
         }
       }
 
-      const { error: roundError } = await updateRound(supabase, roundId, {
+      const { error: roundError } = await updateRound(
+        supabase,
+        roundId,
+        {
         sg_off_tee: round2(result.round.offTee),
         sg_approach: round2(result.round.approach),
         sg_around_green: round2(result.round.aroundGreen),
@@ -143,7 +146,9 @@ export function useCompleteRound() {
         // direct link without re-running the fallback.
         course_tee_id: tee?.id ?? courseTeeId ?? null,
         score_differential: differential,
-      })
+        },
+        userId,
+      )
       if (roundError) throw roundError
 
       // ---- Handicap index recompute --------------------------------------

--- a/apps/web/src/hooks/useCompleteRound.ts
+++ b/apps/web/src/hooks/useCompleteRound.ts
@@ -153,19 +153,25 @@ export function useCompleteRound() {
 
       // ---- Handicap index recompute --------------------------------------
       if (differential != null) {
-        const { data: recentDiffs } = await supabase
+        const { data: recentDiffs, error: diffsError } = await supabase
           .from('rounds')
           .select('score_differential')
           .eq('user_id', userId)
           .not('score_differential', 'is', null)
           .order('played_at', { ascending: false })
           .limit(20)
+        if (diffsError) throw diffsError
         const diffs = (recentDiffs ?? [])
           .map((r) => r.score_differential)
           .filter((d): d is number => d != null)
         const newIndex = calculateHandicapIndex(diffs)
         if (newIndex != null) {
-          await updateProfile(supabase, userId, { handicap_index: newIndex })
+          const { error: profileError } = await updateProfile(
+            supabase,
+            userId,
+            { handicap_index: newIndex },
+          )
+          if (profileError) throw profileError
         }
       }
 

--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -79,7 +79,11 @@ export function useImportApiCourse() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (args: ImportFromApiArgs) => {
-      const { data: existing } = await getCourseByExternalId(supabase, args.apiId)
+      const { data: existing, error: existingError } = await getCourseByExternalId(
+        supabase,
+        args.apiId,
+      )
+      if (existingError) throw existingError
       if (existing) return existing as CourseRow
 
       let detail: OpenGolfApiCourse | null = null

--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -84,7 +84,7 @@ export function useImportApiCourse() {
         args.apiId,
       )
       if (existingError) throw existingError
-      if (existing) return existing as CourseRow
+      if (existing) return existing
 
       let detail: OpenGolfApiCourse | null = null
       try {

--- a/apps/web/src/hooks/useDetailedStats.ts
+++ b/apps/web/src/hooks/useDetailedStats.ts
@@ -25,6 +25,13 @@ export function useDetailedStats(limit: number): {
     queryFn: async (): Promise<DetailedRound[]> => {
       const { data, error } = await getRoundsWithDetails(supabase, user!.id, limit)
       if (error) throw error
+      // The Supabase types for nested joins (rounds → hole_scores → holes/shots)
+      // come back as unknown — there's no public typegen path that resolves the
+      // *, hole_scores(*, holes(*), shots(*)) shape. Cast is asserted here, not
+      // runtime-checked; if the schema or query changes, statsCalculations will
+      // throw a clear "cannot read property X of undefined" rather than a silent
+      // type lie. Re-run `supabase gen types` and adjust DetailedRound when the
+      // schema moves.
       return (data ?? []) as DetailedRound[]
     },
   })

--- a/apps/web/src/hooks/useDetailedStats.ts
+++ b/apps/web/src/hooks/useDetailedStats.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { getRoundsWithDetails } from '@oga/supabase'
 import { supabase } from '../lib/supabase'
@@ -36,8 +37,16 @@ export function useDetailedStats(limit: number): {
     },
   })
 
-  const rounds = query.data ?? []
-  const data = rounds.length > 0 ? computeDetailedStats(rounds, handicap) : null
+  const rounds = useMemo(() => query.data ?? [], [query.data])
+  // computeDetailedStats walks every shot in every round (O(N×shots)) — wrap
+  // in useMemo so it doesn't re-run on parent renders unrelated to the data.
+  // Returns null while loading and when there are zero rounds; consumers
+  // MUST gate EmptyState on !isLoading first to avoid flashing the empty
+  // state during fetch.
+  const data = useMemo(
+    () => (rounds.length > 0 ? computeDetailedStats(rounds, handicap) : null),
+    [rounds, handicap],
+  )
 
   return {
     data,

--- a/apps/web/src/hooks/useRounds.ts
+++ b/apps/web/src/hooks/useRounds.ts
@@ -26,11 +26,12 @@ export function useRounds(limit = 20) {
 }
 
 export function useRound(roundId: string | undefined) {
+  const { user } = useAuth()
   return useQuery({
-    queryKey: ['round', roundId],
-    enabled: !!roundId,
+    queryKey: ['round', roundId, user?.id],
+    enabled: !!roundId && !!user,
     queryFn: async () => {
-      const { data, error } = await getRound(supabase, roundId!)
+      const { data, error } = await getRound(supabase, roundId!, user!.id)
       if (error) throw error
       return data
     },
@@ -68,7 +69,8 @@ export function useDeleteRound() {
   const { user } = useAuth()
   return useMutation({
     mutationFn: async (roundId: string) => {
-      const { error } = await deleteRound(supabase, roundId)
+      if (!user) throw new Error('Not authenticated')
+      const { error } = await deleteRound(supabase, roundId, user.id)
       if (error) throw error
     },
     onSuccess: () => {

--- a/apps/web/src/hooks/useShots.ts
+++ b/apps/web/src/hooks/useShots.ts
@@ -2,16 +2,18 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { createShot, deleteShot, getShotsForRound, updateShot } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../lib/supabase'
+import { useAuth } from './useAuth'
 
 type ShotInsert = Database['public']['Tables']['shots']['Insert']
 type ShotUpdate = Database['public']['Tables']['shots']['Update']
 
 export function useShotsForRound(roundId: string | undefined) {
+  const { user } = useAuth()
   return useQuery({
-    queryKey: ['shots', 'round', roundId],
-    enabled: !!roundId,
+    queryKey: ['shots', 'round', roundId, user?.id],
+    enabled: !!roundId && !!user,
     queryFn: async () => {
-      const { data, error } = await getShotsForRound(supabase, roundId!)
+      const { data, error } = await getShotsForRound(supabase, roundId!, user!.id)
       if (error) throw error
       return data ?? []
     },
@@ -32,9 +34,11 @@ export function useCreateShot(roundId: string | undefined) {
 
 export function useUpdateShot(roundId: string | undefined) {
   const qc = useQueryClient()
+  const { user } = useAuth()
   return useMutation({
     mutationFn: async ({ id, updates }: { id: string; updates: ShotUpdate }) => {
-      const { data, error } = await updateShot(supabase, id, updates)
+      if (!user) throw new Error('Not authenticated')
+      const { data, error } = await updateShot(supabase, id, updates, user.id)
       if (error) throw error
       return data
     },
@@ -44,9 +48,11 @@ export function useUpdateShot(roundId: string | undefined) {
 
 export function useDeleteShot(roundId: string | undefined) {
   const qc = useQueryClient()
+  const { user } = useAuth()
   return useMutation({
     mutationFn: async (id: string) => {
-      const { error } = await deleteShot(supabase, id)
+      if (!user) throw new Error('Not authenticated')
+      const { error } = await deleteShot(supabase, id, user.id)
       if (error) throw error
     },
     onSuccess: () => qc.invalidateQueries({ queryKey: ['shots', 'round', roundId] }),

--- a/apps/web/src/lib/statsCalculations.ts
+++ b/apps/web/src/lib/statsCalculations.ts
@@ -645,12 +645,19 @@ export interface SlopeImpact {
 }
 
 // Backfill slope axes for legacy rows so impact stats include pre-split data.
+function isLieSlopeForward(v: string | null): v is LieSlopeForward {
+  return v === 'uphill' || v === 'level' || v === 'downhill'
+}
+function isLieSlopeSide(v: string | null): v is LieSlopeSide {
+  return v === 'ball_above' || v === 'ball_below'
+}
+
 function readSlopeAxes(s: ShotRow): {
   forward: LieSlopeForward | null
   side: LieSlopeSide | null
 } {
-  const forward = (s.lie_slope_forward as LieSlopeForward | null) ?? null
-  const side = (s.lie_slope_side as LieSlopeSide | null) ?? null
+  const forward = isLieSlopeForward(s.lie_slope_forward) ? s.lie_slope_forward : null
+  const side = isLieSlopeSide(s.lie_slope_side) ? s.lie_slope_side : null
   if (forward || side) return { forward, side }
   if (s.lie_slope === 'uphill' || s.lie_slope === 'level' || s.lie_slope === 'downhill') {
     return { forward: s.lie_slope, side: null }

--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -427,11 +427,11 @@ function DispersionPlot({
         AIM
       </text>
 
-      {points.map((p, i) => {
+      {points.map((p) => {
         const c = pointColor(p.shotResult)
         return (
           <circle
-            key={i}
+            key={p.id}
             cx={px(p.lateralOffsetYards)}
             cy={py(p.distanceOffsetYards)}
             r={3.5}

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -169,11 +169,15 @@ export function RoundDetailPage() {
     async (point: PlacedPoint) => {
       setPinOverride(point)
       const hs = activeHoleScore
-      if (!hs) return
+      if (!hs || !roundId) return
+      // Belt-and-suspenders: constrain by round_id alongside row id, so a
+      // misconfigured RLS policy can't let a stray UUID write another
+      // user's pin.
       const { error } = await supabase
         .from('hole_scores')
         .update({ pin_lat: point.lat, pin_lng: point.lng })
         .eq('id', hs.id)
+        .eq('round_id', roundId)
       if (error) {
         // Don't roll back the local override — the user's intent stays
         // visible while they retry. Surface the error for diagnostics.
@@ -181,7 +185,7 @@ export function RoundDetailPage() {
         console.error('round pin update failed', error)
       }
     },
-    [activeHoleScore],
+    [activeHoleScore, roundId],
   )
 
   const placeHandlers = useMemo(

--- a/apps/web/src/pages/stats/StrokesGainedPage.tsx
+++ b/apps/web/src/pages/stats/StrokesGainedPage.tsx
@@ -22,7 +22,7 @@ import type {
   SlopeImpact,
 } from '../../lib/statsCalculations'
 
-const N_OPTIONS = [5, 10, 20] as const
+const N_OPTIONS: readonly number[] = [5, 10, 20]
 
 const TICK_STYLE = { fontSize: 11, fill: '#8A8B7E' } as const
 const TOOLTIP_STYLE = {
@@ -72,7 +72,7 @@ export function StrokesGainedPage() {
         </div>
         <Segmented
           value={n}
-          options={N_OPTIONS as unknown as readonly number[]}
+          options={N_OPTIONS}
           onChange={setN}
           renderLabel={(v) => `Last ${v}`}
         />

--- a/packages/core/src/shot-patterns.test.ts
+++ b/packages/core/src/shot-patterns.test.ts
@@ -56,16 +56,18 @@ describe('computeDispersion', () => {
 describe('computeDispersionStats', () => {
   it('returns null for tiny sample', () => {
     expect(computeDispersionStats([])).toBeNull()
-    expect(computeDispersionStats([{ lateralOffsetYards: 0, distanceOffsetYards: 0 }])).toBeNull()
+    expect(
+      computeDispersionStats([{ id: 'tiny', lateralOffsetYards: 0, distanceOffsetYards: 0 }]),
+    ).toBeNull()
   })
 
   it('computes mean / std and labels miss tendency', () => {
     const pts: DispersionPoint[] = [
-      { lateralOffsetYards: 10, distanceOffsetYards: -5 },
-      { lateralOffsetYards: 12, distanceOffsetYards: -10 },
-      { lateralOffsetYards: 9, distanceOffsetYards: 0 },
-      { lateralOffsetYards: 11, distanceOffsetYards: -3 },
-      { lateralOffsetYards: 13, distanceOffsetYards: -8 },
+      { id: 'p1', lateralOffsetYards: 10, distanceOffsetYards: -5 },
+      { id: 'p2', lateralOffsetYards: 12, distanceOffsetYards: -10 },
+      { id: 'p3', lateralOffsetYards: 9, distanceOffsetYards: 0 },
+      { id: 'p4', lateralOffsetYards: 11, distanceOffsetYards: -3 },
+      { id: 'p5', lateralOffsetYards: 13, distanceOffsetYards: -8 },
     ]
     const stats = computeDispersionStats(pts)!
     expect(stats.sampleSize).toBe(5)
@@ -78,6 +80,7 @@ describe('computeDispersionStats', () => {
 
   it('labels balanced patterns as straight', () => {
     const pts: DispersionPoint[] = Array.from({ length: 10 }, (_, i) => ({
+      id: `bal-${i}`,
       lateralOffsetYards: i % 2 === 0 ? 1 : -1,
       distanceOffsetYards: 0,
     }))
@@ -89,9 +92,9 @@ describe('computeDispersionStats', () => {
 
 describe('filterDispersionByLie', () => {
   const pts: DispersionPoint[] = [
-    { lateralOffsetYards: 0, distanceOffsetYards: 0, lieSlope: 'level', lieType: 'fairway' },
-    { lateralOffsetYards: 0, distanceOffsetYards: 0, lieSlope: 'uphill', lieType: 'fairway' },
-    { lateralOffsetYards: 0, distanceOffsetYards: 0, lieSlope: 'level', lieType: 'rough' },
+    { id: 'lf1', lateralOffsetYards: 0, distanceOffsetYards: 0, lieSlope: 'level', lieType: 'fairway' },
+    { id: 'lf2', lateralOffsetYards: 0, distanceOffsetYards: 0, lieSlope: 'uphill', lieType: 'fairway' },
+    { id: 'lf3', lateralOffsetYards: 0, distanceOffsetYards: 0, lieSlope: 'level', lieType: 'rough' },
   ]
   it('filters by slope', () => {
     expect(filterDispersionByLie(pts, 'uphill')).toHaveLength(1)
@@ -107,7 +110,8 @@ describe('filterDispersionByLie', () => {
 describe('getAimCorrection', () => {
   it('reports centered when miss is small', () => {
     const stats = computeDispersionStats(
-      Array.from({ length: 10 }, () => ({
+      Array.from({ length: 10 }, (_, i) => ({
+        id: `c-${i}`,
         lateralOffsetYards: 0.5,
         distanceOffsetYards: 0,
       })),
@@ -117,7 +121,11 @@ describe('getAimCorrection', () => {
 
   it('suggests opposite-side aim for right-miss bias', () => {
     const stats = computeDispersionStats(
-      Array.from({ length: 6 }, () => ({ lateralOffsetYards: 8, distanceOffsetYards: 0 })),
+      Array.from({ length: 6 }, (_, i) => ({
+        id: `r-${i}`,
+        lateralOffsetYards: 8,
+        distanceOffsetYards: 0,
+      })),
     )!
     expect(getAimCorrection(stats)).toContain('left')
     expect(getAimCorrection(stats)).toContain('8')

--- a/packages/core/src/shot-patterns.ts
+++ b/packages/core/src/shot-patterns.ts
@@ -8,6 +8,9 @@ import type {
 import type { Shot } from './types'
 
 export interface DispersionPoint {
+  /** Source shot id — used as a stable React key when rendering the
+   *  dispersion plot, and lets a click handler trace back to the row. */
+  id: string
   /** Yards right of aim (negative = left) */
   lateralOffsetYards: number
   /** Yards long of aim (negative = short) */
@@ -60,6 +63,7 @@ export function computeDispersion(shots: Shot[]): DispersionPoint[] {
     const latYards = (endLat - aimLat) * YARDS_PER_DEG_LAT
     const lngYards = (endLng - aimLng) * yardsPerDegLng(aimLat)
     points.push({
+      id: s.id,
       lateralOffsetYards: lngYards,
       distanceOffsetYards: latYards,
       shotResult: s.shotResult,

--- a/packages/supabase/src/queries/hole-scores.ts
+++ b/packages/supabase/src/queries/hole-scores.ts
@@ -20,10 +20,21 @@ export function upsertHoleScore(client: OgaSupabaseClient, score: HoleScoreInser
     .single()
 }
 
+// hole_scores has no direct user_id column. Belt-and-suspenders is to
+// constrain by round_id (caller knows it), so RLS's parent-table check
+// can't be the only thing standing between a stray UUID and another
+// user's row.
 export function updateHoleScore(
   client: OgaSupabaseClient,
   id: string,
   updates: HoleScoreUpdate,
+  roundId: string,
 ) {
-  return client.from('hole_scores').update(updates).eq('id', id).select().single()
+  return client
+    .from('hole_scores')
+    .update(updates)
+    .eq('id', id)
+    .eq('round_id', roundId)
+    .select()
+    .single()
 }

--- a/packages/supabase/src/queries/rounds.ts
+++ b/packages/supabase/src/queries/rounds.ts
@@ -13,11 +13,19 @@ export function getRounds(client: OgaSupabaseClient, userId: string, limit = 20)
     .limit(limit)
 }
 
-export function getRound(client: OgaSupabaseClient, roundId: string) {
+// Belt-and-suspenders: every read/mutation on user-owned tables takes a
+// userId and filters on it in addition to RLS, so a missing or misconfigured
+// policy can't silently expose another user's data.
+export function getRound(
+  client: OgaSupabaseClient,
+  roundId: string,
+  userId: string,
+) {
   return client
     .from('rounds')
     .select('*, courses(name, location), hole_scores(*, holes(*), shots(*))')
     .eq('id', roundId)
+    .eq('user_id', userId)
     .single()
 }
 
@@ -29,12 +37,23 @@ export function updateRound(
   client: OgaSupabaseClient,
   roundId: string,
   updates: RoundUpdate,
+  userId: string,
 ) {
-  return client.from('rounds').update(updates).eq('id', roundId).select().single()
+  return client
+    .from('rounds')
+    .update(updates)
+    .eq('id', roundId)
+    .eq('user_id', userId)
+    .select()
+    .single()
 }
 
-export function deleteRound(client: OgaSupabaseClient, roundId: string) {
-  return client.from('rounds').delete().eq('id', roundId)
+export function deleteRound(
+  client: OgaSupabaseClient,
+  roundId: string,
+  userId: string,
+) {
+  return client.from('rounds').delete().eq('id', roundId).eq('user_id', userId)
 }
 
 export function getRecentSGData(client: OgaSupabaseClient, userId: string, limit = 10) {

--- a/packages/supabase/src/queries/shots.ts
+++ b/packages/supabase/src/queries/shots.ts
@@ -4,11 +4,16 @@ import type { Database } from '../types'
 type ShotInsert = Database['public']['Tables']['shots']['Insert']
 type ShotUpdate = Database['public']['Tables']['shots']['Update']
 
-export function getShotsForRound(client: OgaSupabaseClient, roundId: string) {
+export function getShotsForRound(
+  client: OgaSupabaseClient,
+  roundId: string,
+  userId: string,
+) {
   return client
     .from('shots')
     .select('*, hole_scores!inner(round_id, holes(number, par))')
     .eq('hole_scores.round_id', roundId)
+    .eq('user_id', userId)
     .order('shot_number')
 }
 
@@ -33,10 +38,25 @@ export function createShot(client: OgaSupabaseClient, shot: ShotInsert) {
   return client.from('shots').insert(shot).select().single()
 }
 
-export function updateShot(client: OgaSupabaseClient, shotId: string, updates: ShotUpdate) {
-  return client.from('shots').update(updates).eq('id', shotId).select().single()
+export function updateShot(
+  client: OgaSupabaseClient,
+  shotId: string,
+  updates: ShotUpdate,
+  userId: string,
+) {
+  return client
+    .from('shots')
+    .update(updates)
+    .eq('id', shotId)
+    .eq('user_id', userId)
+    .select()
+    .single()
 }
 
-export function deleteShot(client: OgaSupabaseClient, shotId: string) {
-  return client.from('shots').delete().eq('id', shotId)
+export function deleteShot(
+  client: OgaSupabaseClient,
+  shotId: string,
+  userId: string,
+) {
+  return client.from('shots').delete().eq('id', shotId).eq('user_id', userId)
 }


### PR DESCRIPTION
## Summary

8 audit follow-ups, one commit each. No new features.

## Closes

- Closes #28 — shot counter desync
- Closes #29 — sync lock stuck after crash
- Closes #30 — RLS belt-and-suspenders user_id filters
- Closes #32 — silent Supabase query failures
- Closes #45 — loading states / heavy compute memoization
- Closes #46 — unsafe \`any\` overrides in mobile data layer
- Closes #47 — unsafe type casts hiding null
- Closes #48 — list keys using array index

## Per-fix highlights

**#30 RLS hardening** — \`getRound\`, \`updateRound\`, \`deleteRound\`, \`getShotsForRound\`, \`updateShot\`, \`deleteShot\` now require \`userId\` and filter on it; \`updateHoleScore\` requires \`roundId\`. RoundDetailPage's pin update also constrained by \`round_id\`. RLS still does the real enforcement; the explicit filter means a missing or misconfigured policy can't silently expose another user's data.

  Manual follow-up: run
  \`SELECT schemaname, tablename, policyname, cmd, qual FROM pg_policies WHERE schemaname='public' ORDER BY tablename, cmd;\`
  in the Supabase SQL editor and verify each user-owned table has \`auth.uid() = user_id\` (or chained-via-FK equivalent) for SELECT/INSERT/UPDATE/DELETE.

**#32 Silent failures** — every Supabase call destructures \`error\` and throws (hooks) or logs (fire-and-forget effects). The most consequential fix: ProfileGuard previously punted any error to \`/onboarding\` (which would clobber the saved profile on save) — now distinguishes a real error (soft error screen, no redirect) from a missing-row.

**#46 \`any\` cluster** — useAuth now uses the SDK's typed callbacks; round/new \`holes.map\` typed via the supabase select. Most of the cluster was already cleaned up by #32's typed destructures.

**#47 Type casts** — N_OPTIONS typed as \`readonly number[]\` so the \`as unknown as readonly number[]\` double-cast disappears. Lie-slope casts replaced with \`isLieSlopeForward\` / \`isLieSlopeSide\` type guards. Unnecessary casts on \`?? []\` results dropped; necessary nested-join casts kept with comments.

**#48 List keys** — DispersionPoint now carries the source shot's \`id\`; tests updated.

**#45 Loading / memoization** — useDetailedStats memoizes the heavy \`computeDetailedStats\` call (O(N×shots)) so it doesn't re-run on every parent render. Loading-state contract documented. ProfileGuard's blank-screen-during-probe was already fixed in the #32 commit.

**#29 Sync lock TTL** — module-scope \`inFlight\` could get stuck \`true\` after a crash mid-flight. Adds an \`inFlightSince\` timestamp and a 30 s TTL; \`acquireLock\` resets a stale lock.

**#28 Counter desync** — replaces \`localShotCount\` / \`localPuttCount\` useState with a single \`pendingForHole: PendingShot[]\` array. Counts derive via useMemo so an optimistic save and a slower count reload can't disagree.

## Verify

- [x] \`pnpm typecheck\` — passes (3/3 workspaces)
- [x] \`pnpm --filter web build\` — passes
- [x] \`apps/mobile npm run typecheck\` — passes
- [x] \`pnpm test\` — 57 passed
- [ ] Run \`SELECT * FROM pg_policies WHERE schemaname='public'\` against prod and post results
- [ ] Local: try deleting another user's round id (manually) — should now fail at client filter even before RLS
- [ ] Local: kill the app mid-sync, reopen — sync TTL kicks in within 30 s rather than locking forever
- [ ] Local: log 18 holes' worth of shots quickly — no counter drift visible in scorecard preview