### PR TITLE
fix: ProfileGuard onboarding redirect uses correct condition

### DIFF
--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -1,0 +1,67 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import type { User } from '@supabase/supabase-js'
+import { supabase } from '../lib/supabase'
+
+interface AuthState {
+  user: User | null
+  loading: boolean
+}
+
+const AuthContext = createContext<AuthState | null>(null)
+
+// Single source of truth for the auth state. Earlier `useAuth` was a
+// hook that ran its own useState + useEffect per call, so every caller
+// (AuthGuard, ProfileGuard, useProfile, every page hook…) had an
+// independent loading flag and its own getSession + onAuthStateChange
+// subscription. ProfileGuard and the useProfile hook nested under it
+// raced — when ProfileGuard's instance settled before useProfile's,
+// useProfile stayed `enabled: false` (its own loading was still true),
+// the query never fired, profile was undefined, and ProfileGuard
+// bounced the user to /onboarding. Collapsing to one shared state
+// eliminates the race AND the N-way duplicate auth subscription.
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let mounted = true
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return
+      setUser(data.session?.user ?? null)
+      setLoading(false)
+    })
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (!mounted) return
+      setUser(session?.user ?? null)
+    })
+
+    return () => {
+      mounted = false
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ user, loading }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuthContext(): AuthState {
+  const ctx = useContext(AuthContext)
+  if (ctx === null) {
+    throw new Error('useAuth must be called inside <AuthProvider>')
+  }
+  return ctx
+}

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -1,32 +1,8 @@
-import { useEffect, useState } from 'react'
 import type { User } from '@supabase/supabase-js'
-import { supabase } from '../lib/supabase'
+import { useAuthContext } from '../contexts/AuthContext'
 
+// Thin re-export so existing call sites keep working unchanged. The
+// real state lives in <AuthProvider> in main.tsx.
 export function useAuth(): { user: User | null; loading: boolean } {
-  const [user, setUser] = useState<User | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    let mounted = true
-
-    supabase.auth.getSession().then(({ data }) => {
-      if (!mounted) return
-      setUser(data.session?.user ?? null)
-      setLoading(false)
-    })
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (!mounted) return
-      setUser(session?.user ?? null)
-    })
-
-    return () => {
-      mounted = false
-      subscription.unsubscribe()
-    }
-  }, [])
-
-  return { user, loading }
+  return useAuthContext()
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from 'react-router-dom'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { router } from './router'
 import { queryClient } from './lib/queryClient'
+import { AuthProvider } from './contexts/AuthContext'
 import './index.css'
 
 const rootEl = document.getElementById('root')
@@ -11,8 +12,10 @@ if (!rootEl) throw new Error('Root element #root not found')
 
 ReactDOM.createRoot(rootEl).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </AuthProvider>
   </React.StrictMode>,
 )


### PR DESCRIPTION
## Root cause

Existing users with \`profiles.onboarding_completed = true\` were being redirected to \`/onboarding\` on every sign-in.

\`useAuth\` was a per-call hook that ran its own \`useState\` + \`useEffect\` + \`supabase.auth.getSession()\` + \`onAuthStateChange\` subscription. Every caller (AuthGuard, ProfileGuard, useProfile, every page hook) got an independent loading flag.

ProfileGuard calls \`useAuth\` directly AND calls \`useProfile\` which itself calls \`useAuth\` — two independent auth state machines per ProfileGuard render. The two \`getSession()\` promises resolve in non-deterministic order. When ProfileGuard's instance settled first:

- ProfileGuard saw \`authLoading=false\`
- \`useProfile\`'s internal instance was still \`loading=true\` → its \`useQuery({ enabled: !loading && !!user })\` stayed disabled
- TanStack v5 reports \`isLoading: false\` for a disabled query (not \`pending && fetching\`)
- ProfileGuard's \`(user && profileLoading)\` gate was therefore false
- ProfileGuard fell through to \`!profile.onboarding_completed\` — \`profile\` was \`undefined\` (query never fired)
- \`!profile\` short-circuited → \`<Navigate to=\"/onboarding\" replace />\` fired

The "dashboard briefly flashes" is the AppShell skeleton before \`Navigate\`'s effect runs. Clearing cookies didn't fix it because the bug isn't cache-state — it's a render-time race that fires on every mount.

## Fix

Single \`AuthContext\` provided at the app root in \`main.tsx\`. One \`useState\`, one \`useEffect\`, one \`onAuthStateChange\` subscription shared by every consumer. \`useAuth\` is now a thin \`useContext\` wrapper so the 17+ existing call sites need zero changes.

ProfileGuard and the \`useProfile\` inside it now read the **same** loading flag — \`useProfile\` is enabled the moment ProfileGuard checks the redirect, so the navigation gate reads the actual query result instead of \`undefined\`.

## Files

- new: \`apps/web/src/contexts/AuthContext.tsx\`
- changed: \`apps/web/src/hooks/useAuth.ts\` (now a thin re-export)
- changed: \`apps/web/src/main.tsx\` (AuthProvider above QueryClientProvider)

## Verification

- \`pnpm typecheck\` (3 packages) — green
- \`pnpm --filter @oga/web build\` — green
- Independent second-opinion review by debug-hunter agent in flight (will post findings here)

## Test plan

- [ ] Sign in as an existing user with \`onboarding_completed=true\` → lands on dashboard, NO flash, no /onboarding redirect
- [ ] Sign in repeatedly (e.g. 5 logins) → no intermittent redirects
- [ ] Sign in as a brand-new user → still gets routed to /onboarding (gate still works)
- [ ] Complete onboarding step 6, click "Set up later" → lands on dashboard, refresh keeps them there
- [ ] Sign out from sidebar → lands on /login (no zombie subscriptions)
- [ ] React DevTools: only one \`AuthProvider\` in the tree; \`onAuthStateChange\` fires once on auth event (not 17 times)

## Known follow-ups (not in this PR)

- \`apps/mobile/hooks/useAuth.ts\` has the same per-call pattern. Mobile's \`(app)/_layout.tsx\` doesn't chain \`useAuth → useProfile → useAuth\` so the specific race doesn't reproduce, but the duplicate-subscription cost still applies. Worth a mobile equivalent in a follow-up if the debug hunter flags it.