### PR TITLE
fix: live round device-test fixes round 2

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
-import { Link } from 'expo-router'
+import { Link, useRouter } from 'expo-router'
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
 import { Swipeable } from 'react-native-gesture-handler'
 import { formatSG } from '@oga/core'
@@ -42,10 +42,18 @@ const KICKER: import('react-native').TextStyle = {
   textTransform: 'uppercase',
 }
 
+interface ActiveRound {
+  id: string
+  courseName: string
+  currentHole: number
+}
+
 export default function Home() {
   const { user } = useAuth()
+  const router = useRouter()
   const [profile, setProfile] = useState<Profile | null>(null)
   const [rounds, setRounds] = useState<RecentRound[]>([])
+  const [activeRound, setActiveRound] = useState<ActiveRound | null>(null)
   const [pending, setPending] = useState(0)
   const [pendingDelete, setPendingDelete] = useState<{
     id: string
@@ -105,6 +113,59 @@ export default function Home() {
       .catch(() => undefined)
   }, [])
 
+  // Active-round detection. Active = total_score IS NULL AND played_at
+  // within the last day, so a round abandoned a week ago doesn't haunt
+  // the home screen forever. The current hole is the highest hole the
+  // player has logged a score on, +1 (capped at 18) — so resuming
+  // jumps back to where they left off, not hole 1.
+  useEffect(() => {
+    if (!user) return
+    let active = true
+    ;(async () => {
+      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10)
+      const { data, error } = await supabase
+        .from('rounds')
+        .select('id, played_at, course_id, courses(name)')
+        .eq('user_id', user.id)
+        .is('total_score', null)
+        .gte('played_at', oneDayAgo)
+        .order('played_at', { ascending: false })
+        .limit(1)
+      if (!active || error || !data?.[0]) {
+        setActiveRound(null)
+        return
+      }
+      const round = data[0] as {
+        id: string
+        played_at: string
+        course_id: string
+        courses?: { name: string | null } | null
+      }
+      const { data: hs } = await supabase
+        .from('hole_scores')
+        .select('score, holes(number)')
+        .eq('round_id', round.id)
+        .gt('score', 0)
+      if (!active) return
+      const maxHole = (hs ?? []).reduce<number>((acc, row) => {
+        const n = (row as { holes?: { number?: number | null } | null }).holes
+          ?.number
+        return typeof n === 'number' && n > acc ? n : acc
+      }, 0)
+      const next = Math.min(18, Math.max(1, maxHole + 1))
+      setActiveRound({
+        id: round.id,
+        courseName: round.courses?.name ?? 'Round',
+        currentHole: next,
+      })
+    })()
+    return () => {
+      active = false
+    }
+  }, [user?.id])
+
   // SG breakdown + trend are pure functions of `rounds` — memoize so
   // unrelated parent re-renders (delete sync, window resize) don't
   // re-walk the array four times for the SG averages and once more for
@@ -147,6 +208,53 @@ export default function Home() {
         <Text style={{ color: '#5C6356', fontSize: 14, marginBottom: 22 }}>
           Last {rounds.length || 0} round{rounds.length === 1 ? '' : 's'}
         </Text>
+
+        {activeRound && (
+          <Pressable
+            onPress={() =>
+              router.push(
+                `/(app)/round/${activeRound.id}/hole/${activeRound.currentHole}?mode=live`,
+              )
+            }
+            style={{
+              borderWidth: 1,
+              borderColor: '#A66A1F',
+              borderRadius: 2,
+              paddingVertical: 14,
+              paddingHorizontal: 16,
+              marginBottom: 14,
+              backgroundColor: '#FBF8F1',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <View>
+              <Text style={{ ...KICKER, color: '#A66A1F', marginBottom: 4 }}>
+                Active round
+              </Text>
+              <Text
+                style={{
+                  color: '#1C211C',
+                  fontSize: 15,
+                  fontWeight: '500',
+                }}
+              >
+                {activeRound.courseName} · Hole {activeRound.currentHole}
+              </Text>
+            </View>
+            <Text
+              style={{
+                color: '#A66A1F',
+                fontSize: 14,
+                fontWeight: '600',
+                letterSpacing: 0.3,
+              }}
+            >
+              Resume →
+            </Text>
+          </Pressable>
+        )}
 
         <Link href="/(app)/round/new?mode=live" asChild>
           <Pressable

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -937,9 +937,18 @@ export default function HoleScreen() {
           </Pressable>
           <Pressable
             onPress={() => setScorecardOpen(true)}
-            style={{ flex: 1 }}
+            style={{ flex: 1, alignItems: 'center' }}
             accessibilityLabel="Open scorecard"
           >
+            <Text
+              style={{
+                ...KICKER,
+                color: '#5C6356',
+                marginBottom: 4,
+              }}
+            >
+              Scorecard ▾
+            </Text>
             <ScorecardPreview
               holes={holes}
               holeScores={holeScores}

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -394,7 +394,12 @@ export default function HoleScreen() {
         },
       ])
       setAim(null)
-      setBall(null)
+      // Leave ball at the just-hit shot's start position. The next shot
+      // is hit from somewhere downrange; the player drags the ball to
+      // refine. The previous behaviour of clearing the ball + reading a
+      // fresh GPS fix snapped the marker to the player's current device
+      // location — which on test builds (or anywhere far from where the
+      // ball actually lies) jumped the marker miles off the course.
       setLoggerOpen(false)
       setRoundState('PLACE_BALL')
       // Background sync — don't await.
@@ -421,17 +426,11 @@ export default function HoleScreen() {
             : hs,
         ),
       )
-      // Re-acquire GPS so the next PLACE_BALL frames the player's new
-      // position. Skipped in past-round mode where GPS is meaningless.
-      if (!isPastMode) {
-        Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High })
-          .then((loc) => {
-            const pos = { lat: loc.coords.latitude, lng: loc.coords.longitude }
-            setGpsPosition(pos)
-            setBall(pos)
-          })
-          .catch(() => undefined)
-      }
+      // Intentionally do NOT snap ball to a fresh GPS reading here. The
+      // watchPosition effect keeps gpsPosition fresh for the nearPin
+      // proximity check, and its functional setBall (prev ?? pos) only
+      // fills the ball when it's null — so a manually-placed (or
+      // carried-over from the prior shot) ball is preserved.
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('shot save failed', err, payload)

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -118,6 +118,7 @@ export default function HoleScreen() {
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [scorecardOpen, setScorecardOpen] = useState(false)
+  const [confirmLeave, setConfirmLeave] = useState(false)
 
   const currentHole = useMemo(
     () => holes.find((h) => h.number === holeNumber) ?? null,
@@ -660,7 +661,7 @@ export default function HoleScreen() {
         }}
       >
         <Pressable
-          onPress={() => router.replace('/(app)')}
+          onPress={() => setConfirmLeave(true)}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           style={{ padding: 6 }}
         >
@@ -1024,6 +1025,19 @@ export default function HoleScreen() {
         busy={deleting}
         onConfirm={handleDeleteRound}
         onCancel={() => setConfirmDelete(false)}
+      />
+
+      <ConfirmDialog
+        visible={confirmLeave}
+        title="Leave round?"
+        message="Your progress is saved and you can resume from the home screen."
+        confirmLabel="Leave"
+        cancelLabel="Stay"
+        onConfirm={() => {
+          setConfirmLeave(false)
+          router.replace('/(app)')
+        }}
+        onCancel={() => setConfirmLeave(false)}
       />
 
       <Modal

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -37,9 +37,10 @@ import {
 import { syncPendingShots } from '../../../../../lib/sync'
 import { distanceYards } from '../../../../../lib/maps'
 import { combinedPuttResult } from '@oga/core'
-import { deleteRound } from '@oga/supabase'
+import { deleteRound, getProfile } from '@oga/supabase'
 import { ConfirmDialog } from '../../../../../components/ui/ConfirmDialog'
 import { useUnits } from '../../../../../hooks/useUnits'
+import { completeRound } from '../../../../../lib/completeRound'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
@@ -119,6 +120,8 @@ export default function HoleScreen() {
   const [deleting, setDeleting] = useState(false)
   const [scorecardOpen, setScorecardOpen] = useState(false)
   const [confirmLeave, setConfirmLeave] = useState(false)
+  const [confirmEnd, setConfirmEnd] = useState(false)
+  const [ending, setEnding] = useState(false)
 
   const currentHole = useMemo(
     () => holes.find((h) => h.number === holeNumber) ?? null,
@@ -599,6 +602,29 @@ export default function HoleScreen() {
   const totalShotsThisHole =
     remoteShotCount + localShotCount > 0 ? remoteShotCount + localShotCount : 0
 
+  async function handleEndRound() {
+    if (!round || !user) return
+    setEnding(true)
+    try {
+      const { data: profile } = await getProfile(supabase, user.id)
+      const handicap =
+        (profile as { handicap_index?: number | null } | null)?.handicap_index ??
+        null
+      await completeRound({
+        roundId: round.id,
+        courseId: round.course_id,
+        userId: user.id,
+        handicap,
+      })
+      router.replace(`/(app)/round/${round.id}`)
+    } catch (err) {
+      Alert.alert('End round failed', (err as Error).message)
+    } finally {
+      setEnding(false)
+      setConfirmEnd(false)
+    }
+  }
+
   async function handleDeleteRound() {
     if (!round || !user) return
     setDeleting(true)
@@ -696,20 +722,36 @@ export default function HoleScreen() {
             {currentHole.yards ? ` · ${toDisplay(currentHole.yards)}` : ''}
           </Text>
         </View>
-        <Pressable
-          onPress={() => setConfirmDelete(true)}
-          accessibilityLabel="Delete round"
-          style={{ paddingHorizontal: 4 }}
-        >
-          <Text
-            style={{
-              ...KICKER,
-              color: 'rgba(163,58,42,0.85)',
-            }}
+        <View style={{ alignItems: 'flex-end', gap: 6 }}>
+          <Pressable
+            onPress={() => setConfirmEnd(true)}
+            accessibilityLabel="End round early"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           >
-            Delete · Shot {shotNumber}
-          </Text>
-        </Pressable>
+            <Text
+              style={{
+                ...KICKER,
+                color: 'rgba(242,238,229,0.85)',
+              }}
+            >
+              End · Shot {shotNumber}
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={() => setConfirmDelete(true)}
+            accessibilityLabel="Delete round"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Text
+              style={{
+                ...KICKER,
+                color: 'rgba(163,58,42,0.85)',
+              }}
+            >
+              Delete
+            </Text>
+          </Pressable>
+        </View>
       </View>
 
       <View style={{ flex: 1 }}>
@@ -1038,6 +1080,17 @@ export default function HoleScreen() {
           router.replace('/(app)')
         }}
         onCancel={() => setConfirmLeave(false)}
+      />
+
+      <ConfirmDialog
+        visible={confirmEnd}
+        title={`End round after hole ${holeNumber}?`}
+        message={`Your round will be saved with ${totalShotsThisHole > 0 ? holeNumber : holeNumber - 1} hole(s) of detail. SG and totals are computed from what's logged so far.`}
+        confirmLabel="End round"
+        cancelLabel="Cancel"
+        busy={ending}
+        onConfirm={handleEndRound}
+        onCancel={() => setConfirmEnd(false)}
       />
 
       <Modal

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -8,6 +8,7 @@ import {
   Text,
   View,
 } from 'react-native'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import * as Location from 'expo-location'
 import type { Database } from '@oga/supabase'
@@ -982,20 +983,27 @@ export default function HoleScreen() {
         animationType="slide"
         onRequestClose={closePuttingSheet}
       >
-        <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
-          <PuttingSheet
-            shotNumber={shotNumber}
-            initialDistanceFt={
-              ball && (roundPin ?? storedPin)
-                ? Math.round(
-                    distanceYards(ball, (roundPin ?? storedPin) as LatLng) * 3,
-                  )
-                : undefined
-            }
-            onSave={persistPutt}
-            onClose={closePuttingSheet}
-          />
-        </View>
+        {/* React Native's <Modal> renders to a separate native window on
+            Android, so the app-root GestureHandlerRootView doesn't apply
+            inside. Wrap the modal contents in their own root to restore
+            the GreenDiagram aim-handle pan gesture (broke after the
+            Reanimated refactor). */}
+        <GestureHandlerRootView style={{ flex: 1 }}>
+          <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
+            <PuttingSheet
+              shotNumber={shotNumber}
+              initialDistanceFt={
+                ball && (roundPin ?? storedPin)
+                  ? Math.round(
+                      distanceYards(ball, (roundPin ?? storedPin) as LatLng) * 3,
+                    )
+                  : undefined
+              }
+              onSave={persistPutt}
+              onClose={closePuttingSheet}
+            />
+          </View>
+        </GestureHandlerRootView>
       </Modal>
 
       <ConfirmDialog

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -1,14 +1,405 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
+import { formatSG } from '@oga/core'
+import type { Database } from '@oga/supabase'
+import { supabase } from '../../../../lib/supabase'
 
+type RoundRow = Database['public']['Tables']['rounds']['Row']
+type HoleRow = Database['public']['Tables']['holes']['Row']
+type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+// Round entry route. Live (incomplete) rounds redirect into the hole
+// flow; completed rounds render a read-only summary so a player viewing
+// a past round from the home list isn't dropped back into the
+// Mark-ball / Set-aim state machine.
 export default function RoundIndex() {
   const { id } = useLocalSearchParams<{ id: string }>()
   const router = useRouter()
 
+  const [round, setRound] = useState<RoundRow | null>(null)
+  const [holes, setHoles] = useState<HoleRow[]>([])
+  const [holeScores, setHoleScores] = useState<HoleScoreRow[]>([])
+  const [courseName, setCourseName] = useState<string>('Round')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
   useEffect(() => {
     if (!id) return
-    router.push(`/(app)/round/${id}/hole/1`)
+    let active = true
+    ;(async () => {
+      try {
+        const { data: r, error: rErr } = await supabase
+          .from('rounds')
+          .select('*, courses(name)')
+          .eq('id', id)
+          .single()
+        if (rErr || !r) throw rErr ?? new Error('Round not found')
+        if (!active) return
+        const row = r as RoundRow & { courses?: { name: string | null } | null }
+        setRound(row)
+        setCourseName(row.courses?.name ?? 'Round')
+        // Live round signal: total_score is set when the round completes
+        // (either Finish round or End round early). Anything else is
+        // still in progress — drop into the hole flow.
+        if (row.total_score == null) {
+          router.replace(`/(app)/round/${id}/hole/1?mode=live`)
+          return
+        }
+        const [hRes, hsRes] = await Promise.all([
+          supabase
+            .from('holes')
+            .select('*')
+            .eq('course_id', row.course_id)
+            .order('number'),
+          supabase.from('hole_scores').select('*').eq('round_id', row.id),
+        ])
+        if (!active) return
+        if (hRes.error) throw hRes.error
+        if (hsRes.error) throw hsRes.error
+        setHoles(hRes.data ?? [])
+        setHoleScores(hsRes.data ?? [])
+      } catch (err) {
+        if (!active) return
+        setError((err as Error).message)
+      } finally {
+        if (active) setLoading(false)
+      }
+    })()
+    return () => {
+      active = false
+    }
   }, [id])
 
-  return null
+  const scoresByHoleId = useMemo(
+    () => new Map(holeScores.map((hs) => [hs.hole_id, hs])),
+    [holeScores],
+  )
+  const sortedHoles = useMemo(
+    () => [...holes].sort((a, b) => a.number - b.number),
+    [holes],
+  )
+
+  if (loading) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#F2EEE5',
+        }}
+      >
+        <ActivityIndicator color="#1F3D2C" />
+      </View>
+    )
+  }
+  if (error || !round) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#F2EEE5',
+          padding: 18,
+        }}
+      >
+        <Text style={{ color: '#A33A2A', fontSize: 13 }}>
+          {error ?? 'Round not found'}
+        </Text>
+      </View>
+    )
+  }
+
+  const sgRows: { label: string; value: number | null }[] = [
+    { label: 'Off tee', value: round.sg_off_tee },
+    { label: 'Approach', value: round.sg_approach },
+    { label: 'Around green', value: round.sg_around_green },
+    { label: 'Putting', value: round.sg_putting },
+  ]
+
+  let runningScore = 0
+  let runningPar = 0
+  for (const h of sortedHoles) {
+    const hs = scoresByHoleId.get(h.id)
+    if (hs?.score != null && hs.score > 0) {
+      runningScore += hs.score
+      runningPar += h.par
+    }
+  }
+  const diff = runningScore - runningPar
+
+  return (
+    <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
+      <View
+        style={{
+          backgroundColor: '#1C211C',
+          paddingTop: 52,
+          paddingBottom: 14,
+          paddingHorizontal: 18,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Pressable
+          onPress={() => router.replace('/(app)')}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+          style={{ padding: 6 }}
+        >
+          <Text style={{ ...KICKER, color: 'rgba(242,238,229,0.6)' }}>← Home</Text>
+        </Pressable>
+        <View style={{ alignItems: 'center' }}>
+          <Text style={{ ...KICKER, color: 'rgba(242,238,229,0.45)', marginBottom: 4 }}>
+            {round.played_at}
+          </Text>
+          <Text
+            style={{
+              color: '#F2EEE5',
+              fontSize: 17,
+              fontWeight: '500',
+              fontStyle: 'italic',
+            }}
+          >
+            {courseName}
+          </Text>
+        </View>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'baseline',
+            justifyContent: 'space-between',
+            marginBottom: 18,
+          }}
+        >
+          <View>
+            <Text style={{ ...KICKER, marginBottom: 4 }}>Total</Text>
+            <Text
+              style={{
+                color: '#1C211C',
+                fontSize: 36,
+                fontWeight: '500',
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {round.total_score ?? '—'}
+            </Text>
+          </View>
+          <View style={{ alignItems: 'flex-end' }}>
+            <Text style={{ ...KICKER, marginBottom: 4 }}>To par</Text>
+            <Text
+              style={{
+                color:
+                  diff < 0 ? '#1F3D2C' : diff > 0 ? '#A33A2A' : '#5C6356',
+                fontSize: 28,
+                fontWeight: '500',
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {runningPar === 0
+                ? '—'
+                : diff === 0
+                  ? 'E'
+                  : diff > 0
+                    ? `+${diff}`
+                    : `${diff}`}
+            </Text>
+          </View>
+        </View>
+
+        <View
+          style={{
+            borderTopWidth: 1,
+            borderColor: '#D9D2BF',
+            paddingTop: 14,
+            marginBottom: 18,
+          }}
+        >
+          <Text style={{ ...KICKER, marginBottom: 12 }}>Strokes gained</Text>
+          {sgRows.map((row) => (
+            <View
+              key={row.label}
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                paddingVertical: 6,
+              }}
+            >
+              <Text style={{ color: '#1C211C', fontSize: 13 }}>{row.label}</Text>
+              <Text
+                style={{
+                  color:
+                    row.value == null
+                      ? '#8A8B7E'
+                      : row.value > 0
+                        ? '#1F3D2C'
+                        : row.value < 0
+                          ? '#A33A2A'
+                          : '#5C6356',
+                  fontSize: 13,
+                  fontVariant: ['tabular-nums'],
+                  fontWeight: '500',
+                }}
+              >
+                {row.value == null ? '—' : formatSG(row.value)}
+              </Text>
+            </View>
+          ))}
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              paddingTop: 8,
+              marginTop: 4,
+              borderTopWidth: 1,
+              borderColor: '#EBE5D6',
+            }}
+          >
+            <Text style={{ color: '#1C211C', fontSize: 14, fontWeight: '600' }}>
+              Total
+            </Text>
+            <Text
+              style={{
+                color:
+                  round.sg_total == null
+                    ? '#8A8B7E'
+                    : round.sg_total > 0
+                      ? '#1F3D2C'
+                      : round.sg_total < 0
+                        ? '#A33A2A'
+                        : '#5C6356',
+                fontSize: 14,
+                fontVariant: ['tabular-nums'],
+                fontWeight: '600',
+              }}
+            >
+              {round.sg_total == null ? '—' : formatSG(round.sg_total)}
+            </Text>
+          </View>
+        </View>
+
+        <View
+          style={{
+            borderTopWidth: 1,
+            borderColor: '#D9D2BF',
+            paddingTop: 14,
+          }}
+        >
+          <Text style={{ ...KICKER, marginBottom: 8 }}>Scorecard</Text>
+          <View
+            style={{
+              flexDirection: 'row',
+              paddingVertical: 8,
+              borderBottomWidth: 1,
+              borderColor: '#D9D2BF',
+            }}
+          >
+            <Text style={{ ...KICKER, flex: 1, color: '#8A8B7E' }}>Hole</Text>
+            <Text
+              style={{ ...KICKER, width: 44, textAlign: 'right', color: '#8A8B7E' }}
+            >
+              Par
+            </Text>
+            <Text
+              style={{ ...KICKER, width: 56, textAlign: 'right', color: '#8A8B7E' }}
+            >
+              Score
+            </Text>
+            <Text
+              style={{ ...KICKER, width: 56, textAlign: 'right', color: '#8A8B7E' }}
+            >
+              +/−
+            </Text>
+          </View>
+          {sortedHoles.map((h) => {
+            const hs = scoresByHoleId.get(h.id)
+            const score = hs?.score ?? null
+            const d = score != null && score > 0 ? score - h.par : null
+            return (
+              <View
+                key={h.id}
+                style={{
+                  flexDirection: 'row',
+                  paddingVertical: 10,
+                  borderBottomWidth: 1,
+                  borderColor: '#EBE5D6',
+                  paddingHorizontal: 6,
+                }}
+              >
+                <Text
+                  style={{
+                    flex: 1,
+                    fontSize: 15,
+                    color: '#1C211C',
+                  }}
+                >
+                  {h.number}
+                </Text>
+                <Text
+                  style={{
+                    width: 44,
+                    textAlign: 'right',
+                    fontSize: 15,
+                    color: '#5C6356',
+                    fontVariant: ['tabular-nums'],
+                  }}
+                >
+                  {h.par}
+                </Text>
+                <Text
+                  style={{
+                    width: 56,
+                    textAlign: 'right',
+                    fontSize: 15,
+                    color: score != null && score > 0 ? '#1C211C' : '#8A8B7E',
+                    fontVariant: ['tabular-nums'],
+                    fontWeight: '500',
+                  }}
+                >
+                  {score != null && score > 0 ? score : '—'}
+                </Text>
+                <Text
+                  style={{
+                    width: 56,
+                    textAlign: 'right',
+                    fontSize: 15,
+                    color:
+                      d == null
+                        ? '#8A8B7E'
+                        : d < 0
+                          ? '#1F3D2C'
+                          : d > 0
+                            ? '#A33A2A'
+                            : '#5C6356',
+                    fontVariant: ['tabular-nums'],
+                  }}
+                >
+                  {d == null ? '—' : d === 0 ? 'E' : d > 0 ? `+${d}` : `${d}`}
+                </Text>
+              </View>
+            )
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  )
 }

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -105,15 +105,21 @@ export function HoleMap({
     [isAimPhase, onSetAim],
   )
 
+  // Gate the long-press gesture to SET_AIM only. Outside that phase the
+  // GestureDetector still wraps the map but no longer captures touches,
+  // which restores the PointAnnotation drag for the ball marker during
+  // PLACE_BALL — Gesture.LongPress was claiming the initial touch and
+  // the native annotation drag never fired.
   const longPress = useMemo(
     () =>
       Gesture.LongPress()
+        .enabled(isAimPhase)
         .minDuration(400)
         .onStart((event) => {
           'worklet'
           runOnJS(dropAimFromScreenPoint)(event.x, event.y)
         }),
-    [dropAimFromScreenPoint],
+    [dropAimFromScreenPoint, isAimPhase],
   )
 
   // Center the camera once on first valid coords. Subsequent center changes

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -451,7 +451,24 @@ export function HoleMap({
                 if (c) onSetBall(c)
               }}
             >
-              <Marker color="#1F3D2C" border="#FBF8F1" size={14} />
+              {/* 44pt transparent hit area so the marker is comfortable
+                  to grab one-handed — Apple HIG minimum target size.
+                  The visual marker stays small; the touchable area
+                  extends well past it. */}
+              <View
+                style={{
+                  width: 44,
+                  height: 44,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Marker
+                  color="#1F3D2C"
+                  border="#FBF8F1"
+                  size={isPlaceBallPhase ? 18 : 14}
+                />
+              </View>
             </Mapbox.PointAnnotation>
           )}
         </Mapbox.MapView>

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Text, View } from 'react-native'
 import Mapbox from '@rnmapbox/maps'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
@@ -79,6 +79,11 @@ export function HoleMap({
   const cameraRef = useRef<Mapbox.Camera>(null)
   const mapViewRef = useRef<Mapbox.MapView>(null)
   const cameraInitialized = useRef(false)
+  // Native side fires "Source X is not in style" when a ShapeSource /
+  // LineLayer mounts before the satellite style has finished loading.
+  // Gate every source behind this flag so React never renders them
+  // before native is ready to accept them.
+  const [styleLoaded, setStyleLoaded] = useState(false)
 
   const isPinMode = phase === 'PIN'
   const isAimPhase = phase === 'SET_AIM'
@@ -304,6 +309,7 @@ export function HoleMap({
           style={{ flex: 1 }}
           styleURL={Mapbox.StyleURL.Satellite}
           onPress={handleTap}
+          onDidFinishLoadingStyle={() => setStyleLoaded(true)}
         >
           <Mapbox.Camera
             ref={cameraRef}
@@ -314,7 +320,7 @@ export function HoleMap({
             }}
           />
 
-          {!isPinMode && previousShotsLine && (
+          {styleLoaded && !isPinMode && previousShotsLine && (
             <Mapbox.ShapeSource id="prevShotsLine" shape={previousShotsLine}>
               <Mapbox.LineLayer
                 id="prevShotsLineLayer"
@@ -338,7 +344,7 @@ export function HoleMap({
               </Mapbox.PointAnnotation>
             ))}
 
-          {aimLine && (
+          {styleLoaded && aimLine && (
             <Mapbox.ShapeSource id="aimLine" shape={aimLine}>
               <Mapbox.LineLayer
                 id="aimLineLayer"

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -287,6 +287,27 @@ export function HoleMap({
     }
   }, [previousShots, ball?.lat, ball?.lng])
 
+  // Per-segment midpoint + distance for the small labels rendered along
+  // the breadcrumb line. Excludes the trailing ball→nothing segment when
+  // ball is the only point. Only segments between fully-resolved waypoint
+  // pairs are kept (the current ball position is included as the final
+  // waypoint so the latest leg also gets a label).
+  const previousShotSegments = useMemo(() => {
+    const pts: LatLng[] = [...(previousShots ?? [])]
+    if (ball) pts.push(ball)
+    const out: { id: string; midpoint: LatLng; yards: number }[] = []
+    for (let i = 0; i < pts.length - 1; i++) {
+      const a = pts[i]!
+      const b = pts[i + 1]!
+      out.push({
+        id: `seg-${i}`,
+        midpoint: { lat: (a.lat + b.lat) / 2, lng: (a.lng + b.lng) / 2 },
+        yards: Math.round(distanceYards(a, b)),
+      })
+    }
+    return out
+  }, [previousShots, ball?.lat, ball?.lng])
+
   function handleTap(feature: unknown) {
     const c = extractCoord(feature)
     if (!c) return
@@ -341,6 +362,39 @@ export function HoleMap({
                 coordinate={toCoord(p)}
               >
                 <Marker color="#A66A1F" border="#FBF8F1" size={9} />
+              </Mapbox.PointAnnotation>
+            ))}
+
+          {/* Small distance label between every pair of consecutive
+              waypoints on the breadcrumb. Smaller / more muted than the
+              aim distance pill so it reads as supporting info, not the
+              primary callout. */}
+          {!isPinMode &&
+            previousShotSegments.map((seg) => (
+              <Mapbox.PointAnnotation
+                key={seg.id}
+                id={seg.id}
+                coordinate={toCoord(seg.midpoint)}
+              >
+                <View
+                  style={{
+                    backgroundColor: 'rgba(28,33,28,0.65)',
+                    borderRadius: 999,
+                    paddingHorizontal: 7,
+                    paddingVertical: 2,
+                  }}
+                >
+                  <Text
+                    style={{
+                      color: '#F2EEE5',
+                      fontSize: 10,
+                      fontWeight: '500',
+                      fontVariant: ['tabular-nums'],
+                    }}
+                  >
+                    {toDisplay(seg.yards)}
+                  </Text>
+                </View>
               </Mapbox.PointAnnotation>
             ))}
 

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -606,29 +606,31 @@ function Marker({ color, border, size }: MarkerProps) {
 
 // Simple flag glyph: vertical pole with a triangular cloth at the top.
 // "dim" = stored course pin (course default, may be wrong); "strong" =
-// today's actual flag position captured this round.
+// today's actual flag position captured this round. Sized large enough
+// to read at zoom 17 against satellite imagery — the previous 16x22
+// version was disappearing into the green on real device tests.
 function Flag({ tone }: { tone: 'dim' | 'strong' }) {
-  const flagColor = tone === 'strong' ? '#A33A2A' : 'rgba(163,58,42,0.6)'
-  const poleColor = tone === 'strong' ? '#FBF8F1' : 'rgba(251,248,241,0.7)'
+  const flagColor = tone === 'strong' ? '#A33A2A' : 'rgba(163,58,42,0.85)'
+  const poleColor = tone === 'strong' ? '#FBF8F1' : '#FBF8F1'
   return (
-    <View style={{ width: 16, height: 22, alignItems: 'flex-start' }}>
+    <View style={{ width: 26, height: 36, alignItems: 'flex-start' }}>
       <View
         style={{
           position: 'absolute',
-          left: 4,
+          left: 6,
           top: 0,
-          width: 2,
-          height: 22,
+          width: 3,
+          height: 36,
           backgroundColor: poleColor,
         }}
       />
       <View
         style={{
           position: 'absolute',
-          left: 6,
+          left: 9,
           top: 1,
-          width: 9,
-          height: 7,
+          width: 15,
+          height: 11,
           backgroundColor: flagColor,
           borderTopRightRadius: 1,
         }}
@@ -636,11 +638,11 @@ function Flag({ tone }: { tone: 'dim' | 'strong' }) {
       <View
         style={{
           position: 'absolute',
-          left: 3,
-          top: 21,
-          width: 4,
-          height: 2,
-          borderRadius: 1,
+          left: 4,
+          top: 33,
+          width: 7,
+          height: 3,
+          borderRadius: 1.5,
           backgroundColor: poleColor,
         }}
       />

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -376,8 +376,31 @@ export function HoleMap({
           )}
 
           {isAimPhase && aim && (
-            <Mapbox.PointAnnotation id="aim" coordinate={toCoord(aim)}>
-              <Marker color="#A66A1F" border="#FBF8F1" size={12} />
+            <Mapbox.PointAnnotation
+              id="aim"
+              coordinate={toCoord(aim)}
+              draggable
+              onDrag={(e: unknown) => {
+                const c = extractCoord(e)
+                if (c) onSetAim(c)
+              }}
+              onDragEnd={(e: unknown) => {
+                const c = extractCoord(e)
+                if (c) onSetAim(c)
+              }}
+            >
+              {/* 44pt transparent hit area around the visual marker so the
+                  drag handle is comfortably reachable mid-round. */}
+              <View
+                style={{
+                  width: 44,
+                  height: 44,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Marker color="#A66A1F" border="#FBF8F1" size={14} />
+              </View>
             </Mapbox.PointAnnotation>
           )}
 

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -1,0 +1,113 @@
+import { computeRoundSG } from '@oga/core'
+import {
+  getHoleScoresForRound,
+  getHolesForCourse,
+  getShotsForRound,
+  updateRound,
+} from '@oga/supabase'
+import type { Database } from '@oga/supabase'
+import { supabase } from './supabase'
+import { syncPendingShots } from './sync'
+
+type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
+type ShotRow = Database['public']['Tables']['shots']['Row']
+type HoleRow = Database['public']['Tables']['holes']['Row']
+
+interface CompleteArgs {
+  roundId: string
+  courseId: string
+  userId: string
+  handicap: number | null
+}
+
+// Mobile equivalent of apps/web/src/hooks/useCompleteRound (sans the
+// react-query / handicap-index recalc plumbing). Drains the pending
+// shot queue, runs computeRoundSG over the persisted shots, and stamps
+// total_score / SG fields onto the round so total_score IS NOT NULL —
+// which removes the round from the home-screen Resume banner.
+export async function completeRound({
+  roundId,
+  courseId,
+  userId,
+  handicap,
+}: CompleteArgs): Promise<void> {
+  await syncPendingShots().catch(() => undefined)
+
+  const [holesRes, holeScoresRes, shotsRes] = await Promise.all([
+    getHolesForCourse(supabase, courseId),
+    getHoleScoresForRound(supabase, roundId),
+    getShotsForRound(supabase, roundId, userId),
+  ])
+  if (holesRes.error) throw holesRes.error
+  if (holeScoresRes.error) throw holeScoresRes.error
+  if (shotsRes.error) throw shotsRes.error
+
+  const holes: HoleRow[] = holesRes.data ?? []
+  const holeScoreRows = (holeScoresRes.data ?? []) as Array<
+    HoleScoreRow & { holes?: HoleRow | null }
+  >
+  const holeScores: HoleScoreRow[] = holeScoreRows.map((row) => {
+    const { holes: _h, ...rest } = row
+    return rest
+  })
+  const shots = (shotsRes.data ?? []) as unknown as ShotRow[]
+
+  const result = computeRoundSG({
+    holes,
+    holeScores,
+    shots,
+    handicap: handicap ?? 18,
+  })
+
+  // Per-hole SG upsert. Mirrors useCompleteRound.ts: carry round_id /
+  // hole_id / score forward so the underlying INSERT path of the upsert
+  // satisfies NOT NULL columns; the conflict on `id` then refreshes
+  // the SG fields only.
+  const holeScoresById = new Map(holeScores.map((hs) => [hs.id, hs]))
+  const sgRows = Object.entries(result.perHoleScore)
+    .map(([holeScoreId, sg]) => {
+      const existing = holeScoresById.get(holeScoreId)
+      if (!existing) return null
+      return {
+        id: holeScoreId,
+        round_id: existing.round_id,
+        hole_id: existing.hole_id,
+        score: existing.score,
+        sg_off_tee: round2(sg.offTee),
+        sg_approach: round2(sg.approach),
+        sg_around_green: round2(sg.aroundGreen),
+        sg_putting: round2(sg.putting),
+      }
+    })
+    .filter((r): r is NonNullable<typeof r> => r != null)
+  if (sgRows.length > 0) {
+    const { error: sgError } = await supabase
+      .from('hole_scores')
+      .upsert(sgRows, { onConflict: 'id' })
+    if (sgError) throw sgError
+  }
+
+  const { error: roundError } = await updateRound(
+    supabase,
+    roundId,
+    {
+      sg_off_tee: round2(result.round.offTee),
+      sg_approach: round2(result.round.approach),
+      sg_around_green: round2(result.round.aroundGreen),
+      sg_putting: round2(result.round.putting),
+      sg_total: round2(result.round.total),
+      total_score: result.totals.totalScore || null,
+      total_putts: result.totals.totalPutts || null,
+      fairways_hit:
+        result.totals.fairwaysTotal > 0 ? result.totals.fairwaysHit : null,
+      fairways_total: result.totals.fairwaysTotal || null,
+      gir: result.totals.gir,
+    },
+    userId,
+  )
+  if (roundError) throw roundError
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}


### PR DESCRIPTION
## Summary

Fixes from the second device test (Samsung SM-S911U). Twelve isolated commits — bug fixes to the live-round flow + small features (scorecard discoverability, resume, end round early, past round read-only view).

### Bug fixes (HoleMap.tsx)
- **Ball drag broken** — `Gesture.LongPress` on the map wrapper was capturing the touch in PLACE_BALL; gating with `.enabled(isAimPhase)` returns the touch to the PointAnnotation drag.
- **Aim distance pill frozen** — aim PointAnnotation is now `draggable` with an `onDrag` that fires `onSetAim` continuously, so the distance pill follows the marker.
- **`Source prevShotsLine is not in style`** — gate `<ShapeSource>`s behind a `styleLoaded` flag set from `onDidFinishLoadingStyle` so React never asks native to wire a layer to a missing source.
- **GPS snap to user's house on shot 2+** — saving a shot used to clear `ball` and re-fetch GPS; now the marker stays at the just-hit shot's start and the player drags to the new position.
- **Ball marker too small to grab** — wrapped in a 44pt transparent hit area (HIG minimum). Visible marker bumps from 14→18 in PLACE_BALL.
- **Pin flag invisible** — flag glyph 16x22 → 26x36, dim tone 60% → 85% opacity, pole solid.

### Features
- **Distance label on breadcrumb line** — small dark pill at every waypoint-to-waypoint midpoint with the segment yardage.
- **Green diagram drag restored** — putting sheet `<Modal>` renders to a separate Android window; nested `GestureHandlerRootView` makes the pan handler activate again.
- **Scorecard ▾ kicker** — the existing tappable preview row now reads as a button.
- **Round persistence + Resume banner** — Leave / Stay confirm on `← Home`; home screen renders an Active round / Resume banner whenever `total_score IS NULL` AND `played_at` within the last day. Resume jumps to the next unplayed hole.
- **End round early** — top-bar `End · Shot N` opens a confirm dialog and runs the same SG / totals path as the web complete-round hook (new `apps/mobile/lib/completeRound.ts`).
- **Past rounds → read-only view** — `/round/[id]` checks `total_score`; live rounds redirect to `/hole/1?mode=live`, completed rounds get a read-only summary (totals, SG breakdown, full scorecard).

## Test plan
- [ ] PLACE_BALL → ball marker drags to new position; pill follows
- [ ] SET_AIM → long-press drops aim, drag updates distance live
- [ ] Save shot 1 → shot 2 PLACE_BALL ball stays at last shot start (no GPS snap)
- [ ] Save shot 2 → no `Source prevShotsLine is not in style` console error
- [ ] Pin flag is visible without zooming on a course with stored pin coords
- [ ] Putting sheet → drag the amber aim handle horizontally; offset commits on release
- [ ] Bottom bar shows `Scorecard ▾`; tapping opens the modal
- [ ] Tap `← Home` → confirm dialog; Stay keeps round, Leave returns to home
- [ ] Active round shows in home `Resume →` banner; tapping resumes at the right hole
- [ ] Top bar `End · Shot N` confirms and finalises the round; resume banner clears
- [ ] After End round, opening that round from home shows the read-only summary, not `/hole/1`