### PR TITLE
fix/perf: data integrity + perf audit batch (9 commits)

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -198,34 +198,50 @@ export default function HoleScreen() {
     lastSavedShotLocalIdRef.current = null
   }, [currentHoleScore?.id])
 
-  // Auto-place ball at current GPS position once per hole. Also keep
-  // gpsPosition fresh so we can detect when the player walks onto the green.
-  // Skipped in past-round mode since the player isn't on the course.
-  // Functional setBall preserves any manual placement (prev wins) without
-  // needing `ball` in deps — which would re-fire the GPS request mid-hole.
+  // Live GPS during the PLACE_BALL phase so the ball marker tracks the
+  // player as they walk between shots. The previous one-shot
+  // getCurrentPositionAsync left the ball at the position from the last
+  // tap-to-place — a player walking 40 yd while filling in shot
+  // metadata would see the next ball auto-placed at the stale spot.
+  //
+  // Subscription is torn down once the player taps "Mark ball here" and
+  // we leave PLACE_BALL — no need to keep the GPS radio active during
+  // SET_AIM / SHOT_DETAIL. Skipped entirely in past-round mode.
+  //
+  // Functional setBall preserves any manual placement (prev wins): once
+  // the player drags the ball, watchPosition still updates gpsPosition
+  // for the nearPin proximity check but doesn't clobber the manual pin.
   useEffect(() => {
     if (!currentHole) return
     if (isPastMode) return
+    if (roundState !== 'PLACE_BALL') return
     let active = true
+    let subscription: Location.LocationSubscription | null = null
     ;(async () => {
       try {
         const perm = await Location.requestForegroundPermissionsAsync()
         if (perm.status !== 'granted') return
-        const loc = await Location.getCurrentPositionAsync({
-          accuracy: Location.Accuracy.High,
-        })
         if (!active) return
-        const pos = { lat: loc.coords.latitude, lng: loc.coords.longitude }
-        setGpsPosition(pos)
-        setBall((prev) => prev ?? pos)
+        subscription = await Location.watchPositionAsync(
+          {
+            accuracy: Location.Accuracy.BestForNavigation,
+            distanceInterval: 2,
+          },
+          (loc) => {
+            const pos = { lat: loc.coords.latitude, lng: loc.coords.longitude }
+            setGpsPosition(pos)
+            setBall((prev) => prev ?? pos)
+          },
+        )
       } catch {
         // GPS not available — user will tap to place.
       }
     })()
     return () => {
       active = false
+      subscription?.remove()
     }
-  }, [currentHole?.id, isPastMode])
+  }, [currentHole?.id, isPastMode, roundState])
 
   // Highlight "On the green" once the player is within 80 yd of the stored
   // pin AND a per-round pin hasn't been captured yet.

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -13,6 +13,7 @@ import {
   formatLocation,
   getOpenGolfApiCourse,
   searchOpenGolfApi,
+  todayLocalDate,
   type OpenGolfApiSearchResult,
 } from '@oga/core'
 import {
@@ -143,7 +144,7 @@ export default function NewRound() {
     setBusy(true)
     setError(null)
     try {
-      const today = new Date().toISOString().slice(0, 10)
+      const today = todayLocalDate()
       const { data: round, error: roundError } = await createRound(supabase, {
         user_id: user.id,
         course_id: courseId,

--- a/apps/mobile/hooks/useUnits.ts
+++ b/apps/mobile/hooks/useUnits.ts
@@ -1,4 +1,4 @@
-import { YARDS_TO_METERS, type DistanceUnit } from '@oga/core'
+import { formatDistance, formatPuttDistance, type DistanceUnit } from '@oga/core'
 import { useUnitsContext } from '../contexts/UnitsContext'
 
 export type { DistanceUnit }
@@ -6,27 +6,17 @@ export type { DistanceUnit }
 // Reads the current distance unit from UnitsProvider — no per-call DB
 // fetch (see contexts/UnitsContext for the single shared fetch). Returns
 // the same { unit, toDisplay, toDisplayFt } shape the component tree
-// already depends on.
+// already depends on; formatters are imported from @oga/core so the
+// conversion factors don't drift between web and mobile.
 export function useUnits() {
   const { unit } = useUnitsContext()
 
   function toDisplay(yards: number, decimals = 0): string {
-    if (!Number.isFinite(yards)) return '—'
-    if (unit === 'meters') {
-      return (yards * YARDS_TO_METERS).toFixed(decimals) + ' m'
-    }
-    return yards.toFixed(decimals) + ' yd'
+    return formatDistance(yards, unit, decimals)
   }
 
-  // Putt distances render in cm under metric mode — most metric
-  // golfers still call putt distance in centimetres even when other
-  // distances are metres. Feet under yards mode.
-  function toDisplayFt(feet: number, _decimals = 1): string {
-    if (!Number.isFinite(feet)) return '—'
-    if (unit === 'meters') {
-      return Math.round(feet * 30.48) + ' cm'
-    }
-    return Math.round(feet) + ' ft'
+  function toDisplayFt(feet: number): string {
+    return formatPuttDistance(feet, unit)
   }
 
   return { unit, toDisplay, toDisplayFt }

--- a/apps/web/src/components/auth/ProfileGuard.tsx
+++ b/apps/web/src/components/auth/ProfileGuard.tsx
@@ -1,94 +1,42 @@
-import { useEffect, useState } from 'react'
 import { Navigate } from 'react-router-dom'
-import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
-
-type ProfileState = 'loading' | 'complete' | 'incomplete' | 'error'
+import { useProfile } from '../../hooks/useProfile'
 
 export function ProfileGuard({ children }: { children: React.ReactNode }) {
   const { user, loading: authLoading } = useAuth()
-  const [profileState, setProfileState] = useState<ProfileState>('loading')
+  // Reads the same React Query cache the rest of the app does so we don't
+  // issue a second profiles query on every protected route mount. Earlier
+  // version called supabase.from('profiles').select(...) directly here.
+  const { data: profile, isLoading: profileLoading, isError } = useProfile()
 
-  useEffect(() => {
-    if (authLoading) return
-    if (!user) return
-
-    let active = true
-    supabase
-      .from('profiles')
-      .select('skill_level, goal')
-      .eq('id', user.id)
-      .maybeSingle()
-      .then(({ data, error }) => {
-        if (!active) return
-        if (error) {
-          // Real failure (network, RLS misconfig). Don't punish the user
-          // by punting them to onboarding — surface the issue and stop.
-          // eslint-disable-next-line no-console
-          console.error('[ProfileGuard]', error.message)
-          setProfileState('error')
-          return
-        }
-        // No row, or row missing required onboarding fields.
-        if (!data || !data.skill_level || !data.goal) {
-          setProfileState('incomplete')
-        } else {
-          setProfileState('complete')
-        }
-      })
-    return () => {
-      active = false
-    }
-  }, [user, authLoading])
-
-  if (authLoading || profileState === 'loading') {
+  if (authLoading || (user && profileLoading)) {
     return (
-      <div
-        style={{
-          minHeight: '100vh',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          fontFamily: 'Inter, sans-serif',
-          fontSize: 13,
-          color: 'var(--caddie-ink-dim)',
-          backgroundColor: 'var(--caddie-bg)',
-        }}
-      >
+      <div className="min-h-screen flex items-center justify-center bg-caddie-bg font-sans text-meta text-caddie-ink-dim">
         Loading…
       </div>
     )
   }
   if (!user) return <Navigate to="/login" replace />
-  if (profileState === 'error') {
-    // Soft error screen so a transient network blip doesn't redirect a
-    // fully-onboarded user to /onboarding (which would clobber their
-    // profile on save).
+
+  // Soft error screen so a transient network blip doesn't redirect a
+  // fully-onboarded user to /onboarding (which would clobber their
+  // profile on save).
+  if (isError) {
     return (
-      <div
-        style={{
-          minHeight: '100vh',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexDirection: 'column',
-          gap: 14,
-          fontFamily: 'Inter, sans-serif',
-          backgroundColor: 'var(--caddie-bg)',
-          color: 'var(--caddie-ink)',
-          padding: 28,
-          textAlign: 'center',
-        }}
-      >
-        <div style={{ fontFamily: 'Fraunces, serif', fontStyle: 'italic', fontSize: 22 }}>
+      <div className="min-h-screen flex flex-col items-center justify-center gap-3 bg-caddie-bg font-sans text-caddie-ink p-7 text-center">
+        <div className="font-serif italic text-h2">
           Couldn't load your profile.
         </div>
-        <div style={{ fontSize: 13, color: 'var(--caddie-ink-dim)' }}>
+        <div className="text-meta text-caddie-ink-dim">
           Check your connection and reload.
         </div>
       </div>
     )
   }
-  if (profileState === 'incomplete') return <Navigate to="/onboarding" replace />
+
+  if (!profile || !profile.skill_level || !profile.goal) {
+    return <Navigate to="/onboarding" replace />
+  }
+
   return <>{children}</>
 }

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -377,7 +377,7 @@ export function ShotEntryModal({
                       >
                         {s.club ?? '—'}
                         {s.lie_type
-                          ? ` · ${LIE_TYPE_LABELS[s.lie_type] ?? s.lie_type}`
+                          ? ` · ${LIE_TYPE_LABELS[s.lie_type as LieType] ?? s.lie_type}`
                           : ''}
                       </div>
                       <div
@@ -764,7 +764,8 @@ export function ShotEntryModal({
 function formatShotSummary(s: ShotRow): string {
   if (s.lie_type === 'green' || s.club === 'putter') {
     const result =
-      (s.putt_result && PUTT_RESULT_LABELS[s.putt_result]) ??
+      (s.putt_result &&
+        PUTT_RESULT_LABELS[s.putt_result as keyof typeof PUTT_RESULT_LABELS]) ??
       s.putt_result ??
       null
     const distance =
@@ -773,7 +774,7 @@ function formatShotSummary(s: ShotRow): string {
     return parts.length ? parts.join(' · ') : '—'
   }
   if (s.shot_result) {
-    return SHOT_RESULT_LABELS[s.shot_result] ?? s.shot_result
+    return SHOT_RESULT_LABELS[s.shot_result as ShotResult] ?? s.shot_result
   }
   return '—'
 }

--- a/apps/web/src/hooks/useUnits.ts
+++ b/apps/web/src/hooks/useUnits.ts
@@ -1,4 +1,4 @@
-import { YARDS_TO_METERS, type DistanceUnit } from '@oga/core'
+import { formatDistance, formatPuttDistance, type DistanceUnit } from '@oga/core'
 import { useProfile } from './useProfile'
 
 export type { DistanceUnit }
@@ -8,22 +8,11 @@ export function useUnits() {
   const unit: DistanceUnit = profile?.distance_unit ?? 'yards'
 
   function toDisplay(yards: number, decimals = 0): string {
-    if (!Number.isFinite(yards)) return '—'
-    if (unit === 'meters') {
-      return (yards * YARDS_TO_METERS).toFixed(decimals) + ' m'
-    }
-    return yards.toFixed(decimals) + ' yd'
+    return formatDistance(yards, unit, decimals)
   }
 
-  // Putt distances render in feet under yards mode (US golf convention)
-  // and in centimetres under metres mode — golfers in metric countries
-  // still call putts in cm even when other distances are metres.
-  function toDisplayFt(feet: number, _decimals = 1): string {
-    if (!Number.isFinite(feet)) return '—'
-    if (unit === 'meters') {
-      return Math.round(feet * 30.48) + ' cm'
-    }
-    return Math.round(feet) + ' ft'
+  function toDisplayFt(feet: number): string {
+    return formatPuttDistance(feet, unit)
   }
 
   return { unit, toDisplay, toDisplayFt }

--- a/apps/web/src/pages/rounds/NewRoundPage.tsx
+++ b/apps/web/src/pages/rounds/NewRoundPage.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { todayLocalDate } from '@oga/core'
 import { CourseSearch } from '../../components/courses/CourseSearch'
 import { TeeSelector } from '../../components/courses/TeeSelector'
 import { useCreateRound } from '../../hooks/useRounds'
@@ -15,7 +16,7 @@ export function NewRoundPage() {
   const createRoundMutation = useCreateRound()
   const [courseId, setCourseId] = useState<string | null>(null)
   const [courseName, setCourseName] = useState('')
-  const [playedAt, setPlayedAt] = useState(() => new Date().toISOString().slice(0, 10))
+  const [playedAt, setPlayedAt] = useState(() => todayLocalDate())
   const [teeColor, setTeeColor] = useState<string>('white')
   const [courseTeeId, setCourseTeeId] = useState<string | null>(null)
   const [mode, setMode] = useState<RoundMode>('past')

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react'
 import { createBrowserRouter, Outlet, type RouteObject } from 'react-router-dom'
 import { AuthGuard } from './components/auth/AuthGuard'
 import { ProfileGuard } from './components/auth/ProfileGuard'
@@ -8,21 +9,46 @@ import { SignupPage } from './pages/auth/SignupPage'
 import { OnboardingPage } from './pages/onboarding/OnboardingPage'
 import { DashboardPage } from './pages/dashboard/DashboardPage'
 import { RoundsPage } from './pages/rounds/RoundsPage'
-import { RoundDetailPage } from './pages/rounds/RoundDetailPage'
 import { NewRoundPage } from './pages/rounds/NewRoundPage'
-import { StrokesGainedPage } from './pages/stats/StrokesGainedPage'
-import { ShotPatternsPage } from './pages/patterns/ShotPatternsPage'
 import { PracticePlanPage } from './pages/practice/PracticePlanPage'
 import { DrillLibraryPage } from './pages/practice/DrillLibraryPage'
-import { LearnPage } from './pages/learn/LearnPage'
 import { SettingsPage } from './pages/settings/SettingsPage'
+
+// Heavy / non-entry routes are loaded on demand. Entry routes (auth,
+// dashboard, rounds list, settings) stay eager so the initial paint
+// after sign-in doesn't waterfall on a chunk fetch.
+//
+// Pages use named exports, so the .then adapter wraps each module to
+// the { default } shape React.lazy expects.
+const StrokesGainedPage = lazy(() =>
+  import('./pages/stats/StrokesGainedPage').then((m) => ({ default: m.StrokesGainedPage })),
+)
+const ShotPatternsPage = lazy(() =>
+  import('./pages/patterns/ShotPatternsPage').then((m) => ({ default: m.ShotPatternsPage })),
+)
+const RoundDetailPage = lazy(() =>
+  import('./pages/rounds/RoundDetailPage').then((m) => ({ default: m.RoundDetailPage })),
+)
+const LearnPage = lazy(() =>
+  import('./pages/learn/LearnPage').then((m) => ({ default: m.LearnPage })),
+)
+
+function RouteFallback() {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center font-sans text-meta text-caddie-ink-dim">
+      Loading…
+    </div>
+  )
+}
 
 function ProtectedShell() {
   return (
     <AuthGuard>
       <ProfileGuard>
         <AppShell>
-          <Outlet />
+          <Suspense fallback={<RouteFallback />}>
+            <Outlet />
+          </Suspense>
         </AppShell>
       </ProfileGuard>
     </AuthGuard>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -6,4 +6,20 @@ export default defineConfig({
   server: {
     port: 5173,
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // Split the heaviest deps into their own chunks so the initial
+        // bundle isn't dragged down by Recharts (~400 KB) and Mapbox
+        // (only loaded by the round map, which is itself lazy). Routes
+        // that don't use Recharts (dashboard, rounds list, settings)
+        // skip its chunk entirely.
+        manualChunks: {
+          recharts: ['recharts'],
+          mapbox: ['mapbox-gl'],
+          core: ['@oga/core'],
+        },
+      },
+    },
+  },
 })

--- a/packages/core/src/__tests__/units.test.ts
+++ b/packages/core/src/__tests__/units.test.ts
@@ -10,6 +10,7 @@ import {
   formatSG,
   formatToPar,
   haversineYards,
+  todayLocalDate,
   toRadians,
 } from '../units'
 
@@ -211,5 +212,24 @@ describe('formatPuttDistance', () => {
   it('non-finite input renders em dash', () => {
     expect(formatPuttDistance(Number.NaN, 'yards')).toBe('—')
     expect(formatPuttDistance(Number.NaN, 'meters')).toBe('—')
+  })
+})
+
+describe('todayLocalDate', () => {
+  it('returns YYYY-MM-DD shape (10 chars, two dashes)', () => {
+    const out = todayLocalDate()
+    expect(out).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+
+  it('matches the host machine local date — not UTC', () => {
+    // Recreate the expected local date the same way the helper does so
+    // the test is timezone-stable in CI (whatever TZ the runner uses).
+    const d = new Date()
+    const expected = [
+      d.getFullYear(),
+      String(d.getMonth() + 1).padStart(2, '0'),
+      String(d.getDate()).padStart(2, '0'),
+    ].join('-')
+    expect(todayLocalDate()).toBe(expected)
   })
 })

--- a/packages/core/src/__tests__/units.test.ts
+++ b/packages/core/src/__tests__/units.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
+  FEET_TO_CM,
+  FEET_TO_METERS,
   FEET_TO_YARDS,
   METERS_TO_YARDS,
   YARDS_TO_METERS,
+  formatDistance,
+  formatPuttDistance,
   formatSG,
   formatToPar,
   haversineYards,
@@ -162,5 +166,50 @@ describe('unit constants', () => {
   it('YARDS_TO_METERS is the canonical 0.9144', () => {
     // Literal-pin: catches an accidental rewrite to 0.91 or 0.9144000.
     expect(YARDS_TO_METERS).toBe(0.9144)
+  })
+
+  it('FEET_TO_METERS is the canonical 0.3048', () => {
+    expect(FEET_TO_METERS).toBe(0.3048)
+  })
+
+  it('FEET_TO_CM is 30.48 — the magic number previously inlined in useUnits', () => {
+    expect(FEET_TO_CM).toBe(30.48)
+  })
+})
+
+describe('formatDistance', () => {
+  it('yards mode renders whole yards by default', () => {
+    expect(formatDistance(150, 'yards')).toBe('150 yd')
+  })
+
+  it('yards mode honours decimals param', () => {
+    expect(formatDistance(150.5, 'yards', 1)).toBe('150.5 yd')
+  })
+
+  it('meters mode converts and labels with m', () => {
+    // 150 yd × 0.9144 = 137.16 m → "137 m" at 0 dp
+    expect(formatDistance(150, 'meters')).toBe('137 m')
+  })
+
+  it('non-finite input renders em dash so callers do not need a guard', () => {
+    expect(formatDistance(Number.NaN, 'yards')).toBe('—')
+    expect(formatDistance(Number.POSITIVE_INFINITY, 'meters')).toBe('—')
+  })
+})
+
+describe('formatPuttDistance', () => {
+  it('yards mode renders rounded feet', () => {
+    expect(formatPuttDistance(8.4, 'yards')).toBe('8 ft')
+    expect(formatPuttDistance(8.5, 'yards')).toBe('9 ft')
+  })
+
+  it('meters mode renders rounded centimetres (golfers call putts in cm)', () => {
+    // 8 ft × 30.48 = 243.84 cm → 244 cm
+    expect(formatPuttDistance(8, 'meters')).toBe('244 cm')
+  })
+
+  it('non-finite input renders em dash', () => {
+    expect(formatPuttDistance(Number.NaN, 'yards')).toBe('—')
+    expect(formatPuttDistance(Number.NaN, 'meters')).toBe('—')
   })
 })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -72,47 +72,6 @@ export const SHOT_CATEGORIES = ['off_tee', 'approach', 'around_green', 'putting'
 // unexpected lands in the column.
 // ---------------------------------------------------------------------------
 
-export const BREAK_DIRECTION_LABELS: Record<string, string> = {
-  left_to_right: 'L → R',
-  right_to_left: 'R → L',
-  straight: 'Straight',
-  uphill: 'Uphill',
-  downhill: 'Downhill',
-  // Legacy single-letter values from pre-split rows.
-  left: 'L → R',
-  right: 'R → L',
-}
-
-export const PUTT_RESULT_LABELS: Record<string, string> = {
-  made: 'Made',
-  short: 'Short',
-  long: 'Long',
-  missed_left: 'Missed left',
-  missed_right: 'Missed right',
-}
-
-export const SHOT_RESULT_LABELS: Record<string, string> = {
-  solid: 'Solid',
-  push_right: 'Push right',
-  pull_left: 'Pull left',
-  fat: 'Fat',
-  thin: 'Thin',
-  shank: 'Shank',
-  topped: 'Topped',
-  penalty: 'Penalty',
-  ob: 'OB',
-}
-
-export const LIE_TYPE_LABELS: Record<string, string> = {
-  tee: 'Tee',
-  fairway: 'Fairway',
-  rough: 'Rough',
-  sand: 'Sand',
-  fringe: 'Fringe',
-  recovery: 'Recovery',
-  green: 'Green',
-}
-
 export type Club = (typeof CLUBS)[number]
 export type LieType = (typeof LIE_TYPES)[number]
 /** @deprecated kept for legacy reads; new code uses LieSlopeForward + LieSlopeSide. */
@@ -124,3 +83,67 @@ export type SkillLevel = (typeof SKILL_LEVELS)[number]
 export type Goal = (typeof GOALS)[number]
 export type Facility = (typeof FACILITIES)[number]
 export type ShotCategory = (typeof SHOT_CATEGORIES)[number]
+
+// Local types for the label maps below. BreakDirection / LegacyPuttResult
+// are mirrored in types.ts (which can't import from this file in the
+// reverse direction without a cycle); the union duplication is small
+// and locks the label maps to the exact set the DB enum allows.
+type BreakDirectionKey =
+  | 'left'
+  | 'right'
+  | 'straight'
+  | 'left_to_right'
+  | 'right_to_left'
+  | 'uphill'
+  | 'downhill'
+
+type LegacyPuttResultKey =
+  | 'made'
+  | 'short'
+  | 'long'
+  | 'missed_left'
+  | 'missed_right'
+
+// Adding a new value in BREAK_DIRECTION (etc.) without adding its label
+// is now a compile error — the previous Record<string, string> typing
+// silently rendered the raw enum value when a key was missing.
+export const BREAK_DIRECTION_LABELS: Record<BreakDirectionKey, string> = {
+  left_to_right: 'L → R',
+  right_to_left: 'R → L',
+  straight: 'Straight',
+  uphill: 'Uphill',
+  downhill: 'Downhill',
+  // Legacy single-letter values from pre-split rows.
+  left: 'L → R',
+  right: 'R → L',
+}
+
+export const PUTT_RESULT_LABELS: Record<LegacyPuttResultKey, string> = {
+  made: 'Made',
+  short: 'Short',
+  long: 'Long',
+  missed_left: 'Missed left',
+  missed_right: 'Missed right',
+}
+
+export const SHOT_RESULT_LABELS: Record<ShotResult, string> = {
+  solid: 'Solid',
+  push_right: 'Push right',
+  pull_left: 'Pull left',
+  fat: 'Fat',
+  thin: 'Thin',
+  shank: 'Shank',
+  topped: 'Topped',
+  penalty: 'Penalty',
+  ob: 'OB',
+}
+
+export const LIE_TYPE_LABELS: Record<LieType, string> = {
+  tee: 'Tee',
+  fairway: 'Fairway',
+  rough: 'Rough',
+  sand: 'Sand',
+  fringe: 'Fringe',
+  recovery: 'Recovery',
+  green: 'Green',
+}

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -3,7 +3,7 @@ import {
   getExpectedStrokes,
   getShotCategory,
 } from './sg-calculator'
-import type { LieSlopeForward, LieSlopeSide, ShotCategory } from './constants'
+import type { LieSlopeForward, LieSlopeSide, ShotCategory, ShotResult } from './constants'
 import { METERS_TO_YARDS, haversineYards, toRadians } from './units'
 import { RESULT_QUALITY } from './types'
 import type { Database } from '@oga/supabase'
@@ -544,7 +544,10 @@ export function costlyLies(rounds: DetailedRound[]): CostlyLieEntry[] {
   for (const { shots } of flatten(rounds)) {
     for (const s of shots) {
       if (!s.lie_type || !s.shot_result) continue
-      const q = RESULT_QUALITY[s.shot_result] ?? 0
+      // shot_result comes from the DB as unconstrained text; cast and
+      // fall back to 0 so an unknown value (legacy / hand-edited row)
+      // contributes neutrally rather than crashing or skewing the bucket.
+      const q = RESULT_QUALITY[s.shot_result as ShotResult] ?? 0
       const b = buckets.get(s.lie_type) ?? { sum: 0, n: 0 }
       b.sum += q
       b.n += 1
@@ -640,7 +643,7 @@ export function slopeImpact(rounds: DetailedRound[]): SlopeImpact {
   for (const { shots } of flatten(rounds)) {
     for (const s of shots) {
       if (!s.shot_result) continue
-      const q = RESULT_QUALITY[s.shot_result] ?? 0
+      const q = RESULT_QUALITY[s.shot_result as ShotResult] ?? 0
       const axes = readSlopeAxes(s)
       if (axes.forward) {
         const b = forwardBuckets.get(axes.forward) ?? { sum: 0, n: 0 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,7 +33,12 @@ export type PuttDirectionResult = 'left' | 'right'
 // Shot-result quality lookup used by stats heuristics (most costly lies,
 // slope impact, etc.). Lower = worse outcome. Domain constant — not a
 // view-config map; UI labels live in SHOT_RESULT_LABELS.
-export const RESULT_QUALITY: Record<string, number> = {
+//
+// Keyed on ShotResult so adding/removing a value in SHOT_RESULTS without
+// updating this map is a compile error rather than silently degrading
+// stats: an unknown shot_result would have read `undefined` here, used
+// as 0 via `?? 0` in stats.ts, neutralising the row.
+export const RESULT_QUALITY: Record<ShotResult, number> = {
   solid: 1,
   push_right: 0,
   pull_left: 0,

--- a/packages/core/src/units.ts
+++ b/packages/core/src/units.ts
@@ -3,9 +3,13 @@
 // the conversion factors don't drift. Storage stays canonical (yards on
 // land, feet on the green); display conversion is the caller's job.
 
+import type { DistanceUnit } from './types'
+
 export const YARDS_TO_METERS = 0.9144
 export const METERS_TO_YARDS = 1.09361
 export const FEET_TO_YARDS = 0.333333
+export const FEET_TO_METERS = 0.3048
+export const FEET_TO_CM = 30.48
 
 export function toRadians(deg: number): number {
   return (deg * Math.PI) / 180
@@ -37,4 +41,26 @@ export function formatSG(n: number): string {
 export function formatToPar(diff: number): string {
   if (diff === 0) return 'E'
   return diff > 0 ? `+${diff}` : `${diff}`
+}
+
+// Shot distances: yards under 'yards' mode, metres under 'meters'. Caller
+// picks decimals (default 0 = whole units, the live-round display default).
+export function formatDistance(yards: number, unit: DistanceUnit, decimals = 0): string {
+  if (!Number.isFinite(yards)) return '—'
+  if (unit === 'meters') {
+    return (yards * YARDS_TO_METERS).toFixed(decimals) + ' m'
+  }
+  return yards.toFixed(decimals) + ' yd'
+}
+
+// Putt distances: feet under 'yards' mode (US convention), centimetres
+// under 'meters' mode (metric golfers still call putt distance in cm even
+// when other distances are metres). Always whole units — sub-foot/cm
+// precision is noise on a putting surface.
+export function formatPuttDistance(feet: number, unit: DistanceUnit): string {
+  if (!Number.isFinite(feet)) return '—'
+  if (unit === 'meters') {
+    return Math.round(feet * FEET_TO_CM) + ' cm'
+  }
+  return Math.round(feet) + ' ft'
 }

--- a/packages/core/src/units.ts
+++ b/packages/core/src/units.ts
@@ -64,3 +64,17 @@ export function formatPuttDistance(feet: number, unit: DistanceUnit): string {
   }
   return Math.round(feet) + ' ft'
 }
+
+// Today's date as YYYY-MM-DD in the player's LOCAL timezone. The naive
+// `new Date().toISOString().slice(0, 10)` returns UTC, which records the
+// wrong date for evening play in any timezone west of UTC (after ~7 pm
+// CST a round logs as tomorrow). rounds.played_at is a `date` column in
+// the DB so we want the local calendar date, not the UTC one.
+export function todayLocalDate(): string {
+  const d = new Date()
+  return [
+    d.getFullYear(),
+    String(d.getMonth() + 1).padStart(2, '0'),
+    String(d.getDate()).padStart(2, '0'),
+  ].join('-')
+}

--- a/packages/supabase/src/queries/rounds.ts
+++ b/packages/supabase/src/queries/rounds.ts
@@ -81,6 +81,13 @@ export function getRecentSGData(client: OgaSupabaseClient, userId: string, limit
 
 // Rounds with full hole-score and shot detail nested. Used by the stats
 // page to compute per-band, per-club, and per-lie aggregates client-side.
+//
+// Stats consume only (number, par, pin_lat, pin_lng) from the joined
+// holes — pin_* drives the proximity fallback when hole_scores has no
+// per-round pin override. The join used to pull holes(*), shipping
+// tee_lat/tee_lng/yards/stroke_index/id/course_id for every hole on
+// every round (18 × 20 = 360 rows of unused columns per stats page
+// load). Narrow projection cuts ~60% of the per-hole payload.
 export function getRoundsWithDetails(
   client: OgaSupabaseClient,
   userId: string,
@@ -89,7 +96,7 @@ export function getRoundsWithDetails(
   return client
     .from('rounds')
     .select(
-      `${ROUND_COLUMNS}, courses(name), hole_scores(*, holes(*), shots(${SHOT_COLUMNS}))`,
+      `${ROUND_COLUMNS}, courses(name), hole_scores(*, holes(number, par, pin_lat, pin_lng), shots(${SHOT_COLUMNS}))`,
     )
     .eq('user_id', userId)
     .order('played_at', { ascending: false })

--- a/supabase/migrations/0015_performance_indexes.sql
+++ b/supabase/migrations/0015_performance_indexes.sql
@@ -1,0 +1,38 @@
+-- Performance indexes surfaced by the postgres-pro audit. Each one targets
+-- a query pattern that currently does a heap fetch / filesort / seqscan
+-- and will hurt at scale (1000+ users, 10000+ rounds).
+--
+-- All four use IF NOT EXISTS so the migration is safe to re-run against a
+-- partially-applied environment.
+
+-- 1. hole_scores RLS policy uses
+--      EXISTS (SELECT 1 FROM rounds WHERE id = round_id AND user_id = auth.uid())
+--    The PK index covers `id` alone, forcing a heap fetch for the user_id
+--    check on every matched row. INCLUDE (user_id) puts user_id in the
+--    index leaf so the planner can satisfy the policy index-only.
+create index if not exists rounds_id_user_covering
+  on public.rounds(id) include (user_id);
+
+-- 2. getShotsByClub filters on (user_id, club) AND `aim_lat IS NOT NULL`
+--    AND `end_lat IS NOT NULL`, then orders by created_at DESC. Existing
+--    shots_club_user_idx is (user_id, club) only — sort spills to disk
+--    and null-coordinate rows still get scanned. A partial composite
+--    that pre-filters nulls and pre-sorts created_at lets the planner
+--    serve the patterns page index-only on the filter + sort.
+create index if not exists shots_club_created_partial
+  on public.shots(user_id, club, created_at desc)
+  where aim_lat is not null and end_lat is not null;
+
+-- 3. getDrills filters drills.skill_levels (text[]) with `.contains([level])`,
+--    which translates to the @> operator. Without a GIN index this is a
+--    seqscan on every drill-picker render.
+create index if not exists drills_skill_levels_gin
+  on public.drills using gin(skill_levels);
+
+-- 4. Trigram index on courses.name to back the fuzzy course search work
+--    queued in #60. Created here so the index is in place before the
+--    feature lands; pg_trgm is a built-in Postgres extension on Supabase.
+create extension if not exists pg_trgm;
+
+create index if not exists courses_name_trgm
+  on public.courses using gin(name gin_trgm_ops);

--- a/supabase/migrations/0016_latlng_precision_and_profile_audit.sql
+++ b/supabase/migrations/0016_latlng_precision_and_profile_audit.sql
@@ -1,0 +1,65 @@
+-- Two storage / audit-quality cleanups from the DBA + postgres-pro audit.
+--
+-- 1. Lat/lng columns were declared bare `numeric` (arbitrary precision,
+--    18 bytes per value, blocks the planner from making accurate
+--    row-size estimates). GPS coordinates need no more than ~7 decimal
+--    places; double precision (8 bytes, IEEE 754 float64) is the
+--    canonical type for geo coordinates and halves storage per row.
+--
+--    Tables touched: courses, holes, hole_scores, shots. Postgres
+--    rebuilds dependent indexes (incl. shots_club_created_partial from
+--    0015) automatically on ALTER COLUMN TYPE.
+--
+-- 2. profiles had no updated_at column. handicap, skill_level,
+--    distance_unit, etc. all mutate; with no timestamp there's no way
+--    to detect a stale cache row or audit a recent change. Adds the
+--    column + a generic update_updated_at() trigger function (named
+--    generically so future tables can reuse it without a per-table
+--    function).
+
+-- ---------------------------------------------------------------------------
+-- 1. lat/lng → double precision
+-- ---------------------------------------------------------------------------
+alter table public.courses
+  alter column lat type double precision,
+  alter column lng type double precision;
+
+alter table public.holes
+  alter column tee_lat type double precision,
+  alter column tee_lng type double precision,
+  alter column pin_lat type double precision,
+  alter column pin_lng type double precision;
+
+alter table public.hole_scores
+  alter column pin_lat type double precision,
+  alter column pin_lng type double precision;
+
+alter table public.shots
+  alter column start_lat type double precision,
+  alter column start_lng type double precision,
+  alter column end_lat type double precision,
+  alter column end_lng type double precision,
+  alter column aim_lat type double precision,
+  alter column aim_lng type double precision;
+
+-- ---------------------------------------------------------------------------
+-- 2. profiles.updated_at + generic trigger
+-- ---------------------------------------------------------------------------
+alter table public.profiles
+  add column if not exists updated_at timestamptz not null default now();
+
+create or replace function public.update_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_updated_at on public.profiles;
+
+create trigger profiles_updated_at
+  before update on public.profiles
+  for each row execute function public.update_updated_at();


### PR DESCRIPTION
## Summary

Nine fixes from the 11-specialist audit covering data integrity, type safety, perf, and UX. Each is a separate commit so reviewing/reverting is granular.

| # | Type | What |
|---|------|------|
| 1 | refactor | Lift `formatDistance`/`formatPuttDistance` (and `FEET_TO_CM` magic) to `@oga/core/units.ts`. Web + mobile `useUnits` become thin wrappers. CLAUDE.md "pure logic in core" rule was being broken. |
| 2 | fix | Tighten `RESULT_QUALITY` + four label maps from `Record<string, *>` to domain-keyed records. Adding/removing a value without updating the map is now a compile error. Three call sites that index by raw DB string get explicit casts with the existing `?? raw` fallback. |
| 3 | fix | `ProfileGuard` was bypassing the React Query cache and issuing a fresh Supabase query on every protected route mount. Switched to `useProfile()`. Also replaced inline styles with Tailwind + `caddie-*` token classes (DESIGN.md compliance). |
| 4 | perf | Migration `0015_performance_indexes.sql`: covering index for `hole_scores` RLS, partial composite for `getShotsByClub` (with null filter + sort), GIN on `drills.skill_levels`, trigram on `courses.name` (prep for #60). |
| 5 | perf | Migration `0016_latlng_precision_and_profile_audit.sql`: bare `numeric` lat/lng → `double precision` (halves storage, better planner estimates) across courses/holes/hole_scores/shots. Adds `profiles.updated_at` + generic `update_updated_at()` trigger function. |
| 6 | fix | GPS `watchPositionAsync` during `PLACE_BALL` phase only. Previous `getCurrentPositionAsync` one-shot left ball at stale position; player walking 40+ yd between shots saw next ball at last spot. Subscription torn down on phase transition so the radio isn't held during metadata entry. |
| 7 | fix | Local date helper `todayLocalDate()` in `@oga/core`. Replaces `new Date().toISOString().slice(0, 10)` in web NewRoundPage + mobile `round/new.tsx`. Evening play in any non-UTC timezone was logging tomorrow's date. |
| 8 | perf | `getRoundsWithDetails` narrows `holes(*)` → `holes(number, par, pin_lat, pin_lng)`. ~60% smaller per-hole payload. `pin_*` kept because `getProximityYards` falls back to course-level pin when `hole_scores.pin_lat` is null. |
| 9 | perf | Web router `React.lazy()` heavy non-entry routes (StrokesGained, ShotPatterns, RoundDetail, Learn) + Vite `manualChunks` for recharts/mapbox/core. Initial bundle 795 KB → 106 KB gzip (-87%). Mapbox (492 KB gzip) only loads on `/rounds/:id`. Recharts only on `/stats` and `/patterns`. |

## Test plan

- [x] `pnpm install` clean
- [x] `pnpm typecheck` (core / supabase / web — all 3 cached green)
- [x] `apps/mobile` `npm run typecheck` clean
- [x] `pnpm --filter web build` succeeds with new chunking; chunk sizes per fix #9
- [x] `pnpm test` — 194 → 205 (+11 new tests for `formatDistance`, `formatPuttDistance`, `FEET_TO_CM`, `FEET_TO_METERS`, `todayLocalDate`)
- [ ] Manual: live round flow — confirm ball marker tracks GPS during PLACE_BALL, stops on SET_AIM
- [ ] Manual: evening sign-up (post-7pm CST) creates a round dated today, not tomorrow
- [ ] After merge: `supabase db push --linked` for migrations 0014 → 0016. Order matters: 0014 (security batch from PR #80) must apply first; 0015 references no 0014 objects but ordering is by filename. 0016 alters columns that 0015's partial index references — Postgres rebuilds the index on column type change automatically.

## Notes

- This branch is independent of `fix/security-critical` (PR #80) but they share the dev base after #80 merged. No conflicts expected.
- `packages/supabase/src/types.ts` was NOT regenerated for `profiles.updated_at` — types regen happens against a live database (`npx supabase gen types typescript --local`). Current code doesn't read the new column; will surface in types after the next regen.
- `course_tees` UPDATE service-role lockdown (PR #80) and ownership column (#72) are still the path to making course-tee writes safe. This batch doesn't touch that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)