### PR TITLE
fix: milestone sweep — 12 small fixes across schema, web, mobile, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   typecheck:

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -36,7 +36,7 @@
         "react-native-svg": "15.2.0",
         "react-native-url-polyfill": "^2.0.0",
         "react-native-web": "~0.19.10",
-        "react-native-worklets-core": "^1.6.3",
+        "react-native-worklets-core": "1.6.3",
         "tailwindcss": "^3.4.7",
         "victory-native": "^36.9.2"
       },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -40,7 +40,7 @@
     "react-native-svg": "15.2.0",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-web": "~0.19.10",
-    "react-native-worklets-core": "^1.6.3",
+    "react-native-worklets-core": "1.6.3",
     "tailwindcss": "^3.4.7",
     "victory-native": "^36.9.2"
   },

--- a/apps/web/src/components/auth/AuthGuard.tsx
+++ b/apps/web/src/components/auth/AuthGuard.tsx
@@ -6,7 +6,7 @@ export function AuthGuard({ children }: { children: ReactNode }) {
   const { user, loading } = useAuth()
   if (loading) {
     return (
-      <div className="flex h-screen items-center justify-center bg-oga-bg-page text-oga-text-muted text-sm">
+      <div className="flex h-screen items-center justify-center bg-caddie-bg text-caddie-ink-dim text-meta">
         Loading…
       </div>
     )

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -246,8 +246,10 @@ export function ShotEntryModal({
       }
       cancelEdit()
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error('shot save failed', err, insert)
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('shot save failed', err, insert)
+      }
       throw err
     }
   }

--- a/apps/web/src/hooks/useDetailedStats.ts
+++ b/apps/web/src/hooks/useDetailedStats.ts
@@ -4,6 +4,7 @@ import { getRoundsWithDetails } from '@oga/supabase'
 import { supabase } from '../lib/supabase'
 import {
   computeDetailedStats,
+  DEFAULT_HANDICAP,
   type DetailedRound,
   type DetailedStats,
 } from '@oga/core'
@@ -18,7 +19,7 @@ export function useDetailedStats(limit: number): {
 } {
   const { user } = useAuth()
   const profile = useProfile()
-  const handicap = profile.data?.handicap_index ?? 15
+  const handicap = profile.data?.handicap_index ?? DEFAULT_HANDICAP
 
   const query = useQuery({
     queryKey: ['detailed-stats', user?.id, limit],

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -23,14 +23,14 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex h-screen items-center justify-center bg-oga-bg-page">
+    <div className="flex h-screen items-center justify-center bg-caddie-bg">
       <form
         onSubmit={handleSubmit}
-        className="w-full max-w-sm bg-oga-bg-card"
+        className="w-full max-w-sm bg-caddie-surface"
         style={{ border: '0.5px solid #E4E4E0', borderRadius: 10, padding: 24 }}
       >
         <h1
-          className="text-oga-text-primary"
+          className="text-caddie-ink"
           style={{ fontSize: 22, fontWeight: 600, marginBottom: 18 }}
         >
           Sign in to OGA
@@ -41,7 +41,7 @@ export function LoginPage() {
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={{
             border: '0.5px solid #E4E4E0',
             borderRadius: 7,
@@ -56,7 +56,7 @@ export function LoginPage() {
           required
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={{
             border: '0.5px solid #E4E4E0',
             borderRadius: 7,
@@ -67,7 +67,7 @@ export function LoginPage() {
         />
         {error && (
           <div
-            className="text-oga-red-dark"
+            className="text-caddie-neg"
             style={{ fontSize: 13, marginBottom: 10 }}
           >
             {error}
@@ -76,17 +76,17 @@ export function LoginPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-oga-black text-white transition-colors hover:bg-oga-text-primary/90 disabled:opacity-50"
+          className="w-full bg-caddie-accent text-caddie-accent-ink transition-opacity hover:opacity-90 disabled:opacity-50"
           style={{ borderRadius: 10, padding: '12px 16px', fontSize: 13, fontWeight: 500 }}
         >
           {loading ? 'Signing in…' : 'Sign in'}
         </button>
         <p
-          className="text-oga-text-muted text-center"
+          className="text-caddie-ink-dim text-center"
           style={{ fontSize: 13, marginTop: 14 }}
         >
           No account?{' '}
-          <Link to="/signup" className="text-oga-green-dark hover:underline">
+          <Link to="/signup" className="text-caddie-accent hover:underline">
             Sign up
           </Link>
         </p>
@@ -98,7 +98,7 @@ export function LoginPage() {
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="text-oga-text-muted uppercase"
+      className="text-caddie-ink-dim uppercase"
       style={{
         fontSize: 11,
         fontWeight: 500,

--- a/apps/web/src/pages/auth/SignupPage.tsx
+++ b/apps/web/src/pages/auth/SignupPage.tsx
@@ -28,14 +28,14 @@ export function SignupPage() {
   }
 
   return (
-    <div className="flex h-screen items-center justify-center bg-oga-bg-page">
+    <div className="flex h-screen items-center justify-center bg-caddie-bg">
       <form
         onSubmit={handleSubmit}
-        className="w-full max-w-sm bg-oga-bg-card"
+        className="w-full max-w-sm bg-caddie-surface"
         style={{ border: '0.5px solid #E4E4E0', borderRadius: 10, padding: 24 }}
       >
         <h1
-          className="text-oga-text-primary"
+          className="text-caddie-ink"
           style={{ fontSize: 22, fontWeight: 600, marginBottom: 18 }}
         >
           Create your OGA account
@@ -45,7 +45,7 @@ export function SignupPage() {
           required
           value={username}
           onChange={(e) => setUsername(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={inputStyle}
         />
         <FieldLabel>Email</FieldLabel>
@@ -54,7 +54,7 @@ export function SignupPage() {
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={inputStyle}
         />
         <FieldLabel>Password</FieldLabel>
@@ -64,12 +64,12 @@ export function SignupPage() {
           minLength={8}
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={{ ...inputStyle, marginBottom: 14 }}
         />
         {error && (
           <div
-            className="text-oga-red-dark"
+            className="text-caddie-neg"
             style={{ fontSize: 13, marginBottom: 10 }}
           >
             {error}
@@ -78,17 +78,17 @@ export function SignupPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-oga-black text-white transition-colors hover:bg-oga-text-primary/90 disabled:opacity-50"
+          className="w-full bg-caddie-accent text-caddie-accent-ink transition-opacity hover:opacity-90 disabled:opacity-50"
           style={{ borderRadius: 10, padding: '12px 16px', fontSize: 13, fontWeight: 500 }}
         >
           {loading ? 'Creating…' : 'Create account'}
         </button>
         <p
-          className="text-oga-text-muted text-center"
+          className="text-caddie-ink-dim text-center"
           style={{ fontSize: 13, marginTop: 14 }}
         >
           Have an account?{' '}
-          <Link to="/login" className="text-oga-green-dark hover:underline">
+          <Link to="/login" className="text-caddie-accent hover:underline">
             Sign in
           </Link>
         </p>
@@ -108,7 +108,7 @@ const inputStyle: React.CSSProperties = {
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="text-oga-text-muted uppercase"
+      className="text-caddie-ink-dim uppercase"
       style={{
         fontSize: 11,
         fontWeight: 500,

--- a/apps/web/src/pages/errors/NotFoundPage.tsx
+++ b/apps/web/src/pages/errors/NotFoundPage.tsx
@@ -1,0 +1,75 @@
+import { useNavigate } from 'react-router-dom'
+
+export function NotFoundPage() {
+  const navigate = useNavigate()
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        backgroundColor: 'var(--caddie-bg)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 28,
+      }}
+    >
+      <div style={{ maxWidth: 520, textAlign: 'center' }}>
+        <div
+          style={{
+            fontFamily: 'JetBrains Mono, monospace',
+            fontSize: 11,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: 'var(--caddie-ink-mute)',
+            marginBottom: 14,
+          }}
+        >
+          404
+        </div>
+        <h1
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontWeight: 500,
+            fontSize: 38,
+            color: 'var(--caddie-ink)',
+            margin: 0,
+            letterSpacing: '-0.015em',
+          }}
+        >
+          Page not found.
+        </h1>
+        <p
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 15,
+            color: 'var(--caddie-ink-dim)',
+            marginTop: 14,
+            marginBottom: 22,
+            lineHeight: 1.5,
+          }}
+        >
+          The page you&rsquo;re looking for doesn&rsquo;t exist.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 14,
+            fontWeight: 600,
+            letterSpacing: 0.28,
+            backgroundColor: 'var(--caddie-accent)',
+            color: 'var(--caddie-accent-ink)',
+            border: 'none',
+            borderRadius: 2,
+            padding: '12px 18px',
+            cursor: 'pointer',
+          }}
+        >
+          ← Back to dashboard
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/rounds/NewRoundPage.tsx
+++ b/apps/web/src/pages/rounds/NewRoundPage.tsx
@@ -53,18 +53,18 @@ export function NewRoundPage() {
     <div className="mx-auto max-w-2xl">
       <div style={{ marginBottom: 18 }}>
         <h1
-          className="text-oga-text-primary"
+          className="text-caddie-ink"
           style={{ fontSize: 22, fontWeight: 600, lineHeight: 1.3 }}
         >
           New round
         </h1>
-        <div className="text-oga-text-muted" style={{ fontSize: 13, marginTop: 2 }}>
+        <div className="text-caddie-ink-dim" style={{ fontSize: 13, marginTop: 2 }}>
           Pick a course and we'll set up the scorecard
         </div>
       </div>
       <form
         onSubmit={handleSubmit}
-        className="bg-oga-bg-card flex flex-col gap-5"
+        className="bg-caddie-surface flex flex-col gap-5"
         style={{ border: '0.5px solid #E4E4E0', borderRadius: 10, padding: 20 }}
       >
         <section>
@@ -97,7 +97,7 @@ export function NewRoundPage() {
           />
           {courseName && courseId && (
             <p
-              className="text-oga-green-dark"
+              className="text-caddie-accent"
               style={{ fontSize: 13, marginTop: 8 }}
             >
               Selected: {courseName}
@@ -127,7 +127,7 @@ export function NewRoundPage() {
               required
               value={playedAt}
               onChange={(e) => setPlayedAt(e.target.value)}
-              className="w-full bg-oga-bg-input text-oga-text-primary"
+              className="w-full bg-caddie-surface-2 text-caddie-ink"
               style={{ border: '0.5px solid #E4E4E0', borderRadius: 7, padding: '8px 10px', fontSize: 13 }}
             />
           </label>
@@ -136,7 +136,7 @@ export function NewRoundPage() {
             <select
               value={teeColor}
               onChange={(e) => setTeeColor(e.target.value)}
-              className="w-full bg-oga-bg-input text-oga-text-primary capitalize"
+              className="w-full bg-caddie-surface-2 text-caddie-ink capitalize"
               style={{ border: '0.5px solid #E4E4E0', borderRadius: 7, padding: '8px 10px', fontSize: 13 }}
             >
               {TEE_COLORS.map((t) => (
@@ -149,7 +149,7 @@ export function NewRoundPage() {
         </section>
 
         {error && (
-          <div className="text-oga-red-dark" style={{ fontSize: 13 }}>
+          <div className="text-caddie-neg" style={{ fontSize: 13 }}>
             {error}
           </div>
         )}
@@ -158,7 +158,7 @@ export function NewRoundPage() {
           <button
             type="button"
             onClick={() => navigate('/rounds')}
-            className="bg-oga-bg-card text-oga-text-primary transition-colors hover:bg-oga-bg-input"
+            className="bg-caddie-surface text-caddie-ink transition-colors hover:bg-caddie-surface-2"
             style={{
               border: '0.5px solid #E4E4E0',
               borderRadius: 10,
@@ -172,7 +172,7 @@ export function NewRoundPage() {
           <button
             type="submit"
             disabled={createRoundMutation.isPending || !courseId}
-            className="bg-oga-black text-white transition-colors hover:bg-oga-text-primary/90 disabled:opacity-50"
+            className="bg-caddie-accent text-caddie-accent-ink transition-opacity hover:opacity-90 disabled:opacity-50"
             style={{
               borderRadius: 10,
               padding: '10px 16px',
@@ -206,8 +206,8 @@ function ModeChip({
       aria-pressed={active}
       className={
         active
-          ? 'bg-oga-black text-white'
-          : 'bg-oga-bg-card text-oga-text-primary hover:bg-oga-bg-input'
+          ? 'bg-caddie-accent text-caddie-accent-ink'
+          : 'bg-caddie-surface text-caddie-ink hover:bg-caddie-surface-2'
       }
       style={{
         flex: 1,
@@ -236,7 +236,7 @@ function ModeChip({
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="text-oga-text-muted uppercase"
+      className="text-caddie-ink-dim uppercase"
       style={{
         fontSize: 11,
         fontWeight: 500,

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -178,7 +178,7 @@ export function RoundDetailPage() {
         .update({ pin_lat: point.lat, pin_lng: point.lng })
         .eq('id', hs.id)
         .eq('round_id', roundId)
-      if (error) {
+      if (error && import.meta.env.DEV) {
         // Don't roll back the local override — the user's intent stays
         // visible while they retry. Surface the error for diagnostics.
         // eslint-disable-next-line no-console

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -17,7 +17,12 @@ import type {
   PlacedPoint,
 } from '../../components/round/RoundMap'
 import { RoundMapInstructionStrip } from '../../components/round/RoundMap'
-import { combinedPuttResult, getShotCategory, haversineYards } from '@oga/core'
+import {
+  combinedPuttResult,
+  DEFAULT_HANDICAP,
+  getShotCategory,
+  haversineYards,
+} from '@oga/core'
 
 // Lazy-load Mapbox GL JS only when the map tab is opened. Cuts ~2 MB off
 // the initial bundle for users who never leave the scorecard.
@@ -257,7 +262,7 @@ export function RoundDetailPage() {
     if (!round.data || !courseId || !user) return
     setCompleteError(null)
     try {
-      const handicap = profile.data?.handicap_index ?? 15
+      const handicap = profile.data?.handicap_index ?? DEFAULT_HANDICAP
       await completeMutation.mutateAsync({
         roundId: round.data.id,
         courseId,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -6,6 +6,7 @@ import { AppShell } from './components/layout/AppShell'
 import { RouteErrorBoundary } from './components/errors/ErrorBoundary'
 import { LoginPage } from './pages/auth/LoginPage'
 import { SignupPage } from './pages/auth/SignupPage'
+import { NotFoundPage } from './pages/errors/NotFoundPage'
 import { OnboardingPage } from './pages/onboarding/OnboardingPage'
 import { DashboardPage } from './pages/dashboard/DashboardPage'
 import { RoundsPage } from './pages/rounds/RoundsPage'
@@ -81,6 +82,7 @@ const routes: RouteObject[] = [
       { path: '/settings', element: <SettingsPage />, errorElement },
     ],
   },
+  { path: '*', element: <NotFoundPage />, errorElement },
 ]
 
 export const router: ReturnType<typeof createBrowserRouter> = createBrowserRouter(routes)

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,3 +1,10 @@
+// Stand-in handicap when a profile hasn't filled one in yet. Picked as
+// the rough median of US recreational golfers (USGA mid-handicap)
+// so SG baselines and bracket lookups don't degenerate to scratch
+// or 30+ for a brand-new user. NEVER store this — only use as a
+// transient calc input.
+export const DEFAULT_HANDICAP = 15
+
 export const CLUBS = [
   'driver',
   '3w',

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -5,6 +5,12 @@
 // transient calc input.
 export const DEFAULT_HANDICAP = 15
 
+// Distance-to-target threshold splitting "approach" from "around green"
+// for SG categorisation, lie inference, and stats bucketing. Keep the
+// three uses (sg-calculator, stats, shotInference) on the same number
+// so a shot can't be SG-classified one way and stats-bucketed another.
+export const NEAR_GREEN_YARDS = 30
+
 export const CLUBS = [
   'driver',
   '3w',

--- a/packages/core/src/sg-calculator.ts
+++ b/packages/core/src/sg-calculator.ts
@@ -1,4 +1,4 @@
-import type { ShotCategory } from './constants'
+import { NEAR_GREEN_YARDS, type ShotCategory } from './constants'
 import {
   APPROACH_BASELINES,
   AROUND_GREEN_BASELINES,
@@ -14,7 +14,10 @@ export function getShotCategory(
   shotNumber: number,
 ): ShotCategory {
   if (shot.lieType === 'green') return 'putting'
-  if (shot.distanceToTarget !== undefined && shot.distanceToTarget <= 30) {
+  if (
+    shot.distanceToTarget !== undefined &&
+    shot.distanceToTarget <= NEAR_GREEN_YARDS
+  ) {
     return 'around_green'
   }
   if (shotNumber === 1 && (par === 4 || par === 5)) return 'off_tee'

--- a/packages/core/src/shotInference.ts
+++ b/packages/core/src/shotInference.ts
@@ -3,7 +3,7 @@
 // coordinates plus tee/pin context, returns suggested club, lie type,
 // distances, and a confidence rating.
 
-import type { Club, LieType } from './constants'
+import { NEAR_GREEN_YARDS, type Club, type LieType } from './constants'
 import { haversineYards } from './units'
 
 export interface PlacedShot {
@@ -75,7 +75,6 @@ function clubForTeeShot(distanceYards: number, par: number): Club {
 // Lie inference
 // ---------------------------------------------------------------------------
 
-const NEAR_GREEN_YARDS = 30
 // Threshold for "this shot started on (or so close to) the green that the
 // next stroke is a putt." 15 yd captures fringe lag putts and short
 // chip-ins that are functionally putts; tighter than 15 misclassifies

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -3,6 +3,7 @@ import {
   getExpectedStrokes,
   getShotCategory,
 } from './sg-calculator'
+import { NEAR_GREEN_YARDS } from './constants'
 import type { LieSlopeForward, LieSlopeSide, ShotCategory, ShotResult } from './constants'
 import { METERS_TO_YARDS, haversineYards, toRadians } from './units'
 import { RESULT_QUALITY } from './types'
@@ -403,7 +404,7 @@ export function ballStrikingStats(rounds: DetailedRound[]): BallStrikingStats {
         if (
           category === 'approach' &&
           s.distance_to_target != null &&
-          s.distance_to_target > 30 &&
+          s.distance_to_target > NEAR_GREEN_YARDS &&
           s.end_lat != null &&
           s.end_lng != null
         ) {

--- a/packages/supabase/src/client.ts
+++ b/packages/supabase/src/client.ts
@@ -28,7 +28,12 @@ export function createOgaClient(opts: CreateClientOptions): OgaSupabaseClient {
       ...(opts.storage ? { storage: opts.storage } : {}),
       autoRefreshToken: opts.autoRefreshToken ?? true,
       persistSession: opts.persistSession ?? true,
-      detectSessionInUrl: opts.detectSessionInUrl ?? true,
+      // No /auth/callback route exists yet. Default-true here would let
+      // supabase-js consume any access_token / refresh_token query
+      // params on whatever page the user lands on, which is a session
+      // injection foothold. Flip back to true (or pass explicitly) when
+      // an OAuth callback route is wired up.
+      detectSessionInUrl: opts.detectSessionInUrl ?? false,
     },
   })
 }

--- a/packages/supabase/src/queries/courses.ts
+++ b/packages/supabase/src/queries/courses.ts
@@ -17,12 +17,12 @@ export function searchCourses(client: OgaSupabaseClient, query: string, limit = 
   if (!trimmed) {
     return client.from('courses').select(COURSE_COLUMNS).order('name').limit(limit)
   }
-  return client
-    .from('courses')
-    .select(COURSE_COLUMNS)
-    .ilike('name', `%${trimmed}%`)
-    .order('name')
-    .limit(limit)
+  // search_courses RPC ranks by pg_trgm similarity (typo-tolerant) then
+  // falls back to ILIKE substring. Migration 0018; trigram index from 0015.
+  return client.rpc('search_courses', {
+    search_query: trimmed,
+    result_limit: limit,
+  })
 }
 
 export function getHolesForCourse(client: OgaSupabaseClient, courseId: string) {

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -590,7 +590,12 @@ export interface Database {
       }
     }
     Views: Record<string, never>
-    Functions: Record<string, never>
+    Functions: {
+      search_courses: {
+        Args: { search_query: string; result_limit?: number }
+        Returns: Database['public']['Tables']['courses']['Row'][]
+      }
+    }
     Enums: Record<string, never>
     CompositeTypes: Record<string, never>
   }

--- a/supabase/migrations/0018_fuzzy_course_search.sql
+++ b/supabase/migrations/0018_fuzzy_course_search.sql
@@ -1,0 +1,27 @@
+-- Fuzzy course search backed by the pg_trgm GIN index added in 0015.
+-- ILIKE alone misses obvious typos ("Pebbel Beach" -> "Pebble Beach")
+-- and fails on word-order variants. The function ORs trigram similarity
+-- with ILIKE so substring matches still surface, then orders by
+-- similarity score so the closest match floats to the top.
+
+create or replace function public.search_courses(
+  search_query text,
+  result_limit int default 10
+)
+returns setof public.courses
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  select *
+  from public.courses
+  where name % search_query
+     or name ilike '%' || search_query || '%'
+  order by
+    similarity(name, search_query) desc,
+    name asc
+  limit result_limit;
+$$;
+
+grant execute on function public.search_courses(text, int) to anon, authenticated;

--- a/supabase/migrations/0019_external_id_unique.sql
+++ b/supabase/migrations/0019_external_id_unique.sql
@@ -1,0 +1,13 @@
+-- Partial unique index on courses.external_id so the OpenGolfAPI
+-- crawler can't insert duplicate course rows for the same upstream id.
+-- NULL is left unconstrained because manual user-created courses don't
+-- have an external_id and we don't want them to collide on a synthetic
+-- empty key.
+--
+-- 0004 added a non-unique idx_courses_external_id; we keep that index
+-- in place — it still services lookup-by-external_id queries — and add
+-- a separate partial UNIQUE on top.
+
+create unique index if not exists courses_external_id_unique
+  on public.courses(external_id)
+  where external_id is not null;

--- a/supabase/migrations/0020_play_frequency_check.sql
+++ b/supabase/migrations/0020_play_frequency_check.sql
@@ -1,0 +1,15 @@
+-- profiles.play_frequency was free text while every other onboarding
+-- field (skill_level, goal, play_style) had a CHECK constraint. The
+-- onboarding form only writes one of four values; pin the schema to
+-- match so a typo'd insert fails fast.
+--
+-- Values come from FREQUENCIES in
+-- apps/web/src/pages/onboarding/steps/Step4Details.tsx — keep this
+-- list in sync if a new option is added there.
+
+alter table public.profiles
+  add constraint play_frequency_values
+  check (
+    play_frequency is null
+    or play_frequency in ('monthly', 'weekly', 'multi_weekly', 'daily')
+  );

--- a/supabase/migrations/0021_shot_result_check.sql
+++ b/supabase/migrations/0021_shot_result_check.sql
@@ -1,0 +1,24 @@
+-- shots.shot_result was free text. Constrain to the SHOT_RESULTS list
+-- in @oga/core/constants so a typo'd insert can't reach storage and
+-- silently break stats bucketing (RESULT_QUALITY in types.ts maps off
+-- this exact set).
+--
+-- Keep the value list in sync with SHOT_RESULTS in
+-- packages/core/src/constants.ts.
+
+alter table public.shots
+  add constraint shot_result_values
+  check (
+    shot_result is null
+    or shot_result in (
+      'solid',
+      'push_right',
+      'pull_left',
+      'fat',
+      'thin',
+      'shank',
+      'topped',
+      'penalty',
+      'ob'
+    )
+  );


### PR DESCRIPTION
## Summary

12 independent small fixes batched into one PR — one commit per fix.

### Schema (4 new migrations, 0018–0021)
- **0018** `search_courses` RPC for typo-tolerant fuzzy course search via pg_trgm similarity (issue #60)
- **0019** Partial unique index on `courses.external_id` so the OpenGolfAPI crawler can't double-insert (issue #107)
- **0020** `play_frequency` CHECK constraint on profiles — matches the four values the onboarding form actually writes
- **0021** `shot_result` CHECK constraint on shots — mirrors `SHOT_RESULTS` in `@oga/core/constants`

### CI / build
- ci.yml now triggers on `dev` push + PRs to `dev` (parity with preview.yml)
- `react-native-worklets-core` pinned exact `1.6.3` per CLAUDE.md mobile dep policy (issue #43)

### Web
- 404 NotFoundPage with catch-all route, DESIGN.md aesthetic (issue #67)
- Replaced last legacy `oga-*` token classes with `caddie-*` in AuthGuard / LoginPage / SignupPage / NewRoundPage (issue #56 / #58)
- `console.error` calls in RoundDetailPage and ShotEntryModal gated behind `import.meta.env.DEV` (issue #55)
- `detectSessionInUrl: false` in supabase client until an `/auth/callback` route exists (security)

### Core
- Promoted `DEFAULT_HANDICAP = 15` to `@oga/core/constants`; web now imports it instead of using a magic literal in two places (issue #105)
- Promoted `NEAR_GREEN_YARDS = 30` to `@oga/core/constants`; sg-calculator, stats, and shotInference all consume the same constant (issue #106)

## Verification
- `pnpm typecheck` — 3/3 packages green
- `pnpm --filter web build` — success
- `apps/mobile npm run typecheck` — clean
- `pnpm test` — 205/205 pass

## Closes
- #43
- #55
- #56
- #58
- #60
- #67
- #105
- #106
- #107

## Follow-up (not in this PR)
- `supabase db push --linked` to apply the four new migrations to the linked DB — left for the maintainer because it touches shared infra.

## Test plan
- [ ] Run `supabase db push --linked` and confirm all four migrations apply cleanly
- [ ] Smoke-test course search with a misspelled query (e.g. "pebbel") — expect Pebble Beach to surface
- [ ] Visit a non-existent route (e.g. `/does-not-exist`) — expect the new 404 page
- [ ] Sign-in / sign-up flows still render correctly with the new caddie tokens
- [ ] Confirm prod console no longer logs the gated errors when a benign network blip occurs