### PR TITLE
chore: drop redundant courses.location column (0013)

### DIFF
--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -190,13 +190,12 @@ export default function NewRound() {
         return
       }
       const detail = await getOpenGolfApiCourse(r.id)
-      const location =
-        [detail.city, detail.state].filter(Boolean).join(', ') ||
-        formatLocation(r) ||
-        null
+      const city = detail.city ?? r.city ?? null
+      const state = detail.state ?? r.state ?? null
       const { data: course, error: courseErr } = await createCourse(supabase, {
         name: detail.name || r.name,
-        location,
+        city,
+        state,
         external_id: r.id,
       })
       if (courseErr || !course) throw courseErr ?? new Error('Course insert failed')
@@ -254,9 +253,17 @@ export default function NewRound() {
           setBusy(true)
           setError(null)
           try {
+            const trimmed = location?.trim() ?? ''
+            const commaIdx = trimmed.indexOf(',')
+            const city =
+              commaIdx >= 0
+                ? trimmed.slice(0, commaIdx).trim() || null
+                : trimmed || null
+            const state =
+              commaIdx >= 0 ? trimmed.slice(commaIdx + 1).trim() || null : null
             const { data: course, error: courseErr } = await createCourse(
               supabase,
-              { name: name.trim(), location: location?.trim() || null },
+              { name: name.trim(), city, state },
             )
             if (courseErr || !course) {
               throw courseErr ?? new Error('Course insert failed')
@@ -344,11 +351,14 @@ export default function NewRound() {
                 >
                   {c.name}
                 </Text>
-                {c.location && (
-                  <Text style={{ color: '#5C6356', fontSize: 12, marginTop: 2 }}>
-                    {c.location}
-                  </Text>
-                )}
+                {(() => {
+                  const where = [c.city, c.state].filter((s) => !!s).join(', ')
+                  return where ? (
+                    <Text style={{ color: '#5C6356', fontSize: 12, marginTop: 2 }}>
+                      {where}
+                    </Text>
+                  ) : null
+                })()}
               </Pressable>
             ))}
           </View>

--- a/apps/web/src/components/courses/CourseSearch.tsx
+++ b/apps/web/src/components/courses/CourseSearch.tsx
@@ -108,7 +108,9 @@ export function CourseSearch({ selectedCourseId, onSelect }: CourseSearchProps) 
                   key={c.id}
                   selected={selectedCourseId === c.id}
                   title={c.name}
-                  subtitle={c.location ?? undefined}
+                  subtitle={
+                    [c.city, c.state].filter((s) => !!s).join(', ') || undefined
+                  }
                   onClick={() => {
                     onSelect(c.id, c.name)
                     setQuery('')

--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -106,14 +106,26 @@ export function useImportApiCourse() {
             }))
           : defaultHolesForCourse('')
 
-      const location =
-        [detail?.city, detail?.state].filter(Boolean).join(', ') ||
-        args.fallbackLocation ||
-        null
+      // Prefer the detail's discrete city/state. If the detail came back
+      // empty, fall back to splitting the freeform fallbackLocation on
+      // its first comma — same UX as the manual form.
+      let city = detail?.city ?? null
+      let state = detail?.state ?? null
+      if (!city && !state && args.fallbackLocation) {
+        const trimmed = args.fallbackLocation.trim()
+        const commaIdx = trimmed.indexOf(',')
+        city =
+          commaIdx >= 0
+            ? trimmed.slice(0, commaIdx).trim() || null
+            : trimmed || null
+        state =
+          commaIdx >= 0 ? trimmed.slice(commaIdx + 1).trim() || null : null
+      }
 
       const { data: course, error } = await createCourse(supabase, {
         name: detail?.name ?? args.fallbackName,
-        location,
+        city,
+        state,
         external_id: args.apiId,
       })
       if (error || !course) throw error ?? new Error('Course insert failed')
@@ -191,6 +203,8 @@ export function useCreateCourseTee() {
 
 interface ManualCourseArgs {
   name: string
+  // Free-form "City, State" string from the form. Split on the first comma
+  // into discrete city + state at insert time.
   location: string | null
   pars: number[]
   gpsTeeCoords?: { lat: number; lng: number } | null
@@ -201,9 +215,16 @@ export function useCreateManualCourse() {
   const qc = useQueryClient()
   return useMutation({
     mutationFn: async (args: ManualCourseArgs) => {
+      const trimmed = args.location?.trim() ?? ''
+      const commaIdx = trimmed.indexOf(',')
+      const city =
+        commaIdx >= 0 ? trimmed.slice(0, commaIdx).trim() || null : trimmed || null
+      const state =
+        commaIdx >= 0 ? trimmed.slice(commaIdx + 1).trim() || null : null
       const { data: course, error: courseError } = await createCourse(supabase, {
         name: args.name.trim(),
-        location: args.location?.trim() || null,
+        city,
+        state,
       })
       if (courseError || !course) {
         throw courseError ?? new Error('Course insert failed')

--- a/packages/supabase/src/queries/rounds.ts
+++ b/packages/supabase/src/queries/rounds.ts
@@ -7,7 +7,7 @@ type RoundUpdate = Database['public']['Tables']['rounds']['Update']
 export function getRounds(client: OgaSupabaseClient, userId: string, limit = 20) {
   return client
     .from('rounds')
-    .select('*, courses(name, location)')
+    .select('*, courses(name, city, state)')
     .eq('user_id', userId)
     .order('played_at', { ascending: false })
     .limit(limit)
@@ -23,7 +23,7 @@ export function getRound(
 ) {
   return client
     .from('rounds')
-    .select('*, courses(name, location), hole_scores(*, holes(*), shots(*))')
+    .select('*, courses(name, city, state), hole_scores(*, holes(*), shots(*))')
     .eq('id', roundId)
     .eq('user_id', userId)
     .single()

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -56,7 +56,6 @@ export interface Database {
         Row: {
           id: string
           name: string
-          location: string | null
           mapbox_id: string | null
           external_id: string | null
           created_by: string | null
@@ -69,7 +68,6 @@ export interface Database {
         Insert: {
           id?: string
           name: string
-          location?: string | null
           mapbox_id?: string | null
           external_id?: string | null
           created_by?: string | null
@@ -82,7 +80,6 @@ export interface Database {
         Update: {
           id?: string
           name?: string
-          location?: string | null
           mapbox_id?: string | null
           external_id?: string | null
           created_by?: string | null

--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -556,7 +556,6 @@ async function findCourseByExternalId(externalId: string): Promise<string | null
 async function insertOrUpdateCourse(args: {
   externalId: string
   name: string
-  location: string | null
   city: string | null
   state: string | null
   lat: number | null
@@ -565,7 +564,6 @@ async function insertOrUpdateCourse(args: {
 }): Promise<{ id: string; isNew: boolean; skipped: boolean }> {
   const fields = {
     name: args.name,
-    location: args.location,
     city: args.city,
     state: args.state,
     lat: args.lat,
@@ -731,11 +729,9 @@ async function crawlOpenGolfApi(
           }
           const city = (detail.city ?? item.city ?? '').trim() || null
           const stateCode = (detail.state ?? item.state ?? state).trim() || null
-          const location = [city, stateCode].filter((s) => !!s).join(', ') || null
           const upsert = await insertOrUpdateCourse({
             externalId,
             name: detail.name,
-            location,
             city,
             state: stateCode,
             lat: detail.lat ?? item.lat ?? null,
@@ -820,12 +816,10 @@ async function crawlOsm(
         const c = targets[i]
         if (!c) continue
         const externalId = `osm_${c.osmType}_${c.osmId}`
-        const location = [c.city, c.state].filter((s) => !!s).join(', ') || c.state
         try {
           const upsert = await insertOrUpdateCourse({
             externalId,
             name: c.name,
-            location,
             city: c.city ?? null,
             state: c.state,
             lat: c.lat,

--- a/supabase/migrations/0013_drop_location_column.sql
+++ b/supabase/migrations/0013_drop_location_column.sql
@@ -1,0 +1,6 @@
+-- Drop the redundant courses.location column. 0011 added discrete `city`
+-- and `state` columns and the crawler has been keeping `location` populated
+-- as "city, state" only for back-compat. Now that every read site can
+-- derive the same string from city + state, the legacy column has no
+-- callers and just doubles the write cost.
+alter table public.courses drop column if exists location;


### PR DESCRIPTION
## Summary

PR #65 added discrete \`city\` + \`state\` columns and the crawler kept \`location\` populated as \`"city, state"\` only for back-compat. Every read site can derive the same string from city + state on the fly, so the legacy column has no callers and just doubles the write cost.

## Changes

- **Migration 0013** — \`alter table public.courses drop column if exists location;\`
- \`packages/supabase/src/types.ts\` — \`location\` removed from courses Row/Insert/Update.
- \`packages/supabase/src/queries/rounds.ts\` — nested selects switch from \`courses(name, location)\` to \`courses(name, city, state)\`.
- \`scripts/crawl-courses.ts\` — \`location\` removed from the upsert payload + \`insertOrUpdateCourse\` helper signature.
- \`apps/web/src/hooks/useCourses.ts\`:
  - \`useCreateManualCourse\` splits the freeform "City, State" input on its first comma into discrete \`city\` + \`state\`.
  - \`useImportApiCourse\` uses the OpenGolfAPI detail's discrete city/state directly, falls back to the same comma-split on \`fallbackLocation\`.
- \`apps/web/src/components/courses/CourseSearch.tsx\` — search row subtitle now joins \`[city, state]\`.
- \`apps/mobile/app/(app)/round/new.tsx\` — same: list subtitle from city + state, manual form splits on comma, OpenGolfAPI import passes city/state directly.

## Notes

- The OpenGolfAPI raw response's own \`location\` field (a \`{lat, lng}\` object) is unrelated to our column and stays in the parsing path.
- Form UX unchanged on both surfaces — the user still types one "City, State" string. Splitting happens at insert time.

## Verify

- [x] \`pnpm typecheck\` — passes (3/3)
- [x] \`pnpm --filter web build\` — passes
- [x] \`apps/mobile npm run typecheck\` — passes
- [ ] \`npx supabase db push --linked\` to apply 0013 in prod
- [ ] After migration: open the rounds list — course subtitles render city + state
- [ ] Manual course form: type "Phoenix, AZ" — DB row shows \`city='Phoenix', state='AZ'\`