### PR TITLE
chore: resolve preview.yml merge conflict markers on main

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,16 +39,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-<<<<<<< HEAD
-      - name: Mobile typecheck
-        run: |
-          cd packages/supabase && npm install --legacy-peer-deps
-          cd ../../apps/mobile && npm install --legacy-peer-deps && npm run typecheck
-=======
       - name: Install supabase package deps
         run: cd packages/supabase && npm install --legacy-peer-deps
       - name: Install core package deps
         run: cd packages/core && npm install --legacy-peer-deps
       - name: Mobile typecheck
         run: cd apps/mobile && npm install --legacy-peer-deps && npm run typecheck
->>>>>>> dev


### PR DESCRIPTION
## Summary
- Removes leftover `<<<<<<< HEAD` / `=======` / `>>>>>>> dev` conflict markers from `.github/workflows/preview.yml` on `main`.
- Adopts the `dev`-side resolution: install `packages/supabase` deps, then `packages/core` deps, then run mobile typecheck — matches CLAUDE.md's documented pre-install order and what `origin/dev` already ships.

## Why
`origin/main`'s `preview.yml` currently has unresolved conflict markers committed (introduced by `30dc3b5`). Any merge from `main` into a branch picks up the broken file and breaks YAML parsing — that's how it leaked back into local `dev` and a feature branch in this same session. `origin/dev` is already clean, so this brings `main` in line with it.

## Test plan
- [ ] GitHub Actions parses the YAML on this PR (no "Invalid workflow file" annotation).
- [ ] After merge, future merges from `main` no longer reintroduce conflict markers.