### PR TITLE
fix: CSP allows Vercel preview scripts, add favicon

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://api.mapbox.com https://events.mapbox.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.mapbox.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://*.mapbox.com https://*.supabase.co; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.mapbox.com https://events.mapbox.com https://api.opengolfapi.org; worker-src blob:;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://api.mapbox.com https://events.mapbox.com https://vercel.live https://*.vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.mapbox.com; font-src 'self' https://fonts.gstatic.com https://*.vercel.live; img-src 'self' data: blob: https://*.mapbox.com https://*.supabase.co https://*.pusher.com https://*.vercel.live; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.mapbox.com https://events.mapbox.com https://api.opengolfapi.org https://vercel.live https://*.vercel.live wss://*.pusher.com; frame-src 'self' https://vercel.live https://*.vercel.live; worker-src blob:;"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/apps/web/public/favicon.svg
+++ b/apps/web/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" fill="#1F3D2C"/>
+  <text x="32" y="42" text-anchor="middle"
+        font-family="Georgia, 'Times New Roman', serif"
+        font-style="italic" font-weight="500" font-size="28"
+        fill="#F2EEE5">OGA</text>
+</svg>


### PR DESCRIPTION
## Summary

- **CSP**: whitelist `vercel.live` + `*.vercel.live` on \`script-src\`, \`connect-src\`, \`frame-src\`, \`font-src\`, \`img-src\`. Adds \`*.pusher.com\` (\`img-src\` + \`wss://\` connect) for the Pusher channel the Vercel preview toolbar opens for live comments.
- **Favicon**: \`apps/web/public/\` didn't exist so the existing \`<link rel='icon' href='/favicon.svg'>\` 404'd. Adds a minimal accent-green OGA mark using design-token colours (\`#1F3D2C\` fill, \`#F2EEE5\` ink). Uses generic serif italic — favicons can't load the Fraunces webfont.

## Verification

- \`pnpm typecheck\` — green
- \`pnpm --filter @oga/web build\` — green; \`dist/favicon.svg\` shipped
- Reminder: when this lands, the CSP source-of-truth note in DECISIONS.md should be updated to reflect \`vercel.live\` + \`*.pusher.com\`

## Test plan

- [ ] Open a Vercel preview deploy — toolbar loads without CSP violations in console
- [ ] \`/favicon.svg\` returns 200 in prod
- [ ] Mapbox map still renders (CSP additions don't break existing origins)