### PR TITLE
fix: foundation sweep 3 — accessibility, splash, perf, docs

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Pressable, Text, View } from 'react-native'
+import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { supabase } from '../../lib/supabase'
@@ -56,7 +56,22 @@ export default function AppLayout() {
     }
   }, [user, authLoading, retryNonce])
 
-  if (authLoading || profileState === 'loading') return null
+  if (authLoading || profileState === 'loading') {
+    // Match the native splash screen's dark background so the cold-start
+    // transition into the React tree doesn't flash a white frame.
+    return (
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: '#1C211C',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <ActivityIndicator color="#E8E4DC" />
+      </View>
+    )
+  }
   if (!user) return <Redirect href="/(auth)/login" />
   if (profileState === 'error') {
     return (

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { supabase } from '../../lib/supabase'
@@ -7,18 +8,28 @@ import { ErrorBoundary } from '../../components/errors/ErrorBoundary'
 import { UnitsProvider } from '../../contexts/UnitsContext'
 
 const ICON_SIZE = 18
+// Transient profile fetch can hang on flaky networks. After this
+// timeout we surface a retry button instead of an infinite spinner.
+const PROFILE_FETCH_TIMEOUT_MS = 10_000
 
-type ProfileState = 'loading' | 'complete' | 'incomplete'
+type ProfileState = 'loading' | 'complete' | 'incomplete' | 'error'
 
 export default function AppLayout() {
   const { user, loading: authLoading } = useAuth()
   const [profileState, setProfileState] = useState<ProfileState>('loading')
+  const [retryNonce, setRetryNonce] = useState(0)
 
   useEffect(() => {
     if (authLoading) return
     if (!user) return
 
     let active = true
+    setProfileState('loading')
+
+    const timeoutId = setTimeout(() => {
+      if (active) setProfileState('error')
+    }, PROFILE_FETCH_TIMEOUT_MS)
+
     supabase
       .from('profiles')
       .select('skill_level, goal')
@@ -26,13 +37,11 @@ export default function AppLayout() {
       .maybeSingle()
       .then(({ data, error }) => {
         if (!active) return
+        clearTimeout(timeoutId)
         if (error) {
           // eslint-disable-next-line no-console
           console.error('[(app)/_layout]', error.message)
-          // Treat as incomplete is the wrong call for a transient error;
-          // leave the user on the loading state until the next render
-          // can retry. Setting incomplete here would punt them to
-          // onboarding and clobber their saved profile.
+          setProfileState('error')
           return
         }
         if (!data || !data.skill_level || !data.goal) {
@@ -43,11 +52,70 @@ export default function AppLayout() {
       })
     return () => {
       active = false
+      clearTimeout(timeoutId)
     }
-  }, [user, authLoading])
+  }, [user, authLoading, retryNonce])
 
   if (authLoading || profileState === 'loading') return null
   if (!user) return <Redirect href="/(auth)/login" />
+  if (profileState === 'error') {
+    return (
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: '#1C211C',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 28,
+        }}
+      >
+        <Text
+          style={{
+            color: '#F2EEE5',
+            fontSize: 20,
+            fontWeight: '500',
+            fontStyle: 'italic',
+            marginBottom: 10,
+            textAlign: 'center',
+          }}
+        >
+          Something went wrong loading your profile.
+        </Text>
+        <Text
+          style={{
+            color: 'rgba(242,238,229,0.65)',
+            fontSize: 14,
+            textAlign: 'center',
+            marginBottom: 22,
+          }}
+        >
+          Check your connection, then try again.
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Try again"
+          onPress={() => setRetryNonce((n) => n + 1)}
+          style={{
+            backgroundColor: '#1F3D2C',
+            borderRadius: 2,
+            paddingVertical: 14,
+            paddingHorizontal: 22,
+          }}
+        >
+          <Text
+            style={{
+              color: '#F2EEE5',
+              fontSize: 14,
+              fontWeight: '600',
+              letterSpacing: 0.3,
+            }}
+          >
+            Try again
+          </Text>
+        </Pressable>
+      </View>
+    )
+  }
   if (profileState === 'incomplete') return <Redirect href="/(auth)/onboarding" />
 
   return (

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -211,6 +211,8 @@ export default function Home() {
 
         {activeRound && (
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Resume active round at ${activeRound.courseName}, hole ${activeRound.currentHole}`}
             onPress={() =>
               router.push(
                 `/(app)/round/${activeRound.id}/hole/${activeRound.currentHole}?mode=live`,
@@ -258,6 +260,8 @@ export default function Home() {
 
         <Link href="/(app)/round/new?mode=live" asChild>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Start live round"
             style={{
               backgroundColor: '#1F3D2C',
               borderRadius: 2,
@@ -291,6 +295,8 @@ export default function Home() {
 
         <Link href="/(app)/round/new?mode=past" asChild>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Log past round"
             style={{
               borderWidth: 1,
               borderColor: '#1F3D2C',
@@ -423,6 +429,8 @@ export default function Home() {
                   }}
                   renderRightActions={() => (
                     <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={`Delete round at ${r.courses?.name ?? 'this round'}`}
                       onPress={() => {
                         swipeRefs.current.get(r.id)?.close()
                         setPendingDelete({
@@ -453,6 +461,8 @@ export default function Home() {
                 >
                   <Link href={`/(app)/round/${r.id}`} asChild>
                     <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={`Open round at ${r.courses?.name ?? 'unknown course'} on ${r.played_at}`}
                       style={{
                         flexDirection: 'row',
                         justifyContent: 'space-between',
@@ -511,6 +521,8 @@ export default function Home() {
               {rounds.length > 5 && (
                 <Link href="/(app)/rounds" asChild>
                   <Pressable
+                    accessibilityRole="link"
+                    accessibilityLabel="See all rounds"
                     style={{
                       paddingVertical: 14,
                       paddingHorizontal: 4,

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -220,6 +220,9 @@ export default function ProfileTab() {
         </Field>
 
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={saving ? 'Saving profile' : 'Save profile changes'}
+          accessibilityState={{ disabled: saving }}
           onPress={save}
           disabled={saving}
           style={{
@@ -266,6 +269,8 @@ export default function ProfileTab() {
           </Text>
           <View style={{ flexDirection: 'row', gap: 10 }}>
             <Pressable
+              accessibilityRole="link"
+              accessibilityLabel="Open Ko-fi sponsorship page"
               onPress={() => Linking.openURL('https://ko-fi.com/nartana')}
               style={{
                 flex: 1,
@@ -288,6 +293,8 @@ export default function ProfileTab() {
               </Text>
             </Pressable>
             <Pressable
+              accessibilityRole="link"
+              accessibilityLabel="Open GitHub Sponsors page"
               onPress={() =>
                 Linking.openURL('https://github.com/sponsors/cner-smith')
               }
@@ -315,6 +322,8 @@ export default function ProfileTab() {
         </View>
 
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Sign out"
           onPress={() => supabase.auth.signOut()}
           style={{
             marginTop: 22,
@@ -374,6 +383,9 @@ function Chip({
 }) {
   return (
     <Pressable
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: active }}
       onPress={onPress}
       style={{
         paddingHorizontal: 10,

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -193,30 +193,25 @@ export default function HoleScreen() {
     if (!currentHoleScore) return
     let active = true
     ;(async () => {
-      const [shotRes, puttRes, startsRes, local] = await Promise.all([
+      // Single fetch covers shot count, putt count, and start coords —
+      // putts are derivable from (club, lie_type) so the two count
+      // queries collapse into one round trip.
+      const [shotsRes, local] = await Promise.all([
         supabase
           .from('shots')
-          .select('id', { count: 'exact', head: true })
-          .eq('hole_score_id', currentHoleScore.id),
-        supabase
-          .from('shots')
-          .select('id', { count: 'exact', head: true })
+          .select('club, lie_type, shot_number, start_lat, start_lng')
           .eq('hole_score_id', currentHoleScore.id)
-          .or('club.eq.putter,lie_type.eq.green'),
-        supabase
-          .from('shots')
-          .select('shot_number, start_lat, start_lng')
-          .eq('hole_score_id', currentHoleScore.id)
-          .not('start_lat', 'is', null)
-          .not('start_lng', 'is', null)
           .order('shot_number'),
         pendingShotsForHoleScore(currentHoleScore.id),
       ])
       if (!active) return
-      setRemoteShotCount(shotRes.count ?? 0)
-      setRemotePuttCount(puttRes.count ?? 0)
+      const shots = shotsRes.data ?? []
+      setRemoteShotCount(shots.length)
+      setRemotePuttCount(
+        shots.filter((s) => s.club === 'putter' || s.lie_type === 'green').length,
+      )
       const starts: LatLng[] = []
-      for (const r of startsRes.data ?? []) {
+      for (const r of shots) {
         if (r.start_lat != null && r.start_lng != null) {
           starts.push({ lat: r.start_lat, lng: r.start_lng })
         }

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -687,6 +687,8 @@ export default function HoleScreen() {
         }}
       >
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Leave round and return home"
           onPress={() => setConfirmLeave(true)}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           style={{ padding: 6 }}
@@ -724,6 +726,7 @@ export default function HoleScreen() {
         </View>
         <View style={{ alignItems: 'flex-end', gap: 6 }}>
           <Pressable
+            accessibilityRole="button"
             onPress={() => setConfirmEnd(true)}
             accessibilityLabel="End round early"
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
@@ -738,6 +741,7 @@ export default function HoleScreen() {
             </Text>
           </Pressable>
           <Pressable
+            accessibilityRole="button"
             onPress={() => setConfirmDelete(true)}
             accessibilityLabel="Delete round"
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
@@ -789,6 +793,8 @@ export default function HoleScreen() {
         {pinPlacementOpen ? (
           <View style={{ flexDirection: 'row', gap: 8, marginBottom: 10 }}>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Cancel pin placement"
               onPress={() => setPinPlacementOpen(false)}
               style={{
                 flex: 1,
@@ -812,6 +818,8 @@ export default function HoleScreen() {
             </Pressable>
             {roundPin && (
               <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Clear pin"
                 onPress={clearRoundPin}
                 style={{
                   flex: 1,
@@ -838,6 +846,9 @@ export default function HoleScreen() {
         ) : roundState === 'SET_AIM' ? (
           <>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={aim ? 'Confirm aim point' : 'Long-press the map to set aim point'}
+              accessibilityState={{ disabled: !aim }}
               onPress={confirmAim}
               disabled={!aim}
               style={{
@@ -867,6 +878,8 @@ export default function HoleScreen() {
               }}
             >
               <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Re-place ball"
                 onPress={() => setRoundState('PLACE_BALL')}
                 hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
                 style={{ padding: 6 }}
@@ -874,6 +887,8 @@ export default function HoleScreen() {
                 <Text style={{ ...KICKER, color: '#8A8B7E' }}>← Re-place ball</Text>
               </Pressable>
               <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Skip aim point"
                 onPress={skipAim}
                 hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
                 style={{ padding: 6 }}
@@ -885,6 +900,9 @@ export default function HoleScreen() {
         ) : (
           <>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={ball ? 'Mark ball at current position' : 'Drop the ball on the map first'}
+              accessibilityState={{ disabled: !ball || saving }}
               onPress={markBallHere}
               disabled={!ball || saving}
               style={{
@@ -911,6 +929,8 @@ export default function HoleScreen() {
               </Text>
             </Pressable>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={roundPin ? 'Move pin' : 'Place pin'}
               onPress={() => setPinPlacementOpen(true)}
               style={{
                 paddingVertical: 8,
@@ -933,6 +953,8 @@ export default function HoleScreen() {
             </Pressable>
             {totalShotsThisHole > 0 && (
               <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={holeNumber < 18 ? 'Finish hole and continue' : 'Finish round'}
                 onPress={finishHole}
                 style={{
                   borderWidth: 1,
@@ -965,6 +987,9 @@ export default function HoleScreen() {
           }}
         >
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Previous hole"
+            accessibilityState={{ disabled: holeNumber === 1 }}
             onPress={() => navigateHole(-1)}
             disabled={holeNumber === 1}
             style={{
@@ -979,6 +1004,7 @@ export default function HoleScreen() {
             <Text style={{ fontSize: 12, color: '#1C211C' }}>← Prev</Text>
           </Pressable>
           <Pressable
+            accessibilityRole="button"
             onPress={() => setScorecardOpen(true)}
             style={{ flex: 1, alignItems: 'center' }}
             accessibilityLabel="Open scorecard"
@@ -999,6 +1025,9 @@ export default function HoleScreen() {
             />
           </Pressable>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Next hole"
+            accessibilityState={{ disabled: holeNumber === 18 }}
             onPress={() => navigateHole(1)}
             disabled={holeNumber === 18}
             style={{
@@ -1214,6 +1243,9 @@ function ScorecardModal({
             return (
               <Pressable
                 key={h.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Jump to hole ${h.number}, par ${h.par}${score != null ? `, score ${score}` : ''}`}
+                accessibilityState={{ selected: active }}
                 onPress={() => onJumpToHole(h.number)}
                 style={{
                   flexDirection: 'row',
@@ -1344,6 +1376,8 @@ function ScorecardModal({
           </View>
         </ScrollView>
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Close scorecard"
           onPress={onClose}
           style={{
             marginTop: 14,

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -6,7 +6,7 @@ import {
   Text,
   View,
 } from 'react-native'
-import { useLocalSearchParams, useRouter } from 'expo-router'
+import { Redirect, useLocalSearchParams, useRouter } from 'expo-router'
 import { formatSG } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../../../lib/supabase'
@@ -37,6 +37,7 @@ export default function RoundIndex() {
   const [courseName, setCourseName] = useState<string>('Round')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [redirectToLive, setRedirectToLive] = useState(false)
 
   useEffect(() => {
     if (!id) return
@@ -55,9 +56,10 @@ export default function RoundIndex() {
         setCourseName(row.courses?.name ?? 'Round')
         // Live round signal: total_score is set when the round completes
         // (either Finish round or End round early). Anything else is
-        // still in progress — drop into the hole flow.
+        // still in progress — drop into the hole flow via <Redirect>
+        // on the next render so we can't navigate after unmount.
         if (row.total_score == null) {
-          router.replace(`/(app)/round/${id}/hole/1?mode=live`)
+          if (active) setRedirectToLive(true)
           return
         }
         const [hRes, hsRes] = await Promise.all([
@@ -84,6 +86,10 @@ export default function RoundIndex() {
       active = false
     }
   }, [id])
+
+  if (redirectToLive && id) {
+    return <Redirect href={`/(app)/round/${id}/hole/1?mode=live`} />
+  }
 
   const scoresByHoleId = useMemo(
     () => new Map(holeScores.map((hs) => [hs.hole_id, hs])),

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -201,6 +201,8 @@ export function PuttingSheet({
           </Text>
         </View>
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Close putting sheet"
           onPress={onClose}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           style={{ padding: 12 }}
@@ -332,6 +334,8 @@ export function PuttingSheet({
 
         <View style={{ marginTop: 22 }}>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Save putt as holed"
             onPress={() => commit(true)}
             style={{
               backgroundColor: '#1F3D2C',
@@ -352,6 +356,8 @@ export function PuttingSheet({
             </Text>
           </Pressable>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Save putt as missed"
             onPress={() => commit(false)}
             style={{
               borderWidth: 1,
@@ -412,6 +418,9 @@ function Chip({
 }) {
   return (
     <Pressable
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: active }}
       onPress={onPress}
       style={{
         backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
@@ -453,6 +462,9 @@ function ResultCell({
   const border = active ? '#1F3D2C' : '#D9D2BF'
   return (
     <Pressable
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: active, disabled }}
       onPress={onPress}
       disabled={disabled}
       style={{

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -184,6 +184,8 @@ export function ShotLogger({
               </Text>
             </View>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Skip all logging for this shot"
               onPress={onSkip}
               hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
               style={{ padding: 6 }}
@@ -337,6 +339,8 @@ export function ShotLogger({
             }}
           >
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Cancel logging shot"
               onPress={onClose}
               style={{
                 flex: 1,
@@ -360,6 +364,8 @@ export function ShotLogger({
               </Text>
             </Pressable>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Save shot and continue"
               onPress={() => onSave(value)}
               style={{
                 flex: 1,
@@ -516,6 +522,9 @@ function ChipRow<T extends string>({ value, options, onChange }: ChipRowProps<T>
           return (
             <Pressable
               key={opt}
+              accessibilityRole="radio"
+              accessibilityLabel={opt.replace(/_/g, ' ')}
+              accessibilityState={{ selected: active }}
               onPress={() => onChange(opt)}
               style={{
                 paddingHorizontal: 10,

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -12,6 +12,13 @@ config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),
 ]
+// disableHierarchicalLookup: required for the Turborepo monorepo
+// layout. Without this, Metro walks up from apps/mobile and resolves
+// React Native packages from the workspace root's node_modules first,
+// which gets duplicate React copies and breaks the RN bridge. Pinning
+// resolution to nodeModulesPaths above keeps the mobile app's own
+// install authoritative. Do not remove without re-validating an EAS
+// build end-to-end.
 config.resolver.disableHierarchicalLookup = true
 
 module.exports = withNativeWind(config, { input: './global.css' })

--- a/apps/web/src/components/errors/ErrorBoundary.tsx
+++ b/apps/web/src/components/errors/ErrorBoundary.tsx
@@ -18,7 +18,7 @@ export class ErrorBoundary extends Component<Props, State> {
 
   override componentDidCatch(error: Error, info: ErrorInfo): void {
     if (import.meta.env.DEV) {
-      console.error('ErrorBoundary caught:', error, info)
+      console.error('[ErrorBoundary/caught]', error, info)
     }
   }
 

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -249,7 +249,7 @@ export function ShotEntryModal({
     } catch (err) {
       if (import.meta.env.DEV) {
         // eslint-disable-next-line no-console
-        console.error('shot save failed', err, insert)
+        console.error('[ShotEntryModal/save]', err, insert)
       }
       throw err
     }

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -187,7 +187,7 @@ export function RoundDetailPage() {
         // Don't roll back the local override — the user's intent stays
         // visible while they retry. Surface the error for diagnostics.
         // eslint-disable-next-line no-console
-        console.error('round pin update failed', error)
+        console.error('[RoundDetailPage/updatePin]', error)
       }
     },
     [activeHoleScore, roundId],

--- a/packages/core/src/sg-calculator.ts
+++ b/packages/core/src/sg-calculator.ts
@@ -65,8 +65,7 @@ function startDistanceFt(shot: Shot): number | undefined {
 }
 
 function holedOut(shot: Shot): boolean {
-  if (shot.lieType === 'green' && shot.puttResult === 'made') return true
-  return false
+  return shot.lieType === 'green' && shot.puttResult === 'made'
 }
 
 export function calculateRoundSG(


### PR DESCRIPTION
## Summary

Eight commits across mobile and web. Two of the planned fixes turned out to be no-ops on inspection — see below.

### Bug fixes
- **#101 — mobile a11y labels.** Added `accessibilityRole` + `accessibilityLabel` to interactive `Pressable`s in `index.tsx`, `profile.tsx`, `ShotLogger.tsx`, `PuttingSheet.tsx`, and `round/[id]/hole/[number].tsx`. Chip selectors (club, lie type, slope intensity, putt distance/direction, ResultCell, profile unit toggle) now report `radio` with `accessibilityState.selected`. Disabled controls report `accessibilityState.disabled`. Backdrop-only `Pressable`s and the round detail header (which already had eyebrow text) skipped intentionally.
- **#96 — profile fetch retry.** `(app)/_layout.tsx` adds a 10-second timeout, an `error` `ProfileState`, and a "Try again" button driven by a retry nonce that re-runs the effect. Network blip no longer leaves the app stuck on a blank loading frame.
- **#95 — cold-start splash.** Replaced the `return null` during auth/profile load with a dark `caddie-bg` (`#1C211C`) + `ActivityIndicator` so the native splash transition into the React tree doesn't flash white.
- **router.push → `<Redirect>`.** `(app)/round/[id]/index.tsx` now sets a `redirectToLive` flag and renders `<Redirect href=…/>` synchronously instead of calling `router.replace` from inside the async fetch — no more navigation-after-unmount risk if the user backs out while the round row is in flight.

### Perf
- **#94 — single shot fetch per hole.** `(app)/round/[id]/hole/[number].tsx` collapses three reads (shot count head, putt count head, start coords select) into one `select('club, lie_type, shot_number, start_lat, start_lng')`. Putt count is derived client-side from `(club === 'putter' || lie_type === 'green')`. Same data, one round trip.

### Docs / cleanup
- **metro.** Inline comment on `config.resolver.disableHierarchicalLookup = true` explaining why removal would break the EAS build.
- **`holedOut`** in `@oga/core/sg-calculator.ts` collapsed from `if … return true; return false` to a direct boolean return.
- **console.error prefixes.** Web app's three `console.error` calls now use the `[Component/action]` shape mobile already uses (`[ShotEntryModal/save]`, `[ErrorBoundary/caught]`, `[RoundDetailPage/updatePin]`).

### No-ops (planned but already correct)
- **#42 partial — Google Fonts `display=swap`.** Already present in `apps/web/index.html`. No change needed.
- **#97 — DECISIONS.md entry for `router.origin: false`.** Updated locally; `DECISIONS.md` is intentionally gitignored per `CLAUDE.md` (commit `1eb7fc2`), so this is a local-only note. Re-raise if the policy on that file changes.

## Test plan
- [x] `pnpm typecheck` — 4/4 packages clean
- [x] `pnpm --filter web build` — succeeds (existing chunk-size warnings only)
- [x] `cd apps/mobile && npm run typecheck` — clean
- [x] `pnpm test` — 200/200
- [ ] manual: TalkBack scan on Home, Profile, hole flow, putting sheet (#101)
- [ ] manual: airplane-mode on app cold start, confirm retry UI shows after 10s and recovers when network returns (#96)
- [ ] manual: cold start with phone in low-power mode, confirm dark splash transition (#95)
- [ ] manual: tap a past round on the home list, confirm scorecard view loads (no live-mode redirect)

Closes #94 #95 #96 #101.