### PR TITLE
fix: live round device testing batch (Samsung SM-S911U)

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -89,6 +89,9 @@ export default function HoleScreen() {
   // are derived via useMemo so an optimistic save and a slow re-load can't
   // disagree about how many shots / putts the user has logged.
   const [pendingForHole, setPendingForHole] = useState<PendingShot[]>([])
+  // Synced shot start positions for this hole. Combined with pending
+  // shot starts to render the breadcrumb of waypoints on the map.
+  const [remoteShotStarts, setRemoteShotStarts] = useState<LatLng[]>([])
   const [loggerOpen, setLoggerOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   // Pin placement is orthogonal to the shot phase machine. When true,
@@ -164,11 +167,13 @@ export default function HoleScreen() {
 
   // Reload remote + local shot/putt counts whenever the active hole_score
   // changes. Putts are counted as shots where club='putter' OR lie_type='green'.
+  // Also pulls remote shot start coords so the on-map waypoint breadcrumb
+  // survives a screen reload mid-hole.
   useEffect(() => {
     if (!currentHoleScore) return
     let active = true
     ;(async () => {
-      const [shotRes, puttRes, local] = await Promise.all([
+      const [shotRes, puttRes, startsRes, local] = await Promise.all([
         supabase
           .from('shots')
           .select('id', { count: 'exact', head: true })
@@ -178,11 +183,25 @@ export default function HoleScreen() {
           .select('id', { count: 'exact', head: true })
           .eq('hole_score_id', currentHoleScore.id)
           .or('club.eq.putter,lie_type.eq.green'),
+        supabase
+          .from('shots')
+          .select('shot_number, start_lat, start_lng')
+          .eq('hole_score_id', currentHoleScore.id)
+          .not('start_lat', 'is', null)
+          .not('start_lng', 'is', null)
+          .order('shot_number'),
         pendingShotsForHoleScore(currentHoleScore.id),
       ])
       if (!active) return
       setRemoteShotCount(shotRes.count ?? 0)
       setRemotePuttCount(puttRes.count ?? 0)
+      const starts: LatLng[] = []
+      for (const r of startsRes.data ?? []) {
+        if (r.start_lat != null && r.start_lng != null) {
+          starts.push({ lat: r.start_lat, lng: r.start_lng })
+        }
+      }
+      setRemoteShotStarts(starts)
       setPendingForHole(local)
     })()
     return () => {
@@ -255,6 +274,26 @@ export default function HoleScreen() {
   // of truth, never out of sync with the underlying queue. Putts are
   // counted as shots where club='putter' OR lie_type='green'.
   const localShotCount = pendingForHole.length
+
+  // Shot waypoints rendered on the map: synced shot starts followed by
+  // pending shot starts (in pending insertion order). The current ball
+  // is intentionally excluded — HoleMap appends it as the line's final
+  // segment so the ball can move while the breadcrumb stays.
+  const previousShots = useMemo(() => {
+    const out: LatLng[] = [...remoteShotStarts]
+    for (const r of pendingForHole) {
+      try {
+        const p = JSON.parse(r.payload) as ShotPayload
+        if (p.start_lat != null && p.start_lng != null) {
+          out.push({ lat: p.start_lat, lng: p.start_lng })
+        }
+      } catch {
+        // skip malformed pending payload
+      }
+    }
+    return out
+  }, [remoteShotStarts, pendingForHole])
+
   const localPuttCount = useMemo(() => {
     let n = 0
     for (const r of pendingForHole) {
@@ -325,6 +364,10 @@ export default function HoleScreen() {
       const isPutt = payload.club === 'putter' || payload.lie_type === 'green'
       // Append to the pending queue — counts derive from this so they can't
       // drift. Status starts 'pending' until syncPendingShots flips it.
+      // The breadcrumb derives previousShots from pendingForHole +
+      // remoteShotStarts (see useMemo above). Pending stays here until
+      // hole change refetches; remote starts refresh on next mount, so
+      // there's no double-count and no need to push optimistically.
       setPendingForHole((prev) => [
         ...prev,
         {
@@ -581,6 +624,7 @@ export default function HoleScreen() {
           tee={tee}
           aim={aim}
           ball={ball}
+          previousShots={previousShots}
           phase={
             pinPlacementOpen
               ? 'PIN'

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   Alert,
+  Modal,
   Pressable,
   ScrollView,
   Text,
@@ -19,6 +20,10 @@ import {
   ShotLogger,
   type ShotLoggerValue,
 } from '../../../../../components/round/ShotLogger'
+import {
+  PuttingSheet,
+  type PuttingValue,
+} from '../../../../../components/round/PuttingSheet'
 import { supabase } from '../../../../../lib/supabase'
 import { useAuth } from '../../../../../hooks/useAuth'
 import {
@@ -43,12 +48,21 @@ const FALLBACK_CENTER: LatLng = { lat: 40.0, lng: -75.0 }
 const PIN_PROMPT_RADIUS_YARDS = 80
 
 // Live-round state machine. Each shot loops through:
-//   PLACE_BALL → SET_AIM → SHOT_DETAIL → PLACE_BALL
+//   PLACE_BALL → SET_AIM → SHOT_DETAIL → PLACE_BALL    (off the green)
+//   PLACE_BALL → PUTTING → PLACE_BALL                  (within ~30 yd of pin)
 // PLACE_BALL: GPS auto-places ball, player drags to refine, confirms with
 //   "Mark ball here →".
 // SET_AIM: camera rotates so play direction is up; long-press drops aim.
 // SHOT_DETAIL: ShotLogger sheet open; save returns to PLACE_BALL.
-type RoundState = 'PLACE_BALL' | 'SET_AIM' | 'SHOT_DETAIL'
+// PUTTING: PuttingSheet open with green diagram; save returns to PLACE_BALL
+//   (player loops here for each successive putt).
+type RoundState = 'PLACE_BALL' | 'SET_AIM' | 'SHOT_DETAIL' | 'PUTTING'
+
+// Distance threshold where the workflow auto-switches to putting.
+// 30 yards lines up with the SG "around-green" boundary; once a player
+// is inside that radius they're on or chipping near the green and the
+// putting flow is more likely than the aim-line flow.
+const PUTTING_RADIUS_YARDS = 30
 
 const KICKER: import('react-native').TextStyle = {
   fontSize: 10,
@@ -477,6 +491,16 @@ export default function HoleScreen() {
       lastSavedShotLocalIdRef.current = null
     }
     setAim(null)
+    // Auto-switch to the putting flow when the player has marked their
+    // position within ~30 yd of the pin — bypasses SET_AIM (long-press
+    // line) and SHOT_DETAIL (club/lie/result), since none of those
+    // matter on a putt. Falls back to the standard aim flow if no pin
+    // is known.
+    const pinTarget = roundPin ?? storedPin ?? null
+    if (pinTarget && distanceYards(ball, pinTarget) <= PUTTING_RADIUS_YARDS) {
+      setRoundState('PUTTING')
+      return
+    }
     setRoundState('SET_AIM')
   }
 
@@ -494,6 +518,31 @@ export default function HoleScreen() {
 
   function closeLogger() {
     setLoggerOpen(false)
+    setRoundState('PLACE_BALL')
+  }
+
+  // Map a PuttingValue into the ShotLoggerValue shape persistShot
+  // expects, then run the same persistence path. Forces club=putter and
+  // lieType=green so downstream stats classify these correctly without
+  // requiring the player to pick them out of a chip row.
+  async function persistPutt(v: PuttingValue) {
+    const meta: ShotLoggerValue = {
+      club: 'putter',
+      lieType: 'green',
+      puttMade: v.puttMade,
+      puttDistanceResult: v.puttDistanceResult,
+      puttDirectionResult: v.puttDirectionResult,
+      puttDistanceFt: v.puttDistanceFt,
+      puttSlopePct: v.puttSlopePct,
+      greenSpeed: v.greenSpeed,
+      breakDirection: v.breakDirection,
+      aimOffsetInches: v.aimOffsetInches,
+      notes: v.notes,
+    }
+    await persistShot(meta)
+  }
+
+  function closePuttingSheet() {
     setRoundState('PLACE_BALL')
   }
 
@@ -827,6 +876,28 @@ export default function HoleScreen() {
         onSkip={() => persistShot(null)}
         onClose={closeLogger}
       />
+
+      <Modal
+        visible={roundState === 'PUTTING'}
+        transparent
+        animationType="slide"
+        onRequestClose={closePuttingSheet}
+      >
+        <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
+          <PuttingSheet
+            shotNumber={shotNumber}
+            initialDistanceFt={
+              ball && (roundPin ?? storedPin)
+                ? Math.round(
+                    distanceYards(ball, (roundPin ?? storedPin) as LatLng) * 3,
+                  )
+                : undefined
+            }
+            onSave={persistPutt}
+            onClose={closePuttingSheet}
+          />
+        </View>
+      </Modal>
 
       <ConfirmDialog
         visible={confirmDelete}

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -116,6 +116,7 @@ export default function HoleScreen() {
   const [gpsPosition, setGpsPosition] = useState<LatLng | null>(null)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [scorecardOpen, setScorecardOpen] = useState(false)
 
   const currentHole = useMemo(
     () => holes.find((h) => h.number === holeNumber) ?? null,
@@ -581,6 +582,22 @@ export default function HoleScreen() {
     router.replace(`/(app)/round/${id}/hole/${next}`)
   }
 
+  // "Finish hole" advances to the next hole. The hole_score row's
+  // score/putts are already updated optimistically each time persistShot
+  // runs, so this is just navigation — no extra DB write needed. On hole
+  // 18 we jump back to the home screen where the just-completed round
+  // appears at the top of the recent-rounds list.
+  function finishHole() {
+    if (holeNumber < 18) {
+      router.replace(`/(app)/round/${id}/hole/${holeNumber + 1}`)
+    } else {
+      router.replace('/(app)')
+    }
+  }
+
+  const totalShotsThisHole =
+    remoteShotCount + localShotCount > 0 ? remoteShotCount + localShotCount : 0
+
   async function handleDeleteRound() {
     if (!round || !user) return
     setDeleting(true)
@@ -871,6 +888,30 @@ export default function HoleScreen() {
                     : 'On the green'}
               </Text>
             </Pressable>
+            {totalShotsThisHole > 0 && (
+              <Pressable
+                onPress={finishHole}
+                style={{
+                  borderWidth: 1,
+                  borderColor: '#1F3D2C',
+                  paddingVertical: 12,
+                  alignItems: 'center',
+                  marginBottom: 10,
+                  borderRadius: 2,
+                }}
+              >
+                <Text
+                  style={{
+                    color: '#1F3D2C',
+                    fontSize: 13,
+                    fontWeight: '600',
+                    letterSpacing: 0.3,
+                  }}
+                >
+                  {holeNumber < 18 ? `Finish hole · next →` : 'Finish round'}
+                </Text>
+              </Pressable>
+            )}
           </>
         )}
         <View
@@ -894,13 +935,17 @@ export default function HoleScreen() {
           >
             <Text style={{ fontSize: 12, color: '#1C211C' }}>← Prev</Text>
           </Pressable>
-          <View style={{ flex: 1 }}>
+          <Pressable
+            onPress={() => setScorecardOpen(true)}
+            style={{ flex: 1 }}
+            accessibilityLabel="Open scorecard"
+          >
             <ScorecardPreview
               holes={holes}
               holeScores={holeScores}
               currentHoleNumber={holeNumber}
             />
-          </View>
+          </Pressable>
           <Pressable
             onPress={() => navigateHole(1)}
             disabled={holeNumber === 18}
@@ -964,6 +1009,270 @@ export default function HoleScreen() {
         onConfirm={handleDeleteRound}
         onCancel={() => setConfirmDelete(false)}
       />
+
+      <Modal
+        visible={scorecardOpen}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setScorecardOpen(false)}
+      >
+        <ScorecardModal
+          holes={holes}
+          holeScores={holeScores}
+          currentHoleNumber={holeNumber}
+          onJumpToHole={(n) => {
+            setScorecardOpen(false)
+            if (n !== holeNumber) {
+              router.replace(`/(app)/round/${id}/hole/${n}`)
+            }
+          }}
+          onClose={() => setScorecardOpen(false)}
+        />
+      </Modal>
+    </View>
+  )
+}
+
+function ScorecardModal({
+  holes,
+  holeScores,
+  currentHoleNumber,
+  onJumpToHole,
+  onClose,
+}: {
+  holes: HoleRow[]
+  holeScores: HoleScoreRow[]
+  currentHoleNumber: number
+  onJumpToHole: (n: number) => void
+  onClose: () => void
+}) {
+  const scoresByHoleId = useMemo(
+    () => new Map(holeScores.map((hs) => [hs.hole_id, hs])),
+    [holeScores],
+  )
+  const sorted = useMemo(
+    () => [...holes].sort((a, b) => a.number - b.number),
+    [holes],
+  )
+  let runningTotal = 0
+  let runningPar = 0
+  return (
+    <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' }}>
+      <Pressable style={{ flex: 1 }} onPress={onClose} />
+      <View
+        style={{
+          backgroundColor: '#FBF8F1',
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+          paddingHorizontal: 18,
+          paddingTop: 14,
+          paddingBottom: 28,
+          maxHeight: '85%',
+        }}
+      >
+        <View
+          style={{
+            alignSelf: 'center',
+            width: 32,
+            height: 4,
+            borderRadius: 2,
+            backgroundColor: '#D9D2BF',
+            marginBottom: 14,
+          }}
+        />
+        <Text
+          style={{
+            ...KICKER,
+            color: '#8A8B7E',
+            marginBottom: 6,
+          }}
+        >
+          Scorecard
+        </Text>
+        <ScrollView
+          style={{ maxHeight: '90%' }}
+          showsVerticalScrollIndicator={false}
+        >
+          <View
+            style={{
+              flexDirection: 'row',
+              paddingVertical: 8,
+              borderBottomWidth: 1,
+              borderColor: '#D9D2BF',
+            }}
+          >
+            <Text style={{ ...KICKER, flex: 1, color: '#8A8B7E' }}>Hole</Text>
+            <Text
+              style={{ ...KICKER, width: 44, textAlign: 'right', color: '#8A8B7E' }}
+            >
+              Par
+            </Text>
+            <Text
+              style={{ ...KICKER, width: 56, textAlign: 'right', color: '#8A8B7E' }}
+            >
+              Score
+            </Text>
+            <Text
+              style={{ ...KICKER, width: 56, textAlign: 'right', color: '#8A8B7E' }}
+            >
+              +/−
+            </Text>
+          </View>
+          {sorted.map((h) => {
+            const hs = scoresByHoleId.get(h.id)
+            const score = hs?.score ?? null
+            if (score != null) {
+              runningTotal += score
+              runningPar += h.par
+            }
+            const diff = score != null ? score - h.par : null
+            const active = h.number === currentHoleNumber
+            return (
+              <Pressable
+                key={h.id}
+                onPress={() => onJumpToHole(h.number)}
+                style={{
+                  flexDirection: 'row',
+                  paddingVertical: 10,
+                  borderBottomWidth: 1,
+                  borderColor: '#EBE5D6',
+                  backgroundColor: active ? '#EBE5D6' : 'transparent',
+                  paddingHorizontal: 6,
+                  borderRadius: 2,
+                }}
+              >
+                <Text
+                  style={{
+                    flex: 1,
+                    fontSize: 15,
+                    color: '#1C211C',
+                    fontWeight: active ? '600' : '400',
+                  }}
+                >
+                  {h.number}
+                </Text>
+                <Text
+                  style={{
+                    width: 44,
+                    textAlign: 'right',
+                    fontSize: 15,
+                    color: '#5C6356',
+                    fontVariant: ['tabular-nums'],
+                  }}
+                >
+                  {h.par}
+                </Text>
+                <Text
+                  style={{
+                    width: 56,
+                    textAlign: 'right',
+                    fontSize: 15,
+                    color: score != null ? '#1C211C' : '#8A8B7E',
+                    fontVariant: ['tabular-nums'],
+                    fontWeight: '500',
+                  }}
+                >
+                  {score ?? '—'}
+                </Text>
+                <Text
+                  style={{
+                    width: 56,
+                    textAlign: 'right',
+                    fontSize: 15,
+                    color:
+                      diff == null
+                        ? '#8A8B7E'
+                        : diff < 0
+                          ? '#1F3D2C'
+                          : diff > 0
+                            ? '#A33A2A'
+                            : '#5C6356',
+                    fontVariant: ['tabular-nums'],
+                  }}
+                >
+                  {diff == null ? '—' : diff === 0 ? 'E' : diff > 0 ? `+${diff}` : `${diff}`}
+                </Text>
+              </Pressable>
+            )
+          })}
+          <View
+            style={{
+              flexDirection: 'row',
+              paddingVertical: 12,
+              borderTopWidth: 1,
+              borderColor: '#9F9580',
+              marginTop: 4,
+              paddingHorizontal: 6,
+            }}
+          >
+            <Text style={{ flex: 1, fontSize: 14, fontWeight: '600', color: '#1C211C' }}>
+              Total played
+            </Text>
+            <Text
+              style={{
+                width: 44,
+                textAlign: 'right',
+                fontSize: 14,
+                fontWeight: '600',
+                color: '#1C211C',
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {runningPar}
+            </Text>
+            <Text
+              style={{
+                width: 56,
+                textAlign: 'right',
+                fontSize: 14,
+                fontWeight: '600',
+                color: '#1C211C',
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {runningTotal}
+            </Text>
+            <Text
+              style={{
+                width: 56,
+                textAlign: 'right',
+                fontSize: 14,
+                fontWeight: '600',
+                color:
+                  runningPar === 0
+                    ? '#8A8B7E'
+                    : runningTotal - runningPar < 0
+                      ? '#1F3D2C'
+                      : runningTotal - runningPar > 0
+                        ? '#A33A2A'
+                        : '#5C6356',
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {runningPar === 0
+                ? '—'
+                : runningTotal === runningPar
+                  ? 'E'
+                  : runningTotal - runningPar > 0
+                    ? `+${runningTotal - runningPar}`
+                    : `${runningTotal - runningPar}`}
+            </Text>
+          </View>
+        </ScrollView>
+        <Pressable
+          onPress={onClose}
+          style={{
+            marginTop: 14,
+            paddingVertical: 12,
+            alignItems: 'center',
+            borderWidth: 1,
+            borderColor: '#D9D2BF',
+            borderRadius: 2,
+          }}
+        >
+          <Text style={{ ...KICKER, color: '#5C6356' }}>Close</Text>
+        </Pressable>
+      </View>
     </View>
   )
 }

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -442,6 +442,11 @@ export default function HoleScreen() {
 
   async function persistRoundPin(loc: LatLng) {
     if (!currentHoleScore) return
+    // Reject tap events that gave us non-finite coords — defensive
+    // guard so we never write null pin_lat by mistake (the original
+    // bug looked like "pin disappeared on tap" and likely traced to a
+    // malformed Mapbox tap feature on the device).
+    if (!Number.isFinite(loc.lat) || !Number.isFinite(loc.lng)) return
     // Optimistic update so the marker appears immediately.
     setHoleScores((prev) =>
       prev.map((hs) =>
@@ -457,6 +462,30 @@ export default function HoleScreen() {
       .eq('id', currentHoleScore.id)
     if (updateErr) {
       Alert.alert('Pin save failed', updateErr.message)
+    }
+  }
+
+  // Explicit "clear today's flag" action. The Cancel button in PIN
+  // mode used to just exit the mode without doing anything to the pin;
+  // device testing showed players wanted Cancel to also remove a
+  // mistakenly-placed flag. Sets pin_lat/pin_lng to null in the DB and
+  // optimistically in state.
+  async function clearRoundPin() {
+    if (!currentHoleScore) return
+    setHoleScores((prev) =>
+      prev.map((hs) =>
+        hs.id === currentHoleScore.id
+          ? { ...hs, pin_lat: null, pin_lng: null }
+          : hs,
+      ),
+    )
+    setPinPlacementOpen(false)
+    const { error: updateErr } = await supabase
+      .from('hole_scores')
+      .update({ pin_lat: null, pin_lng: null })
+      .eq('id', currentHoleScore.id)
+    if (updateErr) {
+      Alert.alert('Pin clear failed', updateErr.message)
     }
   }
 
@@ -698,28 +727,54 @@ export default function HoleScreen() {
         }}
       >
         {pinPlacementOpen ? (
-          <Pressable
-            onPress={() => setPinPlacementOpen(false)}
-            style={{
-              borderWidth: 1,
-              borderColor: '#1F3D2C',
-              paddingVertical: 14,
-              alignItems: 'center',
-              marginBottom: 10,
-              borderRadius: 2,
-            }}
-          >
-            <Text
+          <View style={{ flexDirection: 'row', gap: 8, marginBottom: 10 }}>
+            <Pressable
+              onPress={() => setPinPlacementOpen(false)}
               style={{
-                color: '#1F3D2C',
-                fontSize: 14,
-                fontWeight: '600',
-                letterSpacing: 0.3,
+                flex: 1,
+                borderWidth: 1,
+                borderColor: '#D9D2BF',
+                paddingVertical: 14,
+                alignItems: 'center',
+                borderRadius: 2,
               }}
             >
-              Cancel pin placement
-            </Text>
-          </Pressable>
+              <Text
+                style={{
+                  color: '#5C6356',
+                  fontSize: 14,
+                  fontWeight: '600',
+                  letterSpacing: 0.3,
+                }}
+              >
+                Cancel
+              </Text>
+            </Pressable>
+            {roundPin && (
+              <Pressable
+                onPress={clearRoundPin}
+                style={{
+                  flex: 1,
+                  borderWidth: 1,
+                  borderColor: '#A33A2A',
+                  paddingVertical: 14,
+                  alignItems: 'center',
+                  borderRadius: 2,
+                }}
+              >
+                <Text
+                  style={{
+                    color: '#A33A2A',
+                    fontSize: 14,
+                    fontWeight: '600',
+                    letterSpacing: 0.3,
+                  }}
+                >
+                  Clear flag
+                </Text>
+              </Pressable>
+            )}
+          </View>
         ) : roundState === 'SET_AIM' ? (
           <>
             <Pressable

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -338,15 +338,18 @@ export function HoleMap({
             </Mapbox.PointAnnotation>
           )}
 
-          {/* Stored hole pin: dim flag, only when no per-round pin. */}
-          {!roundPin && pin && (
+          {/* Stored hole pin: dim flag, only when no per-round pin.
+              Hidden in PIN mode so the annotation doesn't intercept the
+              tap that's supposed to place a new flag. */}
+          {!isPinMode && !roundPin && pin && (
             <Mapbox.PointAnnotation id="pin" coordinate={toCoord(pin)}>
               <Flag tone="dim" />
             </Mapbox.PointAnnotation>
           )}
 
-          {/* Per-round pin: prominent flag. */}
-          {roundPin && (
+          {/* Per-round pin: prominent flag. Hidden in PIN mode for the
+              same reason — taps need to reach the map below. */}
+          {!isPinMode && roundPin && (
             <Mapbox.PointAnnotation id="roundPin" coordinate={toCoord(roundPin)}>
               <Flag tone="strong" />
             </Mapbox.PointAnnotation>

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -35,6 +35,14 @@ interface HoleMapProps {
   tee?: LatLng | null
   aim?: LatLng | null
   ball?: LatLng | null
+  /**
+   * Previously-logged shot start positions, in shot order. Rendered as
+   * small amber waypoints with a line connecting consecutive points
+   * AND a final segment from the last waypoint to the current ball, so
+   * the player has a visible breadcrumb of how they got to the
+   * current position. Pass an empty array (or omit) on shot 1.
+   */
+  previousShots?: LatLng[]
   phase?: HoleMapPhase
   onSetAim: (loc: LatLng) => void
   onSetBall: (loc: LatLng) => void
@@ -61,6 +69,7 @@ export function HoleMap({
   tee,
   aim,
   ball,
+  previousShots,
   phase = 'PLACE_BALL',
   onSetAim,
   onSetBall,
@@ -235,6 +244,24 @@ export function HoleMap({
     return { lat: (ball.lat + aim.lat) / 2, lng: (ball.lng + aim.lng) / 2 }
   }, [isAimPhase, ball, aim])
 
+  // Breadcrumb line through every previous shot start, with a final
+  // segment to the current ball so the most recent leg is visible too.
+  // Filtered to require at least 2 points so the LineString geometry
+  // is valid.
+  const previousShotsLine = useMemo(() => {
+    const pts: LatLng[] = previousShots ?? []
+    const ordered = ball ? [...pts, ball] : pts
+    if (ordered.length < 2) return null
+    return {
+      type: 'Feature' as const,
+      properties: {},
+      geometry: {
+        type: 'LineString' as const,
+        coordinates: ordered.map(toCoord),
+      },
+    }
+  }, [previousShots, ball?.lat, ball?.lng])
+
   function handleTap(feature: unknown) {
     const c = extractCoord(feature)
     if (!c) return
@@ -266,6 +293,30 @@ export function HoleMap({
               pitch: 0,
             }}
           />
+
+          {!isPinMode && previousShotsLine && (
+            <Mapbox.ShapeSource id="prevShotsLine" shape={previousShotsLine}>
+              <Mapbox.LineLayer
+                id="prevShotsLineLayer"
+                style={{
+                  lineColor: '#A66A1F',
+                  lineWidth: 1.5,
+                  lineOpacity: 0.7,
+                }}
+              />
+            </Mapbox.ShapeSource>
+          )}
+
+          {!isPinMode &&
+            (previousShots ?? []).map((p, i) => (
+              <Mapbox.PointAnnotation
+                key={`prev-shot-${i}`}
+                id={`prev-shot-${i}`}
+                coordinate={toCoord(p)}
+              >
+                <Marker color="#A66A1F" border="#FBF8F1" size={9} />
+              </Mapbox.PointAnnotation>
+            ))}
 
           {aimLine && (
             <Mapbox.ShapeSource id="aimLine" shape={aimLine}>

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -180,9 +180,14 @@ export function HoleMap({
   }, [ball?.lat, ball?.lng, phase])
 
   // SET_AIM: rotate the camera so direction-of-play (ball → pin) is
-  // toward the top of the screen, zoom out enough to see both ends of
-  // the hole, and tilt for a first-person-ish perspective. The 1.2s
-  // duration is the satisfying UX moment that signals "now aim".
+  // toward the top of the screen, zoom to fit the shot ahead, and
+  // tilt for a first-person-ish perspective. The 1.2s duration is
+  // the satisfying UX moment that signals "now aim".
+  //
+  // Zoom adapts to ball→pin distance so a 90-yd wedge frames the
+  // green tightly while a 380-yd par 5 still shows fairway + green.
+  // Fixed zoom 15 was too far out for short approaches and too close
+  // on long par 5s.
   useEffect(() => {
     if (!isAimPhase) return
     if (!cameraRef.current) return
@@ -198,9 +203,18 @@ export function HoleMap({
       ? (Math.atan2(target.lng - ball.lng, target.lat - ball.lat) * 180) /
         Math.PI
       : 0
+    const distYd = target ? distanceYards(ball, target) : null
+    const zoom =
+      distYd == null
+        ? 15
+        : distYd < 150
+          ? 16
+          : distYd <= 300
+            ? 15
+            : 14
     cameraRef.current.setCamera({
       centerCoordinate: toCoord(focus),
-      zoomLevel: 15,
+      zoomLevel: zoom,
       pitch: 30,
       heading: bearing,
       animationDuration: 1200,

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -111,13 +111,18 @@ export function HoleMap({
   // (e.g. GPS deltas while standing on the tee) should not retrigger
   // setCamera — the style was reloading and the satellite tiles would flash
   // back to a black canvas every time.
+  //
+  // PLACE_BALL is flat top-down (pitch 0) — tilt only happens on the
+  // SET_AIM transition below. A tilted tee-box camera was disorienting
+  // on the device because it framed grass at an angle before the player
+  // had even decided what they were aiming at.
   useEffect(() => {
     if (cameraInitialized.current) return
     if (!cameraRef.current) return
     cameraRef.current.setCamera({
       centerCoordinate: toCoord(center),
       zoomLevel: 17,
-      pitch: 45,
+      pitch: 0,
       animationDuration: 400,
     })
     cameraInitialized.current = true
@@ -158,7 +163,7 @@ export function HoleMap({
     cameraRef.current.setCamera({
       centerCoordinate: toCoord(ball),
       zoomLevel: 17,
-      pitch: 45,
+      pitch: 0,
       heading: 0,
       animationDuration: 800,
     })
@@ -258,7 +263,7 @@ export function HoleMap({
             defaultSettings={{
               centerCoordinate: toCoord(center),
               zoomLevel: 17,
-              pitch: 45,
+              pitch: 0,
             }}
           />
 

--- a/apps/mobile/lib/supabase.ts
+++ b/apps/mobile/lib/supabase.ts
@@ -2,14 +2,77 @@ import 'react-native-url-polyfill/auto'
 import * as SecureStore from 'expo-secure-store'
 import { createOgaClient } from '@oga/supabase'
 
-// Supabase session (access + refresh JWTs) is stored in expo-secure-store,
-// which wraps Android Keystore / iOS Keychain. Refresh tokens are long-lived;
-// AsyncStorage was plaintext on disk, replayable from rooted devices, ADB
-// backups, and sibling apps with FS access.
+// expo-secure-store is backed by Android Keystore / iOS Keychain. Both
+// have a per-key payload limit (Android: 2048 bytes; iOS keychain is
+// looser). Supabase session JSON typically exceeds 2 KB once the access
+// token + refresh token + user metadata are all in there, which triggers
+// a "value larger than 2048 bytes" warning on Android and on some
+// devices fails outright.
+//
+// The adapter chunks long values across `${key}_0`, `${key}_1`, …
+// keys with a sentinel `${key}_chunks` recording the count, and
+// reassembles on read. Values under the chunk size still write to the
+// raw key for back-compat with sessions stored before this fix.
+const CHUNK_SIZE = 1800
+
 const SecureStoreAdapter = {
-  getItem: (key: string) => SecureStore.getItemAsync(key),
-  setItem: (key: string, value: string) => SecureStore.setItemAsync(key, value),
-  removeItem: (key: string) => SecureStore.deleteItemAsync(key),
+  getItem: async (key: string): Promise<string | null> => {
+    const chunkCountRaw = await SecureStore.getItemAsync(`${key}_chunks`)
+    if (chunkCountRaw) {
+      const chunkCount = parseInt(chunkCountRaw, 10)
+      if (!Number.isFinite(chunkCount) || chunkCount <= 0) return null
+      const chunks: string[] = []
+      for (let i = 0; i < chunkCount; i++) {
+        const chunk = await SecureStore.getItemAsync(`${key}_${i}`)
+        if (chunk == null) return null
+        chunks.push(chunk)
+      }
+      return chunks.join('')
+    }
+    return SecureStore.getItemAsync(key)
+  },
+  setItem: async (key: string, value: string): Promise<void> => {
+    if (value.length > CHUNK_SIZE) {
+      const chunks: string[] = []
+      for (let i = 0; i < value.length; i += CHUNK_SIZE) {
+        chunks.push(value.slice(i, i + CHUNK_SIZE))
+      }
+      // Clear any previous unchunked write at this key so getItem
+      // doesn't see stale data from the back-compat fast-path branch.
+      await SecureStore.deleteItemAsync(key).catch(() => undefined)
+      await SecureStore.setItemAsync(`${key}_chunks`, String(chunks.length))
+      for (let i = 0; i < chunks.length; i++) {
+        await SecureStore.setItemAsync(`${key}_${i}`, chunks[i] ?? '')
+      }
+    } else {
+      // Clear any chunks from a previous larger write so the next read
+      // doesn't reassemble stale fragments.
+      const prevCountRaw = await SecureStore.getItemAsync(`${key}_chunks`)
+      if (prevCountRaw) {
+        const prev = parseInt(prevCountRaw, 10)
+        if (Number.isFinite(prev)) {
+          for (let i = 0; i < prev; i++) {
+            await SecureStore.deleteItemAsync(`${key}_${i}`).catch(() => undefined)
+          }
+        }
+        await SecureStore.deleteItemAsync(`${key}_chunks`).catch(() => undefined)
+      }
+      await SecureStore.setItemAsync(key, value)
+    }
+  },
+  removeItem: async (key: string): Promise<void> => {
+    const chunkCountRaw = await SecureStore.getItemAsync(`${key}_chunks`)
+    if (chunkCountRaw) {
+      const chunkCount = parseInt(chunkCountRaw, 10)
+      if (Number.isFinite(chunkCount)) {
+        for (let i = 0; i < chunkCount; i++) {
+          await SecureStore.deleteItemAsync(`${key}_${i}`).catch(() => undefined)
+        }
+      }
+      await SecureStore.deleteItemAsync(`${key}_chunks`).catch(() => undefined)
+    }
+    await SecureStore.deleteItemAsync(key).catch(() => undefined)
+  },
 }
 
 const url = process.env.EXPO_PUBLIC_SUPABASE_URL ?? ''


### PR DESCRIPTION
## Summary

Seven fixes from on-device testing on Samsung SM-S911U. Mostly live-round flow corrections — camera framing, gesture handlers, putting auto-trigger — plus a SecureStore Android Keystore size fix that surfaced once a real session JWT was being stored.

| # | Type | What |
|---|------|------|
| 1 | fix | **SecureStore JWT chunking** — Android Keystore caps payloads at 2048 bytes per key. Real Supabase sessions exceed that. Adapter now chunks `>1800 byte` values across `${key}_0`, `${key}_1`, … with a sentinel `${key}_chunks` counter. setItem clears stale chunks AND any prior unchunked write at the key. |
| 2 | fix | **Camera pitch 0 on PLACE_BALL** — tee-box framing was `pitch: 45` matching SET_AIM, which tilted grass at an angle on a screen the player needed flat for ball placement. Three call sites now use `pitch: 0`; tilt only happens on the SET_AIM transition. |
| 3 | fix | **Shot waypoint breadcrumb** — each shot's start renders as a small amber waypoint with a connector line through previous shots and a final segment to the current ball. Hole screen derives the array from `remoteShotStarts` (synced) + `pendingForHole` payloads (unsynced); the breadcrumb survives a hole reload mid-round. Hidden in PIN mode so taps reach the map. |
| 4 | fix | **Auto-PuttingSheet within 30 yd** — `markBallHere` checks `distanceYards(ball, pin) <= 30` and skips SET_AIM + SHOT_DETAIL, opening PuttingSheet directly. PuttingValue maps to ShotLoggerValue with forced `club='putter'`, `lieType='green'` so SG attribution behaves. New `PUTTING` state in the live-round state machine. |
| 5 | fix | **Pin tap places, cancel/clear split** — Mapbox `PointAnnotation` for the existing flag was intercepting taps in PIN mode (likely cause of the device-tested "tap clears the pin" report). Hide flag annotations in PIN mode so taps land on the map. `persistRoundPin` now guards against non-finite coords. Cancel button split into "Cancel" (exit mode unchanged) and "Clear flag" (only shown when a per-round pin exists). |
| 6 | feat | **Finish hole + scorecard modal** — "Finish hole · next →" CTA appears once any shot is logged on the hole; navigates to the next hole, or home on hole 18 (round summary lands there). The inline ScorecardPreview is now Pressable; tapping opens a full-screen scorecard modal listing all 18 holes with par, score, +/-, plus a Total played foot row. Row tap jumps to that hole. |
| 7 | fix | **Dynamic SET_AIM zoom** — zoom now bands by ball→pin distance: `<150 yd → 16`, `150-300 → 15`, `>300 → 14`. Fixed zoom 15 was wrong both ways: short approaches felt too far out, long par 5s too close. Falls back to 15 when no pin is known. |

## Test plan

- [x] `pnpm typecheck` (3/3 cached)
- [x] mobile `npm run typecheck` clean
- [x] `pnpm test` 205 passing
- [ ] Device: cold-start sign-in → verify SecureStore reassembles chunked JWT, no size warning
- [ ] Device: live round hole 1 — verify flat top-down camera on PLACE_BALL, tilt only after Mark ball here
- [ ] Device: log 3+ shots on a hole — verify amber waypoints + connector line render and persist on hole reload
- [ ] Device: walk within 30 yd of pin → verify Mark ball here jumps straight to PuttingSheet (not SET_AIM)
- [ ] Device: PIN mode → verify tap places flag (no longer clears); Clear flag button only visible when a per-round pin exists
- [ ] Device: log shot, tap "Finish hole" → next hole loads; on hole 18 returns to home
- [ ] Device: tap inline scorecard → modal opens with 18-row scorecard; tap row jumps to that hole
- [ ] Device: short wedge (~80 yd) vs long drive (~400 yd) — verify SET_AIM zoom adapts

🤖 Generated with [Claude Code](https://claude.com/claude-code)