### PR TITLE
perf: GreenDiagram, hot queries, mobile grab-bag, useMemo wrappers (#36 #49 #50 #52)

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -4,6 +4,7 @@ import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { ErrorBoundary } from '../../components/errors/ErrorBoundary'
+import { UnitsProvider } from '../../contexts/UnitsContext'
 
 const ICON_SIZE = 18
 
@@ -51,6 +52,7 @@ export default function AppLayout() {
 
   return (
     <ErrorBoundary>
+    <UnitsProvider>
     <Tabs
       screenOptions={{
         headerShown: false,
@@ -131,6 +133,7 @@ export default function AppLayout() {
       <Tabs.Screen name="round/[id]/index" options={{ href: null }} />
       <Tabs.Screen name="round/[id]/hole/[number]" options={{ href: null }} />
     </Tabs>
+    </UnitsProvider>
     </ErrorBoundary>
   )
 }

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Dimensions, Pressable, ScrollView, Text, View } from 'react-native'
+import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
 import { Link } from 'expo-router'
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
 import { Swipeable } from 'react-native-gesture-handler'
@@ -53,7 +53,7 @@ export default function Home() {
   } | null>(null)
   const [deleting, setDeleting] = useState(false)
   const swipeRefs = useRef<Map<string, Swipeable | null>>(new Map())
-  const screenWidth = Dimensions.get('window').width
+  const { width: screenWidth } = useWindowDimensions()
 
   const handleDelete = useCallback(
     async (id: string) => {

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
 import { Link } from 'expo-router'
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
@@ -105,17 +105,24 @@ export default function Home() {
       .catch(() => undefined)
   }, [])
 
-  const breakdown = SG_KEYS.map((c) => {
-    const values = rounds.map((r) => r[c.key]).filter((v): v is number => v !== null)
-    const avg = values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length
-    return { ...c, value: Number(avg.toFixed(2)) }
-  })
-  const maxAbs = Math.max(...breakdown.map((b) => Math.abs(b.value)), 0.5)
-
-  const trend = [...rounds].reverse().map((r, i) => ({
-    x: i + 1,
-    y: r.sg_total ?? 0,
-  }))
+  // SG breakdown + trend are pure functions of `rounds` — memoize so
+  // unrelated parent re-renders (delete sync, window resize) don't
+  // re-walk the array four times for the SG averages and once more for
+  // the trend points.
+  const { breakdown, maxAbs, trend } = useMemo(() => {
+    const bd = SG_KEYS.map((c) => {
+      const values = rounds.map((r) => r[c.key]).filter((v): v is number => v !== null)
+      const avg =
+        values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length
+      return { ...c, value: Number(avg.toFixed(2)) }
+    })
+    const maxAbsValue = Math.max(...bd.map((b) => Math.abs(b.value)), 0.5)
+    const trendPoints = [...rounds].reverse().map((r, i) => ({
+      x: i + 1,
+      y: r.sg_total ?? 0,
+    }))
+    return { breakdown: bd, maxAbs: maxAbsValue, trend: trendPoints }
+  }, [rounds])
 
   const eyebrow =
     profile?.handicap_index != null ? `Handicap ${profile.handicap_index}` : 'Welcome'

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -82,7 +82,7 @@ export default function Home() {
         console.error('[home/getProfile]', error.message)
         return
       }
-      if (data) setProfile(data)
+      if (data) setProfile(data as unknown as Profile)
     })
     getRecentSGData(supabase, user.id, 20).then(({ data, error }) => {
       if (!active) return

--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Dimensions, Pressable, ScrollView, Text, View } from 'react-native'
+import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
 import Svg, { Circle, Ellipse, Line, Rect, Text as SvgText } from 'react-native-svg'
 import {
   CLUBS,
@@ -319,7 +319,7 @@ function DispersionPlot({
   points: DispersionPoint[]
   stats: DispersionStats | null
 }) {
-  const screenWidth = Dimensions.get('window').width
+  const { width: screenWidth } = useWindowDimensions()
   const size = Math.min(SVG_SIZE, screenWidth - 56)
 
   const maxAbs = Math.max(

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -57,7 +57,7 @@ export default function ProfileTab() {
       }
       if (!data) return
       hydratedUserIdRef.current = user.id
-      setProfile(data)
+      setProfile(data as unknown as Profile)
       setUsername(data.username ?? '')
       setHandicap(data.handicap_index?.toString() ?? '')
       setSkill(data.skill_level ?? null)

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -69,7 +69,21 @@ export default function Stats() {
     [rounds],
   )
 
-  const ordered = [...rounds].reverse()
+  // Pre-build the chart series once per rounds change. The inline
+  // ordered.map(...) inside <VictoryLine> previously rebuilt every
+  // chart-data array on every parent render (window resize, focus,
+  // etc.) and Victory then re-tessellated the lines.
+  const chartSeries = useMemo(() => {
+    const ordered = [...rounds].reverse()
+    return SERIES.map((s) => ({
+      key: s.key,
+      color: s.color,
+      data: ordered.map((r) => ({
+        x: new Date(r.played_at).getTime(),
+        y: r[s.key] ?? 0,
+      })),
+    }))
+  }, [rounds])
 
   return (
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
@@ -236,13 +250,10 @@ export default function Stats() {
                     grid: { stroke: '#EBE5D6' },
                   }}
                 />
-                {SERIES.map((s) => (
+                {chartSeries.map((s) => (
                   <VictoryLine
                     key={s.key}
-                    data={ordered.map((r) => ({
-                      x: new Date(r.played_at).getTime(),
-                      y: r[s.key] ?? 0,
-                    }))}
+                    data={s.data}
                     style={{ data: { stroke: s.color, strokeWidth: 1.5 } }}
                   />
                 ))}

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Dimensions, Pressable, ScrollView, Text, View } from 'react-native'
+import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
 import { formatSG } from '@oga/core'
 import { getRecentSGData } from '@oga/supabase'
@@ -39,7 +39,7 @@ export default function Stats() {
   const [n, setN] = useState<number>(10)
   const [rounds, setRounds] = useState<RecentRound[]>([])
   const [loading, setLoading] = useState(true)
-  const screenWidth = Dimensions.get('window').width
+  const { width: screenWidth } = useWindowDimensions()
 
   useEffect(() => {
     if (!user) return

--- a/apps/mobile/components/round/GreenDiagram.tsx
+++ b/apps/mobile/components/round/GreenDiagram.tsx
@@ -1,13 +1,20 @@
-import { useRef, useState } from 'react'
+import { useRef } from 'react'
 import { Text, View } from 'react-native'
 import Svg, { Circle, Ellipse, Line, Path } from 'react-native-svg'
 import {
   Gesture,
   GestureDetector,
 } from 'react-native-gesture-handler'
-import { runOnJS } from 'react-native-reanimated'
+import Animated, {
+  runOnJS,
+  useAnimatedProps,
+  useSharedValue,
+} from 'react-native-reanimated'
 import type { BreakDirection } from '@oga/core'
 import { useUnits } from '../../hooks/useUnits'
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle)
+const AnimatedPath = Animated.createAnimatedComponent(Path)
 
 export type { BreakDirection }
 
@@ -41,9 +48,15 @@ export function GreenDiagram({
   onAimChange,
 }: GreenDiagramProps) {
   const layoutRef = useRef<{ width: number } | null>(null)
-  const [aimDuringDrag, setAimDuringDrag] = useState<number | null>(null)
-  const startOffsetRef = useRef(aimOffsetInches)
   const { toDisplayFt } = useUnits()
+
+  // Drag is driven entirely by Reanimated shared values so the SVG
+  // handle + dotted curve can animate at 60fps on the UI thread.
+  // Committing back to React state happens once on gesture end — no
+  // setState per frame, no re-render of the whole diagram while dragging.
+  const offsetX = useSharedValue(0)
+  const startOffset = useSharedValue(aimOffsetInches)
+  const layoutWidth = useSharedValue(SVG_WIDTH)
 
   const pinY = breakDirection === 'uphill' ? 56 : breakDirection === 'downhill' ? 80 : 68
   const ballX = 150
@@ -57,44 +70,67 @@ export function GreenDiagram({
   const rightBackY = 100 + (breakDirection === 'uphill' ? -10 : 0)
   const trapezoid = `M30 ${leftFrontY} L270 ${rightFrontY} L240 ${rightBackY} L60 ${leftBackY} Z`
 
-  const currentOffset = aimDuringDrag ?? aimOffsetInches
-  const handleX = clamp(150 + currentOffset * PX_PER_INCH, 50, 250)
   const handleY = 150
-  const curveControlX = handleX * 0.6 + 150 * 0.4
+  const trajectoryEndY = pinY + 60
 
-  function setOffsetFromTranslation(translationX: number) {
+  function commitWithTranslation(translationX: number) {
     const w = layoutRef.current?.width ?? SVG_WIDTH
     const pxPerSvgX = w / SVG_WIDTH
     const offsetInchesDelta = translationX / pxPerSvgX / PX_PER_INCH
-    const next = Math.round(clamp(startOffsetRef.current + offsetInchesDelta, -50, 50))
-    setAimDuringDrag(next)
-  }
-
-  function commit() {
-    if (aimDuringDrag != null) onAimChange(aimDuringDrag)
-    setAimDuringDrag(null)
+    const next = Math.round(
+      clamp(aimOffsetInches + offsetInchesDelta, -50, 50),
+    )
+    if (next !== aimOffsetInches) onAimChange(next)
   }
 
   const pan = Gesture.Pan()
     .activeOffsetX([-2, 2])
     .onBegin(() => {
       'worklet'
-      runOnJS(rememberStart)(aimOffsetInches)
+      startOffset.value = aimOffsetInches
+      offsetX.value = 0
     })
     .onUpdate((e) => {
       'worklet'
-      runOnJS(setOffsetFromTranslation)(e.translationX)
+      offsetX.value = e.translationX
     })
-    .onEnd(() => {
+    .onEnd((e) => {
       'worklet'
-      runOnJS(commit)()
+      runOnJS(commitWithTranslation)(e.translationX)
+      offsetX.value = 0
     })
 
-  function rememberStart(start: number) {
-    startOffsetRef.current = start
-  }
+  // Worklet helpers — kept inline so each useAnimatedProps re-creates them
+  // with the latest closure values on prop change (e.g. breakDirection).
+  const handleProps = useAnimatedProps(() => {
+    'worklet'
+    const pxPerSvgX = layoutWidth.value / SVG_WIDTH
+    const deltaInches = offsetX.value / pxPerSvgX / PX_PER_INCH
+    const cx = clampWorklet(
+      150 + (startOffset.value + deltaInches) * PX_PER_INCH,
+      50,
+      250,
+    )
+    return { cx }
+  })
+  const trajectoryProps = useAnimatedProps(() => {
+    'worklet'
+    const pxPerSvgX = layoutWidth.value / SVG_WIDTH
+    const deltaInches = offsetX.value / pxPerSvgX / PX_PER_INCH
+    const handleX = clampWorklet(
+      150 + (startOffset.value + deltaInches) * PX_PER_INCH,
+      50,
+      250,
+    )
+    const curveControlX = handleX * 0.6 + 150 * 0.4
+    return {
+      d: `M${ballX} ${ballY} Q ${curveControlX} ${handleY} 150 ${trajectoryEndY}`,
+    }
+  })
 
-  const aimLabel = formatAim(currentOffset)
+  // Aim label only reflects committed values; intentional trade-off so
+  // the React tree stays still during the drag. Updates on release.
+  const aimLabel = formatAim(aimOffsetInches)
 
   return (
     <View
@@ -140,6 +176,7 @@ export function GreenDiagram({
         <View
           onLayout={(e) => {
             layoutRef.current = { width: e.nativeEvent.layout.width }
+            layoutWidth.value = e.nativeEvent.layout.width
           }}
           style={{ aspectRatio: SVG_WIDTH / SVG_HEIGHT, width: '100%' }}
         >
@@ -164,8 +201,8 @@ export function GreenDiagram({
             <Line x1={150} y1={pinY} x2={150} y2={pinY + 60} stroke="#1C211C" strokeWidth={1.5} />
             <Path d={`M150 ${pinY} L168 ${pinY + 8} L150 ${pinY + 16} Z`} fill="#A33A2A" />
             <Ellipse cx={150} cy={pinY + 60} rx={6} ry={2} fill="#1C211C" opacity={0.75} />
-            <Path
-              d={`M${ballX} ${ballY} Q ${curveControlX} ${handleY} 150 ${pinY + 60}`}
+            <AnimatedPath
+              animatedProps={trajectoryProps}
               fill="none"
               stroke="#A66A1F"
               strokeWidth={1.5}
@@ -174,7 +211,14 @@ export function GreenDiagram({
             />
             <Ellipse cx={ballX} cy={ballY + 6} rx={8} ry={2.5} fill="rgba(28,33,28,0.35)" />
             <Circle cx={ballX} cy={ballY} r={6} fill="#FBF8F1" stroke="#1C211C" strokeWidth={1} />
-            <Circle cx={handleX} cy={handleY} r={12} fill="#A66A1F" stroke="#FBF8F1" strokeWidth={2} />
+            <AnimatedCircle
+              animatedProps={handleProps}
+              cy={handleY}
+              r={12}
+              fill="#A66A1F"
+              stroke="#FBF8F1"
+              strokeWidth={2}
+            />
           </Svg>
         </View>
       </GestureDetector>
@@ -195,6 +239,12 @@ export function GreenDiagram({
 }
 
 function clamp(n: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, n))
+}
+
+// Same as clamp but flagged as a worklet so it can run on the UI thread.
+function clampWorklet(n: number, min: number, max: number): number {
+  'worklet'
   return Math.min(max, Math.max(min, n))
 }
 

--- a/apps/mobile/contexts/UnitsContext.tsx
+++ b/apps/mobile/contexts/UnitsContext.tsx
@@ -1,0 +1,64 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import type { DistanceUnit } from '@oga/core'
+import { getProfile } from '@oga/supabase'
+import { supabase } from '../lib/supabase'
+import { useAuth } from '../hooks/useAuth'
+
+// Single profile fetch for the whole app session. Previously every
+// component instance that called useUnits ran its own getProfile —
+// roughly 36 redundant fetches on a populated round screen. Lift it to
+// one provider near the top of the app tree.
+
+interface UnitsContextValue {
+  unit: DistanceUnit
+  isYards: boolean
+  isMetres: boolean
+}
+
+const DEFAULT: UnitsContextValue = {
+  unit: 'yards',
+  isYards: true,
+  isMetres: false,
+}
+
+const UnitsContext = createContext<UnitsContextValue>(DEFAULT)
+
+export function UnitsProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth()
+  const [unit, setUnit] = useState<DistanceUnit>('yards')
+
+  useEffect(() => {
+    if (!user) return
+    let active = true
+    getProfile(supabase, user.id).then(({ data, error }) => {
+      if (!active) return
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.warn('[UnitsProvider/getProfile]', error.message)
+        return
+      }
+      if (!data) return
+      setUnit(data.distance_unit === 'meters' ? 'meters' : 'yards')
+    })
+    return () => {
+      active = false
+    }
+  }, [user?.id])
+
+  const value: UnitsContextValue = {
+    unit,
+    isYards: unit === 'yards',
+    isMetres: unit === 'meters',
+  }
+  return <UnitsContext.Provider value={value}>{children}</UnitsContext.Provider>
+}
+
+export function useUnitsContext(): UnitsContextValue {
+  return useContext(UnitsContext)
+}

--- a/apps/mobile/hooks/useUnits.ts
+++ b/apps/mobile/hooks/useUnits.ts
@@ -1,36 +1,14 @@
-import { useEffect, useState } from 'react'
 import { YARDS_TO_METERS, type DistanceUnit } from '@oga/core'
-import { getProfile } from '@oga/supabase'
-import { supabase } from '../lib/supabase'
-import { useAuth } from './useAuth'
+import { useUnitsContext } from '../contexts/UnitsContext'
 
 export type { DistanceUnit }
 
-// Mobile mirror of the web useUnits hook. Reads the profile's
-// distance_unit lazily — components can render with the default 'yards'
-// formatting while the value loads.
+// Reads the current distance unit from UnitsProvider — no per-call DB
+// fetch (see contexts/UnitsContext for the single shared fetch). Returns
+// the same { unit, toDisplay, toDisplayFt } shape the component tree
+// already depends on.
 export function useUnits() {
-  const { user } = useAuth()
-  const [unit, setUnit] = useState<DistanceUnit>('yards')
-
-  useEffect(() => {
-    if (!user) return
-    let active = true
-    getProfile(supabase, user.id).then(({ data, error }) => {
-      if (!active) return
-      if (error) {
-        // eslint-disable-next-line no-console
-        console.warn('[useUnits/getProfile]', error.message)
-        return
-      }
-      if (!data) return
-      if (data.distance_unit === 'meters') setUnit('meters')
-      else setUnit('yards')
-    })
-    return () => {
-      active = false
-    }
-  }, [user?.id])
+  const { unit } = useUnitsContext()
 
   function toDisplay(yards: number, decimals = 0): string {
     if (!Number.isFinite(yards)) return '—'

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -108,15 +108,14 @@ export async function setPendingShotEnd(
 
 export async function pendingShotsForHoleScore(holeScoreId: string): Promise<PendingShot[]> {
   const db = await getDb()
-  const rows = await db.getAllAsync<PendingShot>(
-    `SELECT * FROM pending_shots WHERE status = 'pending' ORDER BY created_at ASC`,
+  // Push the hole-score filter into SQLite via json_extract — previously
+  // every call pulled the entire pending queue and JS-filtered, which
+  // re-parsed every payload on every hole change.
+  return db.getAllAsync<PendingShot>(
+    `SELECT * FROM pending_shots
+     WHERE status = 'pending'
+       AND json_extract(payload, '$.hole_score_id') = ?
+     ORDER BY created_at ASC`,
+    holeScoreId,
   )
-  return rows.filter((r) => {
-    try {
-      const p = JSON.parse(r.payload) as ShotPayload
-      return p.hole_score_id === holeScoreId
-    } catch {
-      return false
-    }
-  })
 }

--- a/apps/web/src/hooks/useCompleteRound.ts
+++ b/apps/web/src/hooks/useCompleteRound.ts
@@ -69,7 +69,12 @@ export function useCompleteRound() {
         const { holes: _holes, ...rest } = row
         return rest
       })
-      const shots = (shotsRes.data ?? []) as ShotRow[]
+      // `as unknown as ShotRow[]` because getShotsForRound now narrows the
+      // select to the columns the SG calc actually reads — created_at is
+      // dropped at the DB level. computeRoundSG never touches it; the
+      // cast acknowledges the structural mismatch with the generated
+      // ShotRow row type.
+      const shots = (shotsRes.data ?? []) as unknown as ShotRow[]
       const tees: CourseTeeRow[] = teesRes.data ?? []
 
       const result = computeRoundSG({ holes, holeScores, shots, handicap })

--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -43,8 +43,14 @@ export function useCourseSearch(query: string) {
       ])
       const apiHits: OpenGolfApiSearchResult[] =
         api.status === 'fulfilled' ? api.value : []
+      // searchCourses now returns the narrow column subset (mapbox_id /
+      // created_by / created_at dropped). Cast via unknown to the wider
+      // CourseRow so consumers that pick up a course from this list and
+      // pass it around with the full row type still typecheck.
       const localRows: CourseRow[] =
-        local.status === 'fulfilled' ? local.value.data ?? [] : []
+        local.status === 'fulfilled'
+          ? ((local.value.data ?? []) as unknown as CourseRow[])
+          : []
       return {
         api: apiHits,
         local: localRows,

--- a/apps/web/src/hooks/useDetailedStats.ts
+++ b/apps/web/src/hooks/useDetailedStats.ts
@@ -27,13 +27,12 @@ export function useDetailedStats(limit: number): {
       const { data, error } = await getRoundsWithDetails(supabase, user!.id, limit)
       if (error) throw error
       // The Supabase types for nested joins (rounds → hole_scores → holes/shots)
-      // come back as unknown — there's no public typegen path that resolves the
-      // *, hole_scores(*, holes(*), shots(*)) shape. Cast is asserted here, not
-      // runtime-checked; if the schema or query changes, @oga/core/stats will
-      // throw a clear "cannot read property X of undefined" rather than a silent
-      // type lie. Re-run `supabase gen types` and adjust DetailedRound when the
-      // schema moves.
-      return (data ?? []) as DetailedRound[]
+      // come back as a narrow inferred shape (no created_at on shots, no notes
+      // on the round) because the select uses ROUND_COLUMNS / SHOT_COLUMNS.
+      // computeDetailedStats only reads the SG-relevant columns those lists
+      // include; the via-`unknown` cast acknowledges the structural mismatch
+      // without forcing the generated DetailedRound type to drop fields.
+      return (data ?? []) as unknown as DetailedRound[]
     },
   })
 

--- a/apps/web/src/hooks/useShots.ts
+++ b/apps/web/src/hooks/useShots.ts
@@ -7,6 +7,12 @@ import { useAuth } from './useAuth'
 type ShotInsert = Database['public']['Tables']['shots']['Insert']
 type ShotUpdate = Database['public']['Tables']['shots']['Update']
 
+// getShotsForRound's narrow column list matches every consumer of this
+// hook (no one reads created_at). Cast the inferred narrow shape back to
+// the canonical ShotRow so the call sites — ShotEntryModal's startEdit,
+// the round map's categorizeShot — keep their existing types.
+type ShotRow = Database['public']['Tables']['shots']['Row']
+
 export function useShotsForRound(roundId: string | undefined) {
   const { user } = useAuth()
   return useQuery({
@@ -15,7 +21,7 @@ export function useShotsForRound(roundId: string | undefined) {
     queryFn: async () => {
       const { data, error } = await getShotsForRound(supabase, roundId!, user!.id)
       if (error) throw error
-      return data ?? []
+      return (data ?? []) as unknown as ShotRow[]
     },
   })
 }

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import {
   CartesianGrid,
@@ -38,6 +39,41 @@ export function DashboardPage() {
   const firstName =
     profile.data?.username?.split(/\s+/)[0] ?? null
 
+  // All five reductions over the rounds array share the same dependency
+  // (`rounds`) and run on every render — wrap once so unrelated parent
+  // re-renders don't recompute SG averages, trend coords, and avg score
+  // from scratch. Hook stays above the early returns to keep call order
+  // stable across renders.
+  const stats = useMemo(() => {
+    const avgs = SG_KEYS.map((c) => {
+      const values = rounds
+        .map((r) => r[c.key])
+        .filter((v): v is number => v !== null)
+      const avg =
+        values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length
+      return { ...c, value: Number(avg.toFixed(2)) }
+    })
+    const maxAbs = Math.max(...avgs.map((a) => Math.abs(a.value)), 0.5)
+    const trendData = [...rounds].reverse().map((r) => ({
+      date: r.played_at,
+      sg: r.sg_total ?? 0,
+    }))
+    const totalScore = rounds.reduce((s, r) => s + (r.total_score ?? 0), 0)
+    const totalScoreCount = rounds.filter((r) => r.total_score !== null).length
+    const avgScore = totalScoreCount > 0 ? totalScore / totalScoreCount : 0
+    const totalSG = avgs.reduce((s, a) => s + a.value, 0)
+    const sortedDesc = [...avgs].sort((a, b) => b.value - a.value)
+    return {
+      avgs,
+      maxAbs,
+      trendData,
+      avgScore,
+      totalSG,
+      weakest: sortedDesc[sortedDesc.length - 1]!,
+      strongest: sortedDesc[0]!,
+    }
+  }, [rounds])
+
   if (sg.isLoading) {
     return <div className="text-caddie-ink-mute">Loading…</div>
   }
@@ -56,27 +92,7 @@ export function DashboardPage() {
     )
   }
 
-  const avgs = SG_KEYS.map((c) => {
-    const values = rounds.map((r) => r[c.key]).filter((v): v is number => v !== null)
-    const avg = values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length
-    return { ...c, value: Number(avg.toFixed(2)) }
-  })
-
-  const maxAbs = Math.max(...avgs.map((a) => Math.abs(a.value)), 0.5)
-
-  const trendData = [...rounds].reverse().map((r) => ({
-    date: r.played_at,
-    sg: r.sg_total ?? 0,
-  }))
-
-  const totalScore = rounds.reduce((s, r) => s + (r.total_score ?? 0), 0)
-  const totalScoreCount = rounds.filter((r) => r.total_score !== null).length
-  const avgScore = totalScoreCount > 0 ? totalScore / totalScoreCount : 0
-
-  const totalSG = avgs.reduce((s, a) => s + a.value, 0)
-
-  const weakest = [...avgs].sort((a, b) => a.value - b.value)[0]!
-  const strongest = [...avgs].sort((a, b) => b.value - a.value)[0]!
+  const { avgs, maxAbs, trendData, avgScore, totalSG, weakest, strongest } = stats
 
   return (
     <div>

--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import {
   CLUBS,
   LIE_TYPES,
@@ -338,27 +338,33 @@ function DispersionPlot({
   points: DispersionPoint[]
   stats: DispersionStats | null
 }) {
-  const maxAbs = Math.max(
-    ...points.map((p) =>
-      Math.max(Math.abs(p.lateralOffsetYards), Math.abs(p.distanceOffsetYards)),
-    ),
-    stats ? stats.cone95.lateral : 0,
-    stats ? stats.cone95.distance : 0,
-    20,
-  )
-  const range = maxAbs * 1.15
+  // Spread Math.max over every point ran on every render. Memoize the
+  // dispersion-derived geometry; chip-toggle re-renders no longer
+  // re-walk the points array.
+  const { maxAbs, range, scale, ticks } = useMemo(() => {
+    const max = Math.max(
+      ...points.map((p) =>
+        Math.max(Math.abs(p.lateralOffsetYards), Math.abs(p.distanceOffsetYards)),
+      ),
+      stats ? stats.cone95.lateral : 0,
+      stats ? stats.cone95.distance : 0,
+      20,
+    )
+    const r = max * 1.15
+    const s = (SVG_SIZE / 2) / r
+    const step = r > 50 ? 20 : r > 20 ? 10 : 5
+    const t: number[] = []
+    for (let v = step; v < r; v += step) {
+      t.push(v, -v)
+    }
+    return { maxAbs: max, range: r, scale: s, ticks: t }
+  }, [points, stats])
+
   const cx = SVG_SIZE / 2
   const cy = SVG_SIZE / 2
-  const scale = (SVG_SIZE / 2) / range
 
   const px = (lat: number) => cx + lat * scale
   const py = (dist: number) => cy - dist * scale
-
-  const tickStep = range > 50 ? 20 : range > 20 ? 10 : 5
-  const ticks: number[] = []
-  for (let t = tickStep; t < range; t += tickStep) {
-    ticks.push(t, -t)
-  }
 
   return (
     <svg

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -399,7 +399,7 @@ export function RoundDetailPage() {
             {holesPlayed}/18 holes scored
           </div>
           <RoundRatingLine
-            round={round.data}
+            round={round.data as unknown as RoundRow}
             tees={teesQuery.data ?? []}
           />
         </div>
@@ -468,7 +468,7 @@ export function RoundDetailPage() {
       {round.data.sg_total !== null && (
         <div style={{ marginBottom: 28 }}>
           <RoundSummary
-            round={round.data}
+            round={round.data as unknown as RoundRow}
             holes={holes}
             holeScores={holeScores}
             totalRoundsLogged={totalRoundsLogged}

--- a/packages/supabase/src/queries/courses.ts
+++ b/packages/supabase/src/queries/courses.ts
@@ -4,18 +4,22 @@ import type { Database } from '../types'
 type CourseInsert = Database['public']['Tables']['courses']['Insert']
 type HoleInsert = Database['public']['Tables']['holes']['Insert']
 
+// Cards / pickers only ever render name + city/state and need lat/lng for
+// the hole-map fallback; external_id keeps the OpenGolfAPI link reachable.
+const COURSE_COLUMNS = 'id, name, city, state, lat, lng, external_id'
+
 export function getCourses(client: OgaSupabaseClient) {
-  return client.from('courses').select('*').order('name')
+  return client.from('courses').select(COURSE_COLUMNS).order('name')
 }
 
 export function searchCourses(client: OgaSupabaseClient, query: string, limit = 10) {
   const trimmed = query.trim()
   if (!trimmed) {
-    return client.from('courses').select('*').order('name').limit(limit)
+    return client.from('courses').select(COURSE_COLUMNS).order('name').limit(limit)
   }
   return client
     .from('courses')
-    .select('*')
+    .select(COURSE_COLUMNS)
     .ilike('name', `%${trimmed}%`)
     .order('name')
     .limit(limit)
@@ -73,7 +77,7 @@ export function getCourseByExternalId(
 ) {
   return client
     .from('courses')
-    .select('*')
+    .select(COURSE_COLUMNS)
     .eq('external_id', externalId)
     .maybeSingle()
 }

--- a/packages/supabase/src/queries/profiles.ts
+++ b/packages/supabase/src/queries/profiles.ts
@@ -3,8 +3,14 @@ import type { Database } from '../types'
 
 type ProfileUpdate = Database['public']['Tables']['profiles']['Update']
 
+// Explicit column list — `select('*')` over-fetches every audit / metadata
+// column on every read. These seven are everything the apps actually
+// consume from the profile.
+const PROFILE_COLUMNS =
+  'id, username, handicap_index, skill_level, goal, facilities, distance_unit'
+
 export function getProfile(client: OgaSupabaseClient, userId: string) {
-  return client.from('profiles').select('*').eq('id', userId).single()
+  return client.from('profiles').select(PROFILE_COLUMNS).eq('id', userId).single()
 }
 
 export function updateProfile(

--- a/packages/supabase/src/queries/rounds.ts
+++ b/packages/supabase/src/queries/rounds.ts
@@ -1,13 +1,22 @@
 import type { OgaSupabaseClient } from '../client'
 import type { Database } from '../types'
+import { SHOT_COLUMNS } from './shots'
 
 type RoundInsert = Database['public']['Tables']['rounds']['Insert']
 type RoundUpdate = Database['public']['Tables']['rounds']['Update']
 
+// Explicit column list for the rounds row — drops audit columns and
+// `notes` (not displayed in any list/detail view today). Pair with
+// SHOT_COLUMNS for the nested shots() join so the stats/detail payload
+// no longer ships every audit column for every shot in every round.
+// Single literal so supabase-js's select-type inference doesn't collapse
+// to GenericStringError.
+const ROUND_COLUMNS = 'id, user_id, course_id, played_at, tee_color, total_score, total_putts, fairways_hit, fairways_total, gir, sg_off_tee, sg_approach, sg_around_green, sg_putting, sg_total, course_tee_id, score_differential' as const
+
 export function getRounds(client: OgaSupabaseClient, userId: string, limit = 20) {
   return client
     .from('rounds')
-    .select('*, courses(name, city, state)')
+    .select(`${ROUND_COLUMNS}, courses(name, city, state)`)
     .eq('user_id', userId)
     .order('played_at', { ascending: false })
     .limit(limit)
@@ -23,7 +32,9 @@ export function getRound(
 ) {
   return client
     .from('rounds')
-    .select('*, courses(name, city, state), hole_scores(*, holes(*), shots(*))')
+    .select(
+      `${ROUND_COLUMNS}, courses(name, city, state), hole_scores(*, holes(*), shots(${SHOT_COLUMNS}))`,
+    )
     .eq('id', roundId)
     .eq('user_id', userId)
     .single()
@@ -78,7 +89,7 @@ export function getRoundsWithDetails(
   return client
     .from('rounds')
     .select(
-      '*, courses(name), hole_scores(*, holes(*), shots(*))',
+      `${ROUND_COLUMNS}, courses(name), hole_scores(*, holes(*), shots(${SHOT_COLUMNS}))`,
     )
     .eq('user_id', userId)
     .order('played_at', { ascending: false })

--- a/packages/supabase/src/queries/shots.ts
+++ b/packages/supabase/src/queries/shots.ts
@@ -4,6 +4,15 @@ import type { Database } from '../types'
 type ShotInsert = Database['public']['Tables']['shots']['Insert']
 type ShotUpdate = Database['public']['Tables']['shots']['Update']
 
+// Explicit column list — `select('*')` was pulling created_at on every
+// shot row across stats, patterns, and round detail. Listing the columns
+// the apps actually read trims payload on every shot query (and on the
+// nested shots(...) join inside rounds queries — see ROUND_COLUMNS).
+// Kept as a single literal so supabase-js's PostgrestBuilder can parse
+// it at the type level (concatenation/`+` widens to plain `string`,
+// which collapses the response shape to GenericStringError).
+export const SHOT_COLUMNS = 'id, hole_score_id, user_id, shot_number, start_lat, start_lng, end_lat, end_lng, aim_lat, aim_lng, distance_to_target, club, lie_type, lie_slope, lie_slope_forward, lie_slope_side, shot_result, penalty, ob, aim_offset_yards, break_direction, putt_result, putt_distance_result, putt_direction_result, putt_distance_ft, putt_slope_pct, green_speed, notes' as const
+
 export function getShotsForRound(
   client: OgaSupabaseClient,
   roundId: string,
@@ -11,7 +20,7 @@ export function getShotsForRound(
 ) {
   return client
     .from('shots')
-    .select('*, hole_scores!inner(round_id, holes(number, par))')
+    .select(`${SHOT_COLUMNS}, hole_scores!inner(round_id, holes(number, par))`)
     .eq('hole_scores.round_id', roundId)
     .eq('user_id', userId)
     .order('shot_number')
@@ -25,7 +34,7 @@ export function getShotsByClub(
 ) {
   return client
     .from('shots')
-    .select('*')
+    .select(SHOT_COLUMNS)
     .eq('user_id', userId)
     .eq('club', club)
     .not('aim_lat', 'is', null)


### PR DESCRIPTION
## Summary

Four perf cleanup fixes, one commit each.

### `perf: GreenDiagram pan uses Reanimated shared values, setState on end only (#36)`
The pan gesture was calling `runOnJS(setOffsetFromTranslation)` every frame, kicking React setState on every drag tick — the whole SVG (trapezoid, pin, ball, trajectory, handle) re-rendered every frame.

Drive the drag entirely on the UI thread via shared values (`offsetX`, `startOffset`, `layoutWidth`) feeding `useAnimatedProps` for the moving handle (`AnimatedCircle.cx`) and dotted trajectory (`AnimatedPath.d`). React state only updates on gesture end. Trade-off: the aim label only refreshes on release.

### `perf: replace select(*) with explicit columns on hot query paths (#49)`
`select('*')` was the default everywhere. The worst offender: `hole_scores(*, holes(*), shots(*))` nested inside round detail / stats payloads, pulling audit columns for every shot in every round.

Added `SHOT_COLUMNS` / `ROUND_COLUMNS` / `COURSE_COLUMNS` / `PROFILE_COLUMNS` as single literal-typed constants so supabase-js's `PostgrestBuilder` preserves the inferred row shape (template-string interpolation preserves the literal type; `+` concatenation widens to plain `string` and collapses to `GenericStringError`).

Adapt consumers via `as unknown as <Row>` casts (with comments) where the narrow inferred shape no longer matches the generated `Database` row type.

### `perf: mobile useWindowDimensions, SQL filter pendingShots, UnitsContext (#50)`
- Three Home / Stats / Patterns screens read `Dimensions.get('window').width` at render time → `useWindowDimensions()` (reactive to orientation).
- `pendingShotsForHoleScore` was selecting every pending row and JS-filtering by `hole_score_id`. Pushed the filter into SQLite via `json_extract` on the JSON payload column.
- Lifted `useUnits`'s per-call `getProfile` fetch into a new `UnitsProvider` wrapping `(app)/_layout.tsx`. One profile fetch per session instead of ~36 redundant calls on a populated round screen.

### `perf: wrap inline reductions in useMemo on dashboard and stats (#52)`
Five reductions over `rounds` on `DashboardPage` were inline; `Math.max(...points.map(...))` on `ShotPatternsPage` was inline; mobile stats / home screens recomputed SG averages and trend points every render. Each wrapped in `useMemo` keyed on the source data. `DashboardPage`'s `useMemo` hoisted above the loading / empty-state early returns to keep hook call order stable.

Closes #36
Closes #49
Closes #50
Closes #52

## Test plan
- [x] `pnpm typecheck` (3/3) clean
- [x] mobile `npm run typecheck` clean
- [x] `pnpm test` — 205/205 pass
- [x] `pnpm --filter web build` succeeds
- [ ] Manual: pan the GreenDiagram on a mid-range Android, expect 60fps drag
- [ ] Manual: open Round detail, verify all SG / putts / FH / GIR display unchanged after column narrow
- [ ] Manual: rotate device on Home / Stats / Patterns, charts scale to new width
- [ ] Manual: log a round, verify pendingShotsForHoleScore returns the right shots

🤖 Generated with [Claude Code](https://claude.com/claude-code)