### PR TITLE
v0.2 — Foundation Release (57 commits)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 jobs:
   typecheck:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,16 +39,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-<<<<<<< HEAD
-      - name: Mobile typecheck
-        run: |
-          cd packages/supabase && npm install --legacy-peer-deps
-          cd ../../apps/mobile && npm install --legacy-peer-deps && npm run typecheck
-=======
       - name: Install supabase package deps
         run: cd packages/supabase && npm install --legacy-peer-deps
       - name: Install core package deps
         run: cd packages/core && npm install --legacy-peer-deps
       - name: Mobile typecheck
         run: cd apps/mobile && npm install --legacy-peer-deps && npm run typecheck
->>>>>>> dev

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -129,6 +129,7 @@ export default function AppLayout() {
         }}
       />
       <Tabs.Screen name="learn" options={{ href: null }} />
+      <Tabs.Screen name="rounds" options={{ href: null }} />
       <Tabs.Screen name="round/new" options={{ href: null }} />
       <Tabs.Screen name="round/[id]/index" options={{ href: null }} />
       <Tabs.Screen name="round/[id]/hole/[number]" options={{ href: null }} />

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Pressable, Text, View } from 'react-native'
+import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { supabase } from '../../lib/supabase'
@@ -56,7 +56,22 @@ export default function AppLayout() {
     }
   }, [user, authLoading, retryNonce])
 
-  if (authLoading || profileState === 'loading') return null
+  if (authLoading || profileState === 'loading') {
+    // Match the native splash screen's dark background so the cold-start
+    // transition into the React tree doesn't flash a white frame.
+    return (
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: '#1C211C',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        <ActivityIndicator color="#E8E4DC" />
+      </View>
+    )
+  }
   if (!user) return <Redirect href="/(auth)/login" />
   if (profileState === 'error') {
     return (

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { supabase } from '../../lib/supabase'
@@ -7,18 +8,28 @@ import { ErrorBoundary } from '../../components/errors/ErrorBoundary'
 import { UnitsProvider } from '../../contexts/UnitsContext'
 
 const ICON_SIZE = 18
+// Transient profile fetch can hang on flaky networks. After this
+// timeout we surface a retry button instead of an infinite spinner.
+const PROFILE_FETCH_TIMEOUT_MS = 10_000
 
-type ProfileState = 'loading' | 'complete' | 'incomplete'
+type ProfileState = 'loading' | 'complete' | 'incomplete' | 'error'
 
 export default function AppLayout() {
   const { user, loading: authLoading } = useAuth()
   const [profileState, setProfileState] = useState<ProfileState>('loading')
+  const [retryNonce, setRetryNonce] = useState(0)
 
   useEffect(() => {
     if (authLoading) return
     if (!user) return
 
     let active = true
+    setProfileState('loading')
+
+    const timeoutId = setTimeout(() => {
+      if (active) setProfileState('error')
+    }, PROFILE_FETCH_TIMEOUT_MS)
+
     supabase
       .from('profiles')
       .select('skill_level, goal')
@@ -26,13 +37,11 @@ export default function AppLayout() {
       .maybeSingle()
       .then(({ data, error }) => {
         if (!active) return
+        clearTimeout(timeoutId)
         if (error) {
           // eslint-disable-next-line no-console
           console.error('[(app)/_layout]', error.message)
-          // Treat as incomplete is the wrong call for a transient error;
-          // leave the user on the loading state until the next render
-          // can retry. Setting incomplete here would punt them to
-          // onboarding and clobber their saved profile.
+          setProfileState('error')
           return
         }
         if (!data || !data.skill_level || !data.goal) {
@@ -43,11 +52,70 @@ export default function AppLayout() {
       })
     return () => {
       active = false
+      clearTimeout(timeoutId)
     }
-  }, [user, authLoading])
+  }, [user, authLoading, retryNonce])
 
   if (authLoading || profileState === 'loading') return null
   if (!user) return <Redirect href="/(auth)/login" />
+  if (profileState === 'error') {
+    return (
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: '#1C211C',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 28,
+        }}
+      >
+        <Text
+          style={{
+            color: '#F2EEE5',
+            fontSize: 20,
+            fontWeight: '500',
+            fontStyle: 'italic',
+            marginBottom: 10,
+            textAlign: 'center',
+          }}
+        >
+          Something went wrong loading your profile.
+        </Text>
+        <Text
+          style={{
+            color: 'rgba(242,238,229,0.65)',
+            fontSize: 14,
+            textAlign: 'center',
+            marginBottom: 22,
+          }}
+        >
+          Check your connection, then try again.
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Try again"
+          onPress={() => setRetryNonce((n) => n + 1)}
+          style={{
+            backgroundColor: '#1F3D2C',
+            borderRadius: 2,
+            paddingVertical: 14,
+            paddingHorizontal: 22,
+          }}
+        >
+          <Text
+            style={{
+              color: '#F2EEE5',
+              fontSize: 14,
+              fontWeight: '600',
+              letterSpacing: 0.3,
+            }}
+          >
+            Try again
+          </Text>
+        </Pressable>
+      </View>
+    )
+  }
   if (profileState === 'incomplete') return <Redirect href="/(auth)/onboarding" />
 
   return (

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
-import { Link } from 'expo-router'
+import { Link, useRouter } from 'expo-router'
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
 import { Swipeable } from 'react-native-gesture-handler'
 import { formatSG } from '@oga/core'
@@ -42,10 +42,18 @@ const KICKER: import('react-native').TextStyle = {
   textTransform: 'uppercase',
 }
 
+interface ActiveRound {
+  id: string
+  courseName: string
+  currentHole: number
+}
+
 export default function Home() {
   const { user } = useAuth()
+  const router = useRouter()
   const [profile, setProfile] = useState<Profile | null>(null)
   const [rounds, setRounds] = useState<RecentRound[]>([])
+  const [activeRound, setActiveRound] = useState<ActiveRound | null>(null)
   const [pending, setPending] = useState(0)
   const [pendingDelete, setPendingDelete] = useState<{
     id: string
@@ -105,6 +113,59 @@ export default function Home() {
       .catch(() => undefined)
   }, [])
 
+  // Active-round detection. Active = total_score IS NULL AND played_at
+  // within the last day, so a round abandoned a week ago doesn't haunt
+  // the home screen forever. The current hole is the highest hole the
+  // player has logged a score on, +1 (capped at 18) — so resuming
+  // jumps back to where they left off, not hole 1.
+  useEffect(() => {
+    if (!user) return
+    let active = true
+    ;(async () => {
+      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10)
+      const { data, error } = await supabase
+        .from('rounds')
+        .select('id, played_at, course_id, courses(name)')
+        .eq('user_id', user.id)
+        .is('total_score', null)
+        .gte('played_at', oneDayAgo)
+        .order('played_at', { ascending: false })
+        .limit(1)
+      if (!active || error || !data?.[0]) {
+        setActiveRound(null)
+        return
+      }
+      const round = data[0] as {
+        id: string
+        played_at: string
+        course_id: string
+        courses?: { name: string | null } | null
+      }
+      const { data: hs } = await supabase
+        .from('hole_scores')
+        .select('score, holes(number)')
+        .eq('round_id', round.id)
+        .gt('score', 0)
+      if (!active) return
+      const maxHole = (hs ?? []).reduce<number>((acc, row) => {
+        const n = (row as { holes?: { number?: number | null } | null }).holes
+          ?.number
+        return typeof n === 'number' && n > acc ? n : acc
+      }, 0)
+      const next = Math.min(18, Math.max(1, maxHole + 1))
+      setActiveRound({
+        id: round.id,
+        courseName: round.courses?.name ?? 'Round',
+        currentHole: next,
+      })
+    })()
+    return () => {
+      active = false
+    }
+  }, [user?.id])
+
   // SG breakdown + trend are pure functions of `rounds` — memoize so
   // unrelated parent re-renders (delete sync, window resize) don't
   // re-walk the array four times for the SG averages and once more for
@@ -147,6 +208,53 @@ export default function Home() {
         <Text style={{ color: '#5C6356', fontSize: 14, marginBottom: 22 }}>
           Last {rounds.length || 0} round{rounds.length === 1 ? '' : 's'}
         </Text>
+
+        {activeRound && (
+          <Pressable
+            onPress={() =>
+              router.push(
+                `/(app)/round/${activeRound.id}/hole/${activeRound.currentHole}?mode=live`,
+              )
+            }
+            style={{
+              borderWidth: 1,
+              borderColor: '#A66A1F',
+              borderRadius: 2,
+              paddingVertical: 14,
+              paddingHorizontal: 16,
+              marginBottom: 14,
+              backgroundColor: '#FBF8F1',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <View>
+              <Text style={{ ...KICKER, color: '#A66A1F', marginBottom: 4 }}>
+                Active round
+              </Text>
+              <Text
+                style={{
+                  color: '#1C211C',
+                  fontSize: 15,
+                  fontWeight: '500',
+                }}
+              >
+                {activeRound.courseName} · Hole {activeRound.currentHole}
+              </Text>
+            </View>
+            <Text
+              style={{
+                color: '#A66A1F',
+                fontSize: 14,
+                fontWeight: '600',
+                letterSpacing: 0.3,
+              }}
+            >
+              Resume →
+            </Text>
+          </Pressable>
+        )}
 
         <Link href="/(app)/round/new?mode=live" asChild>
           <Pressable

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -211,6 +211,8 @@ export default function Home() {
 
         {activeRound && (
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Resume active round at ${activeRound.courseName}, hole ${activeRound.currentHole}`}
             onPress={() =>
               router.push(
                 `/(app)/round/${activeRound.id}/hole/${activeRound.currentHole}?mode=live`,
@@ -258,6 +260,8 @@ export default function Home() {
 
         <Link href="/(app)/round/new?mode=live" asChild>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Start live round"
             style={{
               backgroundColor: '#1F3D2C',
               borderRadius: 2,
@@ -291,6 +295,8 @@ export default function Home() {
 
         <Link href="/(app)/round/new?mode=past" asChild>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Log past round"
             style={{
               borderWidth: 1,
               borderColor: '#1F3D2C',
@@ -423,6 +429,8 @@ export default function Home() {
                   }}
                   renderRightActions={() => (
                     <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={`Delete round at ${r.courses?.name ?? 'this round'}`}
                       onPress={() => {
                         swipeRefs.current.get(r.id)?.close()
                         setPendingDelete({
@@ -453,6 +461,8 @@ export default function Home() {
                 >
                   <Link href={`/(app)/round/${r.id}`} asChild>
                     <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={`Open round at ${r.courses?.name ?? 'unknown course'} on ${r.played_at}`}
                       style={{
                         flexDirection: 'row',
                         justifyContent: 'space-between',
@@ -511,6 +521,8 @@ export default function Home() {
               {rounds.length > 5 && (
                 <Link href="/(app)/rounds" asChild>
                   <Pressable
+                    accessibilityRole="link"
+                    accessibilityLabel="See all rounds"
                     style={{
                       paddingVertical: 14,
                       paddingHorizontal: 4,

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -508,6 +508,27 @@ export default function Home() {
                   </Link>
                 </Swipeable>
               ))}
+              {rounds.length > 5 && (
+                <Link href="/(app)/rounds" asChild>
+                  <Pressable
+                    style={{
+                      paddingVertical: 14,
+                      paddingHorizontal: 4,
+                      alignItems: 'flex-end',
+                    }}
+                  >
+                    <Text
+                      style={{
+                        color: '#8A8B7E',
+                        fontSize: 13,
+                        fontWeight: '500',
+                      }}
+                    >
+                      See all rounds →
+                    </Text>
+                  </Pressable>
+                </Link>
+              )}
             </View>
           )}
         </Section>

--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -104,11 +104,10 @@ export default function Patterns() {
   const points = useMemo(() => {
     let pts = computeDispersion(shots.map(rowToShot))
     if (lieType !== ANY || lieSlope !== ANY) {
-      pts = filterDispersionByLie(
-        pts,
-        lieSlope === ANY ? undefined : lieSlope,
-        lieType === ANY ? undefined : lieType,
-      )
+      pts = filterDispersionByLie(pts, {
+        lieSlope: lieSlope === ANY ? undefined : lieSlope,
+        lieType: lieType === ANY ? undefined : lieType,
+      })
     }
     return pts
   }, [shots, lieType, lieSlope])

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -220,6 +220,9 @@ export default function ProfileTab() {
         </Field>
 
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={saving ? 'Saving profile' : 'Save profile changes'}
+          accessibilityState={{ disabled: saving }}
           onPress={save}
           disabled={saving}
           style={{
@@ -266,6 +269,8 @@ export default function ProfileTab() {
           </Text>
           <View style={{ flexDirection: 'row', gap: 10 }}>
             <Pressable
+              accessibilityRole="link"
+              accessibilityLabel="Open Ko-fi sponsorship page"
               onPress={() => Linking.openURL('https://ko-fi.com/nartana')}
               style={{
                 flex: 1,
@@ -288,6 +293,8 @@ export default function ProfileTab() {
               </Text>
             </Pressable>
             <Pressable
+              accessibilityRole="link"
+              accessibilityLabel="Open GitHub Sponsors page"
               onPress={() =>
                 Linking.openURL('https://github.com/sponsors/cner-smith')
               }
@@ -315,6 +322,8 @@ export default function ProfileTab() {
         </View>
 
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Sign out"
           onPress={() => supabase.auth.signOut()}
           style={{
             marginTop: 22,
@@ -374,6 +383,9 @@ function Chip({
 }) {
   return (
     <Pressable
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: active }}
       onPress={onPress}
       style={{
         paddingHorizontal: 10,

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -193,30 +193,25 @@ export default function HoleScreen() {
     if (!currentHoleScore) return
     let active = true
     ;(async () => {
-      const [shotRes, puttRes, startsRes, local] = await Promise.all([
+      // Single fetch covers shot count, putt count, and start coords —
+      // putts are derivable from (club, lie_type) so the two count
+      // queries collapse into one round trip.
+      const [shotsRes, local] = await Promise.all([
         supabase
           .from('shots')
-          .select('id', { count: 'exact', head: true })
-          .eq('hole_score_id', currentHoleScore.id),
-        supabase
-          .from('shots')
-          .select('id', { count: 'exact', head: true })
+          .select('club, lie_type, shot_number, start_lat, start_lng')
           .eq('hole_score_id', currentHoleScore.id)
-          .or('club.eq.putter,lie_type.eq.green'),
-        supabase
-          .from('shots')
-          .select('shot_number, start_lat, start_lng')
-          .eq('hole_score_id', currentHoleScore.id)
-          .not('start_lat', 'is', null)
-          .not('start_lng', 'is', null)
           .order('shot_number'),
         pendingShotsForHoleScore(currentHoleScore.id),
       ])
       if (!active) return
-      setRemoteShotCount(shotRes.count ?? 0)
-      setRemotePuttCount(puttRes.count ?? 0)
+      const shots = shotsRes.data ?? []
+      setRemoteShotCount(shots.length)
+      setRemotePuttCount(
+        shots.filter((s) => s.club === 'putter' || s.lie_type === 'green').length,
+      )
       const starts: LatLng[] = []
-      for (const r of startsRes.data ?? []) {
+      for (const r of shots) {
         if (r.start_lat != null && r.start_lng != null) {
           starts.push({ lat: r.start_lat, lng: r.start_lng })
         }

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -687,6 +687,8 @@ export default function HoleScreen() {
         }}
       >
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Leave round and return home"
           onPress={() => setConfirmLeave(true)}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           style={{ padding: 6 }}
@@ -724,6 +726,7 @@ export default function HoleScreen() {
         </View>
         <View style={{ alignItems: 'flex-end', gap: 6 }}>
           <Pressable
+            accessibilityRole="button"
             onPress={() => setConfirmEnd(true)}
             accessibilityLabel="End round early"
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
@@ -738,6 +741,7 @@ export default function HoleScreen() {
             </Text>
           </Pressable>
           <Pressable
+            accessibilityRole="button"
             onPress={() => setConfirmDelete(true)}
             accessibilityLabel="Delete round"
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
@@ -789,6 +793,8 @@ export default function HoleScreen() {
         {pinPlacementOpen ? (
           <View style={{ flexDirection: 'row', gap: 8, marginBottom: 10 }}>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Cancel pin placement"
               onPress={() => setPinPlacementOpen(false)}
               style={{
                 flex: 1,
@@ -812,6 +818,8 @@ export default function HoleScreen() {
             </Pressable>
             {roundPin && (
               <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Clear pin"
                 onPress={clearRoundPin}
                 style={{
                   flex: 1,
@@ -838,6 +846,9 @@ export default function HoleScreen() {
         ) : roundState === 'SET_AIM' ? (
           <>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={aim ? 'Confirm aim point' : 'Long-press the map to set aim point'}
+              accessibilityState={{ disabled: !aim }}
               onPress={confirmAim}
               disabled={!aim}
               style={{
@@ -867,6 +878,8 @@ export default function HoleScreen() {
               }}
             >
               <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Re-place ball"
                 onPress={() => setRoundState('PLACE_BALL')}
                 hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
                 style={{ padding: 6 }}
@@ -874,6 +887,8 @@ export default function HoleScreen() {
                 <Text style={{ ...KICKER, color: '#8A8B7E' }}>← Re-place ball</Text>
               </Pressable>
               <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Skip aim point"
                 onPress={skipAim}
                 hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
                 style={{ padding: 6 }}
@@ -885,6 +900,9 @@ export default function HoleScreen() {
         ) : (
           <>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={ball ? 'Mark ball at current position' : 'Drop the ball on the map first'}
+              accessibilityState={{ disabled: !ball || saving }}
               onPress={markBallHere}
               disabled={!ball || saving}
               style={{
@@ -911,6 +929,8 @@ export default function HoleScreen() {
               </Text>
             </Pressable>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={roundPin ? 'Move pin' : 'Place pin'}
               onPress={() => setPinPlacementOpen(true)}
               style={{
                 paddingVertical: 8,
@@ -933,6 +953,8 @@ export default function HoleScreen() {
             </Pressable>
             {totalShotsThisHole > 0 && (
               <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={holeNumber < 18 ? 'Finish hole and continue' : 'Finish round'}
                 onPress={finishHole}
                 style={{
                   borderWidth: 1,
@@ -965,6 +987,9 @@ export default function HoleScreen() {
           }}
         >
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Previous hole"
+            accessibilityState={{ disabled: holeNumber === 1 }}
             onPress={() => navigateHole(-1)}
             disabled={holeNumber === 1}
             style={{
@@ -979,6 +1004,7 @@ export default function HoleScreen() {
             <Text style={{ fontSize: 12, color: '#1C211C' }}>← Prev</Text>
           </Pressable>
           <Pressable
+            accessibilityRole="button"
             onPress={() => setScorecardOpen(true)}
             style={{ flex: 1, alignItems: 'center' }}
             accessibilityLabel="Open scorecard"
@@ -999,6 +1025,9 @@ export default function HoleScreen() {
             />
           </Pressable>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Next hole"
+            accessibilityState={{ disabled: holeNumber === 18 }}
             onPress={() => navigateHole(1)}
             disabled={holeNumber === 18}
             style={{
@@ -1214,6 +1243,9 @@ function ScorecardModal({
             return (
               <Pressable
                 key={h.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Jump to hole ${h.number}, par ${h.par}${score != null ? `, score ${score}` : ''}`}
+                accessibilityState={{ selected: active }}
                 onPress={() => onJumpToHole(h.number)}
                 style={{
                   flexDirection: 'row',
@@ -1344,6 +1376,8 @@ function ScorecardModal({
           </View>
         </ScrollView>
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Close scorecard"
           onPress={onClose}
           style={{
             marginTop: 14,

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -937,9 +937,18 @@ export default function HoleScreen() {
           </Pressable>
           <Pressable
             onPress={() => setScorecardOpen(true)}
-            style={{ flex: 1 }}
+            style={{ flex: 1, alignItems: 'center' }}
             accessibilityLabel="Open scorecard"
           >
+            <Text
+              style={{
+                ...KICKER,
+                color: '#5C6356',
+                marginBottom: 4,
+              }}
+            >
+              Scorecard ▾
+            </Text>
             <ScorecardPreview
               holes={holes}
               holeScores={holeScores}

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -394,7 +394,12 @@ export default function HoleScreen() {
         },
       ])
       setAim(null)
-      setBall(null)
+      // Leave ball at the just-hit shot's start position. The next shot
+      // is hit from somewhere downrange; the player drags the ball to
+      // refine. The previous behaviour of clearing the ball + reading a
+      // fresh GPS fix snapped the marker to the player's current device
+      // location — which on test builds (or anywhere far from where the
+      // ball actually lies) jumped the marker miles off the course.
       setLoggerOpen(false)
       setRoundState('PLACE_BALL')
       // Background sync — don't await.
@@ -421,17 +426,11 @@ export default function HoleScreen() {
             : hs,
         ),
       )
-      // Re-acquire GPS so the next PLACE_BALL frames the player's new
-      // position. Skipped in past-round mode where GPS is meaningless.
-      if (!isPastMode) {
-        Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High })
-          .then((loc) => {
-            const pos = { lat: loc.coords.latitude, lng: loc.coords.longitude }
-            setGpsPosition(pos)
-            setBall(pos)
-          })
-          .catch(() => undefined)
-      }
+      // Intentionally do NOT snap ball to a fresh GPS reading here. The
+      // watchPosition effect keeps gpsPosition fresh for the nearPin
+      // proximity check, and its functional setBall (prev ?? pos) only
+      // fills the ball when it's null — so a manually-placed (or
+      // carried-over from the prior shot) ball is preserved.
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('shot save failed', err, payload)

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -1016,6 +1016,7 @@ export default function HoleScreen() {
       </View>
 
       <ShotLogger
+        key={shotNumber}
         visible={loggerOpen}
         shotNumber={shotNumber}
         isPutt={false}

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -118,6 +118,7 @@ export default function HoleScreen() {
   const [confirmDelete, setConfirmDelete] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [scorecardOpen, setScorecardOpen] = useState(false)
+  const [confirmLeave, setConfirmLeave] = useState(false)
 
   const currentHole = useMemo(
     () => holes.find((h) => h.number === holeNumber) ?? null,
@@ -660,7 +661,7 @@ export default function HoleScreen() {
         }}
       >
         <Pressable
-          onPress={() => router.replace('/(app)')}
+          onPress={() => setConfirmLeave(true)}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           style={{ padding: 6 }}
         >
@@ -1024,6 +1025,19 @@ export default function HoleScreen() {
         busy={deleting}
         onConfirm={handleDeleteRound}
         onCancel={() => setConfirmDelete(false)}
+      />
+
+      <ConfirmDialog
+        visible={confirmLeave}
+        title="Leave round?"
+        message="Your progress is saved and you can resume from the home screen."
+        confirmLabel="Leave"
+        cancelLabel="Stay"
+        onConfirm={() => {
+          setConfirmLeave(false)
+          router.replace('/(app)')
+        }}
+        onCancel={() => setConfirmLeave(false)}
       />
 
       <Modal

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -37,9 +37,10 @@ import {
 import { syncPendingShots } from '../../../../../lib/sync'
 import { distanceYards } from '../../../../../lib/maps'
 import { combinedPuttResult } from '@oga/core'
-import { deleteRound } from '@oga/supabase'
+import { deleteRound, getProfile } from '@oga/supabase'
 import { ConfirmDialog } from '../../../../../components/ui/ConfirmDialog'
 import { useUnits } from '../../../../../hooks/useUnits'
+import { completeRound } from '../../../../../lib/completeRound'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
@@ -119,6 +120,8 @@ export default function HoleScreen() {
   const [deleting, setDeleting] = useState(false)
   const [scorecardOpen, setScorecardOpen] = useState(false)
   const [confirmLeave, setConfirmLeave] = useState(false)
+  const [confirmEnd, setConfirmEnd] = useState(false)
+  const [ending, setEnding] = useState(false)
 
   const currentHole = useMemo(
     () => holes.find((h) => h.number === holeNumber) ?? null,
@@ -599,6 +602,29 @@ export default function HoleScreen() {
   const totalShotsThisHole =
     remoteShotCount + localShotCount > 0 ? remoteShotCount + localShotCount : 0
 
+  async function handleEndRound() {
+    if (!round || !user) return
+    setEnding(true)
+    try {
+      const { data: profile } = await getProfile(supabase, user.id)
+      const handicap =
+        (profile as { handicap_index?: number | null } | null)?.handicap_index ??
+        null
+      await completeRound({
+        roundId: round.id,
+        courseId: round.course_id,
+        userId: user.id,
+        handicap,
+      })
+      router.replace(`/(app)/round/${round.id}`)
+    } catch (err) {
+      Alert.alert('End round failed', (err as Error).message)
+    } finally {
+      setEnding(false)
+      setConfirmEnd(false)
+    }
+  }
+
   async function handleDeleteRound() {
     if (!round || !user) return
     setDeleting(true)
@@ -696,20 +722,36 @@ export default function HoleScreen() {
             {currentHole.yards ? ` · ${toDisplay(currentHole.yards)}` : ''}
           </Text>
         </View>
-        <Pressable
-          onPress={() => setConfirmDelete(true)}
-          accessibilityLabel="Delete round"
-          style={{ paddingHorizontal: 4 }}
-        >
-          <Text
-            style={{
-              ...KICKER,
-              color: 'rgba(163,58,42,0.85)',
-            }}
+        <View style={{ alignItems: 'flex-end', gap: 6 }}>
+          <Pressable
+            onPress={() => setConfirmEnd(true)}
+            accessibilityLabel="End round early"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           >
-            Delete · Shot {shotNumber}
-          </Text>
-        </Pressable>
+            <Text
+              style={{
+                ...KICKER,
+                color: 'rgba(242,238,229,0.85)',
+              }}
+            >
+              End · Shot {shotNumber}
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={() => setConfirmDelete(true)}
+            accessibilityLabel="Delete round"
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          >
+            <Text
+              style={{
+                ...KICKER,
+                color: 'rgba(163,58,42,0.85)',
+              }}
+            >
+              Delete
+            </Text>
+          </Pressable>
+        </View>
       </View>
 
       <View style={{ flex: 1 }}>
@@ -1038,6 +1080,17 @@ export default function HoleScreen() {
           router.replace('/(app)')
         }}
         onCancel={() => setConfirmLeave(false)}
+      />
+
+      <ConfirmDialog
+        visible={confirmEnd}
+        title={`End round after hole ${holeNumber}?`}
+        message={`Your round will be saved with ${totalShotsThisHole > 0 ? holeNumber : holeNumber - 1} hole(s) of detail. SG and totals are computed from what's logged so far.`}
+        confirmLabel="End round"
+        cancelLabel="Cancel"
+        busy={ending}
+        onConfirm={handleEndRound}
+        onCancel={() => setConfirmEnd(false)}
       />
 
       <Modal

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -8,6 +8,7 @@ import {
   Text,
   View,
 } from 'react-native'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import * as Location from 'expo-location'
 import type { Database } from '@oga/supabase'
@@ -982,20 +983,27 @@ export default function HoleScreen() {
         animationType="slide"
         onRequestClose={closePuttingSheet}
       >
-        <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
-          <PuttingSheet
-            shotNumber={shotNumber}
-            initialDistanceFt={
-              ball && (roundPin ?? storedPin)
-                ? Math.round(
-                    distanceYards(ball, (roundPin ?? storedPin) as LatLng) * 3,
-                  )
-                : undefined
-            }
-            onSave={persistPutt}
-            onClose={closePuttingSheet}
-          />
-        </View>
+        {/* React Native's <Modal> renders to a separate native window on
+            Android, so the app-root GestureHandlerRootView doesn't apply
+            inside. Wrap the modal contents in their own root to restore
+            the GreenDiagram aim-handle pan gesture (broke after the
+            Reanimated refactor). */}
+        <GestureHandlerRootView style={{ flex: 1 }}>
+          <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
+            <PuttingSheet
+              shotNumber={shotNumber}
+              initialDistanceFt={
+                ball && (roundPin ?? storedPin)
+                  ? Math.round(
+                      distanceYards(ball, (roundPin ?? storedPin) as LatLng) * 3,
+                    )
+                  : undefined
+              }
+              onSave={persistPutt}
+              onClose={closePuttingSheet}
+            />
+          </View>
+        </GestureHandlerRootView>
       </Modal>
 
       <ConfirmDialog

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -1,14 +1,405 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
+import { formatSG } from '@oga/core'
+import type { Database } from '@oga/supabase'
+import { supabase } from '../../../../lib/supabase'
 
+type RoundRow = Database['public']['Tables']['rounds']['Row']
+type HoleRow = Database['public']['Tables']['holes']['Row']
+type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+// Round entry route. Live (incomplete) rounds redirect into the hole
+// flow; completed rounds render a read-only summary so a player viewing
+// a past round from the home list isn't dropped back into the
+// Mark-ball / Set-aim state machine.
 export default function RoundIndex() {
   const { id } = useLocalSearchParams<{ id: string }>()
   const router = useRouter()
 
+  const [round, setRound] = useState<RoundRow | null>(null)
+  const [holes, setHoles] = useState<HoleRow[]>([])
+  const [holeScores, setHoleScores] = useState<HoleScoreRow[]>([])
+  const [courseName, setCourseName] = useState<string>('Round')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
   useEffect(() => {
     if (!id) return
-    router.push(`/(app)/round/${id}/hole/1`)
+    let active = true
+    ;(async () => {
+      try {
+        const { data: r, error: rErr } = await supabase
+          .from('rounds')
+          .select('*, courses(name)')
+          .eq('id', id)
+          .single()
+        if (rErr || !r) throw rErr ?? new Error('Round not found')
+        if (!active) return
+        const row = r as RoundRow & { courses?: { name: string | null } | null }
+        setRound(row)
+        setCourseName(row.courses?.name ?? 'Round')
+        // Live round signal: total_score is set when the round completes
+        // (either Finish round or End round early). Anything else is
+        // still in progress — drop into the hole flow.
+        if (row.total_score == null) {
+          router.replace(`/(app)/round/${id}/hole/1?mode=live`)
+          return
+        }
+        const [hRes, hsRes] = await Promise.all([
+          supabase
+            .from('holes')
+            .select('*')
+            .eq('course_id', row.course_id)
+            .order('number'),
+          supabase.from('hole_scores').select('*').eq('round_id', row.id),
+        ])
+        if (!active) return
+        if (hRes.error) throw hRes.error
+        if (hsRes.error) throw hsRes.error
+        setHoles(hRes.data ?? [])
+        setHoleScores(hsRes.data ?? [])
+      } catch (err) {
+        if (!active) return
+        setError((err as Error).message)
+      } finally {
+        if (active) setLoading(false)
+      }
+    })()
+    return () => {
+      active = false
+    }
   }, [id])
 
-  return null
+  const scoresByHoleId = useMemo(
+    () => new Map(holeScores.map((hs) => [hs.hole_id, hs])),
+    [holeScores],
+  )
+  const sortedHoles = useMemo(
+    () => [...holes].sort((a, b) => a.number - b.number),
+    [holes],
+  )
+
+  if (loading) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#F2EEE5',
+        }}
+      >
+        <ActivityIndicator color="#1F3D2C" />
+      </View>
+    )
+  }
+  if (error || !round) {
+    return (
+      <View
+        style={{
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#F2EEE5',
+          padding: 18,
+        }}
+      >
+        <Text style={{ color: '#A33A2A', fontSize: 13 }}>
+          {error ?? 'Round not found'}
+        </Text>
+      </View>
+    )
+  }
+
+  const sgRows: { label: string; value: number | null }[] = [
+    { label: 'Off tee', value: round.sg_off_tee },
+    { label: 'Approach', value: round.sg_approach },
+    { label: 'Around green', value: round.sg_around_green },
+    { label: 'Putting', value: round.sg_putting },
+  ]
+
+  let runningScore = 0
+  let runningPar = 0
+  for (const h of sortedHoles) {
+    const hs = scoresByHoleId.get(h.id)
+    if (hs?.score != null && hs.score > 0) {
+      runningScore += hs.score
+      runningPar += h.par
+    }
+  }
+  const diff = runningScore - runningPar
+
+  return (
+    <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
+      <View
+        style={{
+          backgroundColor: '#1C211C',
+          paddingTop: 52,
+          paddingBottom: 14,
+          paddingHorizontal: 18,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Pressable
+          onPress={() => router.replace('/(app)')}
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+          style={{ padding: 6 }}
+        >
+          <Text style={{ ...KICKER, color: 'rgba(242,238,229,0.6)' }}>← Home</Text>
+        </Pressable>
+        <View style={{ alignItems: 'center' }}>
+          <Text style={{ ...KICKER, color: 'rgba(242,238,229,0.45)', marginBottom: 4 }}>
+            {round.played_at}
+          </Text>
+          <Text
+            style={{
+              color: '#F2EEE5',
+              fontSize: 17,
+              fontWeight: '500',
+              fontStyle: 'italic',
+            }}
+          >
+            {courseName}
+          </Text>
+        </View>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'baseline',
+            justifyContent: 'space-between',
+            marginBottom: 18,
+          }}
+        >
+          <View>
+            <Text style={{ ...KICKER, marginBottom: 4 }}>Total</Text>
+            <Text
+              style={{
+                color: '#1C211C',
+                fontSize: 36,
+                fontWeight: '500',
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {round.total_score ?? '—'}
+            </Text>
+          </View>
+          <View style={{ alignItems: 'flex-end' }}>
+            <Text style={{ ...KICKER, marginBottom: 4 }}>To par</Text>
+            <Text
+              style={{
+                color:
+                  diff < 0 ? '#1F3D2C' : diff > 0 ? '#A33A2A' : '#5C6356',
+                fontSize: 28,
+                fontWeight: '500',
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {runningPar === 0
+                ? '—'
+                : diff === 0
+                  ? 'E'
+                  : diff > 0
+                    ? `+${diff}`
+                    : `${diff}`}
+            </Text>
+          </View>
+        </View>
+
+        <View
+          style={{
+            borderTopWidth: 1,
+            borderColor: '#D9D2BF',
+            paddingTop: 14,
+            marginBottom: 18,
+          }}
+        >
+          <Text style={{ ...KICKER, marginBottom: 12 }}>Strokes gained</Text>
+          {sgRows.map((row) => (
+            <View
+              key={row.label}
+              style={{
+                flexDirection: 'row',
+                justifyContent: 'space-between',
+                paddingVertical: 6,
+              }}
+            >
+              <Text style={{ color: '#1C211C', fontSize: 13 }}>{row.label}</Text>
+              <Text
+                style={{
+                  color:
+                    row.value == null
+                      ? '#8A8B7E'
+                      : row.value > 0
+                        ? '#1F3D2C'
+                        : row.value < 0
+                          ? '#A33A2A'
+                          : '#5C6356',
+                  fontSize: 13,
+                  fontVariant: ['tabular-nums'],
+                  fontWeight: '500',
+                }}
+              >
+                {row.value == null ? '—' : formatSG(row.value)}
+              </Text>
+            </View>
+          ))}
+          <View
+            style={{
+              flexDirection: 'row',
+              justifyContent: 'space-between',
+              paddingTop: 8,
+              marginTop: 4,
+              borderTopWidth: 1,
+              borderColor: '#EBE5D6',
+            }}
+          >
+            <Text style={{ color: '#1C211C', fontSize: 14, fontWeight: '600' }}>
+              Total
+            </Text>
+            <Text
+              style={{
+                color:
+                  round.sg_total == null
+                    ? '#8A8B7E'
+                    : round.sg_total > 0
+                      ? '#1F3D2C'
+                      : round.sg_total < 0
+                        ? '#A33A2A'
+                        : '#5C6356',
+                fontSize: 14,
+                fontVariant: ['tabular-nums'],
+                fontWeight: '600',
+              }}
+            >
+              {round.sg_total == null ? '—' : formatSG(round.sg_total)}
+            </Text>
+          </View>
+        </View>
+
+        <View
+          style={{
+            borderTopWidth: 1,
+            borderColor: '#D9D2BF',
+            paddingTop: 14,
+          }}
+        >
+          <Text style={{ ...KICKER, marginBottom: 8 }}>Scorecard</Text>
+          <View
+            style={{
+              flexDirection: 'row',
+              paddingVertical: 8,
+              borderBottomWidth: 1,
+              borderColor: '#D9D2BF',
+            }}
+          >
+            <Text style={{ ...KICKER, flex: 1, color: '#8A8B7E' }}>Hole</Text>
+            <Text
+              style={{ ...KICKER, width: 44, textAlign: 'right', color: '#8A8B7E' }}
+            >
+              Par
+            </Text>
+            <Text
+              style={{ ...KICKER, width: 56, textAlign: 'right', color: '#8A8B7E' }}
+            >
+              Score
+            </Text>
+            <Text
+              style={{ ...KICKER, width: 56, textAlign: 'right', color: '#8A8B7E' }}
+            >
+              +/−
+            </Text>
+          </View>
+          {sortedHoles.map((h) => {
+            const hs = scoresByHoleId.get(h.id)
+            const score = hs?.score ?? null
+            const d = score != null && score > 0 ? score - h.par : null
+            return (
+              <View
+                key={h.id}
+                style={{
+                  flexDirection: 'row',
+                  paddingVertical: 10,
+                  borderBottomWidth: 1,
+                  borderColor: '#EBE5D6',
+                  paddingHorizontal: 6,
+                }}
+              >
+                <Text
+                  style={{
+                    flex: 1,
+                    fontSize: 15,
+                    color: '#1C211C',
+                  }}
+                >
+                  {h.number}
+                </Text>
+                <Text
+                  style={{
+                    width: 44,
+                    textAlign: 'right',
+                    fontSize: 15,
+                    color: '#5C6356',
+                    fontVariant: ['tabular-nums'],
+                  }}
+                >
+                  {h.par}
+                </Text>
+                <Text
+                  style={{
+                    width: 56,
+                    textAlign: 'right',
+                    fontSize: 15,
+                    color: score != null && score > 0 ? '#1C211C' : '#8A8B7E',
+                    fontVariant: ['tabular-nums'],
+                    fontWeight: '500',
+                  }}
+                >
+                  {score != null && score > 0 ? score : '—'}
+                </Text>
+                <Text
+                  style={{
+                    width: 56,
+                    textAlign: 'right',
+                    fontSize: 15,
+                    color:
+                      d == null
+                        ? '#8A8B7E'
+                        : d < 0
+                          ? '#1F3D2C'
+                          : d > 0
+                            ? '#A33A2A'
+                            : '#5C6356',
+                    fontVariant: ['tabular-nums'],
+                  }}
+                >
+                  {d == null ? '—' : d === 0 ? 'E' : d > 0 ? `+${d}` : `${d}`}
+                </Text>
+              </View>
+            )
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  )
 }

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -6,7 +6,7 @@ import {
   Text,
   View,
 } from 'react-native'
-import { useLocalSearchParams, useRouter } from 'expo-router'
+import { Redirect, useLocalSearchParams, useRouter } from 'expo-router'
 import { formatSG } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../../../lib/supabase'
@@ -37,6 +37,7 @@ export default function RoundIndex() {
   const [courseName, setCourseName] = useState<string>('Round')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [redirectToLive, setRedirectToLive] = useState(false)
 
   useEffect(() => {
     if (!id) return
@@ -55,9 +56,10 @@ export default function RoundIndex() {
         setCourseName(row.courses?.name ?? 'Round')
         // Live round signal: total_score is set when the round completes
         // (either Finish round or End round early). Anything else is
-        // still in progress — drop into the hole flow.
+        // still in progress — drop into the hole flow via <Redirect>
+        // on the next render so we can't navigate after unmount.
         if (row.total_score == null) {
-          router.replace(`/(app)/round/${id}/hole/1?mode=live`)
+          if (active) setRedirectToLive(true)
           return
         }
         const [hRes, hsRes] = await Promise.all([
@@ -84,6 +86,10 @@ export default function RoundIndex() {
       active = false
     }
   }, [id])
+
+  if (redirectToLive && id) {
+    return <Redirect href={`/(app)/round/${id}/hole/1?mode=live`} />
+  }
 
   const scoresByHoleId = useMemo(
     () => new Map(holeScores.map((hs) => [hs.hole_id, hs])),

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -72,8 +72,10 @@ export default function NewRound() {
   }, [query])
 
   // Capture GPS once (best-effort) so manual / API course creation can
-  // anchor hole 1 to the user's tee location.
+  // anchor hole 1 to the user's tee location. Past-round entry is
+  // historical — never prompt for location in that mode.
   useEffect(() => {
+    if (mode !== 'live') return
     if (gps.status !== 'idle') return
     setGps({ status: 'pending' })
     ;(async () => {
@@ -95,7 +97,7 @@ export default function NewRound() {
         setGps({ status: 'denied' })
       }
     })()
-  }, [gps.status])
+  }, [gps.status, mode])
 
   // Run search whenever debounced query changes.
   useEffect(() => {

--- a/apps/mobile/app/(app)/rounds.tsx
+++ b/apps/mobile/app/(app)/rounds.tsx
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Pressable, ScrollView, Text, View } from 'react-native'
+import { Link } from 'expo-router'
+import { Swipeable } from 'react-native-gesture-handler'
+import { formatSG } from '@oga/core'
+import { deleteRound, getRecentSGData } from '@oga/supabase'
+import { supabase } from '../../lib/supabase'
+import { useAuth } from '../../hooks/useAuth'
+import { AppBar } from '../../components/ui/AppBar'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+
+interface RoundRow {
+  id: string
+  played_at: string
+  total_score: number | null
+  sg_total: number | null
+  courses?: { name: string | null } | null
+}
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+export default function RoundsList() {
+  const { user } = useAuth()
+  const [rounds, setRounds] = useState<RoundRow[]>([])
+  const [pendingDelete, setPendingDelete] = useState<{
+    id: string
+    name: string
+  } | null>(null)
+  const [deleting, setDeleting] = useState(false)
+  const swipeRefs = useRef<Map<string, Swipeable | null>>(new Map())
+
+  useEffect(() => {
+    if (!user) return
+    let active = true
+    getRecentSGData(supabase, user.id, 500).then(({ data, error }) => {
+      if (!active) return
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.error('[rounds/getRecentSGData]', error.message)
+        return
+      }
+      if (data) setRounds(data as RoundRow[])
+    })
+    return () => {
+      active = false
+    }
+  }, [user?.id])
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      if (!user) return
+      setDeleting(true)
+      try {
+        const { error } = await deleteRound(supabase, id, user.id)
+        if (error) throw error
+        setRounds((prev) => prev.filter((r) => r.id !== id))
+      } finally {
+        setDeleting(false)
+        setPendingDelete(null)
+        swipeRefs.current.delete(id)
+      }
+    },
+    [user],
+  )
+
+  return (
+    <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
+      <AppBar title="All rounds" />
+      <ScrollView
+        contentContainerStyle={{
+          paddingHorizontal: 18,
+          paddingTop: 12,
+          paddingBottom: 28,
+        }}
+      >
+        {rounds.length === 0 ? (
+          <Text style={{ color: '#8A8B7E', fontSize: 13, marginTop: 18 }}>
+            No rounds yet.
+          </Text>
+        ) : (
+          <View style={{ borderTopWidth: 1, borderColor: '#D9D2BF' }}>
+            {rounds.map((r) => (
+              <Swipeable
+                key={r.id}
+                ref={(ref) => {
+                  swipeRefs.current.set(r.id, ref)
+                }}
+                renderRightActions={() => (
+                  <Pressable
+                    onPress={() => {
+                      swipeRefs.current.get(r.id)?.close()
+                      setPendingDelete({
+                        id: r.id,
+                        name: r.courses?.name ?? 'this round',
+                      })
+                    }}
+                    style={{
+                      backgroundColor: '#A33A2A',
+                      justifyContent: 'center',
+                      alignItems: 'center',
+                      paddingHorizontal: 22,
+                    }}
+                  >
+                    <Text
+                      style={{
+                        color: '#F2EEE5',
+                        fontSize: 13,
+                        fontWeight: '600',
+                        letterSpacing: 0.3,
+                      }}
+                    >
+                      Delete
+                    </Text>
+                  </Pressable>
+                )}
+                overshootRight={false}
+              >
+                <Link href={`/(app)/round/${r.id}`} asChild>
+                  <Pressable
+                    style={{
+                      flexDirection: 'row',
+                      justifyContent: 'space-between',
+                      alignItems: 'center',
+                      paddingVertical: 14,
+                      paddingHorizontal: 4,
+                      borderBottomWidth: 1,
+                      borderColor: '#D9D2BF',
+                      backgroundColor: '#F2EEE5',
+                    }}
+                  >
+                    <View style={{ flex: 1, paddingRight: 12 }}>
+                      <Text style={{ ...KICKER, marginBottom: 4 }}>
+                        {r.played_at}
+                      </Text>
+                      <Text
+                        style={{
+                          color: '#1C211C',
+                          fontSize: 17,
+                          fontWeight: '500',
+                          fontStyle: 'italic',
+                        }}
+                      >
+                        {r.courses?.name ?? 'Round'}
+                      </Text>
+                    </View>
+                    <View
+                      style={{
+                        flexDirection: 'row',
+                        alignItems: 'baseline',
+                        gap: 14,
+                      }}
+                    >
+                      <Text
+                        style={{
+                          color: '#1C211C',
+                          fontSize: 22,
+                          fontWeight: '500',
+                          fontVariant: ['tabular-nums'],
+                        }}
+                      >
+                        {r.total_score ?? '—'}
+                      </Text>
+                      <Text
+                        style={{
+                          color:
+                            r.sg_total == null
+                              ? '#8A8B7E'
+                              : r.sg_total >= 0
+                                ? '#1F3D2C'
+                                : '#A33A2A',
+                          fontSize: 13,
+                          fontWeight: '500',
+                          fontVariant: ['tabular-nums'],
+                        }}
+                      >
+                        {r.sg_total == null ? '—' : formatSG(r.sg_total)}
+                      </Text>
+                    </View>
+                  </Pressable>
+                </Link>
+              </Swipeable>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+      <ConfirmDialog
+        visible={!!pendingDelete}
+        title="Delete this round?"
+        message={
+          pendingDelete
+            ? `${pendingDelete.name} will be removed along with its hole scores and shots. This cannot be undone.`
+            : undefined
+        }
+        confirmLabel="Delete"
+        destructive
+        busy={deleting}
+        onConfirm={async () => {
+          if (pendingDelete) await handleDelete(pendingDelete.id)
+        }}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </View>
+  )
+}

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -105,15 +105,21 @@ export function HoleMap({
     [isAimPhase, onSetAim],
   )
 
+  // Gate the long-press gesture to SET_AIM only. Outside that phase the
+  // GestureDetector still wraps the map but no longer captures touches,
+  // which restores the PointAnnotation drag for the ball marker during
+  // PLACE_BALL — Gesture.LongPress was claiming the initial touch and
+  // the native annotation drag never fired.
   const longPress = useMemo(
     () =>
       Gesture.LongPress()
+        .enabled(isAimPhase)
         .minDuration(400)
         .onStart((event) => {
           'worklet'
           runOnJS(dropAimFromScreenPoint)(event.x, event.y)
         }),
-    [dropAimFromScreenPoint],
+    [dropAimFromScreenPoint, isAimPhase],
   )
 
   // Center the camera once on first valid coords. Subsequent center changes

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -451,7 +451,24 @@ export function HoleMap({
                 if (c) onSetBall(c)
               }}
             >
-              <Marker color="#1F3D2C" border="#FBF8F1" size={14} />
+              {/* 44pt transparent hit area so the marker is comfortable
+                  to grab one-handed — Apple HIG minimum target size.
+                  The visual marker stays small; the touchable area
+                  extends well past it. */}
+              <View
+                style={{
+                  width: 44,
+                  height: 44,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Marker
+                  color="#1F3D2C"
+                  border="#FBF8F1"
+                  size={isPlaceBallPhase ? 18 : 14}
+                />
+              </View>
             </Mapbox.PointAnnotation>
           )}
         </Mapbox.MapView>

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Text, View } from 'react-native'
 import Mapbox from '@rnmapbox/maps'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
@@ -79,6 +79,11 @@ export function HoleMap({
   const cameraRef = useRef<Mapbox.Camera>(null)
   const mapViewRef = useRef<Mapbox.MapView>(null)
   const cameraInitialized = useRef(false)
+  // Native side fires "Source X is not in style" when a ShapeSource /
+  // LineLayer mounts before the satellite style has finished loading.
+  // Gate every source behind this flag so React never renders them
+  // before native is ready to accept them.
+  const [styleLoaded, setStyleLoaded] = useState(false)
 
   const isPinMode = phase === 'PIN'
   const isAimPhase = phase === 'SET_AIM'
@@ -304,6 +309,7 @@ export function HoleMap({
           style={{ flex: 1 }}
           styleURL={Mapbox.StyleURL.Satellite}
           onPress={handleTap}
+          onDidFinishLoadingStyle={() => setStyleLoaded(true)}
         >
           <Mapbox.Camera
             ref={cameraRef}
@@ -314,7 +320,7 @@ export function HoleMap({
             }}
           />
 
-          {!isPinMode && previousShotsLine && (
+          {styleLoaded && !isPinMode && previousShotsLine && (
             <Mapbox.ShapeSource id="prevShotsLine" shape={previousShotsLine}>
               <Mapbox.LineLayer
                 id="prevShotsLineLayer"
@@ -338,7 +344,7 @@ export function HoleMap({
               </Mapbox.PointAnnotation>
             ))}
 
-          {aimLine && (
+          {styleLoaded && aimLine && (
             <Mapbox.ShapeSource id="aimLine" shape={aimLine}>
               <Mapbox.LineLayer
                 id="aimLineLayer"

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -287,6 +287,27 @@ export function HoleMap({
     }
   }, [previousShots, ball?.lat, ball?.lng])
 
+  // Per-segment midpoint + distance for the small labels rendered along
+  // the breadcrumb line. Excludes the trailing ball→nothing segment when
+  // ball is the only point. Only segments between fully-resolved waypoint
+  // pairs are kept (the current ball position is included as the final
+  // waypoint so the latest leg also gets a label).
+  const previousShotSegments = useMemo(() => {
+    const pts: LatLng[] = [...(previousShots ?? [])]
+    if (ball) pts.push(ball)
+    const out: { id: string; midpoint: LatLng; yards: number }[] = []
+    for (let i = 0; i < pts.length - 1; i++) {
+      const a = pts[i]!
+      const b = pts[i + 1]!
+      out.push({
+        id: `seg-${i}`,
+        midpoint: { lat: (a.lat + b.lat) / 2, lng: (a.lng + b.lng) / 2 },
+        yards: Math.round(distanceYards(a, b)),
+      })
+    }
+    return out
+  }, [previousShots, ball?.lat, ball?.lng])
+
   function handleTap(feature: unknown) {
     const c = extractCoord(feature)
     if (!c) return
@@ -341,6 +362,39 @@ export function HoleMap({
                 coordinate={toCoord(p)}
               >
                 <Marker color="#A66A1F" border="#FBF8F1" size={9} />
+              </Mapbox.PointAnnotation>
+            ))}
+
+          {/* Small distance label between every pair of consecutive
+              waypoints on the breadcrumb. Smaller / more muted than the
+              aim distance pill so it reads as supporting info, not the
+              primary callout. */}
+          {!isPinMode &&
+            previousShotSegments.map((seg) => (
+              <Mapbox.PointAnnotation
+                key={seg.id}
+                id={seg.id}
+                coordinate={toCoord(seg.midpoint)}
+              >
+                <View
+                  style={{
+                    backgroundColor: 'rgba(28,33,28,0.65)',
+                    borderRadius: 999,
+                    paddingHorizontal: 7,
+                    paddingVertical: 2,
+                  }}
+                >
+                  <Text
+                    style={{
+                      color: '#F2EEE5',
+                      fontSize: 10,
+                      fontWeight: '500',
+                      fontVariant: ['tabular-nums'],
+                    }}
+                  >
+                    {toDisplay(seg.yards)}
+                  </Text>
+                </View>
               </Mapbox.PointAnnotation>
             ))}
 

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -606,29 +606,31 @@ function Marker({ color, border, size }: MarkerProps) {
 
 // Simple flag glyph: vertical pole with a triangular cloth at the top.
 // "dim" = stored course pin (course default, may be wrong); "strong" =
-// today's actual flag position captured this round.
+// today's actual flag position captured this round. Sized large enough
+// to read at zoom 17 against satellite imagery — the previous 16x22
+// version was disappearing into the green on real device tests.
 function Flag({ tone }: { tone: 'dim' | 'strong' }) {
-  const flagColor = tone === 'strong' ? '#A33A2A' : 'rgba(163,58,42,0.6)'
-  const poleColor = tone === 'strong' ? '#FBF8F1' : 'rgba(251,248,241,0.7)'
+  const flagColor = tone === 'strong' ? '#A33A2A' : 'rgba(163,58,42,0.85)'
+  const poleColor = tone === 'strong' ? '#FBF8F1' : '#FBF8F1'
   return (
-    <View style={{ width: 16, height: 22, alignItems: 'flex-start' }}>
+    <View style={{ width: 26, height: 36, alignItems: 'flex-start' }}>
       <View
         style={{
           position: 'absolute',
-          left: 4,
+          left: 6,
           top: 0,
-          width: 2,
-          height: 22,
+          width: 3,
+          height: 36,
           backgroundColor: poleColor,
         }}
       />
       <View
         style={{
           position: 'absolute',
-          left: 6,
+          left: 9,
           top: 1,
-          width: 9,
-          height: 7,
+          width: 15,
+          height: 11,
           backgroundColor: flagColor,
           borderTopRightRadius: 1,
         }}
@@ -636,11 +638,11 @@ function Flag({ tone }: { tone: 'dim' | 'strong' }) {
       <View
         style={{
           position: 'absolute',
-          left: 3,
-          top: 21,
-          width: 4,
-          height: 2,
-          borderRadius: 1,
+          left: 4,
+          top: 33,
+          width: 7,
+          height: 3,
+          borderRadius: 1.5,
           backgroundColor: poleColor,
         }}
       />

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -376,8 +376,31 @@ export function HoleMap({
           )}
 
           {isAimPhase && aim && (
-            <Mapbox.PointAnnotation id="aim" coordinate={toCoord(aim)}>
-              <Marker color="#A66A1F" border="#FBF8F1" size={12} />
+            <Mapbox.PointAnnotation
+              id="aim"
+              coordinate={toCoord(aim)}
+              draggable
+              onDrag={(e: unknown) => {
+                const c = extractCoord(e)
+                if (c) onSetAim(c)
+              }}
+              onDragEnd={(e: unknown) => {
+                const c = extractCoord(e)
+                if (c) onSetAim(c)
+              }}
+            >
+              {/* 44pt transparent hit area around the visual marker so the
+                  drag handle is comfortably reachable mid-round. */}
+              <View
+                style={{
+                  width: 44,
+                  height: 44,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Marker color="#A66A1F" border="#FBF8F1" size={14} />
+              </View>
             </Mapbox.PointAnnotation>
           )}
 

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -201,6 +201,8 @@ export function PuttingSheet({
           </Text>
         </View>
         <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Close putting sheet"
           onPress={onClose}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           style={{ padding: 12 }}
@@ -332,6 +334,8 @@ export function PuttingSheet({
 
         <View style={{ marginTop: 22 }}>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Save putt as holed"
             onPress={() => commit(true)}
             style={{
               backgroundColor: '#1F3D2C',
@@ -352,6 +356,8 @@ export function PuttingSheet({
             </Text>
           </Pressable>
           <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Save putt as missed"
             onPress={() => commit(false)}
             style={{
               borderWidth: 1,
@@ -412,6 +418,9 @@ function Chip({
 }) {
   return (
     <Pressable
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: active }}
       onPress={onPress}
       style={{
         backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
@@ -453,6 +462,9 @@ function ResultCell({
   const border = active ? '#1F3D2C' : '#D9D2BF'
   return (
     <Pressable
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: active, disabled }}
       onPress={onPress}
       disabled={disabled}
       style={{

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -184,6 +184,8 @@ export function ShotLogger({
               </Text>
             </View>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Skip all logging for this shot"
               onPress={onSkip}
               hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
               style={{ padding: 6 }}
@@ -337,6 +339,8 @@ export function ShotLogger({
             }}
           >
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Cancel logging shot"
               onPress={onClose}
               style={{
                 flex: 1,
@@ -360,6 +364,8 @@ export function ShotLogger({
               </Text>
             </Pressable>
             <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Save shot and continue"
               onPress={() => onSave(value)}
               style={{
                 flex: 1,
@@ -516,6 +522,9 @@ function ChipRow<T extends string>({ value, options, onChange }: ChipRowProps<T>
           return (
             <Pressable
               key={opt}
+              accessibilityRole="radio"
+              accessibilityLabel={opt.replace(/_/g, ' ')}
+              accessibilityState={{ selected: active }}
               onPress={() => onChange(opt)}
               style={{
                 paddingHorizontal: 10,

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -201,7 +201,7 @@ export function ShotLogger({
           </View>
 
           <ScrollView
-            style={{ maxHeight: 480 }}
+            style={{ maxHeight: '75%' }}
             contentContainerStyle={{ paddingTop: 14 }}
           >
             <Section title="Club">

--- a/apps/mobile/hooks/useUnits.ts
+++ b/apps/mobile/hooks/useUnits.ts
@@ -8,7 +8,13 @@ export type { DistanceUnit }
 // the same { unit, toDisplay, toDisplayFt } shape the component tree
 // already depends on; formatters are imported from @oga/core so the
 // conversion factors don't drift between web and mobile.
-export function useUnits() {
+export interface UseUnitsResult {
+  unit: DistanceUnit
+  toDisplay: (yards: number, decimals?: number) => string
+  toDisplayFt: (feet: number) => string
+}
+
+export function useUnits(): UseUnitsResult {
   const { unit } = useUnitsContext()
 
   function toDisplay(yards: number, decimals = 0): string {

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -1,0 +1,113 @@
+import { computeRoundSG } from '@oga/core'
+import {
+  getHoleScoresForRound,
+  getHolesForCourse,
+  getShotsForRound,
+  updateRound,
+} from '@oga/supabase'
+import type { Database } from '@oga/supabase'
+import { supabase } from './supabase'
+import { syncPendingShots } from './sync'
+
+type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
+type ShotRow = Database['public']['Tables']['shots']['Row']
+type HoleRow = Database['public']['Tables']['holes']['Row']
+
+interface CompleteArgs {
+  roundId: string
+  courseId: string
+  userId: string
+  handicap: number | null
+}
+
+// Mobile equivalent of apps/web/src/hooks/useCompleteRound (sans the
+// react-query / handicap-index recalc plumbing). Drains the pending
+// shot queue, runs computeRoundSG over the persisted shots, and stamps
+// total_score / SG fields onto the round so total_score IS NOT NULL —
+// which removes the round from the home-screen Resume banner.
+export async function completeRound({
+  roundId,
+  courseId,
+  userId,
+  handicap,
+}: CompleteArgs): Promise<void> {
+  await syncPendingShots().catch(() => undefined)
+
+  const [holesRes, holeScoresRes, shotsRes] = await Promise.all([
+    getHolesForCourse(supabase, courseId),
+    getHoleScoresForRound(supabase, roundId),
+    getShotsForRound(supabase, roundId, userId),
+  ])
+  if (holesRes.error) throw holesRes.error
+  if (holeScoresRes.error) throw holeScoresRes.error
+  if (shotsRes.error) throw shotsRes.error
+
+  const holes: HoleRow[] = holesRes.data ?? []
+  const holeScoreRows = (holeScoresRes.data ?? []) as Array<
+    HoleScoreRow & { holes?: HoleRow | null }
+  >
+  const holeScores: HoleScoreRow[] = holeScoreRows.map((row) => {
+    const { holes: _h, ...rest } = row
+    return rest
+  })
+  const shots = (shotsRes.data ?? []) as unknown as ShotRow[]
+
+  const result = computeRoundSG({
+    holes,
+    holeScores,
+    shots,
+    handicap: handicap ?? 18,
+  })
+
+  // Per-hole SG upsert. Mirrors useCompleteRound.ts: carry round_id /
+  // hole_id / score forward so the underlying INSERT path of the upsert
+  // satisfies NOT NULL columns; the conflict on `id` then refreshes
+  // the SG fields only.
+  const holeScoresById = new Map(holeScores.map((hs) => [hs.id, hs]))
+  const sgRows = Object.entries(result.perHoleScore)
+    .map(([holeScoreId, sg]) => {
+      const existing = holeScoresById.get(holeScoreId)
+      if (!existing) return null
+      return {
+        id: holeScoreId,
+        round_id: existing.round_id,
+        hole_id: existing.hole_id,
+        score: existing.score,
+        sg_off_tee: round2(sg.offTee),
+        sg_approach: round2(sg.approach),
+        sg_around_green: round2(sg.aroundGreen),
+        sg_putting: round2(sg.putting),
+      }
+    })
+    .filter((r): r is NonNullable<typeof r> => r != null)
+  if (sgRows.length > 0) {
+    const { error: sgError } = await supabase
+      .from('hole_scores')
+      .upsert(sgRows, { onConflict: 'id' })
+    if (sgError) throw sgError
+  }
+
+  const { error: roundError } = await updateRound(
+    supabase,
+    roundId,
+    {
+      sg_off_tee: round2(result.round.offTee),
+      sg_approach: round2(result.round.approach),
+      sg_around_green: round2(result.round.aroundGreen),
+      sg_putting: round2(result.round.putting),
+      sg_total: round2(result.round.total),
+      total_score: result.totals.totalScore || null,
+      total_putts: result.totals.totalPutts || null,
+      fairways_hit:
+        result.totals.fairwaysTotal > 0 ? result.totals.fairwaysHit : null,
+      fairways_total: result.totals.fairwaysTotal || null,
+      gir: result.totals.gir,
+    },
+    userId,
+  )
+  if (roundError) throw roundError
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -12,6 +12,13 @@ config.resolver.nodeModulesPaths = [
   path.resolve(projectRoot, 'node_modules'),
   path.resolve(workspaceRoot, 'node_modules'),
 ]
+// disableHierarchicalLookup: required for the Turborepo monorepo
+// layout. Without this, Metro walks up from apps/mobile and resolves
+// React Native packages from the workspace root's node_modules first,
+// which gets duplicate React copies and breaks the RN bridge. Pinning
+// resolution to nodeModulesPaths above keeps the mobile app's own
+// install authoritative. Do not remove without re-validating an EAS
+// build end-to-end.
 config.resolver.disableHierarchicalLookup = true
 
 module.exports = withNativeWind(config, { input: './global.css' })

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -36,7 +36,7 @@
         "react-native-svg": "15.2.0",
         "react-native-url-polyfill": "^2.0.0",
         "react-native-web": "~0.19.10",
-        "react-native-worklets-core": "^1.6.3",
+        "react-native-worklets-core": "1.6.3",
         "tailwindcss": "^3.4.7",
         "victory-native": "^36.9.2"
       },

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -40,7 +40,7 @@
     "react-native-svg": "15.2.0",
     "react-native-url-polyfill": "^2.0.0",
     "react-native-web": "~0.19.10",
-    "react-native-worklets-core": "^1.6.3",
+    "react-native-worklets-core": "1.6.3",
     "tailwindcss": "^3.4.7",
     "victory-native": "^36.9.2"
   },

--- a/apps/web/src/components/auth/AuthGuard.tsx
+++ b/apps/web/src/components/auth/AuthGuard.tsx
@@ -6,7 +6,7 @@ export function AuthGuard({ children }: { children: ReactNode }) {
   const { user, loading } = useAuth()
   if (loading) {
     return (
-      <div className="flex h-screen items-center justify-center bg-oga-bg-page text-oga-text-muted text-sm">
+      <div className="flex h-screen items-center justify-center bg-caddie-bg text-caddie-ink-dim text-meta">
         Loading…
       </div>
     )

--- a/apps/web/src/components/errors/ErrorBoundary.tsx
+++ b/apps/web/src/components/errors/ErrorBoundary.tsx
@@ -18,7 +18,7 @@ export class ErrorBoundary extends Component<Props, State> {
 
   override componentDidCatch(error: Error, info: ErrorInfo): void {
     if (import.meta.env.DEV) {
-      console.error('ErrorBoundary caught:', error, info)
+      console.error('[ErrorBoundary/caught]', error, info)
     }
   }
 

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -249,7 +249,7 @@ export function ShotEntryModal({
     } catch (err) {
       if (import.meta.env.DEV) {
         // eslint-disable-next-line no-console
-        console.error('shot save failed', err, insert)
+        console.error('[ShotEntryModal/save]', err, insert)
       }
       throw err
     }

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -28,6 +28,7 @@ import {
 import { useAuth } from '../../hooks/useAuth'
 import { LieSlopeGrid } from '../forms/LieSlopeGrid'
 import { GreenDiagram } from '../round/GreenDiagram'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { useUnits } from '../../hooks/useUnits'
 
 const BREAK_OPTIONS: {
@@ -279,10 +280,13 @@ export function ShotEntryModal({
     }))
   }
 
-  async function remove(id: string) {
-    if (!confirm('Delete this shot?')) return
-    await deleteShot.mutateAsync(id)
-    if (editing === id) cancelEdit()
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null)
+
+  async function confirmDelete() {
+    if (!pendingDeleteId) return
+    await deleteShot.mutateAsync(pendingDeleteId)
+    if (editing === pendingDeleteId) cancelEdit()
+    setPendingDeleteId(null)
   }
 
   const isPutt = draft.lieType === 'green'
@@ -404,7 +408,7 @@ export function ShotEntryModal({
                       </button>
                       <button
                         type="button"
-                        onClick={() => remove(s.id)}
+                        onClick={() => setPendingDeleteId(s.id)}
                         className="font-mono uppercase text-caddie-neg"
                         style={{
                           fontSize: 10,
@@ -755,6 +759,15 @@ export function ShotEntryModal({
           </section>
         </div>
       </div>
+      <ConfirmDialog
+        open={pendingDeleteId !== null}
+        title="Delete this shot?"
+        destructive
+        confirmLabel="Delete"
+        busy={deleteShot.isPending}
+        onConfirm={confirmDelete}
+        onCancel={() => setPendingDeleteId(null)}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -246,8 +246,10 @@ export function ShotEntryModal({
       }
       cancelEdit()
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error('shot save failed', err, insert)
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('shot save failed', err, insert)
+      }
       throw err
     }
   }

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
 import { supabase } from '../lib/supabase'
 
-export function useAuth() {
+export function useAuth(): { user: User | null; loading: boolean } {
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
 

--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -43,10 +43,10 @@ export function useCourseSearch(query: string) {
       ])
       const apiHits: OpenGolfApiSearchResult[] =
         api.status === 'fulfilled' ? api.value : []
-      // searchCourses now returns the narrow column subset (mapbox_id /
-      // created_by / created_at dropped). Cast via unknown to the wider
-      // CourseRow so consumers that pick up a course from this list and
-      // pass it around with the full row type still typecheck.
+      // searchCourses now returns the narrow column subset (created_by /
+      // created_at dropped). Cast via unknown to the wider CourseRow so
+      // consumers that pick up a course from this list and pass it around
+      // with the full row type still typecheck.
       const localRows: CourseRow[] =
         local.status === 'fulfilled'
           ? ((local.value.data ?? []) as unknown as CourseRow[])

--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   searchOpenGolfApi,
@@ -18,6 +17,7 @@ import {
 } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../lib/supabase'
+import { useDebounce } from './useDebounce'
 
 type CourseRow = Database['public']['Tables']['courses']['Row']
 type HoleInsert = Database['public']['Tables']['holes']['Insert']
@@ -27,11 +27,7 @@ type HoleInsert = Database['public']['Tables']['holes']['Insert']
 // always surface even if OpenGolfAPI has no match. Deduped by
 // external_id and name.
 export function useCourseSearch(query: string) {
-  const [debounced, setDebounced] = useState(query)
-  useEffect(() => {
-    const id = setTimeout(() => setDebounced(query), 300)
-    return () => clearTimeout(id)
-  }, [query])
+  const debounced = useDebounce(query, 300)
 
   return useQuery({
     queryKey: ['courses', 'search', debounced],

--- a/apps/web/src/hooks/useDebounce.ts
+++ b/apps/web/src/hooks/useDebounce.ts
@@ -1,0 +1,10 @@
+import { useEffect, useState } from 'react'
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(id)
+  }, [value, delay])
+  return debounced
+}

--- a/apps/web/src/hooks/useDetailedStats.ts
+++ b/apps/web/src/hooks/useDetailedStats.ts
@@ -4,6 +4,7 @@ import { getRoundsWithDetails } from '@oga/supabase'
 import { supabase } from '../lib/supabase'
 import {
   computeDetailedStats,
+  DEFAULT_HANDICAP,
   type DetailedRound,
   type DetailedStats,
 } from '@oga/core'
@@ -18,7 +19,7 @@ export function useDetailedStats(limit: number): {
 } {
   const { user } = useAuth()
   const profile = useProfile()
-  const handicap = profile.data?.handicap_index ?? 15
+  const handicap = profile.data?.handicap_index ?? DEFAULT_HANDICAP
 
   const query = useQuery({
     queryKey: ['detailed-stats', user?.id, limit],

--- a/apps/web/src/hooks/useUnits.ts
+++ b/apps/web/src/hooks/useUnits.ts
@@ -3,7 +3,13 @@ import { useProfile } from './useProfile'
 
 export type { DistanceUnit }
 
-export function useUnits() {
+export interface UseUnitsResult {
+  unit: DistanceUnit
+  toDisplay: (yards: number, decimals?: number) => string
+  toDisplayFt: (feet: number) => string
+}
+
+export function useUnits(): UseUnitsResult {
   const { data: profile } = useProfile()
   const unit: DistanceUnit = profile?.distance_unit ?? 'yards'
 

--- a/apps/web/src/hooks/useUnits.ts
+++ b/apps/web/src/hooks/useUnits.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { formatDistance, formatPuttDistance, type DistanceUnit } from '@oga/core'
 import { useProfile } from './useProfile'
 
@@ -13,13 +14,14 @@ export function useUnits(): UseUnitsResult {
   const { data: profile } = useProfile()
   const unit: DistanceUnit = profile?.distance_unit ?? 'yards'
 
-  function toDisplay(yards: number, decimals = 0): string {
-    return formatDistance(yards, unit, decimals)
-  }
-
-  function toDisplayFt(feet: number): string {
-    return formatPuttDistance(feet, unit)
-  }
+  const toDisplay = useCallback(
+    (yards: number, decimals = 0): string => formatDistance(yards, unit, decimals),
+    [unit],
+  )
+  const toDisplayFt = useCallback(
+    (feet: number): string => formatPuttDistance(feet, unit),
+    [unit],
+  )
 
   return { unit, toDisplay, toDisplayFt }
 }

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -23,14 +23,14 @@ export function LoginPage() {
   }
 
   return (
-    <div className="flex h-screen items-center justify-center bg-oga-bg-page">
+    <div className="flex h-screen items-center justify-center bg-caddie-bg">
       <form
         onSubmit={handleSubmit}
-        className="w-full max-w-sm bg-oga-bg-card"
+        className="w-full max-w-sm bg-caddie-surface"
         style={{ border: '0.5px solid #E4E4E0', borderRadius: 10, padding: 24 }}
       >
         <h1
-          className="text-oga-text-primary"
+          className="text-caddie-ink"
           style={{ fontSize: 22, fontWeight: 600, marginBottom: 18 }}
         >
           Sign in to OGA
@@ -41,7 +41,7 @@ export function LoginPage() {
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={{
             border: '0.5px solid #E4E4E0',
             borderRadius: 7,
@@ -56,7 +56,7 @@ export function LoginPage() {
           required
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={{
             border: '0.5px solid #E4E4E0',
             borderRadius: 7,
@@ -67,7 +67,7 @@ export function LoginPage() {
         />
         {error && (
           <div
-            className="text-oga-red-dark"
+            className="text-caddie-neg"
             style={{ fontSize: 13, marginBottom: 10 }}
           >
             {error}
@@ -76,17 +76,17 @@ export function LoginPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-oga-black text-white transition-colors hover:bg-oga-text-primary/90 disabled:opacity-50"
+          className="w-full bg-caddie-accent text-caddie-accent-ink transition-opacity hover:opacity-90 disabled:opacity-50"
           style={{ borderRadius: 10, padding: '12px 16px', fontSize: 13, fontWeight: 500 }}
         >
           {loading ? 'Signing in…' : 'Sign in'}
         </button>
         <p
-          className="text-oga-text-muted text-center"
+          className="text-caddie-ink-dim text-center"
           style={{ fontSize: 13, marginTop: 14 }}
         >
           No account?{' '}
-          <Link to="/signup" className="text-oga-green-dark hover:underline">
+          <Link to="/signup" className="text-caddie-accent hover:underline">
             Sign up
           </Link>
         </p>
@@ -98,7 +98,7 @@ export function LoginPage() {
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="text-oga-text-muted uppercase"
+      className="text-caddie-ink-dim uppercase"
       style={{
         fontSize: 11,
         fontWeight: 500,

--- a/apps/web/src/pages/auth/SignupPage.tsx
+++ b/apps/web/src/pages/auth/SignupPage.tsx
@@ -28,14 +28,14 @@ export function SignupPage() {
   }
 
   return (
-    <div className="flex h-screen items-center justify-center bg-oga-bg-page">
+    <div className="flex h-screen items-center justify-center bg-caddie-bg">
       <form
         onSubmit={handleSubmit}
-        className="w-full max-w-sm bg-oga-bg-card"
+        className="w-full max-w-sm bg-caddie-surface"
         style={{ border: '0.5px solid #E4E4E0', borderRadius: 10, padding: 24 }}
       >
         <h1
-          className="text-oga-text-primary"
+          className="text-caddie-ink"
           style={{ fontSize: 22, fontWeight: 600, marginBottom: 18 }}
         >
           Create your OGA account
@@ -45,7 +45,7 @@ export function SignupPage() {
           required
           value={username}
           onChange={(e) => setUsername(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={inputStyle}
         />
         <FieldLabel>Email</FieldLabel>
@@ -54,7 +54,7 @@ export function SignupPage() {
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={inputStyle}
         />
         <FieldLabel>Password</FieldLabel>
@@ -64,12 +64,12 @@ export function SignupPage() {
           minLength={8}
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="w-full bg-oga-bg-input text-oga-text-primary"
+          className="w-full bg-caddie-surface text-caddie-ink"
           style={{ ...inputStyle, marginBottom: 14 }}
         />
         {error && (
           <div
-            className="text-oga-red-dark"
+            className="text-caddie-neg"
             style={{ fontSize: 13, marginBottom: 10 }}
           >
             {error}
@@ -78,17 +78,17 @@ export function SignupPage() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-oga-black text-white transition-colors hover:bg-oga-text-primary/90 disabled:opacity-50"
+          className="w-full bg-caddie-accent text-caddie-accent-ink transition-opacity hover:opacity-90 disabled:opacity-50"
           style={{ borderRadius: 10, padding: '12px 16px', fontSize: 13, fontWeight: 500 }}
         >
           {loading ? 'Creating…' : 'Create account'}
         </button>
         <p
-          className="text-oga-text-muted text-center"
+          className="text-caddie-ink-dim text-center"
           style={{ fontSize: 13, marginTop: 14 }}
         >
           Have an account?{' '}
-          <Link to="/login" className="text-oga-green-dark hover:underline">
+          <Link to="/login" className="text-caddie-accent hover:underline">
             Sign in
           </Link>
         </p>
@@ -108,7 +108,7 @@ const inputStyle: React.CSSProperties = {
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="text-oga-text-muted uppercase"
+      className="text-caddie-ink-dim uppercase"
       style={{
         fontSize: 11,
         fontWeight: 500,

--- a/apps/web/src/pages/errors/NotFoundPage.tsx
+++ b/apps/web/src/pages/errors/NotFoundPage.tsx
@@ -1,0 +1,75 @@
+import { useNavigate } from 'react-router-dom'
+
+export function NotFoundPage() {
+  const navigate = useNavigate()
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        backgroundColor: 'var(--caddie-bg)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 28,
+      }}
+    >
+      <div style={{ maxWidth: 520, textAlign: 'center' }}>
+        <div
+          style={{
+            fontFamily: 'JetBrains Mono, monospace',
+            fontSize: 11,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: 'var(--caddie-ink-mute)',
+            marginBottom: 14,
+          }}
+        >
+          404
+        </div>
+        <h1
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontWeight: 500,
+            fontSize: 38,
+            color: 'var(--caddie-ink)',
+            margin: 0,
+            letterSpacing: '-0.015em',
+          }}
+        >
+          Page not found.
+        </h1>
+        <p
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 15,
+            color: 'var(--caddie-ink-dim)',
+            marginTop: 14,
+            marginBottom: 22,
+            lineHeight: 1.5,
+          }}
+        >
+          The page you&rsquo;re looking for doesn&rsquo;t exist.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate('/')}
+          style={{
+            fontFamily: 'Inter, sans-serif',
+            fontSize: 14,
+            fontWeight: 600,
+            letterSpacing: 0.28,
+            backgroundColor: 'var(--caddie-accent)',
+            color: 'var(--caddie-accent-ink)',
+            border: 'none',
+            borderRadius: 2,
+            padding: '12px 18px',
+            cursor: 'pointer',
+          }}
+        >
+          ← Back to dashboard
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/learn/LearnPage.tsx
+++ b/apps/web/src/pages/learn/LearnPage.tsx
@@ -305,7 +305,7 @@ function JumpSheet({
 }
 
 function useActiveSection(): string | null {
-  const [active, setActive] = useState<string | null>(SECTION_LINKS[0]!.id)
+  const [active, setActive] = useState<string | null>(SECTION_LINKS[0]?.id ?? null)
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {

--- a/apps/web/src/pages/rounds/NewRoundPage.tsx
+++ b/apps/web/src/pages/rounds/NewRoundPage.tsx
@@ -53,18 +53,18 @@ export function NewRoundPage() {
     <div className="mx-auto max-w-2xl">
       <div style={{ marginBottom: 18 }}>
         <h1
-          className="text-oga-text-primary"
+          className="text-caddie-ink"
           style={{ fontSize: 22, fontWeight: 600, lineHeight: 1.3 }}
         >
           New round
         </h1>
-        <div className="text-oga-text-muted" style={{ fontSize: 13, marginTop: 2 }}>
+        <div className="text-caddie-ink-dim" style={{ fontSize: 13, marginTop: 2 }}>
           Pick a course and we'll set up the scorecard
         </div>
       </div>
       <form
         onSubmit={handleSubmit}
-        className="bg-oga-bg-card flex flex-col gap-5"
+        className="bg-caddie-surface flex flex-col gap-5"
         style={{ border: '0.5px solid #E4E4E0', borderRadius: 10, padding: 20 }}
       >
         <section>
@@ -97,7 +97,7 @@ export function NewRoundPage() {
           />
           {courseName && courseId && (
             <p
-              className="text-oga-green-dark"
+              className="text-caddie-accent"
               style={{ fontSize: 13, marginTop: 8 }}
             >
               Selected: {courseName}
@@ -127,7 +127,7 @@ export function NewRoundPage() {
               required
               value={playedAt}
               onChange={(e) => setPlayedAt(e.target.value)}
-              className="w-full bg-oga-bg-input text-oga-text-primary"
+              className="w-full bg-caddie-surface-2 text-caddie-ink"
               style={{ border: '0.5px solid #E4E4E0', borderRadius: 7, padding: '8px 10px', fontSize: 13 }}
             />
           </label>
@@ -136,7 +136,7 @@ export function NewRoundPage() {
             <select
               value={teeColor}
               onChange={(e) => setTeeColor(e.target.value)}
-              className="w-full bg-oga-bg-input text-oga-text-primary capitalize"
+              className="w-full bg-caddie-surface-2 text-caddie-ink capitalize"
               style={{ border: '0.5px solid #E4E4E0', borderRadius: 7, padding: '8px 10px', fontSize: 13 }}
             >
               {TEE_COLORS.map((t) => (
@@ -149,7 +149,7 @@ export function NewRoundPage() {
         </section>
 
         {error && (
-          <div className="text-oga-red-dark" style={{ fontSize: 13 }}>
+          <div className="text-caddie-neg" style={{ fontSize: 13 }}>
             {error}
           </div>
         )}
@@ -158,7 +158,7 @@ export function NewRoundPage() {
           <button
             type="button"
             onClick={() => navigate('/rounds')}
-            className="bg-oga-bg-card text-oga-text-primary transition-colors hover:bg-oga-bg-input"
+            className="bg-caddie-surface text-caddie-ink transition-colors hover:bg-caddie-surface-2"
             style={{
               border: '0.5px solid #E4E4E0',
               borderRadius: 10,
@@ -172,7 +172,7 @@ export function NewRoundPage() {
           <button
             type="submit"
             disabled={createRoundMutation.isPending || !courseId}
-            className="bg-oga-black text-white transition-colors hover:bg-oga-text-primary/90 disabled:opacity-50"
+            className="bg-caddie-accent text-caddie-accent-ink transition-opacity hover:opacity-90 disabled:opacity-50"
             style={{
               borderRadius: 10,
               padding: '10px 16px',
@@ -206,8 +206,8 @@ function ModeChip({
       aria-pressed={active}
       className={
         active
-          ? 'bg-oga-black text-white'
-          : 'bg-oga-bg-card text-oga-text-primary hover:bg-oga-bg-input'
+          ? 'bg-caddie-accent text-caddie-accent-ink'
+          : 'bg-caddie-surface text-caddie-ink hover:bg-caddie-surface-2'
       }
       style={{
         flex: 1,
@@ -236,7 +236,7 @@ function ModeChip({
 function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
     <div
-      className="text-oga-text-muted uppercase"
+      className="text-caddie-ink-dim uppercase"
       style={{
         fontSize: 11,
         fontWeight: 500,

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -852,11 +852,10 @@ function RoundRatingLine({
   round: RoundRow
   tees: CourseTeeRow[]
 }) {
+  const teeColor = round.tee_color?.toLowerCase()
   const tee =
     tees.find((t) => t.id === round.course_tee_id) ??
-    (round.tee_color
-      ? tees.find((t) => t.tee_color === round.tee_color!.toLowerCase())
-      : null) ??
+    (teeColor ? tees.find((t) => t.tee_color === teeColor) : null) ??
     null
   const hasRating =
     tee && tee.course_rating != null && tee.slope_rating != null

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -187,7 +187,7 @@ export function RoundDetailPage() {
         // Don't roll back the local override — the user's intent stays
         // visible while they retry. Surface the error for diagnostics.
         // eslint-disable-next-line no-console
-        console.error('round pin update failed', error)
+        console.error('[RoundDetailPage/updatePin]', error)
       }
     },
     [activeHoleScore, roundId],

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -178,7 +178,7 @@ export function RoundDetailPage() {
         .update({ pin_lat: point.lat, pin_lng: point.lng })
         .eq('id', hs.id)
         .eq('round_id', roundId)
-      if (error) {
+      if (error && import.meta.env.DEV) {
         // Don't roll back the local override — the user's intent stays
         // visible while they retry. Surface the error for diagnostics.
         // eslint-disable-next-line no-console

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -17,7 +17,12 @@ import type {
   PlacedPoint,
 } from '../../components/round/RoundMap'
 import { RoundMapInstructionStrip } from '../../components/round/RoundMap'
-import { combinedPuttResult, getShotCategory, haversineYards } from '@oga/core'
+import {
+  combinedPuttResult,
+  DEFAULT_HANDICAP,
+  getShotCategory,
+  haversineYards,
+} from '@oga/core'
 
 // Lazy-load Mapbox GL JS only when the map tab is opened. Cuts ~2 MB off
 // the initial bundle for users who never leave the scorecard.
@@ -257,7 +262,7 @@ export function RoundDetailPage() {
     if (!round.data || !courseId || !user) return
     setCompleteError(null)
     try {
-      const handicap = profile.data?.handicap_index ?? 15
+      const handicap = profile.data?.handicap_index ?? DEFAULT_HANDICAP
       await completeMutation.mutateAsync({
         roundId: round.data.id,
         courseId,

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -6,6 +6,7 @@ import { AppShell } from './components/layout/AppShell'
 import { RouteErrorBoundary } from './components/errors/ErrorBoundary'
 import { LoginPage } from './pages/auth/LoginPage'
 import { SignupPage } from './pages/auth/SignupPage'
+import { NotFoundPage } from './pages/errors/NotFoundPage'
 import { OnboardingPage } from './pages/onboarding/OnboardingPage'
 import { DashboardPage } from './pages/dashboard/DashboardPage'
 import { RoundsPage } from './pages/rounds/RoundsPage'
@@ -81,6 +82,7 @@ const routes: RouteObject[] = [
       { path: '/settings', element: <SettingsPage />, errorElement },
     ],
   },
+  { path: '*', element: <NotFoundPage />, errorElement },
 ]
 
 export const router: ReturnType<typeof createBrowserRouter> = createBrowserRouter(routes)

--- a/packages/core/src/__tests__/sg.test.ts
+++ b/packages/core/src/__tests__/sg.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
-  averageSGBreakdown,
   calculateRoundSG,
   calculateShotSG,
   getExpectedStrokes,
   type ShotWithContext,
 } from '../sg-calculator'
 import { computeRoundSG } from '../sg'
-import type { SGBreakdown, Shot } from '../types'
+import type { Shot } from '../types'
 import type { Database } from '@oga/supabase'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
@@ -64,32 +63,6 @@ describe('getExpectedStrokes — direct', () => {
   it('clamps to bracket — handicap 50 reads from the 30-bracket table', () => {
     // High handicap clamps to bracket 30. From 150 yd that's 5.01.
     expect(getExpectedStrokes('approach', 150, undefined, 50)).toBe(5.01)
-  })
-})
-
-describe('averageSGBreakdown', () => {
-  const r1: SGBreakdown = { offTee: 1.0, approach: 0.5, aroundGreen: 0.0, putting: -0.5, total: 1.0 }
-  const r2: SGBreakdown = { offTee: -1.0, approach: -0.5, aroundGreen: 0.0, putting: 0.5, total: -1.0 }
-
-  it('averages each category over multiple rounds', () => {
-    const avg = averageSGBreakdown([r1, r2])
-    expect(avg.offTee).toBe(0)
-    expect(avg.approach).toBe(0)
-    expect(avg.putting).toBe(0)
-    expect(avg.total).toBe(0)
-  })
-
-  it('empty input returns zero breakdown — not NaN', () => {
-    const avg = averageSGBreakdown([])
-    expect(avg.offTee).toBe(0)
-    expect(avg.approach).toBe(0)
-    expect(avg.aroundGreen).toBe(0)
-    expect(avg.putting).toBe(0)
-    expect(avg.total).toBe(0)
-  })
-
-  it('single round returns its own breakdown', () => {
-    expect(averageSGBreakdown([r1])).toEqual(r1)
   })
 })
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -97,39 +97,18 @@ export type Goal = (typeof GOALS)[number]
 export type Facility = (typeof FACILITIES)[number]
 export type ShotCategory = (typeof SHOT_CATEGORIES)[number]
 
-// Local types for the label maps below. BreakDirection / LegacyPuttResult
-// are mirrored in types.ts (which can't import from this file in the
-// reverse direction without a cycle); the union duplication is small
-// and locks the label maps to the exact set the DB enum allows.
-type BreakDirectionKey =
-  | 'left'
-  | 'right'
-  | 'straight'
-  | 'left_to_right'
-  | 'right_to_left'
-  | 'uphill'
-  | 'downhill'
-
+// LegacyPuttResultKey mirrors LegacyPuttResult in types.ts (which can't
+// import from this file without a cycle); the union duplication locks
+// PUTT_RESULT_LABELS to the exact set the DB enum allows. Adding a new
+// value without its label is a compile error — the previous
+// Record<string, string> typing silently rendered the raw enum value
+// when a key was missing.
 type LegacyPuttResultKey =
   | 'made'
   | 'short'
   | 'long'
   | 'missed_left'
   | 'missed_right'
-
-// Adding a new value in BREAK_DIRECTION (etc.) without adding its label
-// is now a compile error — the previous Record<string, string> typing
-// silently rendered the raw enum value when a key was missing.
-export const BREAK_DIRECTION_LABELS: Record<BreakDirectionKey, string> = {
-  left_to_right: 'L → R',
-  right_to_left: 'R → L',
-  straight: 'Straight',
-  uphill: 'Uphill',
-  downhill: 'Downhill',
-  // Legacy single-letter values from pre-split rows.
-  left: 'L → R',
-  right: 'R → L',
-}
 
 export const PUTT_RESULT_LABELS: Record<LegacyPuttResultKey, string> = {
   made: 'Made',

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,3 +1,10 @@
+// Stand-in handicap when a profile hasn't filled one in yet. Picked as
+// the rough median of US recreational golfers (USGA mid-handicap)
+// so SG baselines and bracket lookups don't degenerate to scratch
+// or 30+ for a brand-new user. NEVER store this — only use as a
+// transient calc input.
+export const DEFAULT_HANDICAP = 15
+
 export const CLUBS = [
   'driver',
   '3w',

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -5,6 +5,12 @@
 // transient calc input.
 export const DEFAULT_HANDICAP = 15
 
+// Distance-to-target threshold splitting "approach" from "around green"
+// for SG categorisation, lie inference, and stats bucketing. Keep the
+// three uses (sg-calculator, stats, shotInference) on the same number
+// so a shot can't be SG-classified one way and stats-bucketed another.
+export const NEAR_GREEN_YARDS = 30
+
 export const CLUBS = [
   'driver',
   '3w',

--- a/packages/core/src/opengolfapi.ts
+++ b/packages/core/src/opengolfapi.ts
@@ -124,9 +124,8 @@ function normalizeTees(raws: RawTee[] | undefined): OpenGolfApiTee[] {
 function pickHoles(raw: RawCourse): RawHole[] {
   if (Array.isArray(raw.holes) && raw.holes.length) return raw.holes
   if (Array.isArray(raw.scorecard) && raw.scorecard.length) return raw.scorecard
-  if (Array.isArray(raw.tees) && raw.tees[0]?.holes?.length) {
-    return raw.tees[0]!.holes!
-  }
+  const firstTeeHoles = raw.tees?.[0]?.holes
+  if (Array.isArray(firstTeeHoles) && firstTeeHoles.length) return firstTeeHoles
   return []
 }
 
@@ -187,12 +186,12 @@ export async function searchOpenGolfApi(
     `/courses/search?q=${encodeURIComponent(trimmed)}`,
     signal,
   )) as { results?: RawCourse[]; data?: RawCourse[] } | RawCourse[]
-  const results = Array.isArray(data)
+  const results: RawCourse[] = Array.isArray(data)
     ? data
-    : Array.isArray((data as { results?: RawCourse[] }).results)
-      ? (data as { results?: RawCourse[] }).results!
-      : Array.isArray((data as { data?: RawCourse[] }).data)
-        ? (data as { data?: RawCourse[] }).data!
+    : Array.isArray(data.results)
+      ? data.results
+      : Array.isArray(data.data)
+        ? data.data
         : []
   return results
     .map(normalizeSearch)

--- a/packages/core/src/sg-calculator.test.ts
+++ b/packages/core/src/sg-calculator.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import {
-  averageSGBreakdown,
   calculateRoundSG,
   calculateShotSG,
   getExpectedStrokes,
@@ -8,7 +7,7 @@ import {
   type ShotWithContext,
 } from './sg-calculator'
 import { getHandicapBracket, interpolateBaseline } from './sg-baselines'
-import type { SGBreakdown, Shot } from './types'
+import type { Shot } from './types'
 
 function shotCtx(
   shot: Partial<Shot> & { par: number; isLastShot: boolean; shotNumber: number },
@@ -182,19 +181,3 @@ describe('calculateRoundSG', () => {
   })
 })
 
-describe('averageSGBreakdown', () => {
-  it('zeros when no rounds', () => {
-    const r = averageSGBreakdown([])
-    expect(r.total).toBe(0)
-  })
-  it('averages component-wise', () => {
-    const a: SGBreakdown = { offTee: 1, approach: 2, aroundGreen: 3, putting: 4, total: 10 }
-    const b: SGBreakdown = { offTee: 3, approach: 4, aroundGreen: 5, putting: 6, total: 18 }
-    const avg = averageSGBreakdown([a, b])
-    expect(avg.offTee).toBe(2)
-    expect(avg.approach).toBe(3)
-    expect(avg.aroundGreen).toBe(4)
-    expect(avg.putting).toBe(5)
-    expect(avg.total).toBe(14)
-  })
-})

--- a/packages/core/src/sg-calculator.ts
+++ b/packages/core/src/sg-calculator.ts
@@ -1,4 +1,4 @@
-import type { ShotCategory } from './constants'
+import { NEAR_GREEN_YARDS, type ShotCategory } from './constants'
 import {
   APPROACH_BASELINES,
   AROUND_GREEN_BASELINES,
@@ -14,7 +14,10 @@ export function getShotCategory(
   shotNumber: number,
 ): ShotCategory {
   if (shot.lieType === 'green') return 'putting'
-  if (shot.distanceToTarget !== undefined && shot.distanceToTarget <= 30) {
+  if (
+    shot.distanceToTarget !== undefined &&
+    shot.distanceToTarget <= NEAR_GREEN_YARDS
+  ) {
     return 'around_green'
   }
   if (shotNumber === 1 && (par === 4 || par === 5)) return 'off_tee'

--- a/packages/core/src/sg-calculator.ts
+++ b/packages/core/src/sg-calculator.ts
@@ -65,8 +65,7 @@ function startDistanceFt(shot: Shot): number | undefined {
 }
 
 function holedOut(shot: Shot): boolean {
-  if (shot.lieType === 'green' && shot.puttResult === 'made') return true
-  return false
+  return shot.lieType === 'green' && shot.puttResult === 'made'
 }
 
 export function calculateRoundSG(

--- a/packages/core/src/sg-calculator.ts
+++ b/packages/core/src/sg-calculator.ts
@@ -130,24 +130,3 @@ export function calculateRoundSG(
   return breakdown
 }
 
-export function averageSGBreakdown(rounds: SGBreakdown[]): SGBreakdown {
-  if (rounds.length === 0) return { ...EMPTY_SG }
-  const sum = rounds.reduce<SGBreakdown>(
-    (acc, r) => ({
-      offTee: acc.offTee + r.offTee,
-      approach: acc.approach + r.approach,
-      aroundGreen: acc.aroundGreen + r.aroundGreen,
-      putting: acc.putting + r.putting,
-      total: acc.total + r.total,
-    }),
-    { ...EMPTY_SG },
-  )
-  const n = rounds.length
-  return {
-    offTee: sum.offTee / n,
-    approach: sum.approach / n,
-    aroundGreen: sum.aroundGreen / n,
-    putting: sum.putting / n,
-    total: sum.total / n,
-  }
-}

--- a/packages/core/src/shot-patterns.test.ts
+++ b/packages/core/src/shot-patterns.test.ts
@@ -97,13 +97,15 @@ describe('filterDispersionByLie', () => {
     { id: 'lf3', lateralOffsetYards: 0, distanceOffsetYards: 0, lieSlope: 'level', lieType: 'rough' },
   ]
   it('filters by slope', () => {
-    expect(filterDispersionByLie(pts, 'uphill')).toHaveLength(1)
+    expect(filterDispersionByLie(pts, { lieSlope: 'uphill' })).toHaveLength(1)
   })
   it('filters by type', () => {
-    expect(filterDispersionByLie(pts, undefined, 'fairway')).toHaveLength(2)
+    expect(filterDispersionByLie(pts, { lieType: 'fairway' })).toHaveLength(2)
   })
   it('filters by both', () => {
-    expect(filterDispersionByLie(pts, 'level', 'fairway')).toHaveLength(1)
+    expect(
+      filterDispersionByLie(pts, { lieSlope: 'level', lieType: 'fairway' }),
+    ).toHaveLength(1)
   })
 })
 

--- a/packages/core/src/shot-patterns.ts
+++ b/packages/core/src/shot-patterns.ts
@@ -137,15 +137,8 @@ export interface DispersionFilter {
 
 export function filterDispersionByLie(
   points: DispersionPoint[],
-  filterOrSlope?: DispersionFilter | LieSlope,
-  lieTypeArg?: LieType,
+  filter: DispersionFilter = {},
 ): DispersionPoint[] {
-  // Back-compat: filterDispersionByLie(points, lieSlope, lieType) still works.
-  const filter: DispersionFilter =
-    typeof filterOrSlope === 'string'
-      ? { lieSlope: filterOrSlope, lieType: lieTypeArg }
-      : { ...(filterOrSlope ?? {}), lieType: filterOrSlope?.lieType ?? lieTypeArg }
-
   return points.filter((p) => {
     if (filter.lieType && p.lieType !== filter.lieType) return false
     if (

--- a/packages/core/src/shotInference.ts
+++ b/packages/core/src/shotInference.ts
@@ -3,7 +3,7 @@
 // coordinates plus tee/pin context, returns suggested club, lie type,
 // distances, and a confidence rating.
 
-import type { Club, LieType } from './constants'
+import { NEAR_GREEN_YARDS, type Club, type LieType } from './constants'
 import { haversineYards } from './units'
 
 export interface PlacedShot {
@@ -75,7 +75,6 @@ function clubForTeeShot(distanceYards: number, par: number): Club {
 // Lie inference
 // ---------------------------------------------------------------------------
 
-const NEAR_GREEN_YARDS = 30
 // Threshold for "this shot started on (or so close to) the green that the
 // next stroke is a putt." 15 yd captures fringe lag putts and short
 // chip-ins that are functionally putts; tighter than 15 misclassifies

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -747,4 +747,3 @@ export function computeDetailedStats(
 
 // Re-export so consumers can import the shape constants.
 export const APPROACH_BAND_KEYS = APPROACH_BANDS.map((b) => b.key)
-export type { ShotCategory }

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -3,6 +3,7 @@ import {
   getExpectedStrokes,
   getShotCategory,
 } from './sg-calculator'
+import { NEAR_GREEN_YARDS } from './constants'
 import type { LieSlopeForward, LieSlopeSide, ShotCategory, ShotResult } from './constants'
 import { METERS_TO_YARDS, haversineYards, toRadians } from './units'
 import { RESULT_QUALITY } from './types'
@@ -403,7 +404,7 @@ export function ballStrikingStats(rounds: DetailedRound[]): BallStrikingStats {
         if (
           category === 'approach' &&
           s.distance_to_target != null &&
-          s.distance_to_target > 30 &&
+          s.distance_to_target > NEAR_GREEN_YARDS &&
           s.end_lat != null &&
           s.end_lng != null
         ) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -151,7 +151,7 @@ export interface Shot {
   notes?: string
 }
 
-export type LegacyPuttResult =
+type LegacyPuttResult =
   | 'made'
   | 'short'
   | 'long'

--- a/packages/supabase/src/client.ts
+++ b/packages/supabase/src/client.ts
@@ -28,7 +28,12 @@ export function createOgaClient(opts: CreateClientOptions): OgaSupabaseClient {
       ...(opts.storage ? { storage: opts.storage } : {}),
       autoRefreshToken: opts.autoRefreshToken ?? true,
       persistSession: opts.persistSession ?? true,
-      detectSessionInUrl: opts.detectSessionInUrl ?? true,
+      // No /auth/callback route exists yet. Default-true here would let
+      // supabase-js consume any access_token / refresh_token query
+      // params on whatever page the user lands on, which is a session
+      // injection foothold. Flip back to true (or pass explicitly) when
+      // an OAuth callback route is wired up.
+      detectSessionInUrl: opts.detectSessionInUrl ?? false,
     },
   })
 }

--- a/packages/supabase/src/queries/courses.ts
+++ b/packages/supabase/src/queries/courses.ts
@@ -17,12 +17,12 @@ export function searchCourses(client: OgaSupabaseClient, query: string, limit = 
   if (!trimmed) {
     return client.from('courses').select(COURSE_COLUMNS).order('name').limit(limit)
   }
-  return client
-    .from('courses')
-    .select(COURSE_COLUMNS)
-    .ilike('name', `%${trimmed}%`)
-    .order('name')
-    .limit(limit)
+  // search_courses RPC ranks by pg_trgm similarity (typo-tolerant) then
+  // falls back to ILIKE substring. Migration 0018; trigram index from 0015.
+  return client.rpc('search_courses', {
+    search_query: trimmed,
+    result_limit: limit,
+  })
 }
 
 export function getHolesForCourse(client: OgaSupabaseClient, courseId: string) {

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -590,7 +590,12 @@ export interface Database {
       }
     }
     Views: Record<string, never>
-    Functions: Record<string, never>
+    Functions: {
+      search_courses: {
+        Args: { search_query: string; result_limit?: number }
+        Returns: Database['public']['Tables']['courses']['Row'][]
+      }
+    }
     Enums: Record<string, never>
     CompositeTypes: Record<string, never>
   }

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -56,7 +56,6 @@ export interface Database {
         Row: {
           id: string
           name: string
-          mapbox_id: string | null
           external_id: string | null
           created_by: string | null
           created_at: string
@@ -68,7 +67,6 @@ export interface Database {
         Insert: {
           id?: string
           name: string
-          mapbox_id?: string | null
           external_id?: string | null
           created_by?: string | null
           created_at?: string
@@ -80,7 +78,6 @@ export interface Database {
         Update: {
           id?: string
           name?: string
-          mapbox_id?: string | null
           external_id?: string | null
           created_by?: string | null
           created_at?: string

--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -1021,6 +1021,32 @@ interface CourseRowMin {
   external_id: string | null
 }
 
+// Paginated fetch of OSM-imported courses for a state. Supabase's default
+// row cap is 1000 — paginating in 500-row chunks keeps us well under that
+// even if one state grows past it (and so we can see the ceiling in logs
+// instead of silently truncating).
+async function fetchOsmCoursesForState(
+  state: string,
+): Promise<CourseRowMin[]> {
+  const PAGE_SIZE = 500
+  const all: CourseRowMin[] = []
+  let from = 0
+  while (true) {
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id, name, external_id')
+      .eq('state', state)
+      .like('external_id', 'osm_%')
+      .range(from, from + PAGE_SIZE - 1)
+    if (error) throw error
+    const rows = (data ?? []) as CourseRowMin[]
+    all.push(...rows)
+    if (rows.length < PAGE_SIZE) break
+    from += PAGE_SIZE
+  }
+  return all
+}
+
 async function crawlEnrich(
   states: string[],
   force: boolean,
@@ -1048,13 +1074,26 @@ async function crawlEnrich(
     try {
       // OSM-imported courses for this state. Excludes manual or
       // already-OpenGolfAPI-imported courses to keep the scope tight.
-      const { data: courseRows, error: coursesErr } = await supabase
-        .from('courses')
-        .select('id, name, external_id')
-        .eq('state', state)
-        .like('external_id', 'osm_%')
-      if (coursesErr) throw coursesErr
-      const courses = (courseRows ?? []) as CourseRowMin[]
+      console.log(`[enrich:${state}] fetching courses from DB...`)
+      let courses: CourseRowMin[]
+      try {
+        courses = await fetchOsmCoursesForState(state)
+      } catch (err) {
+        const e = err as Error
+        console.error(`[enrich:${state}] DB fetch failed:`, {
+          message: e.message,
+          stack: e.stack,
+        })
+        await setCrawlState(crawlId, {
+          status: 'error',
+          itemsProcessed: 0,
+          errorMessage: `DB fetch failed: ${e.message}`,
+        })
+        continue
+      }
+      console.log(
+        `[enrich:${state}] fetched ${courses.length} courses from DB`,
+      )
       const targets = limit != null ? courses.slice(0, limit) : courses
       // Big states have hit OpenGolfAPI rate limits with the default 1100ms
       // cadence — bump to 2000ms when there's >200 to grind through.
@@ -1140,11 +1179,16 @@ async function crawlEnrich(
         `[enrich:${state}] done — ${stateEnriched} enriched, ${stateUnmatched} no-match, ${stateErrors} errors`,
       )
     } catch (err) {
-      console.error(`[enrich:${state}] fatal: ${(err as Error).message}`)
+      const e = err as Error
+      console.error(`[enrich:${state}] fatal: ${e.message}`)
+      console.error(`[enrich:${state}] fatal details:`, {
+        message: e.message,
+        stack: e.stack,
+      })
       await setCrawlState(crawlId, {
         status: 'error',
         itemsProcessed: stateProcessed,
-        errorMessage: (err as Error).message,
+        errorMessage: e.message,
       })
     }
   }

--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -1038,13 +1038,48 @@ async function fetchOsmCoursesForState(
       .eq('state', state)
       .like('external_id', 'osm_%')
       .range(from, from + PAGE_SIZE - 1)
-    if (error) throw error
+    if (error) {
+      throw new Error(
+        `courses fetch failed (state=${state}, range=${from}-${from + PAGE_SIZE - 1}): ${error.message ?? JSON.stringify(error)}`,
+      )
+    }
     const rows = (data ?? []) as CourseRowMin[]
     all.push(...rows)
     if (rows.length < PAGE_SIZE) break
     from += PAGE_SIZE
   }
   return all
+}
+
+// Bulk tee lookup, chunked to avoid PostgREST's URL-length limit. With ~868
+// UUIDs the single `.in('course_id', courseIds)` call serialises into a URL
+// long enough to trip a 400 — and the supabase client throws its raw
+// PostgrestError, which has no `stack`, so the outer catch reports just
+// "Bad Request" with no clue where it came from. 200 ids/chunk is well
+// under any cap.
+async function fetchAlreadyTeedCourseIds(
+  courseIds: string[],
+  label: string,
+): Promise<Set<string>> {
+  const teedSet = new Set<string>()
+  if (courseIds.length === 0) return teedSet
+  const CHUNK = 200
+  for (let i = 0; i < courseIds.length; i += CHUNK) {
+    const chunk = courseIds.slice(i, i + CHUNK)
+    const { data, error } = await supabase
+      .from('course_tees')
+      .select('course_id')
+      .in('course_id', chunk)
+    if (error) {
+      throw new Error(
+        `[${label}] course_tees lookup failed (chunk ${i}-${i + chunk.length - 1}, ${chunk.length} ids): ${error.message ?? JSON.stringify(error)}`,
+      )
+    }
+    for (const row of data ?? []) {
+      if (row.course_id) teedSet.add(row.course_id)
+    }
+  }
+  return teedSet
 }
 
 async function crawlEnrich(
@@ -1103,20 +1138,35 @@ async function crawlEnrich(
       )
 
       // Bulk-fetch existing tees so we can skip already-enriched courses
-      // without one round-trip per course.
+      // without one round-trip per course. Chunked to dodge the IN-list
+      // URL-length cap.
       const courseIds = targets.map((c) => c.id)
-      const teedSet = new Set<string>()
-      if (courseIds.length > 0) {
-        const { data: teesRows, error: teesErr } = await supabase
-          .from('course_tees')
-          .select('course_id')
-          .in('course_id', courseIds)
-        if (teesErr) throw teesErr
-        for (const row of teesRows ?? []) {
-          if (row.course_id) teedSet.add(row.course_id)
-        }
+      let teedSet: Set<string>
+      try {
+        console.log(
+          `[enrich:${state}] looking up existing tees for ${courseIds.length} course(s)...`,
+        )
+        teedSet = await fetchAlreadyTeedCourseIds(courseIds, `enrich:${state}`)
+        console.log(
+          `[enrich:${state}] ${teedSet.size} course(s) already have tees`,
+        )
+      } catch (err) {
+        const e = err as Error
+        console.error(`[enrich:${state}] tees lookup failed:`, {
+          message: e.message,
+          stack: e.stack,
+        })
+        await setCrawlState(crawlId, {
+          status: 'error',
+          itemsProcessed: 0,
+          errorMessage: `tees lookup failed: ${e.message}`,
+        })
+        continue
       }
 
+      console.log(
+        `[enrich:${state}] starting loop, first course: ${courses[0]?.name}`,
+      )
       for (let i = 0; i < targets.length; i++) {
         const course = targets[i]
         if (!course) continue
@@ -1151,7 +1201,11 @@ async function crawlEnrich(
             .from('courses')
             .update({ external_id: ogaExternalId })
             .eq('id', course.id)
-          if (updateErr) throw updateErr
+          if (updateErr) {
+            throw new Error(
+              `external_id update failed (course=${course.id}): ${updateErr.message ?? JSON.stringify(updateErr)}`,
+            )
+          }
           stateEnriched++
           totalEnriched++
           if ((i + 1) % 50 === 0 || i === targets.length - 1) {

--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -309,6 +309,49 @@ async function fetchJson(url: string): Promise<unknown> {
   return res.json()
 }
 
+// Enrichment-path fetch. Never throws — returns null when the request can't be
+// recovered. Handles 429 (Retry-After-style sleep), 404 (silent miss), and one
+// retry on transient HTTP / network errors.
+async function fetchJsonResilient(
+  url: string,
+  label: string,
+): Promise<unknown | null> {
+  let failedAttempts = 0
+  const MAX_ATTEMPTS = 2
+  while (true) {
+    try {
+      const res = await fetch(url, { headers: { Accept: 'application/json' } })
+      if (res.status === 429) {
+        console.warn(`[${label}] Rate limited — waiting 30s`)
+        await sleep(30000)
+        continue
+      }
+      if (res.status === 404) return null
+      if (!res.ok) {
+        failedAttempts++
+        if (failedAttempts < MAX_ATTEMPTS) {
+          console.warn(`[${label}] HTTP ${res.status} — retrying in 5s: ${url}`)
+          await sleep(5000)
+          continue
+        }
+        console.warn(`[${label}] HTTP ${res.status} — giving up: ${url}`)
+        return null
+      }
+      return await res.json()
+    } catch (err) {
+      failedAttempts++
+      const msg = (err as Error).message
+      if (failedAttempts < MAX_ATTEMPTS) {
+        console.warn(`[${label}] ${msg} — retrying in 5s`)
+        await sleep(5000)
+        continue
+      }
+      console.warn(`[${label}] ${msg} — giving up`)
+      return null
+    }
+  }
+}
+
 function pickArray(payload: unknown): RawCourse[] {
   if (Array.isArray(payload)) return payload as RawCourse[]
   if (payload && typeof payload === 'object') {
@@ -929,12 +972,16 @@ const MATCH_THRESHOLD = 0.7
 
 // Look up the OpenGolfAPI course that best matches `name` within `state`.
 // Returns the full detail (with tees) if a confident match is found.
+// Uses resilient fetcher — never throws on transient network/HTTP errors.
 async function findOgaMatchForCourse(
   name: string,
   state: string,
+  label: string,
+  interReqDelayMs: number,
 ): Promise<OgaCourseDetail | null> {
-  const url = `${OPENGOLFAPI_BASE}/courses/search?q=${encodeURIComponent(name)}&state=${encodeURIComponent(state)}`
-  const payload = await fetchJson(url)
+  const searchUrl = `${OPENGOLFAPI_BASE}/courses/search?q=${encodeURIComponent(name)}&state=${encodeURIComponent(state)}`
+  const payload = await fetchJsonResilient(searchUrl, label)
+  if (!payload) return null
   const raws = pickArray(payload)
   let best: { item: OgaListItem; score: number } | null = null
   for (const raw of raws) {
@@ -947,8 +994,25 @@ async function findOgaMatchForCourse(
     if (score > (best?.score ?? 0)) best = { item, score }
   }
   if (!best || best.score < MATCH_THRESHOLD) return null
-  await sleep(OPENGOLFAPI_DELAY_MS)
-  return fetchOgaCourseDetail(best.item.id)
+  await sleep(interReqDelayMs)
+  const detailUrl = `${OPENGOLFAPI_BASE}/courses/${encodeURIComponent(best.item.id)}`
+  const detailPayload = await fetchJsonResilient(detailUrl, label)
+  if (!detailPayload) return null
+  let raw: RawCourse | null = null
+  if (Array.isArray(detailPayload)) {
+    raw = (detailPayload[0] ?? null) as RawCourse | null
+  } else if (detailPayload && typeof detailPayload === 'object') {
+    const obj = detailPayload as { course?: unknown; data?: unknown }
+    if (obj.course && typeof obj.course === 'object') {
+      raw = obj.course as RawCourse
+    } else if (obj.data && typeof obj.data === 'object' && !Array.isArray(obj.data)) {
+      raw = obj.data as RawCourse
+    } else {
+      raw = detailPayload as RawCourse
+    }
+  }
+  if (!raw) return null
+  return normalizeDetail(raw)
 }
 
 interface CourseRowMin {
@@ -992,7 +1056,12 @@ async function crawlEnrich(
       if (coursesErr) throw coursesErr
       const courses = (courseRows ?? []) as CourseRowMin[]
       const targets = limit != null ? courses.slice(0, limit) : courses
-      console.log(`[enrich:${state}] ${targets.length} OSM course(s) to consider`)
+      // Big states have hit OpenGolfAPI rate limits with the default 1100ms
+      // cadence — bump to 2000ms when there's >200 to grind through.
+      const perReqDelay = targets.length > 200 ? 2000 : OPENGOLFAPI_DELAY_MS
+      console.log(
+        `[enrich:${state}] ${targets.length} OSM course(s) to consider (delay ${perReqDelay}ms)`,
+      )
 
       // Bulk-fetch existing tees so we can skip already-enriched courses
       // without one round-trip per course.
@@ -1017,12 +1086,17 @@ async function crawlEnrich(
           continue
         }
         try {
-          const match = await findOgaMatchForCourse(course.name, state)
+          const match = await findOgaMatchForCourse(
+            course.name,
+            state,
+            `enrich:${state}`,
+            perReqDelay,
+          )
           stateProcessed++
           if (!match) {
             stateUnmatched++
             totalUnmatched++
-            await sleep(OPENGOLFAPI_DELAY_MS)
+            await sleep(perReqDelay)
             continue
           }
           if (match.tees.length > 0) {
@@ -1054,7 +1128,7 @@ async function crawlEnrich(
             `[enrich:${state}] ${course.name}: ${(err as Error).message}`,
           )
         }
-        await sleep(OPENGOLFAPI_DELAY_MS)
+        await sleep(perReqDelay)
       }
 
       await setCrawlState(crawlId, {

--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -596,44 +596,39 @@ async function findCourseByExternalId(externalId: string): Promise<string | null
   return data?.id ?? null
 }
 
-async function insertOrUpdateCourse(args: {
+// Upsert keyed on external_id (partial unique index from migration 0019).
+// Re-running the crawler updates the existing row in place rather than
+// inserting a parallel duplicate; the previous select-then-insert flow
+// could race two crawlers into a double-insert and silently produced
+// thousands of duplicate rows.
+//
+// Manual user-created courses (no external_id) NEVER come through here —
+// they go through createCourse() in the web hooks and stay plain inserts.
+async function upsertCourse(args: {
   externalId: string
   name: string
   city: string | null
   state: string | null
   lat: number | null
   lng: number | null
-  force: boolean
-}): Promise<{ id: string; isNew: boolean; skipped: boolean }> {
-  const fields = {
-    name: args.name,
-    city: args.city,
-    state: args.state,
-    lat: args.lat,
-    lng: args.lng,
-  }
-  const existing = await findCourseByExternalId(args.externalId)
-  if (existing && !args.force) {
-    return { id: existing, isNew: false, skipped: true }
-  }
-  if (existing) {
-    const { error } = await supabase
-      .from('courses')
-      .update(fields)
-      .eq('id', existing)
-    if (error) throw error
-    return { id: existing, isNew: false, skipped: false }
-  }
+}): Promise<{ id: string }> {
   const { data, error } = await supabase
     .from('courses')
-    .insert({
-      ...fields,
-      external_id: args.externalId,
-    })
+    .upsert(
+      {
+        external_id: args.externalId,
+        name: args.name,
+        city: args.city,
+        state: args.state,
+        lat: args.lat,
+        lng: args.lng,
+      },
+      { onConflict: 'external_id', ignoreDuplicates: false },
+    )
     .select('id')
     .single()
-  if (error || !data) throw error ?? new Error('course insert failed')
-  return { id: data.id, isNew: true, skipped: false }
+  if (error || !data) throw error ?? new Error('course upsert failed')
+  return { id: data.id }
 }
 
 async function upsertHoles(courseId: string, holes: OgaHole[]): Promise<void> {
@@ -772,22 +767,20 @@ async function crawlOpenGolfApi(
           }
           const city = (detail.city ?? item.city ?? '').trim() || null
           const stateCode = (detail.state ?? item.state ?? state).trim() || null
-          const upsert = await insertOrUpdateCourse({
+          const { id: courseId } = await upsertCourse({
             externalId,
             name: detail.name,
             city,
             state: stateCode,
             lat: detail.lat ?? item.lat ?? null,
             lng: detail.lng ?? item.lng ?? null,
-            force,
           })
-          if (!upsert.skipped) {
-            await upsertHoles(upsert.id, detail.holes)
-            await upsertTees(upsert.id, detail.tees)
-            totalImported++
-          } else {
-            totalSkipped++
-          }
+          // Holes + tees always re-upserted from the freshly-fetched
+          // detail. Their own upsert keys (course_id,number /
+          // course_id,tee_color) keep this idempotent.
+          await upsertHoles(courseId, detail.holes)
+          await upsertTees(courseId, detail.tees)
+          totalImported++
           stateCount++
 
           if ((i + 1) % 100 === 0 || i === targets.length - 1) {
@@ -860,17 +853,15 @@ async function crawlOsm(
         if (!c) continue
         const externalId = `osm_${c.osmType}_${c.osmId}`
         try {
-          const upsert = await insertOrUpdateCourse({
+          await upsertCourse({
             externalId,
             name: c.name,
             city: c.city ?? null,
             state: c.state,
             lat: c.lat,
             lng: c.lng,
-            force,
           })
-          if (upsert.skipped) totalSkipped++
-          else totalImported++
+          totalImported++
           stateCount++
           if ((i + 1) % 100 === 0 || i === targets.length - 1) {
             console.log(`[osm:${state}] ${i + 1}/${targets.length} — last: ${c.name}`)

--- a/scripts/import-osm-course.ts
+++ b/scripts/import-osm-course.ts
@@ -369,7 +369,7 @@ async function upsertCourse(
 
   const { data, error } = await supabase
     .from('courses')
-    .insert({ name, mapbox_id: null, lat: centroid.lat, lng: centroid.lon })
+    .insert({ name, lat: centroid.lat, lng: centroid.lon })
     .select('id')
     .single()
   if (error || !data) throw error ?? new Error('course insert failed')

--- a/supabase/migrations/0017_drop_mapbox_id.sql
+++ b/supabase/migrations/0017_drop_mapbox_id.sql
@@ -1,0 +1,6 @@
+-- Drop unused courses.mapbox_id column. The Mapbox course-search integration
+-- never shipped — courses are linked via external_id (OpenGolfAPI / OSM)
+-- instead. Column has been NULL on every row in production.
+
+alter table public.courses
+  drop column if exists mapbox_id;

--- a/supabase/migrations/0018_fuzzy_course_search.sql
+++ b/supabase/migrations/0018_fuzzy_course_search.sql
@@ -1,0 +1,27 @@
+-- Fuzzy course search backed by the pg_trgm GIN index added in 0015.
+-- ILIKE alone misses obvious typos ("Pebbel Beach" -> "Pebble Beach")
+-- and fails on word-order variants. The function ORs trigram similarity
+-- with ILIKE so substring matches still surface, then orders by
+-- similarity score so the closest match floats to the top.
+
+create or replace function public.search_courses(
+  search_query text,
+  result_limit int default 10
+)
+returns setof public.courses
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  select *
+  from public.courses
+  where name % search_query
+     or name ilike '%' || search_query || '%'
+  order by
+    similarity(name, search_query) desc,
+    name asc
+  limit result_limit;
+$$;
+
+grant execute on function public.search_courses(text, int) to anon, authenticated;

--- a/supabase/migrations/0019_external_id_unique.sql
+++ b/supabase/migrations/0019_external_id_unique.sql
@@ -1,0 +1,13 @@
+-- Partial unique index on courses.external_id so the OpenGolfAPI
+-- crawler can't insert duplicate course rows for the same upstream id.
+-- NULL is left unconstrained because manual user-created courses don't
+-- have an external_id and we don't want them to collide on a synthetic
+-- empty key.
+--
+-- 0004 added a non-unique idx_courses_external_id; we keep that index
+-- in place — it still services lookup-by-external_id queries — and add
+-- a separate partial UNIQUE on top.
+
+create unique index if not exists courses_external_id_unique
+  on public.courses(external_id)
+  where external_id is not null;

--- a/supabase/migrations/0020_play_frequency_check.sql
+++ b/supabase/migrations/0020_play_frequency_check.sql
@@ -1,0 +1,15 @@
+-- profiles.play_frequency was free text while every other onboarding
+-- field (skill_level, goal, play_style) had a CHECK constraint. The
+-- onboarding form only writes one of four values; pin the schema to
+-- match so a typo'd insert fails fast.
+--
+-- Values come from FREQUENCIES in
+-- apps/web/src/pages/onboarding/steps/Step4Details.tsx — keep this
+-- list in sync if a new option is added there.
+
+alter table public.profiles
+  add constraint play_frequency_values
+  check (
+    play_frequency is null
+    or play_frequency in ('monthly', 'weekly', 'multi_weekly', 'daily')
+  );

--- a/supabase/migrations/0021_shot_result_check.sql
+++ b/supabase/migrations/0021_shot_result_check.sql
@@ -1,0 +1,24 @@
+-- shots.shot_result was free text. Constrain to the SHOT_RESULTS list
+-- in @oga/core/constants so a typo'd insert can't reach storage and
+-- silently break stats bucketing (RESULT_QUALITY in types.ts maps off
+-- this exact set).
+--
+-- Keep the value list in sync with SHOT_RESULTS in
+-- packages/core/src/constants.ts.
+
+alter table public.shots
+  add constraint shot_result_values
+  check (
+    shot_result is null
+    or shot_result in (
+      'solid',
+      'push_right',
+      'pull_left',
+      'fat',
+      'thin',
+      'shank',
+      'topped',
+      'penalty',
+      'ob'
+    )
+  );


### PR DESCRIPTION
## What's in this release

### Security
- JWT stored in expo-secure-store with chunking for Android 2048-byte limit
- Course name constraints + username regex validation
- course_tees UPDATE locked to service role
- Vite 6.4.2+ (CVE-2025-24721, CVE-2025-25489 patched)
- detectSessionInUrl: false until OAuth callback exists
- console.error gated behind DEV in production

### Reliability  
- Error boundaries on web and mobile
- Async state races fixed
- N+1 batch inserts fixed
- Sync lock TTL prevents stuck inFlight
- Shot counter desync fixed
- Derived state mirrors hydrate once
- Cache invalidation gaps fixed
- NetInfo reconnect + AppState retry for offline sync
- Profile fetch error shows retry not infinite spinner
- Splash screen not blank white on cold start

### Architecture
- statsCalculations + sgCalc lifted to @oga/core
- formatDistance/formatPuttDistance in core
- DEFAULT_HANDICAP and NEAR_GREEN_YARDS consolidated
- Shared domain types in core
- 200 tests passing on core math
- Dead exports removed from @oga/core

### Performance
- Web bundle 795KB → 106KB gzip (-87%) via code splitting
- DB indexes: RLS covering, partial shot, GIN drills, trigram courses
- lat/lng double precision
- getRoundsWithDetails holes payload narrowed
- Single query for shot + putt count
- font-display swap on Google Fonts
- useUnits toDisplay wrapped in useCallback

### Course Database
- 15,870 US golf courses (deduplicated)
- 15,753 with GPS coordinates
- 8,444 with tee ratings and slopes
- OSM-first crawler with OpenGolfAPI enrichment
- Crawler now upserts on external_id (no more duplicates)
- Fuzzy course search via pg_trgm

### Mobile Live Round
- Map opens flat top-down on tee box
- Mark ball → aim point → shot detail state machine
- Map rotates to hole direction after marking ball
- Distance pill on aim line (large, readable outdoors)
- Auto putting sheet when within 30yd of pin
- Shot breadcrumb trail persists across shots
- Dynamic zoom based on distance to pin
- Finish hole button + scorecard modal
- Pin placement fixed
- Round persistence and resume from home screen
- End round early with confirmation
- Past rounds open read-only view not live round interface
- GPS uses last shot position on shot 2+ not home location
- Larger ball marker drag target (44pt)
- ShotLogger modal resets on second open
- GPS not requested in past round mode

### Bug Fixes
- Putt count syncs to scorecard after map save
- KeyboardAvoidingView on auth and shot forms
- Hit slop on critical tap targets
- AppBar uses useSafeAreaInsets
- Settings page accessible from web sidebar
- Web settings parity with mobile profile
- ProfileGuard uses React Query cache
- GPS watchPosition during PLACE_BALL phase
- Local date for new round (no UTC off-by-one)
- GreenDiagram pan uses Reanimated shared values
- Legacy oga-* tokens replaced with caddie-*
- window.confirm replaced with ConfirmDialog
- Recent rounds home shows 5 with see all link
- 404 not found page with catch-all route
- Accessibility labels on mobile interactive controls
- Redirect component instead of router.push in useEffect

### CI/CD
- CI now runs on dev branch and PRs to dev
- react-native-worklets-core pinned exact 1.6.3

### Database Migrations (0017-0021)
- 0017: drop unused courses.mapbox_id column
- 0018: fuzzy course search RPC via pg_trgm
- 0019: unique constraint on courses.external_id
- 0020: play_frequency CHECK constraint
- 0021: shot_result CHECK constraint