### PR TITLE
fix: onboarding loop after custom bag step

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -32,7 +32,7 @@ export default function AppLayout() {
 
     supabase
       .from('profiles')
-      .select('skill_level, goal')
+      .select('onboarding_completed')
       .eq('id', user.id)
       .maybeSingle()
       .then(({ data, error }) => {
@@ -44,7 +44,7 @@ export default function AppLayout() {
           setProfileState('error')
           return
         }
-        if (!data || !data.skill_level || !data.goal) {
+        if (!data || !data.onboarding_completed) {
           setProfileState('incomplete')
         } else {
           setProfileState('complete')

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -67,16 +67,6 @@ export default function MobileOnboarding() {
       return
     }
     setSaving(true)
-    const { error } = await updateProfile(supabase, user.id, {
-      skill_level: skill,
-      handicap_index: numericHandicap,
-      goal,
-    })
-    if (error) {
-      setSaving(false)
-      Alert.alert('Save failed', error.message)
-      return
-    }
     if (seedBag && bagSelection.size > 0) {
       try {
         const reseeded = DEFAULT_BAG.filter((c) =>
@@ -88,14 +78,28 @@ export default function MobileOnboarding() {
         }))
         await seedDefaultBag(supabase, user.id, reseeded)
       } catch (e) {
-        // Bag seeding is best-effort; profile save already succeeded so
-        // we don't block navigation. The user can populate the bag from
-        // /bag any time. Surface the error so they know it failed.
+        // Bag seeding is best-effort; let the user know but don't
+        // block their onboarding completion. They can rebuild the bag
+        // from Profile → My Bag.
         Alert.alert(
           'Bag setup skipped',
           `Could not save bag: ${(e as Error).message}. You can build it from Profile → My Bag.`,
         )
       }
+    }
+    // Single profile write — saves the required fields AND flips the
+    // onboarding gate atomically. If the bag write above failed the
+    // gate still flips so the user isn't trapped on /onboarding.
+    const { error } = await updateProfile(supabase, user.id, {
+      skill_level: skill,
+      handicap_index: numericHandicap,
+      goal,
+      onboarding_completed: true,
+    })
+    if (error) {
+      setSaving(false)
+      Alert.alert('Save failed', error.message)
+      return
     }
     setSaving(false)
     router.replace('/(app)')

--- a/apps/web/src/components/auth/ProfileGuard.tsx
+++ b/apps/web/src/components/auth/ProfileGuard.tsx
@@ -34,7 +34,15 @@ export function ProfileGuard({ children }: { children: React.ReactNode }) {
     )
   }
 
-  if (!profile || !profile.skill_level || !profile.goal) {
+  // Single explicit gate. Earlier check (`!skill_level || !goal`) raced
+  // a stale TanStack Query cache populated during the pre-onboarding
+  // sign-in pass — the cache returned the pre-onboarding row
+  // synchronously while the background refetch was still in flight,
+  // so a user who just completed onboarding got bounced back to
+  // /onboarding. The explicit boolean + setQueryData in
+  // useUpdateProfile makes the cache reflect the freshly-saved state
+  // on the very next read.
+  if (!profile || !profile.onboarding_completed) {
     return <Navigate to="/onboarding" replace />
   }
 

--- a/apps/web/src/hooks/useProfile.ts
+++ b/apps/web/src/hooks/useProfile.ts
@@ -29,6 +29,14 @@ export function useUpdateProfile() {
       if (error) throw error
       return data
     },
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['profile', user?.id] }),
+    // Seed the cache with the row the server just returned BEFORE the
+    // background refetch kicks off. Without this, ProfileGuard reads
+    // the pre-mutation cache (skill_level=null, onboarding_completed=
+    // false) on the next /-route mount and bounces the user back to
+    // /onboarding even though the DB is up to date.
+    onSuccess: (data) => {
+      if (data) qc.setQueryData(['profile', user?.id], data)
+      qc.invalidateQueries({ queryKey: ['profile', user?.id] })
+    },
   })
 }

--- a/apps/web/src/pages/onboarding/OnboardingPage.tsx
+++ b/apps/web/src/pages/onboarding/OnboardingPage.tsx
@@ -92,6 +92,9 @@ export function OnboardingPage() {
         sort_order: idx,
       }))
       await seedDefaultBag(supabase, user.id, reseeded)
+      // Flip the gate AFTER the bag write so a failed bag save can't
+      // strand the user on a half-completed onboarding.
+      await updateProfile.mutateAsync({ onboarding_completed: true })
       navigate('/', { replace: true })
     } catch (err) {
       setError(toUserMessage(err))
@@ -100,8 +103,18 @@ export function OnboardingPage() {
     }
   }
 
-  function skipBag() {
-    navigate('/', { replace: true })
+  async function skipBag() {
+    if (!user) return
+    setError(null)
+    setSavingBag(true)
+    try {
+      await updateProfile.mutateAsync({ onboarding_completed: true })
+      navigate('/', { replace: true })
+    } catch (err) {
+      setError(toUserMessage(err))
+    } finally {
+      setSavingBag(false)
+    }
   }
 
   return (
@@ -185,6 +198,7 @@ export function OnboardingPage() {
             onContinue={saveBagAndFinish}
             onSkip={skipBag}
             busy={savingBag}
+            error={error}
           />
         )}
       </div>

--- a/apps/web/src/pages/onboarding/steps/Step6Bag.tsx
+++ b/apps/web/src/pages/onboarding/steps/Step6Bag.tsx
@@ -11,6 +11,7 @@ interface Step6BagProps {
   onContinue: () => void
   onSkip: () => void
   busy: boolean
+  error: string | null
 }
 
 export function Step6Bag({
@@ -20,6 +21,7 @@ export function Step6Bag({
   onContinue,
   onSkip,
   busy,
+  error,
 }: Step6BagProps) {
   function toggle(clubType: string) {
     const next = new Set(selected)
@@ -33,7 +35,7 @@ export function Step6Bag({
       <StepHeading
         kicker="Optional"
         title="Build your bag."
-        subtitle="Tap to add or remove clubs. Only the clubs in your bag will show up when logging shots. You can update this any time in settings."
+        subtitle="Select the clubs you carry. Tap to toggle. You can customise your bag fully in settings later."
       />
       <div
         style={{
@@ -52,15 +54,33 @@ export function Step6Bag({
               onClick={() => toggle(c.club_type)}
               aria-pressed={active}
               style={{
-                backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
-                color: active ? '#F2EEE5' : '#1C211C',
-                border: 'none',
+                // Outline style for unselected, filled accent + leading
+                // checkmark for selected — gives an obvious binary read
+                // at a glance instead of "two shades of green".
+                backgroundColor: active ? '#1F3D2C' : 'transparent',
+                color: active ? '#F2EEE5' : '#5C6356',
+                border: active ? '1px solid #1F3D2C' : '1px solid #D9D2BF',
                 borderRadius: 2,
                 padding: '8px 12px',
                 fontSize: 13,
                 fontWeight: active ? 500 : 400,
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 6,
               }}
             >
+              <span
+                aria-hidden
+                style={{
+                  display: 'inline-block',
+                  width: 12,
+                  fontSize: 12,
+                  lineHeight: 1,
+                  textAlign: 'center',
+                }}
+              >
+                {active ? '✓' : ''}
+              </span>
               {c.name}
             </button>
           )
@@ -72,19 +92,45 @@ export function Step6Bag({
       >
         {selected.size} of {DEFAULT_BAG.length} selected
       </div>
+      <p
+        className="text-caddie-ink-mute"
+        style={{ fontSize: 12, marginTop: 8, lineHeight: 1.5 }}
+      >
+        You can add custom clubs and reorder your bag any time in
+        Settings → My Bag.
+      </p>
+      {error && (
+        <div
+          className="text-caddie-neg"
+          role="alert"
+          style={{
+            border: '1px solid #A33A2A',
+            borderRadius: 2,
+            padding: '10px 12px',
+            fontSize: 13,
+            marginTop: 14,
+          }}
+        >
+          {error}
+        </div>
+      )}
       <OnboardingButtons
         onBack={onBack}
         onContinue={onContinue}
-        canContinue={selected.size > 0}
+        // The bag step is optional — even zero selected is a valid
+        // "Looks good" (it just leaves the bag empty, equivalent to
+        // skipping). The earlier `selected.size > 0` gate looked like
+        // the button was broken when the user trimmed everything.
+        canContinue={true}
         continueLabel={busy ? 'Saving…' : 'Looks good'}
         busy={busy}
       />
       <button
         type="button"
         onClick={onSkip}
-        className="font-mono uppercase text-caddie-ink-mute hover:text-caddie-ink"
+        className="font-mono uppercase text-caddie-ink-dim hover:text-caddie-ink"
         style={{
-          fontSize: 10,
+          fontSize: 11,
           letterSpacing: '0.14em',
           padding: '14px 0 0',
           background: 'transparent',
@@ -95,7 +141,7 @@ export function Step6Bag({
         }}
         disabled={busy}
       >
-        Skip for now →
+        Set up later →
       </button>
     </div>
   )

--- a/packages/supabase/src/queries/profiles.ts
+++ b/packages/supabase/src/queries/profiles.ts
@@ -4,10 +4,10 @@ import type { Database } from '../types'
 type ProfileUpdate = Database['public']['Tables']['profiles']['Update']
 
 // Explicit column list — `select('*')` over-fetches every audit / metadata
-// column on every read. These seven are everything the apps actually
-// consume from the profile.
+// column on every read. ProfileGuard / mobile route gate read
+// onboarding_completed; the rest are app fields.
 const PROFILE_COLUMNS =
-  'id, username, handicap_index, skill_level, goal, facilities, distance_unit'
+  'id, username, handicap_index, skill_level, goal, facilities, distance_unit, onboarding_completed'
 
 export function getProfile(client: OgaSupabaseClient, userId: string) {
   return client.from('profiles').select(PROFILE_COLUMNS).eq('id', userId).single()

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -24,6 +24,7 @@ export interface Database {
           facilities: string[] | null
           play_style: 'casual' | 'mixed' | 'competitive' | null
           distance_unit: 'yards' | 'meters'
+          onboarding_completed: boolean
           created_at: string
         }
         Insert: {
@@ -36,6 +37,7 @@ export interface Database {
           facilities?: string[] | null
           play_style?: 'casual' | 'mixed' | 'competitive' | null
           distance_unit?: 'yards' | 'meters'
+          onboarding_completed?: boolean
           created_at?: string
         }
         Update: {
@@ -48,6 +50,7 @@ export interface Database {
           facilities?: string[] | null
           play_style?: 'casual' | 'mixed' | 'competitive' | null
           distance_unit?: 'yards' | 'meters'
+          onboarding_completed?: boolean
           created_at?: string
         }
         Relationships: []

--- a/supabase/migrations/0023_profile_onboarding_completed.sql
+++ b/supabase/migrations/0023_profile_onboarding_completed.sql
@@ -1,0 +1,13 @@
+-- 0023_profile_onboarding_completed.sql
+-- Explicit completion flag so the post-onboarding redirect doesn't race
+-- against cached "fields might be null" reads. Existing users with
+-- skill_level + goal already filled in are backfilled to true so they
+-- aren't bounced back through onboarding when they next sign in.
+
+ALTER TABLE public.profiles
+  ADD COLUMN onboarding_completed boolean NOT NULL DEFAULT false;
+
+UPDATE public.profiles
+  SET onboarding_completed = true
+  WHERE skill_level IS NOT NULL
+    AND goal IS NOT NULL;


### PR DESCRIPTION
Three fixes from device testing after #150 merged.

## Root cause

The onboarding completion gate inferred "complete" from `!profile.skill_level || !profile.goal`. After step 5 saves the profile and step 6 navigates to `/`, ProfileGuard reads from the TanStack Query cache. The cache was populated during the initial sign-in pass (when Sidebar mounted under `/` and `useProfile` ran before the guard redirected to `/onboarding`), so it held the pre-onboarding row with `skill_level=null`. ProfileGuard reads stale cache synchronously while the background refetch is still in flight, sees null, redirects back to `/onboarding`. The user lands on step 1 again.

That single race manifests as both "Looks good goes nowhere" and "Skip for now loops to start". Existing users who somehow had a similar stale-cache window also got bounced.

## Fix

1. **Migration 0023** — new `profiles.onboarding_completed boolean NOT NULL DEFAULT false` with a backfill: every existing user who already has `skill_level` + `goal` is marked completed, so the deploy doesn't trap them. Web `ProfileGuard` and mobile `(app)/_layout` now read this single column.
2. **`useUpdateProfile.onSuccess`** primes the cache via `setQueryData(['profile', userId], data)` before invalidating. ProfileGuard's next read sees the freshly-saved row, no race.
3. **Step 6 paths** flip `onboarding_completed=true` before navigating. "Looks good" runs the bag seed first, then the profile flip — so a failed bag write can't strand the user on a half-completed flow. "Skip for now" just flips. Both paths surface errors in the step UI instead of disappearing.
4. **Mobile onboarding `save()`** writes `onboarding_completed=true` in the single profile update, after the best-effort bag seed. A failed bag seed no longer blocks the gate.
5. **Step 6 UX**:
   - Selected chips: accent fill + leading `✓`. Unselected: outline + muted text. The previous two-shades-of-green rendering looked uniform.
   - Subtitle rewritten to make toggle behaviour explicit and set expectation that this is quick-start, not the full editor.
   - "You can add custom clubs and reorder anytime in Settings → My Bag" note below the counter.
   - "Skip for now" → "Set up later →" so the affordance reads as forward-motion.
   - `canContinue` relaxed: zero selected is a valid "Looks good" (equivalent to skipping); the previous `> 0` gate made the primary button look broken when a user trimmed everything.

## Verification

- `pnpm typecheck` (3 packages) — green
- `pnpm test` (224) — green
- `pnpm --filter @oga/web build` — green
- `cd apps/mobile && npm run typecheck` — green

## Manual step

`supabase db push --linked` to apply 0023 to prod. The backfill is idempotent (only writes rows where the column was still default false).

## Test plan

- [ ] Apply migration 0023
- [ ] As an existing user with skill_level + goal set, sign in — lands on dashboard, not onboarding
- [ ] As a new user, complete steps 1–5, on step 6 click "Looks good" with all 15 selected — bag seeded, lands on dashboard, refresh keeps them on dashboard
- [ ] Same as above but trim to 0 selected — "Looks good" still works (acts as skip)
- [ ] On step 6, click "Set up later →" — lands on dashboard, refresh keeps them there
- [ ] On step 6, simulate save failure (kill network) — error renders in step UI instead of silent
- [ ] Selected chip rendering: `✓` visible on filled accent, unselected chips outlined with muted text