### PR TITLE
chore: drop unused courses.mapbox_id column (0017)

### DIFF
--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -43,10 +43,10 @@ export function useCourseSearch(query: string) {
       ])
       const apiHits: OpenGolfApiSearchResult[] =
         api.status === 'fulfilled' ? api.value : []
-      // searchCourses now returns the narrow column subset (mapbox_id /
-      // created_by / created_at dropped). Cast via unknown to the wider
-      // CourseRow so consumers that pick up a course from this list and
-      // pass it around with the full row type still typecheck.
+      // searchCourses now returns the narrow column subset (created_by /
+      // created_at dropped). Cast via unknown to the wider CourseRow so
+      // consumers that pick up a course from this list and pass it around
+      // with the full row type still typecheck.
       const localRows: CourseRow[] =
         local.status === 'fulfilled'
           ? ((local.value.data ?? []) as unknown as CourseRow[])

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -56,7 +56,6 @@ export interface Database {
         Row: {
           id: string
           name: string
-          mapbox_id: string | null
           external_id: string | null
           created_by: string | null
           created_at: string
@@ -68,7 +67,6 @@ export interface Database {
         Insert: {
           id?: string
           name: string
-          mapbox_id?: string | null
           external_id?: string | null
           created_by?: string | null
           created_at?: string
@@ -80,7 +78,6 @@ export interface Database {
         Update: {
           id?: string
           name?: string
-          mapbox_id?: string | null
           external_id?: string | null
           created_by?: string | null
           created_at?: string

--- a/scripts/import-osm-course.ts
+++ b/scripts/import-osm-course.ts
@@ -369,7 +369,7 @@ async function upsertCourse(
 
   const { data, error } = await supabase
     .from('courses')
-    .insert({ name, mapbox_id: null, lat: centroid.lat, lng: centroid.lon })
+    .insert({ name, lat: centroid.lat, lng: centroid.lon })
     .select('id')
     .single()
   if (error || !data) throw error ?? new Error('course insert failed')

--- a/supabase/migrations/0017_drop_mapbox_id.sql
+++ b/supabase/migrations/0017_drop_mapbox_id.sql
@@ -1,0 +1,6 @@
+-- Drop unused courses.mapbox_id column. The Mapbox course-search integration
+-- never shipped — courses are linked via external_id (OpenGolfAPI / OSM)
+-- instead. Column has been NULL on every row in production.
+
+alter table public.courses
+  drop column if exists mapbox_id;


### PR DESCRIPTION
## Summary
- Adds migration \`0017_drop_mapbox_id.sql\` — \`alter table public.courses drop column if exists mapbox_id;\`.
- Removes \`mapbox_id\` from \`courses\` Row / Insert / Update in \`packages/supabase/src/types.ts\`.
- Drops the \`mapbox_id: null\` literal from \`scripts/import-osm-course.ts\` insert payload.
- Updates the stale comment in \`apps/web/src/hooks/useCourses.ts\` that referenced the now-gone column.

## Why
The Mapbox course-search integration was scoped but never shipped — courses are linked via \`external_id\` (OpenGolfAPI / OSM) instead. \`mapbox_id\` has been NULL on every row in production, and DECISIONS.md (and the surrounding code) treat \`external_id\` as the canonical course identifier. Dropping the column tightens the schema and removes a footgun for future inserts.

## Migration ordering
Next available number per CLAUDE.md was tracking 0014 in the doc, but \`supabase/migrations/\` already runs through \`0016_latlng_precision_and_profile_audit.sql\`, so this is correctly filed as \`0017_…\`.

## Test plan
- [x] \`pnpm typecheck\` passes (web + core + supabase).
- [x] \`pnpm --filter web build\` succeeds, no new warnings.
- [ ] \`npx supabase db reset\` against the migration set runs cleanly end-to-end.
- [ ] After deploy + apply, regenerate types via \`npx supabase gen types typescript --linked\` and confirm no diff vs the hand-edit in this PR.