### PR TITLE
docs: rewrite README and contributing guide for current state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,34 +1,100 @@
 # Contributing to OGA
 
-Thanks for showing up. OGA stays free and open because contributors make it better — drills, course data, bug fixes, design polish all welcome.
+Thanks for showing up. OGA stays free and open because contributors make it
+better — drills, course data, bug fixes, design polish all welcome.
 
 ## Dev environment
 
-See the [Quick start](./README.md#quick-start) in the README for the full sequence (`supabase start`, `pnpm install`, `pnpm dev --filter web`). Make sure `pnpm typecheck` and `pnpm test` both pass before you start touching code so you have a clean baseline.
+Setup steps live in the [README](./README.md#self-hosting): install
+dependencies, link a Supabase project, apply migrations, set env vars.
+Confirm a clean baseline before touching code:
 
-## Development workflow
+```bash
+pnpm typecheck       # 4 packages must be clean
+pnpm test            # Vitest, in @oga/core
+pnpm --filter web build
+cd apps/mobile && npm run typecheck
+```
+
+CI runs the same four commands. A PR with a red CI gate will not be
+reviewed until it's green.
+
+## Project rules — `CLAUDE.md`
+
+The project's day-to-day development rules — branch strategy, scope
+discipline, mobile dependency pins, where business logic must live —
+are in `CLAUDE.md` at the repo root. **`CLAUDE.md`, `DESIGN.md`, and
+`DECISIONS.md` are intentionally `.gitignored`** (they evolve quickly
+and would otherwise generate noisy diffs).
+
+If you're contributing more than a one-off PR, ping Conner
+([@cner-smith](https://github.com/cner-smith)) for the current copy of
+those files. The most important rules in summary:
+
+- **Default to no.** Ship the minimum that satisfies the requirement.
+- **3-caller rule for extraction.** No helper / hook / component gets
+  pulled out of its parent until it has three or more callers, or
+  the inline version is genuinely unreadable.
+- **Pure logic lives in `@oga/core`.** No business math or shared
+  domain types in `apps/web/src/lib` or `apps/mobile/lib`.
+- **Mobile deps prefer exact pins.** Especially `nativewind@4.1.23` —
+  see `CLAUDE.md` for why.
+
+## Workflow
 
 ### Branching
-- Branch from dev: `git checkout dev && git pull && git checkout -b feature/your-feature`
-- Name branches: `feature/thing`, `fix/bug-name`, `chore/cleanup`
-- Never push directly to main or dev
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feature/your-feature   # or fix/, chore/
+```
+
+- Branch from `dev`, never from `main`.
+- Name branches: `feature/<thing>`, `fix/<bug>`, `chore/<task>`.
+- Never push directly to `main` or `dev` — both have required-status-check
+  branch protection that rejects direct pushes.
+
+### Rebasing before PR
+
+Rebase against `origin/dev` before opening or updating a PR. Don't merge
+`dev` into your branch.
+
+```bash
+git fetch origin
+git rebase origin/dev
+git push --force-with-lease origin <your-branch>
+```
 
 ### Opening a PR
-1. Push your branch
-2. Open a PR against `dev` (not main)
-3. Fill out the PR template
-4. CI must pass before merging
 
-### Releases
-Maintainers periodically merge dev → main to cut a release.
+1. Push your branch.
+2. Open a PR against `dev` (not `main`).
+3. CI must be green before review.
+4. Title in imperative present tense ("Add lie-slope filter to patterns").
+5. **One concern per PR.** UI restyle, bug fix, and new feature do not
+   belong in the same PR.
+
+Maintainers periodically merge `dev → main` via PR to cut a release;
+contributors don't open PRs against `main`.
+
+### Commit messages
+
+- Imperative mood, short subject ("fix: putt distance result split").
+- Reference issues with `(#123)` when relevant; close them in the PR
+  description, not the commit.
+- No tooling-generated trailers (no `Co-Authored-By: Claude`, no
+  `🤖 Generated with …` footers).
 
 ## Reporting bugs
 
-Open a [GitHub issue](https://github.com/cner-smith/opengolfapp/issues). Include:
+Open a [GitHub issue](https://github.com/cner-smith/opengolfapp/issues).
+Include:
 
 - What you did, what you expected, what actually happened.
-- Browser / OS / device + version (web), or Expo SDK + Android version (mobile).
-- Console output or stack trace if there is one.
+- Browser / OS / device + version (web), or Expo SDK + Android version
+  (mobile).
+- Console output or stack trace.
 - Screenshot for any UI bug.
 
 Reproducible steps beat lengthy descriptions every time.
@@ -41,27 +107,17 @@ Also a GitHub issue, with the `feature` label. Tell us:
 - Why the existing screens don't already cover it.
 - One concrete acceptance criterion ("I can do X and see Y").
 
-If a feature breaks one of the project's design pillars — free forever, lie-slope-aware tracking, aim point is always explicit user input, plans are calibrated to skill level — say why up front. That's the highest bar.
+If a feature breaks one of the project's design pillars — free forever,
+lie-slope-aware tracking, aim point is always explicit user input,
+plans are calibrated to skill level — say why up front. That's the
+highest bar.
 
-## Pull request process
+## Adding drills (highest-leverage contribution)
 
-1. Branch off `main` (`git checkout -b your-handle/short-description`).
-2. Make the change. **One concern per PR** — UI restyle, bug fix, and new feature do not belong in the same PR.
-3. Run the local gates:
-   ```bash
-   pnpm typecheck       # 4 packages, must be clean
-   pnpm test            # 31 tests in @oga/core
-   pnpm lint            # eslint over web + packages
-   pnpm format          # prettier
-   ```
-4. Push, open the PR. Title in imperative present tense ("Add lie-slope filter to patterns").
-5. CI must be green. Reviewer will check that the PR stays minimum-scope — see the code style notes below.
+The practice planner picks drills from `public.drills` in Supabase.
+Adding good drills directly improves every plan generated.
 
-## Adding drills (the highest-leverage contribution)
-
-The AI practice planner picks from `public.drills` in Supabase. **Adding good drills directly improves the plans every user gets.**
-
-The schema:
+Schema:
 
 ```sql
 drills (
@@ -78,24 +134,59 @@ drills (
 
 Drill checklist before submitting:
 
-- [ ] **Category is honest.** Putting drills go in putting; chip-and-runs go in around_green even if you hit them with an iron.
-- [ ] **Duration is realistic.** A drill that needs 200 balls is 30+ minutes, not 15.
-- [ ] **Facility is the actual access required.** Don't list `range` if it can be done at home; use `anywhere`.
-- [ ] **Skill levels are appropriate.** A 9-shot shape grid is `developing`/`competitive` — a beginner won't get value.
-- [ ] **Instructions are specific and measurable.** Bad: "practice your wedges". Good: "Hit 5 balls each at 50 / 75 / 100 yards. Track carry distance and compare to your gapping chart."
+- [ ] **Category is honest.** Putting drills go in putting; chip-and-runs
+      go in `around_green` even if you hit them with an iron.
+- [ ] **Duration is realistic.** A drill that needs 200 balls is 30+
+      minutes, not 15.
+- [ ] **Facility is the actual access required.** Don't list `range` if
+      it can be done at home; use `anywhere`.
+- [ ] **Skill levels are appropriate.** A 9-shot shape grid is
+      `developing`/`competitive` — a beginner won't get value.
+- [ ] **Instructions are specific and measurable.** Bad: "practice your
+      wedges". Good: "Hit 5 balls each at 50 / 75 / 100 yards. Track
+      carry distance and compare to your gapping chart."
 
-To add: drop new rows into `supabase/seed.sql` following the existing pattern, run `npx supabase db reset` locally to verify, then PR. Title format: `seed: add <drill-name>`.
+To add: drop new rows into `supabase/seed.sql` following the existing
+pattern, run `npx supabase db reset` locally to verify, then PR. Title
+format: `seed: add <drill-name>`.
+
+## Course data
+
+OGA's courses come from a one-shot crawler over OpenStreetMap +
+OpenGolfAPI; see [`scripts/crawl-courses.ts`](./scripts/crawl-courses.ts).
+For local development, the fastest way to get realistic course data is
+a single state:
+
+```bash
+SUPABASE_URL=<your-url> \
+SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key> \
+  pnpm crawl:courses --source osm-first --states OK
+```
+
+Re-run with `--status` to see progress, or pass new state codes — the
+crawler is resumable via the `crawl_state` table.
+
+Bug reports for missing or wrong course data are welcome. Include the
+course name, expected city/state, and what's wrong.
 
 ## Code style
 
-- TypeScript strict everywhere. Don't add `any` to silence an error — fix the type.
+- TypeScript strict everywhere. Don't add `any` to silence an error —
+  fix the type.
 - Prettier handles formatting (`pnpm format`). Don't argue with it.
-- ESLint catches the rest (`pnpm lint`). Don't add `// eslint-disable-next-line` without a comment explaining why.
-- Comments only when the **why** is non-obvious from the name and types alone. Don't narrate what the code does.
-- No emojis in source code or commit messages unless we're laying down user-facing copy.
+- ESLint catches the rest (`pnpm lint`). No `// eslint-disable-next-line`
+  without a comment explaining why.
+- Comments only when the **why** is non-obvious from the name and types
+  alone. Don't narrate what the code does.
+- No emojis in source code or commit messages unless we're laying down
+  user-facing copy.
 
-Default to no. Ship the minimum that satisfies the requirement. Don't extract a helper unless it has three or more callers. Don't add config vars, options, or parameters for hypothetical future use. PRs that add scope beyond their stated concern will be asked to split.
+Default to no. Ship the minimum that satisfies the requirement. Don't
+extract a helper unless it has three or more callers. Don't add config
+vars, options, or parameters for hypothetical future use. PRs that add
+scope beyond their stated concern will be asked to split.
 
 ## License
 
-By contributing you agree that your contributions are licensed under the [MIT License](./LICENSE).
+By contributing you agree that your contributions are licensed under
+the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -4,82 +4,194 @@
 
 Free, open source golf tracking and improvement platform.
 
-## What it does
+OGA does what paid apps like Arccos, Shot Scope, and Break X Golf do — shot
+tracking, strokes gained analysis, shot pattern dispersion, lie-aware
+filtering — and charges nothing. The core belief: getting better at golf
+shouldn't be paywalled.
 
-- **Strokes gained tracking** vs. handicap-bracket baselines (off tee, approach, around green, putting)
-- **Shot patterns** — per-club dispersion cones, miss tendency, lie-aware filtering, aim correction tips
-- **AI practice plans** — drill recommendations tuned to your weakest categories (Phase 5)
-- **Live round GPS tracking** on Android — Mapbox satellite view, tap for ball, long-press for aim, offline-first SQLite
+## Live app
 
-## Why it exists
+- Web: https://opengolfapp-web.vercel.app
+- Android: EAS development builds today; Play Store listing TBD
+- iOS: deferred — pending an Apple developer account
 
-Everything serious in golf is paywalled. Getting better at the game shouldn't be.
+## Features
+
+- **Round logging** — hole-by-hole shot entry with club, lie type, and
+  split lie-slope axes (forward/back tilt + ball above/below feet).
+- **Live round mode** — Android-only, GPS-assisted shot tracking.
+  Mapbox satellite view, Kalman-smoothed ball position, 3-tap flow.
+- **Strokes gained** — off tee, approach, around green, putting; baselines
+  interpolated by handicap bracket from Mark Broadie's "Every Shot Counts".
+- **Shot patterns** — per-club dispersion ellipses (68% / 95%), miss
+  tendency, aim-correction tips, lie-aware filtering.
+- **Course database** — ~15,870 US golf courses with GPS coordinates;
+  fuzzy search backed by `pg_trgm`.
+- **Handicap index** — calculated from your last N rounds against
+  course rating + slope.
+- **Learn section** — golf glossary and progress-focused education.
+- **Putting model** — independent short/long and left/right miss axes,
+  green speed, slope %, and break direction captured per putt.
+
+A Claude-powered practice plan generator is in the roadmap (issue
+tracked on GitHub) but is not yet wired up. Don't expect AI plans
+to be functional today.
 
 ## Tech stack
 
-React + Vite (web), React Native + Expo SDK 51 (mobile, Android-first), Supabase (Postgres + auth + edge functions), TypeScript end-to-end, Mapbox for the live round map, Recharts on web and Victory Native on mobile.
-
-## Quick start
-
-```bash
-# 1. Spin up local Supabase
-npx supabase start
-npx supabase db reset       # applies migrations + seed
-
-# 2. Install + run web
-pnpm install
-pnpm dev --filter web       # http://localhost:5173
-
-# 3. (Optional) Mobile dev build
-cd apps/mobile && npm install
-npx expo run:android        # requires a connected device or emulator
-```
-
-Copy `apps/web/.env.example` to `apps/web/.env.local` and `apps/mobile/.env.example` to `apps/mobile/.env`, then fill in your Supabase URL + anon key (and Mapbox token if you want the live round map). For mobile device testing, the Supabase URL must be your machine's LAN IP, not `localhost`.
-
-Optional demo data:
-
-```bash
-pnpm seed:demo              # creates demo@oga.app + 15 rounds of realistic data
-```
-
-## Populating the courses database
-
-The `courses` / `holes` / `course_tees` tables ship empty. Populate them
-from free sources by running the crawler — manual one-off, not scheduled:
-
-```bash
-SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
-  pnpm crawl:courses --source opengolfapi          # all 50 US states (~5h)
-pnpm crawl:courses --source opengolfapi --states TX,OK,CA
-pnpm crawl:courses --source osm --states OK        # OSM golf course centroids
-pnpm crawl:courses --status                        # show progress
-```
-
-Resumable: re-running picks up where it left off via the `crawl_state`
-table. Add `--force` to re-import existing courses. See the script
-header in [`scripts/crawl-courses.ts`](./scripts/crawl-courses.ts) for
-details.
+- **Monorepo:** Turborepo + pnpm workspaces.
+- **Web:** Vite + React 18 + TypeScript + Tailwind. Recharts for charts.
+- **Mobile:** Expo SDK 51 + Expo Router + React Native 0.74. NativeWind
+  pinned at `4.1.23`. Builds run on EAS.
+- **Backend:** Supabase (Postgres + Auth + Row Level Security).
+- **Maps:** Mapbox GL JS (web) + `@rnmapbox/maps` (mobile).
+- **Packages:**
+  - `@oga/core` — pure TypeScript: math, stats, SG calculation, Kalman GPS
+    smoother, shot-pattern fitting, all shared domain types.
+  - `@oga/supabase` — generated Supabase types + client factory + query
+    helpers.
 
 ## Self-hosting
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https://github.com/cner-smith/opengolfapp)
+The short version is below. For the full walk-through (forking, Vercel
+deploy, EAS setup, troubleshooting), see [docs/self-hosting.md](./docs/self-hosting.md).
 
-1. Create a free Supabase project, run the migrations from `supabase/migrations/` and the seed from `supabase/seed.sql`.
-2. Click the Vercel button above (or `vercel deploy` locally).
-3. Set `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_MAPBOX_TOKEN` in Vercel's project settings.
+### Prerequisites
 
-Full step-by-step in [docs/self-hosting.md](./docs/self-hosting.md).
+- Node.js 20+
+- pnpm 10+
+- Supabase account (free tier is plenty)
+- Mapbox account (free tier covers 50,000 map loads/month — required for
+  mobile, optional for web)
+
+### Setup
+
+```bash
+# 1. Clone
+git clone https://github.com/cner-smith/opengolfapp.git
+cd opengolfapp
+
+# 2. Install dependencies
+#    Mobile is decoupled from the workspace and uses npm with
+#    --legacy-peer-deps; do not lift it into pnpm.
+pnpm install
+cd apps/mobile && npm install --legacy-peer-deps && cd ../..
+
+# 3. Create a Supabase project at https://supabase.com
+#    Copy the project URL, anon key, and service-role key.
+
+# 4. Apply database migrations (0001–0021)
+npx supabase link --project-ref <your-project-ref>
+npx supabase db push
+```
+
+Set up environment variables.
+
+`apps/web/.env.local`:
+
+```
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-anon-key>
+VITE_MAPBOX_TOKEN=<your-mapbox-public-token>
+```
+
+`apps/mobile/.env`:
+
+```
+EXPO_PUBLIC_SUPABASE_URL=<your-supabase-url>
+EXPO_PUBLIC_SUPABASE_ANON_KEY=<your-anon-key>
+EXPO_PUBLIC_MAPBOX_TOKEN=<your-mapbox-public-token>
+```
+
+For mobile device testing, `EXPO_PUBLIC_SUPABASE_URL` must be your
+machine's LAN IP (e.g. `http://192.168.1.108:54321`) when pointing at
+local Supabase, not `localhost`.
+
+### Populate the course database (optional but recommended)
+
+The `courses` / `holes` / `course_tees` tables ship empty. The crawler
+pulls golf-course outlines from OpenStreetMap (Overpass) and enriches
+with tee ratings + slopes from OpenGolfAPI. Service-role only.
+
+```bash
+SUPABASE_URL=<your-url> \
+SUPABASE_SERVICE_ROLE_KEY=<your-service-role-key> \
+  pnpm crawl:courses --source osm-first
+
+# One state for a quick smoke test
+pnpm crawl:courses --source osm-first --states OK
+
+# Resume / status
+pnpm crawl:courses --status
+```
+
+Full US (50 states + DC) is roughly 10–15 hours. The crawler is
+resumable via the `crawl_state` table — re-run to pick up where it left
+off. See the header of [`scripts/crawl-courses.ts`](./scripts/crawl-courses.ts)
+for all flags.
+
+### Run the apps
+
+```bash
+# Web (http://localhost:5173)
+pnpm dev --filter web
+
+# Mobile — Expo Metro bundler, scan the QR code with the Expo Go app
+cd apps/mobile
+npm run dev
+```
+
+### Build for Android (EAS)
+
+Mobile uses Expo CNG — `android/` is regenerated on every EAS build, so
+don't hand-edit native files.
+
+```bash
+cd apps/mobile
+npx eas-cli build --platform android --profile development
+```
+
+Profiles in `eas.json`: `development`, `preview`, `production`.
+
+### Run tests
+
+```bash
+pnpm typecheck   # tsc -b across the workspace
+pnpm test        # Vitest in @oga/core
+```
+
+## Project structure
+
+```
+apps/
+  web/              # Vite + React 18 web app
+  mobile/           # Expo + React Native (Android-first)
+packages/
+  core/             # Pure TypeScript: math, stats, SG, Kalman, types
+  supabase/         # Generated types + client factory
+supabase/
+  migrations/       # 0001_initial_schema.sql … 0021_shot_result_check.sql
+  seed.sql          # Demo courses + drill library
+scripts/
+  crawl-courses.ts  # Course crawler (OSM + OpenGolfAPI)
+  seed-demo.ts      # Demo user + 15 rounds of synthetic data
+```
 
 ## Contributing
 
-Drills, course layouts, bug fixes, and feature work all welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) — drill submissions are the highest-leverage contribution because the AI practice planner picks from this library.
+Drills, course data, bug fixes, and feature work all welcome. Branches
+flow `feature/* → dev → main`; never push directly to `dev` or `main`.
+CI must be green (typecheck + tests + web build + mobile typecheck) before
+a PR is reviewed. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full
+workflow and code style.
 
-## Support
+## Support OGA
+
+OGA is free forever and runs on volunteer time + a small Supabase /
+Vercel / Mapbox bill. If it's helped your game, donations cover
+infrastructure costs:
 
 [![Sponsor on GitHub](https://img.shields.io/github/sponsors/cner-smith?logo=github&logoColor=white&label=Sponsor&color=1D9E75)](https://github.com/sponsors/cner-smith) [![Ko-fi](https://img.shields.io/badge/Ko--fi-Buy%20me%20a%20coffee-1D9E75?logo=ko-fi&logoColor=white)](https://ko-fi.com/nartana)
-
-OGA is free forever. If it's helped your game, consider [sponsoring the project](https://github.com/sponsors/cner-smith) or [tossing a coffee on Ko-fi](https://ko-fi.com/nartana) to help cover server costs.
 
 ## License
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -37,14 +37,23 @@ You'll also need the **service_role** key for the seed script. Treat it like a d
 
 ## 3. Run the migrations
 
-Migrations live in `supabase/migrations/`:
+Migrations live in `supabase/migrations/`, numbered sequentially from
+`0001_initial_schema.sql` through `0021_shot_result_check.sql` at the
+time of writing. Highlights:
 
-- `0001_initial_schema.sql` — base schema (profiles, courses, rounds, hole_scores, shots, drills, practice_plans).
-- `0002_hole_score_pin_position.sql` — adds `pin_lat`/`pin_lng` to `hole_scores` for the per-round pin captured during live play.
-- `0003_split_lie_slope.sql` — splits `lie_slope` into independent `lie_slope_forward` (uphill/level/downhill) and `lie_slope_side` (ball above/below) axes; legacy column kept for back-compat reads.
-- `0004_course_external_id.sql` — adds `courses.external_id` (+ index) for OpenGolfAPI imports.
-- `0005_putting_fields.sql` — adds `putt_slope_pct` (0-4) and `green_speed` (slow/medium/fast) to `shots`.
-- `0006_putt_result_split.sql` — splits putt result into `putt_distance_result` (short/long) and `putt_direction_result` (left/right); legacy `putt_result` kept and backfilled.
+- `0001` — base schema (profiles, courses, rounds, hole_scores, shots,
+  drills, practice_plans) with RLS policies on every user-owned table.
+- `0002` — per-round pin override (`hole_scores.pin_lat/pin_lng`).
+- `0003` — splits `lie_slope` into independent `lie_slope_forward` and
+  `lie_slope_side` axes; legacy column kept for back-compat reads.
+- `0006` — splits putt result into independent `putt_distance_result`
+  (short/long) and `putt_direction_result` (left/right) axes.
+- `0008` — `course_tees` (per-tee handicap rating + slope).
+- `0010`–`0012` — crawl-pipeline tables for course ingestion.
+- `0013` — drops `courses.location` in favor of discrete `city`/`state`.
+- `0017` — drops the never-used `courses.mapbox_id`.
+- `0018`–`0021` — fuzzy course search (`pg_trgm`), unique index on
+  `external_id`, CHECK constraints on `play_frequency` and `shot_result`.
 
 Apply them in order. Either:
 
@@ -55,7 +64,7 @@ npx supabase link --project-ref <your-project-ref>
 npx supabase db push
 ```
 
-`db push` applies every file in `supabase/migrations/` that hasn't run yet, in filename order, so a single command covers `0001` and `0002` on a fresh project.
+`db push` applies every file in `supabase/migrations/` that hasn't run yet, in filename order, so a single command covers `0001` through the latest migration on a fresh project.
 
 **Option B — SQL editor:**
 


### PR DESCRIPTION
## Summary

Audited and rewrote the public-facing docs to match the project's actual state.

### `README.md`
- Reorganized into the structure: tagline → live app → features → tech stack → self-hosting → project structure → contributing → support → license.
- Replaced the stale "AI practice plans (Phase 5)" feature claim with a note that the generator is on the roadmap but not yet wired up (matches the truth in `CLAUDE.md`).
- Added accurate live-app links: web (Vercel), Android EAS dev build, iOS deferred pending Apple developer account.
- Self-hosting section now captures the real prerequisites (Node 20+, pnpm 10+ — was wrong before), the workspace + mobile decoupling (`npm install --legacy-peer-deps`), the current crawler invocation (`--source osm-first`), and the EAS profile names from `eas.json`.
- Added a project-structure tree so contributors can orient.
- Kept the deploy button, sponsor badges, and Ko-fi link.

### `CONTRIBUTING.md`
- Removed the contradictory "branch off `main`" instruction — the branching section now consistently says branch off `dev`.
- Dropped the stale "31 tests in `@oga/core`" claim; CI gate description now lists the four real jobs (typecheck, test, web build, mobile typecheck).
- Added a new section pointing contributors at `CLAUDE.md` / `DESIGN.md` / `DECISIONS.md` (gitignored) and explaining how to get a copy from Conner.
- Added a course-data section pointing at the crawler with a single-state quickstart.
- Added a commit-message section that explicitly forbids tooling-generated trailers and footers.
- Kept the drill-submission section verbatim (it's the highest-leverage contribution and still accurate).

### `docs/self-hosting.md`
- Replaced the migration list (which only covered `0001`–`0006`) with a current summary that names the highlights through `0021_shot_result_check.sql` and notes that `db push` applies everything in order.
- Other sections were already accurate (Vercel deploy, EAS, troubleshooting) — left them alone.

## Verification

- `git diff --stat`: 3 files, +310/-98.
- No code changes — `pnpm typecheck` / `pnpm test` not affected.
- Spot-checked every command in the README's self-hosting block against `package.json` and `apps/mobile/package.json` (`pnpm dev`, `pnpm crawl:courses --source osm-first`, `npm run dev`, `eas build`).

## Test plan

- [ ] Skim the rendered README on the GitHub PR page for layout / link breakage
- [ ] Verify the live web app URL still resolves
- [ ] Confirm the EAS build profile names still match `apps/mobile/eas.json`