### PR TITLE
fix: Kalman audit findings 1, 2, 4, 5, 6, 7

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -110,6 +110,12 @@ export default function HoleScreen() {
   // the entire screen at GPS cadence (1-2 Hz). Reset on hole change,
   // manual drag, or when leaving PLACE_BALL — see useEffect below.
   const kalmanStateRef = useRef<KalmanState | null>(null)
+  // Set true the moment the player manually drags or taps the ball;
+  // freezes the GPS callback's setBall so the next reading can't
+  // clobber the manual placement. Cleared on hole change and on
+  // PLACE_BALL phase exit (so the next shot's PLACE_BALL re-engages
+  // GPS auto-tracking).
+  const manuallyPlacedRef = useRef(false)
   // local_id of the just-saved pending shot, so the next PLACE_BALL
   // can fill in that shot's end_lat/end_lng with the new ball position.
   const lastSavedShotLocalIdRef = useRef<number | null>(null)
@@ -275,6 +281,11 @@ export default function HoleScreen() {
             distanceInterval: 2,
           },
           (loc) => {
+            // Manual placement freezes GPS-driven ball updates. Without
+            // this, the next reading after a drag would re-init the
+            // filter at the raw GPS point and snap ball back, wiping
+            // the player's refinement.
+            if (manuallyPlacedRef.current) return
             const rawPoint = {
               lat: loc.coords.latitude,
               lng: loc.coords.longitude,
@@ -301,8 +312,11 @@ export default function HoleScreen() {
       subscription?.remove()
       // Phase exit clears the filter so re-entry to PLACE_BALL on the
       // next shot starts smoothing from a fresh fix rather than an
-      // old anchor that may now be hundreds of yards away.
+      // old anchor that may now be hundreds of yards away. Also clears
+      // the manual-placement freeze so the next PLACE_BALL cycle
+      // resumes GPS auto-tracking unless the player drags again.
       kalmanStateRef.current = null
+      manuallyPlacedRef.current = false
     }
   }, [currentHole?.id, isPastMode, roundState])
 
@@ -311,6 +325,7 @@ export default function HoleScreen() {
   // (past mode, or no current hole) before subscribing.
   useEffect(() => {
     kalmanStateRef.current = null
+    manuallyPlacedRef.current = false
   }, [currentHole?.id])
 
   // Highlight "On the green" once the player is within 80 yd of the stored
@@ -806,10 +821,17 @@ export default function HoleScreen() {
           }
           onSetAim={setAim}
           onSetBall={(loc) => {
-            // Manual drag/tap is an explicit override — drop the
-            // filter so the next GPS reading starts smoothing from
-            // the new anchor rather than the prior auto-tracked spot.
-            kalmanStateRef.current = null
+            // Manual drag/tap is an explicit override. Freeze GPS
+            // updates for this PLACE_BALL cycle and re-anchor the
+            // Kalman filter at the manual point with a low variance
+            // (1 m²) — strong prior so any future un-freeze still
+            // resists snapping back to a noisy raw fix.
+            manuallyPlacedRef.current = true
+            kalmanStateRef.current = {
+              lat: loc.lat,
+              lng: loc.lng,
+              variance: 1,
+            }
             setBall(loc)
           }}
           onPlacePin={persistRoundPin}

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -544,12 +544,21 @@ export default function HoleScreen() {
       Alert.alert('Place the ball first', 'Tap the map to drop the ball.')
       return
     }
+    // Lock the ball position right now, before any awaits below.
+    // A GPS callback firing during the SQLite write could otherwise
+    // shift `ball` between the moment the player tapped "Mark" and
+    // the moment persistShot reads it for the next shot's
+    // start_lat/lng. Same snapshot also drives the previous shot's
+    // end_lat/lng patch.
+    const ballSnapshot = { lat: ball.lat, lng: ball.lng }
+    // Tapping "Mark ball here" is an explicit position commit — same
+    // semantics as a manual drag for the purposes of GPS freezing.
+    manuallyPlacedRef.current = true
     // Fill in the previous shot's landing — this position is where it
     // ended. Pending rows get patched in SQLite; synced rows get a
     // best-effort remote update.
     const prevLocalId = lastSavedShotLocalIdRef.current
     if (prevLocalId != null) {
-      const ballSnapshot = ball
       const result = await setPendingShotEnd(
         prevLocalId,
         ballSnapshot.lat,
@@ -569,6 +578,10 @@ export default function HoleScreen() {
       }
       lastSavedShotLocalIdRef.current = null
     }
+    // Re-pin ball state to the snapshot so the new shot's start_lat/lng
+    // (read from `ball` in persistShot) is the value the player
+    // committed to, not anything an in-flight GPS callback wrote.
+    setBall(ballSnapshot)
     setAim(null)
     // Auto-switch to the putting flow when the player has marked their
     // position within ~30 yd of the pin — bypasses SET_AIM (long-press
@@ -576,7 +589,7 @@ export default function HoleScreen() {
     // matter on a putt. Falls back to the standard aim flow if no pin
     // is known.
     const pinTarget = roundPin ?? storedPin ?? null
-    if (pinTarget && distanceYards(ball, pinTarget) <= PUTTING_RADIUS_YARDS) {
+    if (pinTarget && distanceYards(ballSnapshot, pinTarget) <= PUTTING_RADIUS_YARDS) {
       setRoundState('PUTTING')
       return
     }

--- a/packages/core/src/__tests__/kalman.test.ts
+++ b/packages/core/src/__tests__/kalman.test.ts
@@ -35,15 +35,15 @@ describe('createKalmanState', () => {
 
 describe('updateKalman', () => {
   it('falls back to 5 m default measurement noise when accuracy missing', () => {
-    // With state variance 0 and no accuracy on the new reading,
-    // predicted variance = Q*dt = 3, R = 25, gain = 3/28 ≈ 0.107.
-    // New point is 1 m east; updated lng should land close to gain·1m.
-    const state = createKalmanState({ lat: OKC.lat, lng: OKC.lng, accuracy: 0 })
+    // State seeded without accuracy → variance = DEFAULT_INIT (49).
+    // Update with no accuracy on the reading → R = DEFAULT (25).
+    // dt = 1, Q = 3 → predV = 52, K = 52 / 77.
+    const state = createKalmanState({ lat: OKC.lat, lng: OKC.lng })
     const next = updateKalman(state, {
       lat: OKC.lat,
       lng: OKC.lng + METRE_LNG,
     })
-    const expectedGain = 3 / (3 + 25)
+    const expectedGain = 52 / (52 + 25)
     const drift = (next.lng - OKC.lng) / METRE_LNG
     expect(drift).toBeCloseTo(expectedGain, 4)
   })

--- a/packages/core/src/__tests__/kalman.test.ts
+++ b/packages/core/src/__tests__/kalman.test.ts
@@ -99,27 +99,39 @@ describe('smoothGPSTrack', () => {
     expect(out[0]?.lng).toBe(OKC.lng)
   })
 
-  it('noisy readings around a true position converge toward truth', () => {
-    // Deterministic alternating noise around (OKC.lat, OKC.lng): each
-    // reading is offset by ±5 m on each axis. Mean is exactly the
-    // true point, so the smoothed track should drift toward it.
-    const noisy: GPSPoint[] = []
-    const offsets = [+5, -5, +5, -5, +5, -5, +5, -5, +5, -5, +5, -5]
-    for (let i = 0; i < offsets.length; i++) {
-      const off = offsets[i]!
-      noisy.push({
-        lat: OKC.lat + METRE_LAT * off,
-        lng: OKC.lng + METRE_LNG * off,
-        accuracy: 5,
-        timestamp: i * 1000,
-      })
-    }
+  it('smoothed RMSE beats raw RMSE by at least 30%, last point within 1.5 m', () => {
+    // Deterministic zero-mean noise sequence (sums to 0). With Q=3,
+    // R=25 the steady-state Kalman gain is ~0.3, so the filter
+    // attenuates noise meaningfully. RMSE comparison is the right
+    // measure here — the prior "last smoothed closer than last raw"
+    // assertion passed for trivial reasons whenever the final raw
+    // point happened to be far from truth.
+    const offsetsM = [3, -2, 4, -3, 2, -4, 3, -1, 1, -3]
+    const noisy: GPSPoint[] = offsetsM.map((m, i) => ({
+      lat: OKC.lat + METRE_LAT * m,
+      lng: OKC.lng + METRE_LNG * m,
+      accuracy: 5,
+      timestamp: i * 1000,
+    }))
     const smoothed = smoothGPSTrack(noisy)
+
+    const rmseMetres = (track: GPSPoint[]): number => {
+      let sum = 0
+      for (const p of track) {
+        // Yards via haversine, converted back to metres.
+        const distMetres = haversineYards(OKC.lat, OKC.lng, p.lat, p.lng) / 1.09361
+        sum += distMetres * distMetres
+      }
+      return Math.sqrt(sum / track.length)
+    }
+
+    const rawRmse = rmseMetres(noisy)
+    const smoothedRmse = rmseMetres(smoothed)
+    expect(smoothedRmse).toBeLessThan(rawRmse * 0.7)
+
     const last = smoothed[smoothed.length - 1]!
-    const lastRaw = noisy[noisy.length - 1]!
-    const lastRawDist = haversineYards(OKC.lat, OKC.lng, lastRaw.lat, lastRaw.lng)
-    const lastSmoothedDist = haversineYards(OKC.lat, OKC.lng, last.lat, last.lng)
-    expect(lastSmoothedDist).toBeLessThan(lastRawDist)
+    const lastDistMetres = haversineYards(OKC.lat, OKC.lng, last.lat, last.lng) / 1.09361
+    expect(lastDistMetres).toBeLessThan(1.5)
   })
 
   it('smoothed straight-line walk has lower point-to-point variance than raw', () => {
@@ -153,3 +165,87 @@ function pointToPointVarianceMetres(points: GPSPoint[]): number {
   }
   return sum
 }
+
+describe('edge cases', () => {
+  it('accuracy:0 falls back to default initial variance, filter does not collapse', () => {
+    // Some Android GPS states report accuracy 0. Without the floor
+    // this would seed variance=0 → K=1 → filter ignores every prior
+    // and just passes raw readings through. Floor must reject 0.
+    const s = createKalmanState({ lat: OKC.lat, lng: OKC.lng, accuracy: 0 })
+    expect(s.variance).toBe(49)
+  })
+
+  it('updateKalman with accuracy:0 falls back to default R=25, not R=0', () => {
+    const state = createKalmanState({ lat: OKC.lat, lng: OKC.lng, accuracy: 5 })
+    const next = updateKalman(state, {
+      lat: OKC.lat,
+      lng: OKC.lng + METRE_LNG,
+      accuracy: 0,
+    })
+    // With state variance 25, predV = 28, R fallback = 25, K = 28/53.
+    // If R=0 leaked through, K=1 and drift would be exactly 1.0.
+    const drift = (next.lng - OKC.lng) / METRE_LNG
+    expect(drift).toBeCloseTo(28 / 53, 4)
+  })
+
+  it('accuracy:NaN treated as missing, uses default R', () => {
+    const state = createKalmanState({ lat: OKC.lat, lng: OKC.lng, accuracy: 5 })
+    const next = updateKalman(state, {
+      lat: OKC.lat,
+      lng: OKC.lng + METRE_LNG,
+      accuracy: NaN,
+    })
+    expect(Number.isFinite(next.lat)).toBe(true)
+    expect(Number.isFinite(next.lng)).toBe(true)
+    expect(Number.isFinite(next.variance)).toBe(true)
+    const drift = (next.lng - OKC.lng) / METRE_LNG
+    expect(drift).toBeCloseTo(28 / 53, 4)
+  })
+
+  it('reading with NaN lat is ignored, state unchanged', () => {
+    const state = createKalmanState({ lat: OKC.lat, lng: OKC.lng, accuracy: 5 })
+    const next = updateKalman(state, { lat: NaN, lng: OKC.lng, accuracy: 5 })
+    expect(next).toBe(state)
+  })
+
+  it('reading with NaN lng is ignored, state unchanged', () => {
+    const state = createKalmanState({ lat: OKC.lat, lng: OKC.lng, accuracy: 5 })
+    const next = updateKalman(state, { lat: OKC.lat, lng: NaN, accuracy: 5 })
+    expect(next).toBe(state)
+  })
+
+  it('backward timestamp clamps dt to 0, filter freezes gracefully', () => {
+    // dt < 0 must not push variance backward. Math.max(0, …) clamps
+    // dt to 0 → Q*dt = 0 → predV = state.variance. With identical
+    // accuracy on state and reading, K reduces to var/(var+R).
+    const state = createKalmanState({
+      lat: OKC.lat,
+      lng: OKC.lng,
+      accuracy: 5,
+      timestamp: 5000,
+    })
+    const next = updateKalman(state, {
+      lat: OKC.lat,
+      lng: OKC.lng + METRE_LNG,
+      accuracy: 5,
+      timestamp: 1000,
+    })
+    expect(Number.isFinite(next.variance)).toBe(true)
+    expect(next.variance).toBeGreaterThan(0)
+    // Predicted variance = state.variance (25) + 0 = 25; K = 25/50.
+    const drift = (next.lng - OKC.lng) / METRE_LNG
+    expect(drift).toBeCloseTo(0.5, 4)
+  })
+
+  it('createKalmanState with NaN lat throws descriptive error', () => {
+    expect(() =>
+      createKalmanState({ lat: NaN, lng: OKC.lng, accuracy: 5 }),
+    ).toThrow(/lat and lng must be finite/)
+  })
+
+  it('createKalmanState with NaN lng throws descriptive error', () => {
+    expect(() =>
+      createKalmanState({ lat: OKC.lat, lng: NaN, accuracy: 5 }),
+    ).toThrow(/lat and lng must be finite/)
+  })
+})

--- a/packages/core/src/kalman.ts
+++ b/packages/core/src/kalman.ts
@@ -43,7 +43,21 @@ const DEFAULT_MEASUREMENT_VARIANCE = 25
 const DEFAULT_PROCESS_NOISE = 3
 
 export function createKalmanState(point: GPSPoint): KalmanState {
-  const variance = point.accuracy != null ? point.accuracy ** 2 : DEFAULT_INIT_VARIANCE
+  // Refuse to seed from a malformed coordinate. NaN here would
+  // permanently corrupt every subsequent updateKalman result, so fail
+  // loud at the boundary rather than silently produce NaN positions.
+  if (!Number.isFinite(point.lat) || !Number.isFinite(point.lng)) {
+    throw new Error('createKalmanState: lat and lng must be finite numbers')
+  }
+  // accuracy must be a finite, positive number to be meaningful. A
+  // reported 0 (some Android GPS states) would seed the filter with
+  // zero variance and cause it to ignore every subsequent reading;
+  // NaN would propagate. Either case falls back to the 7 m default.
+  const safeAccuracy =
+    point.accuracy != null && Number.isFinite(point.accuracy) && point.accuracy > 0
+      ? point.accuracy
+      : null
+  const variance = safeAccuracy != null ? safeAccuracy ** 2 : DEFAULT_INIT_VARIANCE
   return {
     lat: point.lat,
     lng: point.lng,
@@ -61,6 +75,11 @@ export function updateKalman(
   point: GPSPoint,
   options?: KalmanOptions,
 ): KalmanState {
+  // Drop corrupt readings outright — a single NaN measurement would
+  // poison the filter for the rest of the session.
+  if (!Number.isFinite(point.lat) || !Number.isFinite(point.lng)) {
+    return state
+  }
   const Q = options?.processNoise ?? DEFAULT_PROCESS_NOISE
   const dt =
     point.timestamp != null && state.timestamp != null
@@ -68,7 +87,13 @@ export function updateKalman(
       : 1
 
   const predictedVariance = state.variance + Q * dt
-  const R = point.accuracy != null ? point.accuracy ** 2 : DEFAULT_MEASUREMENT_VARIANCE
+  // Same accuracy guard as createKalmanState — accuracy:0 would set
+  // R=0 and force K=1 (raw passthrough); NaN would propagate.
+  const safeAccuracy =
+    point.accuracy != null && Number.isFinite(point.accuracy) && point.accuracy > 0
+      ? point.accuracy
+      : null
+  const R = safeAccuracy != null ? safeAccuracy ** 2 : DEFAULT_MEASUREMENT_VARIANCE
   const K = predictedVariance / (predictedVariance + R)
 
   return {


### PR DESCRIPTION
## Summary
Addresses all six audit findings on the Kalman GPS smoother (PR #146).

| # | Finding | Severity | Fix |
|---|---|---|---|
| 1 | \`accuracy: 0\` collapses filter to identity (R=0 → K=1, raw passthrough) | TUNING | Treat \`accuracy <= 0\` and non-finite as missing → fall back to defaults |
| 2 | NaN propagation poisons filter permanently | MINOR | Guard \`accuracy\`, \`lat\`, \`lng\` with \`Number.isFinite\` in \`updateKalman\`; \`createKalmanState\` throws on NaN coords |
| 4 | **Manual drag clobbered by next GPS tick (regression vs pre-Kalman)** | **REAL BUG** | \`manuallyPlacedRef\` freezes GPS \`setBall\` for the rest of the PLACE_BALL cycle; filter re-anchored at manual point with low variance |
| 5 | Convergence test passed for trivial reasons | MINOR | Replaced with RMSE-based assertion: smoothed RMSE < 0.7 × raw RMSE, last point within 1.5 m of truth |
| 6 | Missing NaN/edge-case tests | MINOR | Added 8 tests covering accuracy:0, accuracy:NaN, lat/lng NaN, backward timestamps, createKalmanState NaN throws |
| 7 | \`markBallHere\` race shifts start coord during SQLite await | MINOR | Snapshot ball at top before any await; \`setBall(snapshot)\` after await; flag also flipped to freeze GPS |

## Verification
- \`pnpm typecheck\` — 4/4 packages clean
- \`pnpm test\` — **220/220** (was 212; +1 strengthened convergence + 8 edge cases, -1 trivial test removed)
- \`pnpm --filter web build\` — 106 KB gzipped initial route
- \`cd apps/mobile && npm run typecheck\` — clean

## Commits
1. \`fix: Kalman accuracy:0 floor and NaN guard (findings 1+2)\`
2. \`fix: manual drag survives GPS tick via manuallyPlacedRef (finding 4)\`
3. \`fix: snapshot ball at markBallHere top before awaits (finding 7)\`
4. \`test: strengthen Kalman convergence test + edge cases (findings 5+6)\`

## Test plan
- [ ] Live round on device — drag ball to refine, confirm ball stays put, GPS no longer overrides
- [ ] Tap "Mark ball here" — confirm next shot's start_lat/lng matches the marked position even on slow networks/SQLite
- [ ] Hole change — confirm GPS auto-tracking re-engages on the new hole