### PR TITLE
feat: comprehensive tests for @oga/core math (closes #38)

### DIFF
--- a/packages/core/src/__tests__/round.test.ts
+++ b/packages/core/src/__tests__/round.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildInitialRows,
+  legacySlopeToAxes,
+  type PlacedPoint,
+} from '../round'
+import { decombinedPuttResult } from '../types'
+
+// OKC tee at 35.4676 / -97.5164. Build markers along a meridian so
+// distance math is just yards-of-latitude.
+const M_PER_DEG_LAT = 111_320
+const YDS_PER_METER = 1.09361
+const TEE = { lat: 35.4676, lng: -97.5164 }
+
+function offsetLatYards(yards: number): number {
+  return TEE.lat + yards / YDS_PER_METER / M_PER_DEG_LAT
+}
+
+const PIN = offsetLatYards(380)
+
+describe('buildInitialRows', () => {
+  it('produces one row per placed point', () => {
+    const points: PlacedPoint[] = [
+      { lat: TEE.lat, lng: TEE.lng },
+      { lat: offsetLatYards(220), lng: TEE.lng },
+      { lat: offsetLatYards(370), lng: TEE.lng },
+      { lat: offsetLatYards(379), lng: TEE.lng },
+    ]
+    const rows = buildInitialRows(points, 4, PIN, TEE.lng)
+    expect(rows).toHaveLength(4)
+    expect(rows.map((r) => r.shotNumber)).toEqual([1, 2, 3, 4])
+  })
+
+  it('row N\'s end coords match point N+1\'s coords', () => {
+    const points: PlacedPoint[] = [
+      { lat: TEE.lat, lng: TEE.lng },
+      { lat: offsetLatYards(220), lng: TEE.lng },
+      { lat: offsetLatYards(370), lng: TEE.lng },
+    ]
+    const rows = buildInitialRows(points, 4, PIN, TEE.lng)
+    expect(rows[0]!.endLat).toBe(points[1]!.lat)
+    expect(rows[1]!.endLat).toBe(points[2]!.lat)
+  })
+
+  it('last row ends at the pin (player holed out)', () => {
+    const points: PlacedPoint[] = [
+      { lat: TEE.lat, lng: TEE.lng },
+      { lat: offsetLatYards(220), lng: TEE.lng },
+      { lat: offsetLatYards(370), lng: TEE.lng },
+    ]
+    const rows = buildInitialRows(points, 4, PIN, TEE.lng)
+    const last = rows.at(-1)!
+    expect(last.isLastShot).toBe(true)
+    expect(last.endLat).toBe(PIN)
+    expect(last.endLng).toBe(TEE.lng)
+  })
+
+  it('inferred lie + club come through unchanged from inferShot', () => {
+    // Tee shot of ~220 yd → driver, lie=tee.
+    const points: PlacedPoint[] = [
+      { lat: TEE.lat, lng: TEE.lng },
+      { lat: offsetLatYards(220), lng: TEE.lng },
+    ]
+    const rows = buildInitialRows(points, 4, PIN, TEE.lng)
+    expect(rows[0]!.lieType).toBe('tee')
+    expect(rows[0]!.club).toBe('driver')
+  })
+
+  it('last shot starting on the green defaults puttMade=true', () => {
+    // 4 markers, last placed ~1 yd from the pin → on-green threshold
+    // (15 yd) → final inferred lie is 'green', and the helper marks
+    // puttMade so the player just confirms.
+    const points: PlacedPoint[] = [
+      { lat: TEE.lat, lng: TEE.lng },
+      { lat: offsetLatYards(220), lng: TEE.lng },
+      { lat: offsetLatYards(370), lng: TEE.lng },
+      { lat: offsetLatYards(379), lng: TEE.lng },
+    ]
+    const rows = buildInitialRows(points, 4, PIN, TEE.lng)
+    const last = rows.at(-1)!
+    expect(last.lieType).toBe('green')
+    expect(last.puttMade).toBe(true)
+  })
+
+  it('non-green last shot leaves puttMade undefined and lie=rough', () => {
+    // Two-shot hole that "finishes" from the fairway — buildInitialRows
+    // assumes a hole-out at the pin, so the final row's lieType comes
+    // from inferShot. The penultimate marker is 180 yd from pin →
+    // off-green → inferShot returns 'rough'.
+    const points: PlacedPoint[] = [
+      { lat: TEE.lat, lng: TEE.lng },
+      { lat: offsetLatYards(200), lng: TEE.lng },
+    ]
+    const rows = buildInitialRows(points, 4, PIN, TEE.lng)
+    const last = rows.at(-1)!
+    expect(last.lieType).toBe('rough')
+    expect(last.puttMade).toBeUndefined()
+  })
+
+  it('empty input → empty output, does not throw', () => {
+    expect(buildInitialRows([], 4, PIN, TEE.lng)).toEqual([])
+  })
+
+  it('single-shot hole-out (eagle) — one row, isLast=true, ends at pin', () => {
+    const points: PlacedPoint[] = [{ lat: TEE.lat, lng: TEE.lng }]
+    const rows = buildInitialRows(points, 4, PIN, TEE.lng)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.isLastShot).toBe(true)
+    expect(rows[0]!.endLat).toBe(PIN)
+  })
+})
+
+describe('decombinedPuttResult', () => {
+  // Inverse of combinedPuttResult — produces a human label from the
+  // two miss axes. All four combos pinned because the shape has been
+  // re-touched twice and we don't want it to regress.
+  it('distance only — short', () => {
+    expect(decombinedPuttResult('short', null)).toBe('Short')
+  })
+
+  it('distance only — long', () => {
+    expect(decombinedPuttResult('long', null)).toBe('Long')
+  })
+
+  it('direction only — left', () => {
+    expect(decombinedPuttResult(null, 'left')).toBe('Missed left')
+  })
+
+  it('direction only — right', () => {
+    expect(decombinedPuttResult(null, 'right')).toBe('Missed right')
+  })
+
+  it('both axes — comma-joined', () => {
+    expect(decombinedPuttResult('short', 'left')).toBe('Short, Missed left')
+    expect(decombinedPuttResult('long', 'right')).toBe('Long, Missed right')
+  })
+
+  it('both null — empty string', () => {
+    expect(decombinedPuttResult(null, null)).toBe('')
+  })
+})
+
+describe('legacySlopeToAxes', () => {
+  // Single-axis lie_slope was split into forward + side. This helper
+  // routes legacy values to whichever axis they came from so post-split
+  // editors can still display pre-split rows.
+  it('uphill / level / downhill go to the forward axis', () => {
+    expect(legacySlopeToAxes('uphill')).toEqual({ forward: 'uphill' })
+    expect(legacySlopeToAxes('level')).toEqual({ forward: 'level' })
+    expect(legacySlopeToAxes('downhill')).toEqual({ forward: 'downhill' })
+  })
+
+  it('ball_above / ball_below go to the side axis', () => {
+    expect(legacySlopeToAxes('ball_above')).toEqual({ side: 'ball_above' })
+    expect(legacySlopeToAxes('ball_below')).toEqual({ side: 'ball_below' })
+  })
+
+  it('null input returns empty object (no axes set)', () => {
+    expect(legacySlopeToAxes(null)).toEqual({})
+  })
+
+  it('never returns both forward and side — single legacy axis only', () => {
+    for (const legacy of ['uphill', 'level', 'downhill', 'ball_above', 'ball_below'] as const) {
+      const out = legacySlopeToAxes(legacy)
+      const hasBoth = out.forward !== undefined && out.side !== undefined
+      expect(hasBoth).toBe(false)
+    }
+  })
+})

--- a/packages/core/src/__tests__/sg-baselines.test.ts
+++ b/packages/core/src/__tests__/sg-baselines.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import {
+  APPROACH_BASELINES,
+  AROUND_GREEN_BASELINES,
+  HANDICAP_BRACKETS,
+  PUTTING_BASELINES,
+  getHandicapBracket,
+  interpolateBaseline,
+} from '../sg-baselines'
+
+describe('getHandicapBracket', () => {
+  // Bracket cutoffs documented in sg-baselines.ts:
+  //   ≤2 → 0, ≤7 → 5, ≤12 → 10, ≤17 → 15, ≤22 → 20, ≤27 → 25, else 30.
+  // Boundary tests guard against off-by-one regressions.
+  it('clamps low — handicap below scratch falls into bracket 0', () => {
+    expect(getHandicapBracket(-5)).toBe(0)
+    expect(getHandicapBracket(0)).toBe(0)
+  })
+
+  it('clamps high — handicap above 30 falls into bracket 30', () => {
+    expect(getHandicapBracket(36)).toBe(30)
+    expect(getHandicapBracket(55)).toBe(30)
+    expect(getHandicapBracket(100)).toBe(30)
+  })
+
+  it('exact boundary values land in the lower bracket', () => {
+    expect(getHandicapBracket(2)).toBe(0)
+    expect(getHandicapBracket(7)).toBe(5)
+    expect(getHandicapBracket(12)).toBe(10)
+    expect(getHandicapBracket(17)).toBe(15)
+    expect(getHandicapBracket(22)).toBe(20)
+    expect(getHandicapBracket(27)).toBe(25)
+  })
+
+  it('one above boundary moves to next bracket', () => {
+    expect(getHandicapBracket(2.01)).toBe(5)
+    expect(getHandicapBracket(7.01)).toBe(10)
+    expect(getHandicapBracket(12.01)).toBe(15)
+    expect(getHandicapBracket(17.01)).toBe(20)
+    expect(getHandicapBracket(22.01)).toBe(25)
+    expect(getHandicapBracket(27.01)).toBe(30)
+  })
+
+  it('one below boundary stays in current bracket', () => {
+    expect(getHandicapBracket(1.99)).toBe(0)
+    expect(getHandicapBracket(6.99)).toBe(5)
+    expect(getHandicapBracket(11.99)).toBe(10)
+    expect(getHandicapBracket(16.99)).toBe(15)
+    expect(getHandicapBracket(21.99)).toBe(20)
+    expect(getHandicapBracket(26.99)).toBe(25)
+  })
+
+  it('mid-range handicaps map to expected brackets', () => {
+    expect(getHandicapBracket(5)).toBe(5)
+    expect(getHandicapBracket(10)).toBe(10)
+    expect(getHandicapBracket(15)).toBe(15)
+    expect(getHandicapBracket(20)).toBe(20)
+    expect(getHandicapBracket(25)).toBe(25)
+    expect(getHandicapBracket(30)).toBe(30)
+  })
+
+  it('every returned bracket is a member of HANDICAP_BRACKETS', () => {
+    for (const h of [-5, 0, 3, 8, 13, 18, 23, 28, 35, 100]) {
+      expect(HANDICAP_BRACKETS).toContain(getHandicapBracket(h))
+    }
+  })
+})
+
+describe('interpolateBaseline', () => {
+  const table = { 50: 2.6, 100: 2.85, 150: 3.12, 200: 3.35 }
+
+  it('returns the exact value at a known key', () => {
+    expect(interpolateBaseline(table, 50)).toBe(2.6)
+    expect(interpolateBaseline(table, 100)).toBe(2.85)
+    expect(interpolateBaseline(table, 200)).toBe(3.35)
+  })
+
+  it('clamps to first key when distance is below the range', () => {
+    expect(interpolateBaseline(table, 25)).toBe(2.6)
+    expect(interpolateBaseline(table, 0)).toBe(2.6)
+    expect(interpolateBaseline(table, -10)).toBe(2.6)
+  })
+
+  it('clamps to last key when distance is above the range', () => {
+    expect(interpolateBaseline(table, 250)).toBe(3.35)
+    expect(interpolateBaseline(table, 1000)).toBe(3.35)
+  })
+
+  it('linearly interpolates between adjacent keys (midpoint)', () => {
+    // Halfway between 100 (2.85) and 150 (3.12) → 2.985
+    expect(interpolateBaseline(table, 125)).toBeCloseTo(2.985, 6)
+  })
+
+  it('linearly interpolates between adjacent keys (off-center)', () => {
+    // 20% of the way from 50 (2.6) to 100 (2.85): 2.6 + 0.2*0.25 = 2.65
+    expect(interpolateBaseline(table, 60)).toBeCloseTo(2.65, 6)
+  })
+
+  it('throws on an empty table', () => {
+    expect(() => interpolateBaseline({}, 100)).toThrow()
+  })
+})
+
+describe('interpolateBaseline — putting baselines (feet)', () => {
+  const scratch = PUTTING_BASELINES[0]
+
+  // Concrete value pins — sourced from sg-baselines.ts. Catches a
+  // table-edit regression. Not a tautology because we're asserting
+  // documented baselines, not just "table value matches itself".
+  it('scratch from 3 ft has expected ≈ 1.03 strokes', () => {
+    expect(interpolateBaseline(scratch, 3)).toBe(1.03)
+  })
+
+  it('scratch from 10 ft has expected ≈ 1.37 strokes', () => {
+    expect(interpolateBaseline(scratch, 10)).toBe(1.37)
+  })
+
+  it('scratch from 60 ft has expected ≈ 2.18 strokes', () => {
+    expect(interpolateBaseline(scratch, 60)).toBe(2.18)
+  })
+
+  it('5 ft is harder for higher handicap brackets — strictly monotone', () => {
+    // Same distance, scratch < 30-handicap (lower expected = closer to
+    // holed). Seed prev to a known floor instead of -Infinity so the
+    // first bracket is bounded too.
+    let prev = 0
+    for (const h of HANDICAP_BRACKETS) {
+      const expected = interpolateBaseline(PUTTING_BASELINES[h], 5)
+      expect(expected).toBeGreaterThan(prev)
+      prev = expected
+    }
+  })
+
+  it('further putts always need strictly more strokes (within a bracket)', () => {
+    // For a single bracket, expected strokes grow with distance. Use
+    // strict > to surface a flat-table regression that ≥ would miss.
+    let prev = 0
+    for (const dist of [3, 5, 8, 10, 15, 20, 30, 40, 60]) {
+      const e = interpolateBaseline(scratch, dist)
+      expect(e).toBeGreaterThan(prev)
+      prev = e
+    }
+  })
+})
+
+describe('interpolateBaseline — approach baselines (yards)', () => {
+  const scratch = APPROACH_BASELINES[0]
+
+  it('scratch approach from 50 yd ≈ 2.60 strokes', () => {
+    expect(interpolateBaseline(scratch, 50)).toBe(2.6)
+  })
+
+  it('scratch approach from 150 yd ≈ 3.12 strokes', () => {
+    expect(interpolateBaseline(scratch, 150)).toBe(3.12)
+  })
+
+  it('scratch approach from 225 yd ≈ 3.45 strokes (table max)', () => {
+    expect(interpolateBaseline(scratch, 225)).toBe(3.45)
+  })
+
+  it('30 yd clamps to the 50 yd value (table minimum)', () => {
+    expect(interpolateBaseline(scratch, 30)).toBe(scratch[50])
+  })
+
+  it('300 yd clamps to the 225 yd value (table maximum)', () => {
+    expect(interpolateBaseline(scratch, 300)).toBe(scratch[225])
+  })
+
+  it('150 yd interp is strictly monotone across handicap brackets', () => {
+    // Worse handicap → higher expected strokes from 150 yd. Seed prev
+    // to a finite floor so the first bracket is bounded.
+    let prev = 0
+    for (const h of HANDICAP_BRACKETS) {
+      const e = interpolateBaseline(APPROACH_BASELINES[h], 150)
+      expect(e).toBeGreaterThan(prev)
+      prev = e
+    }
+  })
+})
+
+describe('interpolateBaseline — around-green baselines (yards)', () => {
+  const scratch = AROUND_GREEN_BASELINES[0]
+
+  it('scratch around-green from 5 yd ≈ 2.18 strokes', () => {
+    expect(interpolateBaseline(scratch, 5)).toBe(2.18)
+  })
+
+  it('scratch around-green from 30 yd ≈ 2.64 strokes', () => {
+    expect(interpolateBaseline(scratch, 30)).toBe(2.64)
+  })
+
+  it('40 yd clamps to 30 yd value (around-green tops out at 30)', () => {
+    // Anything past 30 yd is "approach" by getShotCategory anyway;
+    // this is just defensive.
+    expect(interpolateBaseline(scratch, 40)).toBe(scratch[30])
+  })
+
+  it('between 5 and 10 interpolates smoothly', () => {
+    const a = scratch[5]!
+    const b = scratch[10]!
+    // 7 yd is 40% of the way from 5 → 10
+    const expected = a + 0.4 * (b - a)
+    expect(interpolateBaseline(scratch, 7)).toBeCloseTo(expected, 6)
+  })
+})

--- a/packages/core/src/__tests__/sg.test.ts
+++ b/packages/core/src/__tests__/sg.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from 'vitest'
+import {
+  averageSGBreakdown,
+  calculateRoundSG,
+  calculateShotSG,
+  getExpectedStrokes,
+  type ShotWithContext,
+} from '../sg-calculator'
+import { computeRoundSG } from '../sg'
+import type { SGBreakdown, Shot } from '../types'
+import type { Database } from '@oga/supabase'
+
+type HoleRow = Database['public']['Tables']['holes']['Row']
+type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
+type ShotRow = Database['public']['Tables']['shots']['Row']
+
+// Build a ShotWithContext from a sparse spec — keeps tests readable.
+function shot(
+  spec: Partial<Shot> & {
+    par: number
+    isLastShot: boolean
+    shotNumber: number
+  },
+): ShotWithContext {
+  return {
+    id: spec.id ?? `shot-${spec.shotNumber}`,
+    holeScoreId: spec.holeScoreId ?? 'hs',
+    userId: spec.userId ?? 'user',
+    shotNumber: spec.shotNumber,
+    par: spec.par,
+    isLastShot: spec.isLastShot,
+    distanceToTarget: spec.distanceToTarget,
+    lieType: spec.lieType,
+    puttDistanceFt: spec.puttDistanceFt,
+    puttResult: spec.puttResult,
+    penalty: spec.penalty ?? false,
+    ob: spec.ob ?? false,
+  }
+}
+
+describe('getExpectedStrokes — direct', () => {
+  it('approach 150 yd for scratch player → 3.12 (table value)', () => {
+    expect(getExpectedStrokes('approach', 150, undefined, 0)).toBe(3.12)
+  })
+
+  it('off_tee uses the approach baseline table for the start distance', () => {
+    // Tee shots share the approach interpolation.
+    expect(getExpectedStrokes('off_tee', 150, undefined, 0)).toBe(3.12)
+  })
+
+  it('around_green 5 yd for scratch player → 2.18', () => {
+    expect(getExpectedStrokes('around_green', 5, undefined, 0)).toBe(2.18)
+  })
+
+  it('putting needs the feet distance, ignores yards', () => {
+    expect(getExpectedStrokes('putting', undefined, 10, 0)).toBe(1.37)
+  })
+
+  it('returns null when the required distance is missing', () => {
+    expect(getExpectedStrokes('approach', undefined, undefined, 15)).toBeNull()
+    expect(getExpectedStrokes('putting', undefined, undefined, 15)).toBeNull()
+  })
+
+  it('clamps to bracket — handicap 50 reads from the 30-bracket table', () => {
+    // High handicap clamps to bracket 30. From 150 yd that's 5.01.
+    expect(getExpectedStrokes('approach', 150, undefined, 50)).toBe(5.01)
+  })
+})
+
+describe('averageSGBreakdown', () => {
+  const r1: SGBreakdown = { offTee: 1.0, approach: 0.5, aroundGreen: 0.0, putting: -0.5, total: 1.0 }
+  const r2: SGBreakdown = { offTee: -1.0, approach: -0.5, aroundGreen: 0.0, putting: 0.5, total: -1.0 }
+
+  it('averages each category over multiple rounds', () => {
+    const avg = averageSGBreakdown([r1, r2])
+    expect(avg.offTee).toBe(0)
+    expect(avg.approach).toBe(0)
+    expect(avg.putting).toBe(0)
+    expect(avg.total).toBe(0)
+  })
+
+  it('empty input returns zero breakdown — not NaN', () => {
+    const avg = averageSGBreakdown([])
+    expect(avg.offTee).toBe(0)
+    expect(avg.approach).toBe(0)
+    expect(avg.aroundGreen).toBe(0)
+    expect(avg.putting).toBe(0)
+    expect(avg.total).toBe(0)
+  })
+
+  it('single round returns its own breakdown', () => {
+    expect(averageSGBreakdown([r1])).toEqual(r1)
+  })
+})
+
+describe('calculateShotSG (pure formula)', () => {
+  it('SG = start − end − 1 — neutral when no progress made', () => {
+    expect(calculateShotSG(3.0, 2.0)).toBe(0)
+  })
+
+  it('positive when end is much closer than start', () => {
+    expect(calculateShotSG(4.0, 2.0)).toBe(1)
+    expect(calculateShotSG(3.5, 1.0)).toBe(1.5)
+  })
+
+  it('negative when expected progress was not made', () => {
+    expect(calculateShotSG(3.0, 2.5)).toBe(-0.5)
+    expect(calculateShotSG(2.0, 2.0)).toBe(-1)
+  })
+})
+
+describe('calculateRoundSG — driveable par 4', () => {
+  // Drive that leaves 70 yd, wedge to 10 ft, 1-putt holed.
+  // Hand-computed against the baselines in sg-baselines.ts so the
+  // assertions catch a baseline-table or formula regression.
+  function buildRound(): ShotWithContext[] {
+    return [
+      shot({ shotNumber: 1, par: 4, isLastShot: false, lieType: 'tee', distanceToTarget: 350 }),
+      shot({ shotNumber: 2, par: 4, isLastShot: false, lieType: 'fairway', distanceToTarget: 70 }),
+      shot({ shotNumber: 3, par: 4, isLastShot: false, lieType: 'green', puttDistanceFt: 10 }),
+      shot({ shotNumber: 4, par: 4, isLastShot: true, lieType: 'green', puttDistanceFt: 1, puttResult: 'made' }),
+    ]
+  }
+
+  it('off-tee SG = 0.31 for hcp 20 — drive cleared 280 yd', () => {
+    // start (off_tee, 350 yd → APPROACH[20] clamped 225) = 4.82
+    // end (next shot from 70 yd fairway, APPROACH[20][70] interp) = 3.508
+    // SG = 4.82 − 3.508 − 1 = 0.312
+    const sg = calculateRoundSG(buildRound(), 20)
+    expect(sg.offTee).toBeCloseTo(0.312, 2)
+  })
+
+  it('approach SG = 0.75 for hcp 20 — wedge to 10 ft', () => {
+    // start (approach, 70 yd → APPROACH[20] interp) = 3.508
+    // end (next shot 10 ft on green, PUTTING[20][10]) = 1.76
+    // SG = 3.508 − 1.76 − 1 = 0.748
+    const sg = calculateRoundSG(buildRound(), 20)
+    expect(sg.approach).toBeCloseTo(0.748, 2)
+  })
+
+  it('putting SG = -0.24 for hcp 20 — left a 1 ft second, holed', () => {
+    // putt 1 (10 ft → 1.76) → next 1 ft (clamped 3 ft → 1.13): -0.37
+    // putt 2 (1 ft, last + holed): 1.13 − 0 − 1 = 0.13
+    // putting total = -0.24
+    const sg = calculateRoundSG(buildRound(), 20)
+    expect(sg.putting).toBeCloseTo(-0.24, 2)
+  })
+})
+
+describe('calculateRoundSG — 3-putt from 6 feet (handicap 0)', () => {
+  // Approach from 150 yd → green 6 ft, 3-putt for bogey.
+  const ROUND: ShotWithContext[] = [
+    shot({ shotNumber: 1, par: 4, isLastShot: false, lieType: 'tee', distanceToTarget: 380 }),
+    shot({ shotNumber: 2, par: 4, isLastShot: false, lieType: 'fairway', distanceToTarget: 150 }),
+    // Three-putt from 6 ft.
+    shot({ shotNumber: 3, par: 4, isLastShot: false, lieType: 'green', puttDistanceFt: 6 }),
+    shot({ shotNumber: 4, par: 4, isLastShot: false, lieType: 'green', puttDistanceFt: 1.5 }),
+    shot({ shotNumber: 5, par: 4, isLastShot: true, lieType: 'green', puttDistanceFt: 0.5, puttResult: 'made' }),
+  ]
+
+  it('putting SG = -1.81 — pinned to the hand-computed value', () => {
+    // putt 1 (6 ft → 1.193, next 1.5 ft → 1.03): -0.837
+    // putt 2 (1.5 ft → 1.03, next 0.5 ft → 1.03): -1.0
+    // putt 3 (0.5 ft → 1.03, holed → 0): 0.03
+    // sum = -1.807
+    const sg = calculateRoundSG(ROUND, 0)
+    expect(sg.putting).toBeCloseTo(-1.807, 2)
+  })
+
+  it('round total ≈ -1.55 strokes lost — 3-putt drags it negative', () => {
+    // offTee(-0.67) + approach(0.927) + putting(-1.807) ≈ -1.55
+    const sg = calculateRoundSG(ROUND, 0)
+    expect(sg.total).toBeCloseTo(-1.55, 1)
+  })
+})
+
+describe('calculateRoundSG — holing out from 50 yards', () => {
+  // Par 4 holed from 50 yd on shot 2 (eagle 2). isLastShot=true on
+  // shot 2 means the SG calc treats endExpected as 0.
+  const ROUND: ShotWithContext[] = [
+    shot({ shotNumber: 1, par: 4, isLastShot: false, lieType: 'tee', distanceToTarget: 380 }),
+    shot({ shotNumber: 2, par: 4, isLastShot: true, lieType: 'fairway', distanceToTarget: 50 }),
+  ]
+
+  it('scratch hole-out from 50 yd → +1.60 strokes gained', () => {
+    // APPROACH[0][50] = 2.6, end = 0 → SG = 1.6
+    const sg = calculateRoundSG(ROUND, 0)
+    expect(sg.approach).toBeCloseTo(1.6, 2)
+  })
+
+  it('hcp-20 hole-out from 50 yd → +2.30 strokes gained', () => {
+    // APPROACH[20][50] = 3.30 → SG = 2.30. Higher-handicap players
+    // gain more from the same magic shot because their baseline is
+    // worse — ~0.7 strokes more than scratch in this scenario.
+    const sg = calculateRoundSG(ROUND, 20)
+    expect(sg.approach).toBeCloseTo(2.3, 2)
+    const scratch = calculateRoundSG(ROUND, 0).approach
+    expect(sg.approach - scratch).toBeGreaterThan(0.5)
+  })
+})
+
+describe('calculateRoundSG — empty / degenerate inputs', () => {
+  it('no shots → all-zero breakdown', () => {
+    const sg = calculateRoundSG([], 15)
+    expect(sg.offTee).toBe(0)
+    expect(sg.approach).toBe(0)
+    expect(sg.aroundGreen).toBe(0)
+    expect(sg.putting).toBe(0)
+    expect(sg.total).toBe(0)
+  })
+
+  it('par-3 tee shot routes to approach, not off-tee', () => {
+    // Off-tee category is reserved for par 4/5 — par 3 tee shots count
+    // as approach in SG analysis. So a par-3 round should have offTee=0
+    // even though the player did hit a tee shot.
+    const round: ShotWithContext[] = [
+      shot({ shotNumber: 1, par: 3, isLastShot: false, lieType: 'tee', distanceToTarget: 150 }),
+      shot({ shotNumber: 2, par: 3, isLastShot: false, lieType: 'green', puttDistanceFt: 25 }),
+      shot({ shotNumber: 3, par: 3, isLastShot: true, lieType: 'green', puttDistanceFt: 0.5, puttResult: 'made' }),
+    ]
+    const sg = calculateRoundSG(round, 15)
+    expect(sg.offTee).toBe(0)
+  })
+})
+
+describe('computeRoundSG (sg.ts) — DB row → result adapter', () => {
+  // Build minimal DB rows. Only the fields computeRoundSG reads matter.
+  function holeRow(overrides: Partial<HoleRow>): HoleRow {
+    return {
+      id: overrides.id ?? 'h1',
+      course_id: overrides.course_id ?? 'c',
+      number: overrides.number ?? 1,
+      par: overrides.par ?? 4,
+      yards: overrides.yards ?? 380,
+      stroke_index: overrides.stroke_index ?? 1,
+      tee_lat: overrides.tee_lat ?? null,
+      tee_lng: overrides.tee_lng ?? null,
+      pin_lat: overrides.pin_lat ?? null,
+      pin_lng: overrides.pin_lng ?? null,
+    }
+  }
+
+  function holeScoreRow(overrides: Partial<HoleScoreRow>): HoleScoreRow {
+    return {
+      id: overrides.id ?? 'hs',
+      round_id: overrides.round_id ?? 'r',
+      hole_id: overrides.hole_id ?? 'h1',
+      score: overrides.score ?? 4,
+      putts: overrides.putts ?? null,
+      fairway_hit: overrides.fairway_hit ?? null,
+      gir: overrides.gir ?? null,
+      pin_lat: overrides.pin_lat ?? null,
+      pin_lng: overrides.pin_lng ?? null,
+      sg_off_tee: overrides.sg_off_tee ?? null,
+      sg_approach: overrides.sg_approach ?? null,
+      sg_around_green: overrides.sg_around_green ?? null,
+      sg_putting: overrides.sg_putting ?? null,
+    }
+  }
+
+  function shotRow(overrides: Partial<ShotRow>): ShotRow {
+    return {
+      id: overrides.id ?? `s-${overrides.shot_number ?? 1}`,
+      hole_score_id: overrides.hole_score_id ?? 'hs',
+      user_id: overrides.user_id ?? 'u',
+      shot_number: overrides.shot_number ?? 1,
+      start_lat: overrides.start_lat ?? null,
+      start_lng: overrides.start_lng ?? null,
+      end_lat: overrides.end_lat ?? null,
+      end_lng: overrides.end_lng ?? null,
+      aim_lat: overrides.aim_lat ?? null,
+      aim_lng: overrides.aim_lng ?? null,
+      distance_to_target: overrides.distance_to_target ?? null,
+      club: overrides.club ?? null,
+      lie_type: overrides.lie_type ?? null,
+      lie_slope: overrides.lie_slope ?? null,
+      lie_slope_forward: overrides.lie_slope_forward ?? null,
+      lie_slope_side: overrides.lie_slope_side ?? null,
+      shot_result: overrides.shot_result ?? null,
+      penalty: overrides.penalty ?? false,
+      ob: overrides.ob ?? false,
+      aim_offset_yards: overrides.aim_offset_yards ?? null,
+      break_direction: overrides.break_direction ?? null,
+      putt_result: overrides.putt_result ?? null,
+      putt_distance_result: overrides.putt_distance_result ?? null,
+      putt_direction_result: overrides.putt_direction_result ?? null,
+      putt_distance_ft: overrides.putt_distance_ft ?? null,
+      putt_slope_pct: overrides.putt_slope_pct ?? null,
+      green_speed: overrides.green_speed ?? null,
+      notes: overrides.notes ?? null,
+      created_at: overrides.created_at ?? '2026-01-01T00:00:00Z',
+    }
+  }
+
+  it('aggregates totals across multiple holes', () => {
+    const holes = [
+      holeRow({ id: 'h1', par: 4 }),
+      holeRow({ id: 'h2', par: 4 }),
+    ]
+    const holeScores = [
+      holeScoreRow({ id: 'hs1', hole_id: 'h1', score: 4, putts: 2, fairway_hit: true, gir: true }),
+      holeScoreRow({ id: 'hs2', hole_id: 'h2', score: 5, putts: 2, fairway_hit: false, gir: false }),
+    ]
+    const shots = [
+      shotRow({ shot_number: 1, hole_score_id: 'hs1', lie_type: 'tee', distance_to_target: 380 }),
+      shotRow({ shot_number: 2, hole_score_id: 'hs1', lie_type: 'green', putt_distance_ft: 5 }),
+      shotRow({ shot_number: 1, hole_score_id: 'hs2', lie_type: 'tee', distance_to_target: 380 }),
+    ]
+    const result = computeRoundSG({ holes, holeScores, shots, handicap: 15 })
+    expect(result.totals.totalScore).toBe(9)
+    expect(result.totals.totalPutts).toBe(4)
+    expect(result.totals.fairwaysHit).toBe(1)
+    expect(result.totals.fairwaysTotal).toBe(2)
+    expect(result.totals.gir).toBe(1)
+  })
+
+  it('skips hole_scores with no shots — no crash', () => {
+    const holes = [holeRow({ id: 'h1', par: 4 })]
+    const holeScores = [holeScoreRow({ id: 'hs1', hole_id: 'h1', score: 4 })]
+    const result = computeRoundSG({ holes, holeScores, shots: [], handicap: 15 })
+    expect(result.round.total).toBe(0)
+    expect(result.perHoleScore).toEqual({})
+  })
+
+  it('par-3 holes do not contribute to fairwaysTotal', () => {
+    const holes = [holeRow({ id: 'h1', par: 3 })]
+    const holeScores = [holeScoreRow({ id: 'hs1', hole_id: 'h1', score: 3 })]
+    const result = computeRoundSG({ holes, holeScores, shots: [], handicap: 15 })
+    expect(result.totals.fairwaysTotal).toBe(0)
+    expect(result.totals.fairwaysHit).toBe(0)
+  })
+})
+
+describe('calculateRoundSG — penalty / OB attribution', () => {
+  // Penalty on a tee shot should subtract a stroke from off-tee SG.
+  it('penalty stroke subtracts 1 from the affected category SG', () => {
+    const clean: ShotWithContext[] = [
+      shot({ shotNumber: 1, par: 4, isLastShot: false, lieType: 'tee', distanceToTarget: 380 }),
+      shot({ shotNumber: 2, par: 4, isLastShot: true, lieType: 'fairway', distanceToTarget: 50 }),
+    ]
+    const withPenalty: ShotWithContext[] = [
+      shot({ shotNumber: 1, par: 4, isLastShot: false, lieType: 'tee', distanceToTarget: 380, penalty: true }),
+      shot({ shotNumber: 2, par: 4, isLastShot: true, lieType: 'fairway', distanceToTarget: 50 }),
+    ]
+    const a = calculateRoundSG(clean, 15)
+    const b = calculateRoundSG(withPenalty, 15)
+    expect(b.offTee).toBeCloseTo(a.offTee - 1, 6)
+    // Approach SG and other categories unchanged.
+    expect(b.approach).toBeCloseTo(a.approach, 6)
+  })
+})

--- a/packages/core/src/__tests__/shotInference.test.ts
+++ b/packages/core/src/__tests__/shotInference.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest'
+import { inferShot, type PlacedShot } from '../shotInference'
+import { getShotCategory } from '../sg-calculator'
+
+// Synthetic OKC-area coords with clean 1° latitude → 121,830 yd math.
+// offsetLat shifts a base latitude north by N yards using the
+// canonical 111,320 m / 1.09361 yd / m factor.
+const M_PER_DEG_LAT = 111_320
+const YDS_PER_METER = 1.09361
+const TEE = { lat: 35.4676, lng: -97.5164 }
+
+function offsetLatYards(lat: number, yards: number): number {
+  return lat + yards / YDS_PER_METER / M_PER_DEG_LAT
+}
+
+function placedShot(opts: Partial<PlacedShot>): PlacedShot {
+  return {
+    shotNumber: opts.shotNumber ?? 1,
+    startLat: opts.startLat ?? TEE.lat,
+    startLng: opts.startLng ?? TEE.lng,
+    endLat: opts.endLat ?? TEE.lat,
+    endLng: opts.endLng ?? TEE.lng,
+    pinLat: opts.pinLat ?? offsetLatYards(TEE.lat, 380),
+    pinLng: opts.pinLng ?? TEE.lng,
+    totalShotsOnHole: opts.totalShotsOnHole ?? 4,
+    par: opts.par ?? 4,
+  }
+}
+
+describe('inferShot — club selection', () => {
+  it('280 yd tee shot on a par 4 picks driver', () => {
+    const result = inferShot(
+      placedShot({
+        shotNumber: 1,
+        endLat: offsetLatYards(TEE.lat, 280),
+        par: 4,
+      }),
+    )
+    expect(result.suggestedClub).toBe('driver')
+  })
+
+  it('150 yd approach picks a mid-iron (6i per the table)', () => {
+    const start = offsetLatYards(TEE.lat, 220)
+    const end = offsetLatYards(TEE.lat, 370) // 150 yd farther
+    const result = inferShot(
+      placedShot({
+        shotNumber: 2,
+        startLat: start,
+        endLat: end,
+        totalShotsOnHole: 4,
+        par: 4,
+        pinLat: offsetLatYards(TEE.lat, 380),
+      }),
+    )
+    expect(result.suggestedClub).toBe('6i')
+  })
+
+  it('~8 yd chip picks the lob wedge', () => {
+    const start = offsetLatYards(TEE.lat, 360)
+    const end = offsetLatYards(TEE.lat, 368)
+    const result = inferShot(
+      placedShot({
+        shotNumber: 3,
+        startLat: start,
+        endLat: end,
+        totalShotsOnHole: 4,
+        par: 4,
+        pinLat: offsetLatYards(TEE.lat, 380),
+      }),
+    )
+    expect(result.suggestedClub).toBe('lw')
+  })
+
+  it('5 ft putt (start on green) picks putter', () => {
+    const pin = offsetLatYards(TEE.lat, 380)
+    // 5 ft = ~1.67 yd from pin → on-green threshold is 15 yd.
+    const start = offsetLatYards(TEE.lat, 380 - 1.67)
+    const result = inferShot(
+      placedShot({
+        shotNumber: 4,
+        startLat: start,
+        endLat: pin,
+        pinLat: pin,
+        totalShotsOnHole: 4,
+        par: 4,
+      }),
+    )
+    expect(result.suggestedLieType).toBe('green')
+    expect(result.suggestedClub).toBe('putter')
+  })
+
+  it('190 yd tee shot on a par 4 picks 3-wood (180-200 yd bucket)', () => {
+    // clubForTeeShot: ≥200 driver, ≥180 3w. 190 falls into 3w.
+    const result = inferShot(
+      placedShot({
+        shotNumber: 1,
+        endLat: offsetLatYards(TEE.lat, 190),
+        par: 4,
+      }),
+    )
+    expect(result.suggestedClub).toBe('3w')
+  })
+
+  it('220 yd shot on a par 4 picks driver (boundary >= 200)', () => {
+    const result = inferShot(
+      placedShot({
+        shotNumber: 1,
+        endLat: offsetLatYards(TEE.lat, 220),
+        par: 4,
+      }),
+    )
+    expect(result.suggestedClub).toBe('driver')
+  })
+
+  it('par-3 tee shot uses iron table not tee-shot table', () => {
+    // 175 yd par-3 tee → general iron table (≥165 → 4i). Picked 175
+    // — well inside the bucket — so the test isn't sensitive to the
+    // ~0.1 % drift between flat-earth and haversine at this latitude.
+    const result = inferShot(
+      placedShot({
+        shotNumber: 1,
+        endLat: offsetLatYards(TEE.lat, 175),
+        par: 3,
+        pinLat: offsetLatYards(TEE.lat, 175),
+      }),
+    )
+    expect(result.suggestedClub).toBe('4i')
+  })
+})
+
+describe('inferShot — confidence rating', () => {
+  it('tee shots are always high confidence', () => {
+    const result = inferShot(
+      placedShot({
+        shotNumber: 1,
+        endLat: offsetLatYards(TEE.lat, 250),
+      }),
+    )
+    expect(result.confidence).toBe('high')
+  })
+
+  it('shots starting on the green are high confidence (a putt)', () => {
+    const pin = offsetLatYards(TEE.lat, 380)
+    const start = offsetLatYards(TEE.lat, 379)
+    const result = inferShot(
+      placedShot({
+        shotNumber: 4,
+        startLat: start,
+        endLat: pin,
+        pinLat: pin,
+        totalShotsOnHole: 4,
+      }),
+    )
+    expect(result.confidence).toBe('high')
+  })
+
+  it('mid-iron approaches (100–200 yd) are medium confidence', () => {
+    const start = offsetLatYards(TEE.lat, 220)
+    const end = offsetLatYards(TEE.lat, 370)
+    const result = inferShot(
+      placedShot({
+        shotNumber: 2,
+        startLat: start,
+        endLat: end,
+        totalShotsOnHole: 4,
+        pinLat: offsetLatYards(TEE.lat, 380),
+      }),
+    )
+    expect(result.confidence).toBe('medium')
+  })
+
+  it('partial wedges and very long shots flag as low confidence', () => {
+    // 60 yd shot, not on green start, par 4.
+    const start = offsetLatYards(TEE.lat, 290)
+    const end = offsetLatYards(TEE.lat, 350)
+    const result = inferShot(
+      placedShot({
+        shotNumber: 3,
+        startLat: start,
+        endLat: end,
+        totalShotsOnHole: 4,
+        pinLat: offsetLatYards(TEE.lat, 380),
+      }),
+    )
+    expect(result.confidence).toBe('low')
+  })
+})
+
+describe('getShotCategory', () => {
+  // Categorizes for the SG engine — return values are the snake_case
+  // canonical set: 'off_tee' | 'approach' | 'around_green' | 'putting'.
+
+  it('shots with lieType=green are putts regardless of distance', () => {
+    expect(
+      getShotCategory({ lieType: 'green', distanceToTarget: undefined }, 4, 3),
+    ).toBe('putting')
+  })
+
+  it('par 4 shot 1 with lieType=tee → off_tee', () => {
+    expect(
+      getShotCategory({ lieType: 'tee', distanceToTarget: 380 }, 4, 1),
+    ).toBe('off_tee')
+  })
+
+  it('par 5 shot 1 → off_tee', () => {
+    expect(
+      getShotCategory({ lieType: 'tee', distanceToTarget: 540 }, 5, 1),
+    ).toBe('off_tee')
+  })
+
+  it('par 3 shot 1 is approach not off_tee (per definition)', () => {
+    // Off-tee category is reserved for par 4/5 — par 3 tee shots count
+    // as approach in SG analysis.
+    expect(
+      getShotCategory({ lieType: 'tee', distanceToTarget: 150 }, 3, 1),
+    ).toBe('approach')
+  })
+
+  it('shots inside 30 yd of pin → around_green', () => {
+    expect(
+      getShotCategory({ lieType: 'rough', distanceToTarget: 25 }, 4, 3),
+    ).toBe('around_green')
+  })
+
+  it('30 yd is the boundary — exactly 30 is around_green', () => {
+    expect(
+      getShotCategory({ lieType: 'fringe', distanceToTarget: 30 }, 4, 3),
+    ).toBe('around_green')
+  })
+
+  it('31 yd flips to approach', () => {
+    expect(
+      getShotCategory({ lieType: 'rough', distanceToTarget: 31 }, 4, 3),
+    ).toBe('approach')
+  })
+
+  it('par 4 shot 2 from fairway → approach', () => {
+    expect(
+      getShotCategory({ lieType: 'fairway', distanceToTarget: 150 }, 4, 2),
+    ).toBe('approach')
+  })
+
+  it('shots without distance and not on green default to approach', () => {
+    expect(
+      getShotCategory({ lieType: 'fairway', distanceToTarget: undefined }, 4, 2),
+    ).toBe('approach')
+  })
+
+  it('priority: 30 yd check beats off_tee — driveable par 4 from tee at 30 yd → around_green', () => {
+    // Documents the impl's branch ordering: green-check, then 30yd
+    // around-green, then off_tee. A tee shot 30 yd from the pin on a
+    // par 4 is therefore around_green, not off_tee. Probably not what
+    // a player would expect — pinned so a refactor that flips the
+    // priority surfaces here.
+    expect(
+      getShotCategory({ lieType: 'tee', distanceToTarget: 30 }, 4, 1),
+    ).toBe('around_green')
+  })
+
+  it('priority: green check beats 30 yd — putt from 25 yd → putting', () => {
+    // Same priority story for the green check.
+    expect(
+      getShotCategory({ lieType: 'green', distanceToTarget: 25 }, 4, 3),
+    ).toBe('putting')
+  })
+})

--- a/packages/core/src/__tests__/stats.test.ts
+++ b/packages/core/src/__tests__/stats.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeDetailedStats,
+  getProximityYards,
+  scoringDistribution,
+  scoringStats,
+  shortGameStats,
+  type DetailedHoleScore,
+  type DetailedRound,
+} from '../stats'
+import { combinedPuttResult } from '../types'
+import type { Database } from '@oga/supabase'
+
+type RoundRow = Database['public']['Tables']['rounds']['Row']
+type HoleRow = Database['public']['Tables']['holes']['Row']
+type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
+type ShotRow = Database['public']['Tables']['shots']['Row']
+
+// Defaults that satisfy the DB row contracts; tests override only the
+// fields they care about.
+function row<T>(overrides: Partial<T>): T {
+  return overrides as T
+}
+
+function makeHole(overrides: Partial<HoleRow>): HoleRow {
+  return row<HoleRow>({
+    id: overrides.id ?? `h-${overrides.number ?? 1}`,
+    course_id: overrides.course_id ?? 'course',
+    number: overrides.number ?? 1,
+    par: overrides.par ?? 4,
+    yards: overrides.yards ?? 380,
+    stroke_index: overrides.stroke_index ?? 1,
+    tee_lat: overrides.tee_lat ?? null,
+    tee_lng: overrides.tee_lng ?? null,
+    pin_lat: overrides.pin_lat ?? null,
+    pin_lng: overrides.pin_lng ?? null,
+    ...overrides,
+  })
+}
+
+function makeShot(overrides: Partial<ShotRow>): ShotRow {
+  return row<ShotRow>({
+    id: overrides.id ?? `s-${overrides.shot_number ?? 1}`,
+    hole_score_id: overrides.hole_score_id ?? 'hs',
+    user_id: overrides.user_id ?? 'u',
+    shot_number: overrides.shot_number ?? 1,
+    start_lat: overrides.start_lat ?? null,
+    start_lng: overrides.start_lng ?? null,
+    end_lat: overrides.end_lat ?? null,
+    end_lng: overrides.end_lng ?? null,
+    aim_lat: overrides.aim_lat ?? null,
+    aim_lng: overrides.aim_lng ?? null,
+    distance_to_target: overrides.distance_to_target ?? null,
+    club: overrides.club ?? null,
+    lie_type: overrides.lie_type ?? null,
+    lie_slope: overrides.lie_slope ?? null,
+    lie_slope_forward: overrides.lie_slope_forward ?? null,
+    lie_slope_side: overrides.lie_slope_side ?? null,
+    shot_result: overrides.shot_result ?? null,
+    penalty: overrides.penalty ?? false,
+    ob: overrides.ob ?? false,
+    aim_offset_yards: overrides.aim_offset_yards ?? null,
+    break_direction: overrides.break_direction ?? null,
+    putt_result: overrides.putt_result ?? null,
+    putt_distance_result: overrides.putt_distance_result ?? null,
+    putt_direction_result: overrides.putt_direction_result ?? null,
+    putt_distance_ft: overrides.putt_distance_ft ?? null,
+    putt_slope_pct: overrides.putt_slope_pct ?? null,
+    green_speed: overrides.green_speed ?? null,
+    notes: overrides.notes ?? null,
+    created_at: overrides.created_at ?? '2026-01-01T00:00:00Z',
+  })
+}
+
+function makeHoleScore(overrides: Partial<DetailedHoleScore>): DetailedHoleScore {
+  return row<DetailedHoleScore>({
+    id: overrides.id ?? 'hs',
+    round_id: overrides.round_id ?? 'r',
+    hole_id: overrides.hole_id ?? 'h-1',
+    score: overrides.score ?? 4,
+    putts: overrides.putts ?? null,
+    fairway_hit: overrides.fairway_hit ?? null,
+    gir: overrides.gir ?? null,
+    pin_lat: overrides.pin_lat ?? null,
+    pin_lng: overrides.pin_lng ?? null,
+    sg_off_tee: overrides.sg_off_tee ?? null,
+    sg_approach: overrides.sg_approach ?? null,
+    sg_around_green: overrides.sg_around_green ?? null,
+    sg_putting: overrides.sg_putting ?? null,
+    holes: overrides.holes ?? null,
+    shots: overrides.shots ?? null,
+  })
+}
+
+function makeRound(overrides: Partial<DetailedRound>): DetailedRound {
+  return row<DetailedRound>({
+    id: overrides.id ?? 'r',
+    user_id: overrides.user_id ?? 'u',
+    course_id: overrides.course_id ?? 'course',
+    played_at: overrides.played_at ?? '2026-01-01',
+    tee_color: overrides.tee_color ?? null,
+    total_score: overrides.total_score ?? null,
+    total_putts: overrides.total_putts ?? null,
+    fairways_hit: overrides.fairways_hit ?? null,
+    fairways_total: overrides.fairways_total ?? null,
+    gir: overrides.gir ?? null,
+    sg_off_tee: overrides.sg_off_tee ?? null,
+    sg_approach: overrides.sg_approach ?? null,
+    sg_around_green: overrides.sg_around_green ?? null,
+    sg_putting: overrides.sg_putting ?? null,
+    sg_total: overrides.sg_total ?? null,
+    notes: overrides.notes ?? null,
+    hole_scores: overrides.hole_scores ?? null,
+  })
+}
+
+describe('computeDetailedStats — empty input', () => {
+  it('returns null aggregates instead of NaN or throwing', () => {
+    const stats = computeDetailedStats([], 15)
+    expect(stats.rounds).toBe(0)
+    expect(stats.holesPlayed).toBe(0)
+    expect(stats.sg.offTee).toBeNull()
+    expect(stats.sg.approach).toBeNull()
+    expect(stats.sg.aroundGreen).toBeNull()
+    expect(stats.sg.putting).toBeNull()
+  })
+
+  it('lists are empty, scoring counts are zero', () => {
+    const stats = computeDetailedStats([], 15)
+    expect(stats.sgTrend).toEqual([])
+    expect(stats.missTendency).toEqual([])
+    expect(stats.costlyLies).toEqual([])
+    expect(stats.clubAccuracy).toEqual([])
+    expect(stats.scoring.avgScore).toBeNull()
+    expect(stats.scoring.bestRound).toBeNull()
+    expect(stats.scoringDistribution.total).toBe(0)
+  })
+
+})
+
+describe('sgTrend', () => {
+  it('skips rounds that have no recorded sg_total', () => {
+    const round = makeRound({
+      played_at: '2026-01-15',
+      hole_scores: [],
+      sg_total: null,
+    })
+    const stats = computeDetailedStats([round], 15)
+    expect(stats.sgTrend).toHaveLength(0)
+  })
+
+  it('reverses chronological order (oldest → newest) for charting', () => {
+    // sgTrend is consumed by line charts that read left-to-right as
+    // oldest → newest. The impl reverses the input array and filters
+    // null sg_total. Pin the order so a chart regression surfaces.
+    const rounds = [
+      makeRound({ id: 'r3', played_at: '2026-03-01', sg_total: 0.3, hole_scores: [] }),
+      makeRound({ id: 'r2', played_at: '2026-02-01', sg_total: 0.2, hole_scores: [] }),
+      makeRound({ id: 'r1', played_at: '2026-01-01', sg_total: 0.1, hole_scores: [] }),
+    ]
+    const stats = computeDetailedStats(rounds, 15)
+    expect(stats.sgTrend.map((p) => p.date)).toEqual([
+      '2026-01-01',
+      '2026-02-01',
+      '2026-03-01',
+    ])
+  })
+})
+
+describe('computeDetailedStats — sgAverages', () => {
+  it('averages over rounds that have non-null SG values', () => {
+    const rounds: DetailedRound[] = [
+      makeRound({ id: 'r1', sg_off_tee: 1.0, sg_approach: -0.5, hole_scores: [] }),
+      makeRound({ id: 'r2', sg_off_tee: 0.5, sg_approach: -1.5, hole_scores: [] }),
+    ]
+    const stats = computeDetailedStats(rounds, 15)
+    expect(stats.sg.offTee).toBeCloseTo(0.75, 6)
+    expect(stats.sg.approach).toBeCloseTo(-1.0, 6)
+  })
+
+  it('handles a mix of null + populated SG values per category', () => {
+    const rounds: DetailedRound[] = [
+      makeRound({ id: 'r1', sg_putting: 0.5, hole_scores: [] }),
+      makeRound({ id: 'r2', sg_putting: null, hole_scores: [] }),
+    ]
+    const stats = computeDetailedStats(rounds, 15)
+    expect(stats.sg.putting).toBe(0.5)
+  })
+})
+
+describe('scoringStats', () => {
+  it('avgScore averages totalScore across rounds', () => {
+    const rounds: DetailedRound[] = [
+      makeRound({ id: 'r1', total_score: 80, hole_scores: [] }),
+      makeRound({ id: 'r2', total_score: 90, hole_scores: [] }),
+    ]
+    expect(scoringStats(rounds).avgScore).toBe(85)
+  })
+
+  it('best/worst track the extremes', () => {
+    const rounds: DetailedRound[] = [
+      makeRound({ id: 'r1', total_score: 92, hole_scores: [] }),
+      makeRound({ id: 'r2', total_score: 78, hole_scores: [] }),
+      makeRound({ id: 'r3', total_score: 85, hole_scores: [] }),
+    ]
+    const s = scoringStats(rounds)
+    expect(s.bestRound).toBe(78)
+    expect(s.worstRound).toBe(92)
+  })
+
+  it('separates par-3 / par-4 / par-5 averages', () => {
+    const par3 = makeHole({ id: 'h-3', number: 3, par: 3 })
+    const par5 = makeHole({ id: 'h-5', number: 5, par: 5 })
+    const round: DetailedRound = makeRound({
+      hole_scores: [
+        makeHoleScore({ id: 'hs1', score: 4, hole_id: 'h-3', holes: par3 }),
+        makeHoleScore({ id: 'hs2', score: 6, hole_id: 'h-5', holes: par5 }),
+      ],
+    })
+    const s = scoringStats([round])
+    expect(s.avgPar3).toBe(4)
+    expect(s.avgPar5).toBe(6)
+    expect(s.avgPar4).toBeNull()
+  })
+
+  it('front 9 / back 9 split by hole number', () => {
+    const round: DetailedRound = makeRound({
+      hole_scores: [
+        makeHoleScore({ id: 'hs1', score: 4, holes: makeHole({ id: 'h1', number: 1, par: 4 }) }),
+        makeHoleScore({ id: 'hs2', score: 5, holes: makeHole({ id: 'h2', number: 9, par: 4 }) }),
+        makeHoleScore({ id: 'hs3', score: 6, holes: makeHole({ id: 'h3', number: 10, par: 4 }) }),
+        makeHoleScore({ id: 'hs4', score: 7, holes: makeHole({ id: 'h4', number: 18, par: 4 }) }),
+      ],
+    })
+    const s = scoringStats([round])
+    expect(s.front9Avg).toBe(4.5)
+    expect(s.back9Avg).toBe(6.5)
+  })
+})
+
+describe('scoringDistribution', () => {
+  it('classifies score - par into the right bucket', () => {
+    const round: DetailedRound = makeRound({
+      hole_scores: [
+        // Eagle (par 5 in 3)
+        makeHoleScore({ id: 'hs1', score: 3, holes: makeHole({ id: 'h1', number: 1, par: 5 }) }),
+        // Birdie
+        makeHoleScore({ id: 'hs2', score: 3, holes: makeHole({ id: 'h2', number: 2, par: 4 }) }),
+        // Par
+        makeHoleScore({ id: 'hs3', score: 4, holes: makeHole({ id: 'h3', number: 3, par: 4 }) }),
+        // Bogey
+        makeHoleScore({ id: 'hs4', score: 5, holes: makeHole({ id: 'h4', number: 4, par: 4 }) }),
+        // Double
+        makeHoleScore({ id: 'hs5', score: 6, holes: makeHole({ id: 'h5', number: 5, par: 4 }) }),
+        // Triple+
+        makeHoleScore({ id: 'hs6', score: 8, holes: makeHole({ id: 'h6', number: 6, par: 4 }) }),
+      ],
+    })
+    const dist = scoringDistribution([round])
+    const counts = Object.fromEntries(dist.slices.map((s) => [s.key, s.count]))
+    expect(counts.eagleOrBetter).toBe(1)
+    expect(counts.birdie).toBe(1)
+    expect(counts.par).toBe(1)
+    expect(counts.bogey).toBe(1)
+    expect(counts.double).toBe(1)
+    expect(counts.triplePlus).toBe(1)
+    expect(dist.total).toBe(6)
+  })
+
+  it('percentages sum to 100% (within rounding)', () => {
+    const round: DetailedRound = makeRound({
+      hole_scores: [
+        makeHoleScore({ id: 'hs1', score: 4, holes: makeHole({ id: 'h1', number: 1, par: 4 }) }),
+        makeHoleScore({ id: 'hs2', score: 5, holes: makeHole({ id: 'h2', number: 2, par: 4 }) }),
+      ],
+    })
+    const dist = scoringDistribution([round])
+    const total = dist.slices.reduce((sum, s) => sum + s.pct, 0)
+    expect(total).toBeCloseTo(100, 6)
+  })
+})
+
+describe('shortGameStats — putts and 3-putts', () => {
+  const round: DetailedRound = makeRound({
+    total_putts: 35,
+    hole_scores: [
+      makeHoleScore({
+        id: 'hs1',
+        score: 4,
+        gir: true,
+        putts: 2,
+        holes: makeHole({ id: 'h1', number: 1, par: 4 }),
+        shots: [],
+      }),
+      makeHoleScore({
+        id: 'hs2',
+        score: 6,
+        gir: true,
+        putts: 3,
+        holes: makeHole({ id: 'h2', number: 2, par: 4 }),
+        shots: [],
+      }),
+      makeHoleScore({
+        id: 'hs3',
+        score: 5,
+        gir: false,
+        putts: 2,
+        holes: makeHole({ id: 'h3', number: 3, par: 4 }),
+        shots: [],
+      }),
+    ],
+  })
+
+  it('puttsPerRound averages totals over rounds', () => {
+    expect(shortGameStats([round]).puttsPerRound).toBe(35)
+  })
+
+  it('3-putt percentage counts only holes with ≥3 putts', () => {
+    // 1 of 3 holes had 3+ putts → ~33%
+    expect(shortGameStats([round]).threePuttPct).toBeCloseTo(100 / 3, 4)
+  })
+
+  it('puttsPerGir counts putts only on GIR holes', () => {
+    // GIR holes had 2 + 3 = 5 putts over 2 holes → 2.5
+    expect(shortGameStats([round]).puttsPerGir).toBe(2.5)
+  })
+
+  it('upAndDownPct = 0% when no missed-GIR hole salvaged par', () => {
+    // 1 missed-GIR hole, score=5 (par 4) → not up-and-down → 0%
+    expect(shortGameStats([round]).upAndDownPct).toBe(0)
+  })
+
+  it('upAndDownPct = 100% when every missed-GIR hole was par or better', () => {
+    const r: DetailedRound = makeRound({
+      hole_scores: [
+        // missed GIR, made par → up & down
+        makeHoleScore({
+          id: 'hs1',
+          score: 4,
+          gir: false,
+          putts: 1,
+          holes: makeHole({ id: 'h1', number: 1, par: 4 }),
+          shots: [],
+        }),
+      ],
+    })
+    expect(shortGameStats([r]).upAndDownPct).toBe(100)
+  })
+
+  it('scramblingPct counts holes with around-green shots that finished par-or-better', () => {
+    // Two holes had a fringe lie; one was saved (par), one was not.
+    const r: DetailedRound = makeRound({
+      hole_scores: [
+        makeHoleScore({
+          id: 'hs1',
+          score: 4,
+          gir: false,
+          holes: makeHole({ id: 'h1', number: 1, par: 4 }),
+          shots: [makeShot({ shot_number: 3, lie_type: 'fringe' })],
+        }),
+        makeHoleScore({
+          id: 'hs2',
+          score: 6,
+          gir: false,
+          holes: makeHole({ id: 'h2', number: 2, par: 4 }),
+          shots: [makeShot({ shot_number: 3, lie_type: 'rough' })],
+        }),
+      ],
+    })
+    expect(shortGameStats([r]).scramblingPct).toBe(50)
+  })
+
+  it('sandSavePct measures par-or-better recovery from sand lies', () => {
+    const r: DetailedRound = makeRound({
+      hole_scores: [
+        makeHoleScore({
+          id: 'hs1',
+          score: 4,
+          holes: makeHole({ id: 'h1', number: 1, par: 4 }),
+          shots: [makeShot({ shot_number: 2, lie_type: 'sand' })],
+        }),
+      ],
+    })
+    expect(shortGameStats([r]).sandSavePct).toBe(100)
+  })
+})
+
+describe('getProximityYards', () => {
+  // OKC area; pin at one lat, ball end ~50 yd north.
+  const PIN_LAT = 35.4676
+  const PIN_LNG = -97.5164
+  const NORTH_50YD = 35.4676 + 0.000411 // ~50 yd north
+
+  it('measures distance to the per-round pin override when set', () => {
+    const hs = { pin_lat: PIN_LAT, pin_lng: PIN_LNG }
+    const hole = { pin_lat: null, pin_lng: null }
+    const d = getProximityYards(NORTH_50YD, PIN_LNG, hs, hole)
+    expect(d).not.toBeNull()
+    expect(d!).toBeGreaterThan(45)
+    expect(d!).toBeLessThan(55)
+  })
+
+  it('falls back to hole pin when round override is missing', () => {
+    const hs = { pin_lat: null, pin_lng: null }
+    const hole = { pin_lat: PIN_LAT, pin_lng: PIN_LNG }
+    expect(getProximityYards(NORTH_50YD, PIN_LNG, hs, hole)).not.toBeNull()
+  })
+
+  it('returns null when both round and hole pins are missing', () => {
+    const hs = { pin_lat: null, pin_lng: null }
+    const hole = { pin_lat: null, pin_lng: null }
+    expect(getProximityYards(NORTH_50YD, PIN_LNG, hs, hole)).toBeNull()
+  })
+
+  it('round override wins over hole default', () => {
+    // hs pin in OKC, hole pin in Tulsa — should measure to OKC.
+    const hs = { pin_lat: PIN_LAT, pin_lng: PIN_LNG }
+    const hole = { pin_lat: 36.154, pin_lng: -95.9928 }
+    const d = getProximityYards(NORTH_50YD, PIN_LNG, hs, hole)
+    expect(d).toBeLessThan(100) // OKC, not 170k yd to Tulsa
+  })
+})
+
+describe('combinedPuttResult', () => {
+  // Has been broken twice — exhaustively cover every combo to lock in
+  // the priority order: made > distance > direction.
+  it('made → "made" regardless of axis values', () => {
+    expect(combinedPuttResult({ made: true })).toBe('made')
+    expect(combinedPuttResult({ made: true, distance: 'short' })).toBe('made')
+    expect(combinedPuttResult({ made: true, direction: 'left' })).toBe('made')
+    expect(combinedPuttResult({ made: true, distance: 'long', direction: 'right' })).toBe('made')
+  })
+
+  it('not-made + distance → distance value wins', () => {
+    expect(combinedPuttResult({ made: false, distance: 'short' })).toBe('short')
+    expect(combinedPuttResult({ distance: 'long' })).toBe('long')
+    // Even with direction also set, distance takes priority.
+    expect(combinedPuttResult({ distance: 'short', direction: 'left' })).toBe('short')
+    expect(combinedPuttResult({ distance: 'long', direction: 'right' })).toBe('long')
+  })
+
+  it('not-made + direction-only → missed_<direction>', () => {
+    expect(combinedPuttResult({ direction: 'left' })).toBe('missed_left')
+    expect(combinedPuttResult({ direction: 'right' })).toBe('missed_right')
+  })
+
+  it('all-null inputs return null', () => {
+    expect(combinedPuttResult({})).toBeNull()
+    expect(combinedPuttResult({ made: false })).toBeNull()
+    expect(combinedPuttResult({ made: false, distance: null, direction: null })).toBeNull()
+  })
+})

--- a/packages/core/src/__tests__/units.test.ts
+++ b/packages/core/src/__tests__/units.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from 'vitest'
+import {
+  FEET_TO_YARDS,
+  METERS_TO_YARDS,
+  YARDS_TO_METERS,
+  formatSG,
+  formatToPar,
+  haversineYards,
+  toRadians,
+} from '../units'
+
+// Realistic golf coordinates pinned to OKC area. Picking integer-ish
+// values so the precomputed expectations stay legible.
+const OKC = { lat: 35.4676, lng: -97.5164 }
+const TULSA = { lat: 36.154, lng: -95.9928 }
+
+describe('haversineYards', () => {
+  it('OKC ↔ Tulsa locks to a precomputed 171,874.85 yd value', () => {
+    // Tight pin against a hand-computed great-circle (R=6371km, the
+    // value our impl uses). A radius-constant regression of 0.1%
+    // shifts this by ~170 yd, so the 5-yd window catches it; a
+    // sin/cos swap shifts it by tens of thousands.
+    const d = haversineYards(OKC.lat, OKC.lng, TULSA.lat, TULSA.lng)
+    expect(d).toBeCloseTo(171874.85, 0)
+  })
+
+  it('symmetric — A→B equals B→A', () => {
+    const ab = haversineYards(OKC.lat, OKC.lng, TULSA.lat, TULSA.lng)
+    const ba = haversineYards(TULSA.lat, TULSA.lng, OKC.lat, OKC.lng)
+    expect(ab).toBeCloseTo(ba, 6)
+  })
+
+  it('returns 0 for identical points', () => {
+    expect(haversineYards(OKC.lat, OKC.lng, OKC.lat, OKC.lng)).toBe(0)
+  })
+
+  it('roughly 100 yards apart returns ~100 within 1 yard', () => {
+    // ~100 yards north along a meridian = 100 yd / 121,830 yd/° ≈ 0.000821°
+    const d = haversineYards(OKC.lat, OKC.lng, OKC.lat + 0.000821, OKC.lng)
+    expect(d).toBeGreaterThan(99)
+    expect(d).toBeLessThan(101)
+  })
+
+  it('southern hemisphere returns the right magnitude (~27,180 yd)', () => {
+    // Sydney area — both lats negative. Pin to actual computed value
+    // so a sign-flip bug surfaces instead of just "still positive".
+    const d = haversineYards(-33.86, 151.21, -34.0, 151.0)
+    expect(d).toBeCloseTo(27180.57, 0)
+  })
+
+  it('handles antimeridian-adjacent coords without going negative', () => {
+    // Just east and just west of the date line.
+    const d = haversineYards(0, 179.9, 0, -179.9)
+    expect(d).toBeGreaterThan(0)
+    // ~0.2° at the equator = ~24,360 yd. Wraparound bug would give
+    // ~43,750,000 yd (the long way around).
+    expect(d).toBeLessThan(30000)
+  })
+
+  it('NaN inputs propagate to NaN — not a silent zero', () => {
+    expect(haversineYards(NaN, 0, 0, 0)).toBeNaN()
+    expect(haversineYards(0, NaN, 0, 0)).toBeNaN()
+  })
+})
+
+describe('toRadians', () => {
+  it('180° → π', () => {
+    expect(toRadians(180)).toBeCloseTo(Math.PI, 12)
+  })
+
+  it('0° → 0', () => {
+    expect(toRadians(0)).toBe(0)
+  })
+
+  it('90° → π/2', () => {
+    expect(toRadians(90)).toBeCloseTo(Math.PI / 2, 12)
+  })
+
+  it('360° → 2π', () => {
+    expect(toRadians(360)).toBeCloseTo(2 * Math.PI, 12)
+  })
+
+  it('negative degrees stay negative', () => {
+    expect(toRadians(-90)).toBeCloseTo(-Math.PI / 2, 12)
+  })
+})
+
+describe('formatSG', () => {
+  it('positive values get a + prefix', () => {
+    expect(formatSG(1.23)).toBe('+1.23')
+  })
+
+  it('negative values keep their - sign', () => {
+    expect(formatSG(-1.23)).toBe('-1.23')
+  })
+
+  // Documents the choice: zero is signless. Avoids "+0.00" which reads
+  // as a positive miss when the player was actually neutral.
+  it('zero renders without a sign', () => {
+    expect(formatSG(0)).toBe('0.00')
+  })
+
+  it('rounds to two decimals', () => {
+    expect(formatSG(1.23456)).toBe('+1.23')
+    expect(formatSG(-1.23999)).toBe('-1.24')
+  })
+
+  it('values that round to 0 keep their pre-rounding sign', () => {
+    // 0.001 is positive → renders as +0.00 even though it rounds to
+    // zero. The plus survives because it's set before toFixed.
+    expect(formatSG(0.001)).toBe('+0.00')
+    expect(formatSG(-0.001)).toBe('-0.00')
+  })
+
+  it('handles large magnitudes', () => {
+    expect(formatSG(123.4567)).toBe('+123.46')
+    expect(formatSG(-99.99)).toBe('-99.99')
+  })
+
+  it('NaN renders as "NaN" (does not throw)', () => {
+    // Documents current behavior — keeps a downstream surprise audit
+    // honest. Caller should gate on Number.isFinite before formatting.
+    expect(formatSG(Number.NaN)).toBe('NaN')
+  })
+})
+
+describe('formatToPar', () => {
+  it('positive diff gets a + prefix', () => {
+    expect(formatToPar(2)).toBe('+2')
+  })
+
+  it('negative diff keeps the - sign', () => {
+    expect(formatToPar(-2)).toBe('-2')
+  })
+
+  it('zero renders as E', () => {
+    expect(formatToPar(0)).toBe('E')
+  })
+
+  it('multi-digit values format correctly', () => {
+    expect(formatToPar(10)).toBe('+10')
+    expect(formatToPar(-15)).toBe('-15')
+  })
+})
+
+describe('unit constants', () => {
+  it('YARDS_TO_METERS round-trips with METERS_TO_YARDS within 5e-4', () => {
+    // The constants are 4-5 sig-fig rationals (0.9144 and 1.09361),
+    // not exact reciprocals — round-tripping 100 yd drifts by ~3e-4
+    // yards. Pin precision 3 (tolerance ±5e-4) so the test catches a
+    // typo (e.g. 1.0936 dropped a digit → drift ~5e-3) but doesn't
+    // demand exactness the constants don't promise.
+    const yd = 100
+    const back = yd * YARDS_TO_METERS * METERS_TO_YARDS
+    expect(back).toBeCloseTo(yd, 3)
+  })
+
+  it('FEET_TO_YARDS converts 3 ft to 1 yd within 1e-4', () => {
+    expect(3 * FEET_TO_YARDS).toBeCloseTo(1, 4)
+  })
+
+  it('YARDS_TO_METERS is the canonical 0.9144', () => {
+    // Literal-pin: catches an accidental rewrite to 0.91 or 0.9144000.
+    expect(YARDS_TO_METERS).toBe(0.9144)
+  })
+})


### PR DESCRIPTION
## Summary
- 146 new unit tests across 6 files in \`packages/core/src/__tests__/\` covering the math kernel: units, SG baselines, per-shot/per-round SG, detailed stats, post-round row builder, and putt-result mapping.
- 203 tests pass total (57 pre-existing + 146 new).

## Coverage highlights
- **Units** — \`haversineYards\` pinned to a precomputed great-circle (~5 yd tolerance, catches radius-constant or sin/cos regressions). \`toRadians\`, \`formatSG\`, \`formatToPar\` covered including NaN propagation.
- **Baselines** — \`getHandicapBracket\` tested at every cutoff (n-1, n, n+1). \`interpolateBaseline\` covered for clamp-low, clamp-high, midpoint, off-center, and empty-table throw. Concrete value pins (e.g. scratch from 150 yd ≈ 3.12) so a baseline edit breaks loudly.
- **SG** — Driveable par-4 scenario, 3-putt from 6 ft, hole-out from 50 yd, and par-3 routing all assert specific hand-computed values (\`toBeCloseTo\`). Direct coverage for \`getExpectedStrokes\`, \`averageSGBreakdown\`, \`computeRoundSG\` adapter.
- **Stats** — \`computeDetailedStats\` empty-input, \`sgTrend\` chronological order, scoring distribution buckets, scrambling / sand-save / up-and-down branches in \`shortGameStats\`, \`getProximityYards\` round/hole pin priority, exhaustive \`combinedPuttResult\` matrix.
- **Inference** — Club selection at every bucket boundary (driver, 3w, 4i, lw), confidence levels, \`getShotCategory\` branch priority (around-green vs off-tee at 30 yd).
- **Round** — \`buildInitialRows\` for empty, single-shot, multi-shot, on-green-last, and off-green-last cases. \`decombinedPuttResult\` and \`legacySlopeToAxes\` over their full input space.

## Review process
Two specialist agents reviewed the initial draft:
- **qa-expert** flagged tautologies (table[k] returned by lookup(table, k)), broken logic (test title vs assertion), and coverage gaps (\`getExpectedStrokes\`, \`computeRoundSG\`, \`scramblingPct\`, etc.).
- **silent-failure-hunter** flagged loose tolerances (\`toBeGreaterThan\` instead of \`toBeCloseTo\` with hand-computed values), monotone tests seeded with \`-Infinity\` (vacuous first iteration), and \`not.toBe('green')\` where the specific value should be asserted.

All findings addressed in this commit. Tests now pin specific numeric values rather than asserting one-sided ranges, and monotone tests use a finite seed so the first iteration is bounded.

Closes #38

## Test plan
- [x] \`pnpm test\` — 203 / 203 tests passing across 10 files
- [x] \`pnpm typecheck\` — 3 packages clean (web, core, supabase)
- [x] No tests modified the impl — only additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)