### PR TITLE
fix: add diagnostic logging to enrich phase fatal

### DIFF
--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -1021,6 +1021,32 @@ interface CourseRowMin {
   external_id: string | null
 }
 
+// Paginated fetch of OSM-imported courses for a state. Supabase's default
+// row cap is 1000 — paginating in 500-row chunks keeps us well under that
+// even if one state grows past it (and so we can see the ceiling in logs
+// instead of silently truncating).
+async function fetchOsmCoursesForState(
+  state: string,
+): Promise<CourseRowMin[]> {
+  const PAGE_SIZE = 500
+  const all: CourseRowMin[] = []
+  let from = 0
+  while (true) {
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id, name, external_id')
+      .eq('state', state)
+      .like('external_id', 'osm_%')
+      .range(from, from + PAGE_SIZE - 1)
+    if (error) throw error
+    const rows = (data ?? []) as CourseRowMin[]
+    all.push(...rows)
+    if (rows.length < PAGE_SIZE) break
+    from += PAGE_SIZE
+  }
+  return all
+}
+
 async function crawlEnrich(
   states: string[],
   force: boolean,
@@ -1048,13 +1074,26 @@ async function crawlEnrich(
     try {
       // OSM-imported courses for this state. Excludes manual or
       // already-OpenGolfAPI-imported courses to keep the scope tight.
-      const { data: courseRows, error: coursesErr } = await supabase
-        .from('courses')
-        .select('id, name, external_id')
-        .eq('state', state)
-        .like('external_id', 'osm_%')
-      if (coursesErr) throw coursesErr
-      const courses = (courseRows ?? []) as CourseRowMin[]
+      console.log(`[enrich:${state}] fetching courses from DB...`)
+      let courses: CourseRowMin[]
+      try {
+        courses = await fetchOsmCoursesForState(state)
+      } catch (err) {
+        const e = err as Error
+        console.error(`[enrich:${state}] DB fetch failed:`, {
+          message: e.message,
+          stack: e.stack,
+        })
+        await setCrawlState(crawlId, {
+          status: 'error',
+          itemsProcessed: 0,
+          errorMessage: `DB fetch failed: ${e.message}`,
+        })
+        continue
+      }
+      console.log(
+        `[enrich:${state}] fetched ${courses.length} courses from DB`,
+      )
       const targets = limit != null ? courses.slice(0, limit) : courses
       // Big states have hit OpenGolfAPI rate limits with the default 1100ms
       // cadence — bump to 2000ms when there's >200 to grind through.
@@ -1140,11 +1179,16 @@ async function crawlEnrich(
         `[enrich:${state}] done — ${stateEnriched} enriched, ${stateUnmatched} no-match, ${stateErrors} errors`,
       )
     } catch (err) {
-      console.error(`[enrich:${state}] fatal: ${(err as Error).message}`)
+      const e = err as Error
+      console.error(`[enrich:${state}] fatal: ${e.message}`)
+      console.error(`[enrich:${state}] fatal details:`, {
+        message: e.message,
+        stack: e.stack,
+      })
       await setCrawlState(crawlId, {
         status: 'error',
         itemsProcessed: stateProcessed,
-        errorMessage: (err as Error).message,
+        errorMessage: e.message,
       })
     }
   }


### PR DESCRIPTION
## Summary
- Add `[enrich:STATE] fatal details:` log (message + stack) on the outer state-level catch so we stop guessing where 'Bad Request' originates.
- Pull the OSM-course DB fetch out of the outer try and wrap it in its own try/catch with detailed logging — failure here now reports the cause and `continue`s to the next state instead of crashing the run.
- Paginate the courses query in 500-row chunks via `fetchOsmCoursesForState` so a state ≥1000 OSM courses (CA=868 already close, plus future growth) doesn't silently truncate at Supabase's default cap.
- Add progress markers `fetching courses from DB...` and `fetched N courses from DB` per state.

## Why
Re-runs of `enrich --states CA,FL` are dying at `[enrich:XX] fatal: Bad Request` with no further context, before any per-course log appears. Either the state-level Supabase query or some other pre-loop call is the source. This adds enough log surface to tell which one — and hardens the most likely candidate (the courses fetch) at the same time.

## Test plan
- [ ] Run `tsx scripts/crawl-courses.ts --source enrich --states CA` and observe either the new `fetched N courses from DB` line or the new `DB fetch failed:` block with stack — confirms where the failure is.
- [ ] Repeat for FL.
- [ ] On a small state (e.g. RI), confirm the new pagination still returns the same row count it did before.