### PR TITLE
fix: bag + map UX fixes from web testing

### DIFF
--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -112,7 +112,7 @@ export default function BagScreen() {
   function confirmReset() {
     Alert.alert(
       'Reset to default bag?',
-      'This deletes every club and seeds the default 15-club bag.',
+      'This deletes every club and seeds the default 14-club bag.',
       [
         { text: 'Cancel', style: 'cancel' },
         {

--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -74,6 +74,10 @@ export default function BagScreen() {
   })
   const [showAdd, setShowAdd] = useState(false)
   const [draft, setDraft] = useState<AddDraft>(EMPTY_DRAFT)
+  // Set to a club id when the modal is editing an existing row; null when
+  // it's adding a new club. The modal renders the same form either way;
+  // only the upsert payload differs.
+  const [editingId, setEditingId] = useState<string | null>(null)
 
   async function toggleInBag(c: UserClub) {
     if (!user) return
@@ -143,7 +147,26 @@ export default function BagScreen() {
     return Number.isFinite(n) ? n : null
   }
 
-  async function handleAdd() {
+  function startEdit(c: UserClub) {
+    setDraft({
+      name: c.name,
+      category: clubCategoryFor(c.club_type),
+      clubType: c.club_type,
+      loft: c.loft != null ? String(c.loft) : '',
+      typicalDistance:
+        c.typical_distance_yards != null ? String(c.typical_distance_yards) : '',
+    })
+    setEditingId(c.id)
+    setShowAdd(true)
+  }
+
+  function closeForm() {
+    setShowAdd(false)
+    setEditingId(null)
+    setDraft(EMPTY_DRAFT)
+  }
+
+  async function handleSave() {
     if (!user) return
     if (!draft.name.trim()) {
       Alert.alert('Name is required')
@@ -165,18 +188,25 @@ export default function BagScreen() {
       return
     }
     try {
-      const maxSort = bag.reduce((m, c) => Math.max(m, c.sort_order), -1)
+      const existing = editingId ? bag.find((c) => c.id === editingId) : null
+      const sortOrder = existing
+        ? existing.sort_order
+        : bag.reduce((m, c) => Math.max(m, c.sort_order), -1) + 1
+      // Editing an existing row keeps club_type fixed — that's the
+      // canonical id for stats joins. Only edit name/loft/typical here.
       await upsertClub(user.id, {
+        ...(editingId ? { id: editingId } : {}),
         name: draft.name.trim(),
-        club_type: draft.clubType.trim().toLowerCase(),
+        club_type: existing
+          ? existing.club_type
+          : draft.clubType.trim().toLowerCase(),
         loft: parseNumOrNull(draft.loft),
         typical_distance_yards: parseNumOrNull(draft.typicalDistance),
-        sort_order: maxSort + 1,
-        in_bag: true,
+        sort_order: sortOrder,
+        in_bag: existing ? existing.in_bag : true,
       })
       await refetch()
-      setDraft(EMPTY_DRAFT)
-      setShowAdd(false)
+      closeForm()
     } catch (e) {
       Alert.alert('Save failed', (e as Error).message)
     }
@@ -254,6 +284,7 @@ export default function BagScreen() {
               onLongPress={drag}
               onToggle={() => toggleInBag(item)}
               onDelete={() => confirmDelete(item)}
+              onEdit={() => startEdit(item)}
             />
           )}
           ListFooterComponent={
@@ -300,7 +331,7 @@ export default function BagScreen() {
         visible={showAdd}
         animationType="slide"
         transparent
-        onRequestClose={() => setShowAdd(false)}
+        onRequestClose={closeForm}
       >
         <View
           style={{
@@ -328,7 +359,9 @@ export default function BagScreen() {
                 marginBottom: 14,
               }}
             />
-            <Text style={{ ...KICKER, marginBottom: 4 }}>New club</Text>
+            <Text style={{ ...KICKER, marginBottom: 4 }}>
+              {editingId ? 'Edit club' : 'New club'}
+            </Text>
             <Text
               style={{
                 color: '#1C211C',
@@ -338,47 +371,57 @@ export default function BagScreen() {
                 marginBottom: 18,
               }}
             >
-              Add to bag.
+              {editingId ? 'Edit club.' : 'Add to bag.'}
             </Text>
 
-            <Field label="Category">
-              <CategoryRow
-                value={draft.category}
-                onChange={(c) =>
-                  setDraft((d) => ({
-                    ...d,
-                    category: c,
-                    clubType:
-                      c === 'utility'
-                        ? d.clubType
-                        : CANONICAL_BY_CATEGORY[c][0] ?? '',
-                  }))
-                }
-              />
-            </Field>
+            {!editingId && (
+              <>
+                <Field label="Category">
+                  <CategoryRow
+                    value={draft.category}
+                    onChange={(c) =>
+                      setDraft((d) => ({
+                        ...d,
+                        category: c,
+                        clubType:
+                          c === 'utility'
+                            ? d.clubType
+                            : CANONICAL_BY_CATEGORY[c][0] ?? '',
+                      }))
+                    }
+                  />
+                </Field>
 
-            <Field label="Club type">
-              {draft.category === 'utility' ? (
-                <TextInput
-                  value={draft.clubType}
-                  onChangeText={(v) => setDraft((d) => ({ ...d, clubType: v }))}
-                  placeholder="e.g. chipper, mini_driver, aw"
-                  style={inputStyle}
-                  autoCapitalize="none"
-                />
-              ) : (
-                <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
-                  {CANONICAL_BY_CATEGORY[draft.category].map((c) => (
-                    <Chip
-                      key={c}
-                      label={c}
-                      active={draft.clubType === c}
-                      onPress={() => setDraft((d) => ({ ...d, clubType: c }))}
+                <Field label="Club type">
+                  {draft.category === 'utility' ? (
+                    <TextInput
+                      value={draft.clubType}
+                      onChangeText={(v) =>
+                        setDraft((d) => ({ ...d, clubType: v }))
+                      }
+                      placeholder="e.g. chipper, mini_driver, aw"
+                      style={inputStyle}
+                      autoCapitalize="none"
                     />
-                  ))}
-                </View>
-              )}
-            </Field>
+                  ) : (
+                    <View
+                      style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}
+                    >
+                      {CANONICAL_BY_CATEGORY[draft.category].map((c) => (
+                        <Chip
+                          key={c}
+                          label={c}
+                          active={draft.clubType === c}
+                          onPress={() =>
+                            setDraft((d) => ({ ...d, clubType: c }))
+                          }
+                        />
+                      ))}
+                    </View>
+                  )}
+                </Field>
+              </>
+            )}
 
             <Field label="Display name">
               <TextInput
@@ -416,15 +459,17 @@ export default function BagScreen() {
               </View>
             </View>
 
-            <Text style={{ color: '#8A8B7E', fontSize: 12, marginTop: 6 }}>
-              Category will default to{' '}
-              {CLUB_CATEGORY_LABELS[clubCategoryFor(draft.clubType)]} based on
-              the club_type you chose.
-            </Text>
+            {!editingId && (
+              <Text style={{ color: '#8A8B7E', fontSize: 12, marginTop: 6 }}>
+                Category will default to{' '}
+                {CLUB_CATEGORY_LABELS[clubCategoryFor(draft.clubType)]} based on
+                the club_type you chose.
+              </Text>
+            )}
 
             <View style={{ flexDirection: 'row', gap: 8, marginTop: 18 }}>
               <Pressable
-                onPress={handleAdd}
+                onPress={handleSave}
                 style={{
                   flex: 1,
                   backgroundColor: '#1F3D2C',
@@ -436,14 +481,11 @@ export default function BagScreen() {
                 <Text
                   style={{ color: '#F2EEE5', fontSize: 14, fontWeight: '600' }}
                 >
-                  Add to bag →
+                  {editingId ? 'Save changes →' : 'Add to bag →'}
                 </Text>
               </Pressable>
               <Pressable
-                onPress={() => {
-                  setShowAdd(false)
-                  setDraft(EMPTY_DRAFT)
-                }}
+                onPress={closeForm}
                 style={{
                   paddingVertical: 14,
                   paddingHorizontal: 18,
@@ -466,12 +508,14 @@ function ClubRow({
   onLongPress,
   onToggle,
   onDelete,
+  onEdit,
 }: {
   club: UserClub
   isActive: boolean
   onLongPress: () => void
   onToggle: () => void
   onDelete: () => void
+  onEdit: () => void
 }) {
   return (
     <View
@@ -529,6 +573,14 @@ function ClubRow({
         >
           {club.in_bag ? 'In bag' : 'Benched'}
         </Text>
+      </Pressable>
+      <Pressable
+        onPress={onEdit}
+        accessibilityLabel={`Edit ${club.name}`}
+        hitSlop={8}
+        style={{ paddingHorizontal: 4 }}
+      >
+        <Text style={{ color: '#5C6356', fontSize: 12 }}>Edit</Text>
       </Pressable>
       <Pressable
         onPress={onDelete}

--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -10,9 +10,9 @@ import {
 } from 'react-native'
 import { useRouter } from 'expo-router'
 import {
+  CANONICAL_CLUBS_BY_CATEGORY,
   CLUB_CATEGORIES,
   CLUB_CATEGORY_LABELS,
-  CLUBS,
   clubCategoryFor,
   type ClubCategory,
 } from '@oga/core'
@@ -37,16 +37,6 @@ const KICKER: import('react-native').TextStyle = {
   fontWeight: '500',
   letterSpacing: 1.4,
   textTransform: 'uppercase',
-}
-
-const CANONICAL_BY_CATEGORY: Record<ClubCategory, readonly string[]> = {
-  driver: ['driver'],
-  wood: CLUBS.filter((c) => /^[357]w$/.test(c)),
-  hybrid: CLUBS.filter((c) => /^[345]h$/.test(c)),
-  iron: CLUBS.filter((c) => /^[2-9]i$/.test(c)),
-  wedge: ['pw', 'gw', 'sw', 'lw'],
-  putter: ['putter'],
-  utility: [],
 }
 
 interface AddDraft {
@@ -78,6 +68,9 @@ export default function BagScreen() {
   // it's adding a new club. The modal renders the same form either way;
   // only the upsert payload differs.
   const [editingId, setEditingId] = useState<string | null>(null)
+  // Lets the user enter a free-text club_type when the canonical chip
+  // list for the chosen category doesn't cover what they carry.
+  const [customMode, setCustomMode] = useState(false)
 
   async function toggleInBag(c: UserClub) {
     if (!user) return
@@ -163,6 +156,7 @@ export default function BagScreen() {
   function closeForm() {
     setShowAdd(false)
     setEditingId(null)
+    setCustomMode(false)
     setDraft(EMPTY_DRAFT)
   }
 
@@ -379,35 +373,54 @@ export default function BagScreen() {
                 <Field label="Category">
                   <CategoryRow
                     value={draft.category}
-                    onChange={(c) =>
+                    onChange={(c) => {
+                      setCustomMode(false)
                       setDraft((d) => ({
                         ...d,
                         category: c,
                         clubType:
                           c === 'utility'
                             ? d.clubType
-                            : CANONICAL_BY_CATEGORY[c][0] ?? '',
+                            : CANONICAL_CLUBS_BY_CATEGORY[c][0] ?? '',
                       }))
-                    }
+                    }}
                   />
                 </Field>
 
                 <Field label="Club type">
-                  {draft.category === 'utility' ? (
-                    <TextInput
-                      value={draft.clubType}
-                      onChangeText={(v) =>
-                        setDraft((d) => ({ ...d, clubType: v }))
-                      }
-                      placeholder="e.g. chipper, mini_driver, aw"
-                      style={inputStyle}
-                      autoCapitalize="none"
-                    />
+                  {draft.category === 'utility' || customMode ? (
+                    <View style={{ gap: 6 }}>
+                      <TextInput
+                        value={draft.clubType}
+                        onChangeText={(v) =>
+                          setDraft((d) => ({ ...d, clubType: v }))
+                        }
+                        placeholder="e.g. chipper, attack wedge, 1.5 hybrid"
+                        style={inputStyle}
+                        autoCapitalize="none"
+                      />
+                      {customMode && draft.category !== 'utility' && (
+                        <Pressable
+                          onPress={() => {
+                            setCustomMode(false)
+                            setDraft((d) => ({
+                              ...d,
+                              clubType:
+                                CANONICAL_CLUBS_BY_CATEGORY[d.category][0] ?? '',
+                            }))
+                          }}
+                        >
+                          <Text style={{ color: '#5C6356', fontSize: 12 }}>
+                            ← Back to {CLUB_CATEGORY_LABELS[draft.category]} list
+                          </Text>
+                        </Pressable>
+                      )}
+                    </View>
                   ) : (
                     <View
                       style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}
                     >
-                      {CANONICAL_BY_CATEGORY[draft.category].map((c) => (
+                      {CANONICAL_CLUBS_BY_CATEGORY[draft.category].map((c) => (
                         <Chip
                           key={c}
                           label={c}
@@ -417,6 +430,14 @@ export default function BagScreen() {
                           }
                         />
                       ))}
+                      <Chip
+                        label="Custom…"
+                        active={false}
+                        onPress={() => {
+                          setCustomMode(true)
+                          setDraft((d) => ({ ...d, clubType: '' }))
+                        }}
+                      />
                     </View>
                   )}
                 </Field>

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -219,8 +219,8 @@ export default function MobileOnboarding() {
         {seedBag ? (
           <>
             <Text style={{ color: '#888880', fontSize: 12, marginBottom: 10 }}>
-              Tap to add or remove clubs you carry. Edit any time in Profile →
-              My Bag.
+              Standard bags carry up to 14 clubs. Tap to add or remove. Edit
+              any time in Profile → My Bag.
             </Text>
             <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
               {DEFAULT_BAG.map((c) => (

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -414,7 +414,7 @@ export function HoleMap({
 
           {!isPinMode && tee && (
             <Mapbox.PointAnnotation id="tee" coordinate={toCoord(tee)}>
-              <Marker color="#FBF8F1" border="#5C6356" size={10} />
+              <TeeBadge />
             </Mapbox.PointAnnotation>
           )}
 
@@ -584,6 +584,36 @@ export function HoleMap({
         )}
       </View>
     </GestureDetector>
+  )
+}
+
+// Small "TEE" pill — kept visually identical to the web map's tee
+// marker so the satellite view reads the same on both platforms. The
+// previous bare cream circle was indistinguishable from a ball at the
+// same zoom.
+function TeeBadge() {
+  return (
+    <View
+      style={{
+        backgroundColor: '#FBF8F1',
+        borderWidth: 1,
+        borderColor: '#5C6356',
+        borderRadius: 2,
+        paddingHorizontal: 6,
+        paddingVertical: 3,
+      }}
+    >
+      <Text
+        style={{
+          color: '#5C6356',
+          fontSize: 9,
+          fontWeight: '500',
+          letterSpacing: 1.4,
+        }}
+      >
+        TEE
+      </Text>
+    </View>
   )
 }
 

--- a/apps/web/src/components/courses/CourseSearch.tsx
+++ b/apps/web/src/components/courses/CourseSearch.tsx
@@ -10,6 +10,10 @@ import { toUserMessage } from '../../lib/errors'
 interface CourseSearchProps {
   selectedCourseId: string | null
   onSelect: (courseId: string, courseName: string) => void
+  /** Capture GPS once for stamping the user's tee location on hole 1.
+   *  Only meaningful for live rounds; defaults to false so past-round
+   *  entry doesn't trigger a permission prompt. */
+  requestGps?: boolean
 }
 
 interface GpsState {
@@ -18,7 +22,11 @@ interface GpsState {
   lng?: number
 }
 
-export function CourseSearch({ selectedCourseId, onSelect }: CourseSearchProps) {
+export function CourseSearch({
+  selectedCourseId,
+  onSelect,
+  requestGps = false,
+}: CourseSearchProps) {
   const [query, setQuery] = useState('')
   const [creatingManual, setCreatingManual] = useState(false)
   const [gps, setGps] = useState<GpsState>({ status: 'idle' })
@@ -33,9 +41,11 @@ export function CourseSearch({ selectedCourseId, onSelect }: CourseSearchProps) 
     apiResults.length === 0 &&
     localResults.length === 0
 
-  // Capture GPS once when the search box is opened so manual + API
-  // imports can stamp the user's tee location on hole 1.
+  // Capture GPS once when the parent has opted in (live-round mode) so
+  // manual + API imports can stamp the user's tee location on hole 1.
+  // Past-round entry skips this — no need to prompt for location.
   useEffect(() => {
+    if (!requestGps) return
     if (gps.status !== 'idle') return
     if (typeof navigator === 'undefined' || !navigator.geolocation) {
       setGps({ status: 'denied' })
@@ -52,7 +62,7 @@ export function CourseSearch({ selectedCourseId, onSelect }: CourseSearchProps) 
       () => setGps({ status: 'denied' }),
       { enableHighAccuracy: false, timeout: 10000, maximumAge: 60_000 },
     )
-  }, [gps.status])
+  }, [requestGps, gps.status])
 
   const gpsCoords = gps.status === 'ok' ? { lat: gps.lat!, lng: gps.lng! } : null
 

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -43,7 +43,9 @@ function SidebarSection({
         <NavLink
           key={l.to}
           to={l.to}
-          end={l.to === '/'}
+          // /settings would otherwise highlight when /settings/bag is active
+          // because NavLink uses prefix matching by default.
+          end={l.to === '/' || l.to === '/settings'}
           className={({ isActive }) =>
             [
               'transition-colors block',

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -532,6 +532,7 @@ function upsertLine(
   color: string,
 ) {
   const layerId = `${sourceId}-layer`
+  const outlineLayerId = `${sourceId}-outline`
   const data: GeoJSON.Feature<GeoJSON.LineString> = {
     type: 'Feature',
     properties: {},
@@ -540,21 +541,34 @@ function upsertLine(
   const src = map.getSource(sourceId) as mapboxgl.GeoJSONSource | undefined
   if (src) {
     src.setData(data)
-  } else {
-    map.addSource(sourceId, { type: 'geojson', data })
-    map.addLayer({
-      id: layerId,
-      type: 'line',
-      source: sourceId,
-      layout: { 'line-join': 'round', 'line-cap': 'round' },
-      paint: {
-        'line-color': color,
-        'line-width': 1.5,
-        'line-dasharray': [3, 2],
-        'line-opacity': 0.85,
-      },
-    })
+    return
   }
+  map.addSource(sourceId, { type: 'geojson', data })
+  // Dark outline first so the amber line reads against both bright
+  // satellite (sand) and dark areas (rough/water). Without the outline
+  // the warn amber disappeared into fall fairway tiles.
+  map.addLayer({
+    id: outlineLayerId,
+    type: 'line',
+    source: sourceId,
+    layout: { 'line-join': 'round', 'line-cap': 'round' },
+    paint: {
+      'line-color': '#1C211C',
+      'line-width': 4,
+      'line-opacity': 0.55,
+    },
+  })
+  map.addLayer({
+    id: layerId,
+    type: 'line',
+    source: sourceId,
+    layout: { 'line-join': 'round', 'line-cap': 'round' },
+    paint: {
+      'line-color': color,
+      'line-width': 2.5,
+      'line-opacity': 1,
+    },
+  })
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -73,6 +73,7 @@ export function RoundMap({
   onMovePin,
   onMoveTee,
 }: RoundMapProps) {
+  const { toDisplay } = useUnits()
   // Memoized so downstream effects can dep on the object directly without
   // thrashing on every parent render — coords are the only meaningful
   // identity here.
@@ -282,14 +283,36 @@ export function RoundMap({
     upsertLine(map, lineSourceId, existingCoords, '#A66A1F')
 
     // Trajectory line (placed points): each marker is the START position
-    // of a shot, so segment N→N+1 is the path of shot N. Drawing just
-    // the markers in order without prepending the tee avoids a phantom
-    // "tee → marker 1" segment, since marker 1 IS the tee position.
-    const placedCoords =
+    // of a shot, so segment N→N+1 is the path of shot N. Closing to the
+    // pin renders the final leg from the last marker through the cup.
+    const placedCoords: [number, number][] =
       placedPoints.length === 0
         ? []
-        : placedPoints.map((p) => [p.lng, p.lat] as [number, number])
+        : [
+            ...placedPoints.map((p) => [p.lng, p.lat] as [number, number]),
+            ...(effectivePin
+              ? ([[effectivePin.lng, effectivePin.lat]] as [number, number][])
+              : []),
+          ]
     upsertLine(map, placedLineSourceId, placedCoords, '#A66A1F')
+
+    // Per-segment distance pills. Renders midpoint label between every
+    // pair of consecutive line coords for both existing and placed lines
+    // so the player can see each shot's distance at a glance.
+    for (const coords of [existingCoords, placedCoords]) {
+      for (let i = 0; i < coords.length - 1; i++) {
+        const a = coords[i]!
+        const b = coords[i + 1]!
+        const yards = Math.round(haversineYards(a[1], a[0], b[1], b[0]))
+        if (yards <= 0) continue
+        const mid: [number, number] = [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2]
+        const el = makeDistancePill(toDisplay(yards))
+        const marker = new mapboxgl.Marker({ element: el })
+          .setLngLat(mid)
+          .addTo(map)
+        markerRefs.current.push(marker)
+      }
+    }
   }, [
     existingShots,
     hole,
@@ -299,6 +322,7 @@ export function RoundMap({
     onMoveTee,
     effectivePin,
     effectiveTee,
+    toDisplay,
   ])
 
   // Render markers + connecting line for either existing shots or placed points.
@@ -575,6 +599,24 @@ function makeNumberedMarker(
   content.textContent = String(n)
   outer.appendChild(content)
   return { outer, content }
+}
+
+function makeDistancePill(label: string): HTMLElement {
+  const el = document.createElement('div')
+  el.style.cssText = [
+    'background:rgba(28,33,28,0.85)',
+    'color:#F2EEE5',
+    'font-family:JetBrains Mono, monospace',
+    'font-size:11px',
+    'font-weight:500',
+    'letter-spacing:0.04em',
+    'padding:3px 8px',
+    'border-radius:999px',
+    'pointer-events:none',
+    'white-space:nowrap',
+  ].join(';')
+  el.textContent = label
+  return el
 }
 
 function makeIconMarker(

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -38,6 +38,13 @@ interface RoundMapProps {
    *  logged. The parent owns this state so it can persist across
    *  re-renders and feed the review sheet. */
   placedPoints: PlacedPoint[]
+  /** Aim point per placed shot, parallel to placedPoints. Null when the
+   *  user hasn't set an aim for that shot. Required to feed dispersion
+   *  analysis — captured rather than inferred. */
+  placedAims?: (PlacedPoint | null)[]
+  /** When true, the next map tap sets aim for the most recently placed
+   *  shot instead of pushing a new shot start marker. */
+  aimMode?: boolean
   /** Local override for the pin and tee positions while the user is
    *  reviewing a hole. When set, these win over the values inside
    *  `hole.pinLat/pinLng` / `hole.teeLat/teeLng`. */
@@ -50,6 +57,7 @@ interface RoundMapProps {
   onMovePoint: (index: number, point: PlacedPoint) => void
   onMovePin?: (point: PlacedPoint) => void
   onMoveTee?: (point: PlacedPoint) => void
+  onSetAim?: (index: number, point: PlacedPoint | null) => void
 }
 
 const MARKER_COLORS = {
@@ -65,6 +73,8 @@ export function RoundMap({
   hole,
   existingShots,
   placedPoints,
+  placedAims,
+  aimMode,
   pinOverride,
   teeOverride,
   tapToPlaceDisabled,
@@ -72,6 +82,7 @@ export function RoundMap({
   onMovePoint,
   onMovePin,
   onMoveTee,
+  onSetAim,
 }: RoundMapProps) {
   const { toDisplay } = useUnits()
   // Memoized so downstream effects can dep on the object directly without
@@ -140,19 +151,35 @@ export function RoundMap({
   }, [center?.[0], center?.[1]])
 
   // Wire a click handler for tap-to-place on holes that have no live shots.
+  // When aimMode is on, the next click sets aim for the most recently
+  // placed shot instead of pushing a new shot marker.
   useEffect(() => {
     const map = mapRef.current
     if (!map) return
     function onClick(e: mapboxgl.MapMouseEvent) {
       if (hasExistingShots) return
       if (tapToPlaceDisabled) return
+      if (aimMode && onSetAim) {
+        const idx = placedPoints.length - 1
+        if (idx >= 0) {
+          onSetAim(idx, { lat: e.lngLat.lat, lng: e.lngLat.lng })
+        }
+        return
+      }
       onPlace({ lat: e.lngLat.lat, lng: e.lngLat.lng })
     }
     map.on('click', onClick)
     return () => {
       map.off('click', onClick)
     }
-  }, [onPlace, hasExistingShots, tapToPlaceDisabled])
+  }, [
+    onPlace,
+    hasExistingShots,
+    tapToPlaceDisabled,
+    aimMode,
+    onSetAim,
+    placedPoints.length,
+  ])
 
   const renderLayers = useCallback(() => {
     const map = mapRef.current
@@ -313,10 +340,43 @@ export function RoundMap({
         markerRefs.current.push(marker)
       }
     }
+
+    // Aim markers + dashed aim lines per placed shot. Aim color matches
+    // the rest of the warn palette (#A66A1F) so it reads as "intent",
+    // distinct from the accent ball/pin marker.
+    const aimLineCoords: [number, number][][] = []
+    placedPoints.forEach((p, idx) => {
+      const aim = placedAims?.[idx] ?? null
+      if (!aim) return
+      const aimEl = makeAimMarker()
+      const aimMarker = new mapboxgl.Marker({ element: aimEl })
+        .setLngLat([aim.lng, aim.lat])
+        .addTo(map)
+      markerRefs.current.push(aimMarker)
+      aimLineCoords.push([
+        [p.lng, p.lat],
+        [aim.lng, aim.lat],
+      ])
+      // Distance pill at midpoint of the aim line.
+      const yards = Math.round(haversineYards(p.lat, p.lng, aim.lat, aim.lng))
+      if (yards > 0) {
+        const mid: [number, number] = [
+          (p.lng + aim.lng) / 2,
+          (p.lat + aim.lat) / 2,
+        ]
+        const el = makeDistancePill(`AIM ${toDisplay(yards)}`)
+        const marker = new mapboxgl.Marker({ element: el })
+          .setLngLat(mid)
+          .addTo(map)
+        markerRefs.current.push(marker)
+      }
+    })
+    upsertDashedLines(map, 'aim-lines', aimLineCoords, '#A66A1F')
   }, [
     existingShots,
     hole,
     placedPoints,
+    placedAims,
     onMovePoint,
     onMovePin,
     onMoveTee,
@@ -367,6 +427,12 @@ interface RoundMapInstructionStripProps {
   editing?: boolean
   shotsPlaced: number
   remainingToPin: number | null
+  /** Aim mode: next tap sets aim for the latest placed shot. */
+  aimMode?: boolean
+  /** Number of placed shots that already have an aim point. */
+  aimsSet?: number
+  onToggleAimMode?: (on: boolean) => void
+  onClearLastAim?: () => void
   onUndo: () => void
   onClear: () => void
   onDone: () => void
@@ -382,6 +448,10 @@ export function RoundMapInstructionStrip({
   editing,
   shotsPlaced,
   remainingToPin,
+  aimMode = false,
+  aimsSet = 0,
+  onToggleAimMode,
+  onClearLastAim,
   onUndo,
   onClear,
   onDone,
@@ -422,6 +492,15 @@ export function RoundMapInstructionStrip({
               Drag any marker to refine its position.
             </div>
           </>
+        ) : aimMode ? (
+          <>
+            <div className="kicker" style={{ marginBottom: 2 }}>
+              Aim point — shot {shotsPlaced}
+            </div>
+            <div className="text-caddie-ink" style={{ fontSize: 13 }}>
+              Tap where you were aiming when you hit shot {shotsPlaced}.
+            </div>
+          </>
         ) : (
           <>
             <div className="kicker" style={{ marginBottom: 2 }}>
@@ -434,6 +513,8 @@ export function RoundMapInstructionStrip({
               {shotsPlaced === 0
                 ? 'Start at the tee box.'
                 : `${shotsPlaced} shot${shotsPlaced === 1 ? '' : 's'} placed${
+                    aimsSet > 0 ? ` · ${aimsSet} aim${aimsSet === 1 ? '' : 's'} set` : ''
+                  }${
                     remainingToPin != null
                       ? ` · ${toDisplay(remainingToPin)} to pin`
                       : ''
@@ -458,7 +539,42 @@ export function RoundMapInstructionStrip({
           Done editing →
         </button>
       ) : !hasExistingShots ? (
-        <div style={{ display: 'flex', gap: 8 }}>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {onToggleAimMode && shotsPlaced > 0 && (
+            <button
+              type="button"
+              onClick={() => onToggleAimMode(!aimMode)}
+              aria-pressed={aimMode}
+              style={{
+                border: '1px solid #A66A1F',
+                borderRadius: 2,
+                padding: '6px 10px',
+                fontSize: 12,
+                background: aimMode ? '#A66A1F' : 'transparent',
+                color: aimMode ? '#F2EEE5' : '#A66A1F',
+                fontWeight: 600,
+                letterSpacing: '0.02em',
+              }}
+            >
+              {aimMode ? 'Cancel aim' : 'Set aim'}
+            </button>
+          )}
+          {onClearLastAim && aimsSet > 0 && !aimMode && (
+            <button
+              type="button"
+              onClick={onClearLastAim}
+              className="text-caddie-ink-dim"
+              style={{
+                border: '1px solid #D9D2BF',
+                borderRadius: 2,
+                padding: '6px 10px',
+                fontSize: 12,
+                background: 'transparent',
+              }}
+            >
+              Clear aim
+            </button>
+          )}
           <button
             type="button"
             disabled={shotsPlaced === 0}
@@ -523,6 +639,38 @@ function buildLineCoords(
   }
   if (pin && coords.length > 0) coords.push([pin.lng, pin.lat])
   return coords
+}
+
+function upsertDashedLines(
+  map: mapboxgl.Map,
+  sourceId: string,
+  segments: [number, number][][],
+  color: string,
+) {
+  const layerId = `${sourceId}-layer`
+  const data: GeoJSON.Feature<GeoJSON.MultiLineString> = {
+    type: 'Feature',
+    properties: {},
+    geometry: { type: 'MultiLineString', coordinates: segments },
+  }
+  const src = map.getSource(sourceId) as mapboxgl.GeoJSONSource | undefined
+  if (src) {
+    src.setData(data)
+    return
+  }
+  map.addSource(sourceId, { type: 'geojson', data })
+  map.addLayer({
+    id: layerId,
+    type: 'line',
+    source: sourceId,
+    layout: { 'line-join': 'round', 'line-cap': 'round' },
+    paint: {
+      'line-color': color,
+      'line-width': 1.5,
+      'line-dasharray': [4, 3],
+      'line-opacity': 0.85,
+    },
+  })
 }
 
 function upsertLine(
@@ -613,6 +761,25 @@ function makeNumberedMarker(
   content.textContent = String(n)
   outer.appendChild(content)
   return { outer, content }
+}
+
+function makeAimMarker(): HTMLElement {
+  const outer = document.createElement('div')
+  outer.style.display = 'flex'
+  outer.style.alignItems = 'center'
+  outer.style.justifyContent = 'center'
+  const dot = document.createElement('div')
+  dot.style.cssText = [
+    'width:14px',
+    'height:14px',
+    'border-radius:999px',
+    'background:#A66A1F',
+    'border:2px solid #FBF8F1',
+    'pointer-events:none',
+  ].join(';')
+  outer.appendChild(dot)
+  outer.title = 'Aim point'
+  return outer
 }
 
 function makeDistancePill(label: string): HTMLElement {

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -222,8 +222,13 @@ export function RoundMap({
     }
 
     // Existing shots: numbered markers + dashed trajectory.
+    // Marker N renders at the START of shot N — that's "where the player
+    // stood for shot N", matching the post-round tap flow. Falling back
+    // to end coords for legacy rows that pre-date start_lat/lng.
     const existingValid = existingShots.filter(
-      (s) => s.endLat != null && s.endLng != null,
+      (s) =>
+        (s.startLat != null && s.startLng != null) ||
+        (s.endLat != null && s.endLng != null),
     )
     for (const s of existingValid) {
       const color =
@@ -236,8 +241,10 @@ export function RoundMap({
               : MARKER_COLORS.green
       const parts = makeNumberedMarker(s.shotNumber, color, '#FBF8F1')
       parts.outer.title = `Shot ${s.shotNumber}`
+      const lng = s.startLng ?? s.endLng!
+      const lat = s.startLat ?? s.endLat!
       const marker = new mapboxgl.Marker({ element: parts.outer })
-        .setLngLat([s.endLng!, s.endLat!])
+        .setLngLat([lng, lat])
         .addTo(map)
       markerRefs.current.push(marker)
     }
@@ -268,9 +275,11 @@ export function RoundMap({
       markerRefs.current.push(marker)
     })
 
-    // Trajectory line (existing shots).
-    const existingCoords = buildLineCoords(effectiveTee, existingValid)
-    upsertLine(map, lineSourceId, existingCoords, '#FBF8F1')
+    // Trajectory line (existing shots): connect each shot's start
+    // position in order, then close to the pin so the final segment
+    // shows the last leg.
+    const existingCoords = buildLineCoords(existingValid, effectivePin)
+    upsertLine(map, lineSourceId, existingCoords, '#A66A1F')
 
     // Trajectory line (placed points): each marker is the START position
     // of a shot, so segment N→N+1 is the path of shot N. Drawing just
@@ -478,15 +487,17 @@ export function RoundMapInstructionStrip({
 }
 
 function buildLineCoords(
-  tee: PlacedPoint | null,
   existing: ExistingShot[],
+  pin: PlacedPoint | null,
 ): [number, number][] {
   const coords: [number, number][] = []
-  if (tee) coords.push([tee.lng, tee.lat])
   for (const s of existing) {
-    if (s.endLat == null || s.endLng == null) continue
-    coords.push([s.endLng, s.endLat])
+    const lng = s.startLng ?? s.endLng
+    const lat = s.startLat ?? s.endLat
+    if (lat == null || lng == null) continue
+    coords.push([lng, lat])
   }
+  if (pin && coords.length > 0) coords.push([pin.lng, pin.lat])
   return coords
 }
 

--- a/apps/web/src/pages/onboarding/steps/Step6Bag.tsx
+++ b/apps/web/src/pages/onboarding/steps/Step6Bag.tsx
@@ -35,7 +35,7 @@ export function Step6Bag({
       <StepHeading
         kicker="Optional"
         title="Build your bag."
-        subtitle="Select the clubs you carry. Tap to toggle. You can customise your bag fully in settings later."
+        subtitle="Standard bags carry up to 14 clubs. Select what you carry — tap to toggle. You can customise your bag fully in settings later."
       />
       <div
         style={{

--- a/apps/web/src/pages/rounds/NewRoundPage.tsx
+++ b/apps/web/src/pages/rounds/NewRoundPage.tsx
@@ -95,6 +95,7 @@ export function NewRoundPage() {
               setCourseName(name)
               setCourseTeeId(null)
             }}
+            requestGps={mode === 'live'}
           />
           {courseName && courseId && (
             <p

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -60,6 +60,14 @@ type ViewMode = 'scorecard' | 'map'
 interface HoleViewState {
   activeHoleNumber: number
   placedPoints: PlacedPoint[]
+  /** Aim point per placed shot. Parallel to placedPoints — index N is
+   *  the aim for shot N. Null when the user hasn't placed an aim for
+   *  that shot. Aim point is what the player was aiming at when they
+   *  hit shot N; required for meaningful dispersion analysis. */
+  placedAims: (PlacedPoint | null)[]
+  /** When true, the next map tap sets the aim point for the latest
+   *  placed shot instead of dropping a new shot start marker. */
+  aimMode: boolean
   pinOverride: PlacedPoint | null
   teeOverride: PlacedPoint | null
   reviewOpen: boolean
@@ -73,6 +81,8 @@ type HoleViewAction =
   | { type: 'MOVE_POINT'; index: number; point: PlacedPoint }
   | { type: 'CLEAR_POINTS' }
   | { type: 'POP_POINT' }
+  | { type: 'SET_AIM'; index: number; point: PlacedPoint | null }
+  | { type: 'AIM_MODE'; on: boolean }
   | { type: 'PIN_OVERRIDE'; point: PlacedPoint | null }
   | { type: 'TEE_OVERRIDE'; point: PlacedPoint | null }
   | { type: 'OPEN_REVIEW' }
@@ -84,6 +94,8 @@ type HoleViewAction =
 const HOLE_VIEW_INITIAL: HoleViewState = {
   activeHoleNumber: 1,
   placedPoints: [],
+  placedAims: [],
+  aimMode: false,
   pinOverride: null,
   teeOverride: null,
   reviewOpen: false,
@@ -96,16 +108,35 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
     case 'SWITCH_HOLE':
       return { ...HOLE_VIEW_INITIAL, activeHoleNumber: action.holeNumber }
     case 'PUSH_POINT':
-      return { ...state, placedPoints: [...state.placedPoints, action.point] }
+      return {
+        ...state,
+        placedPoints: [...state.placedPoints, action.point],
+        placedAims: [...state.placedAims, null],
+        // Drop aim mode after placing a new shot — aim mode is sticky to
+        // a specific shot, and pushing a new shot moves the cursor.
+        aimMode: false,
+      }
     case 'MOVE_POINT': {
       const next = state.placedPoints.slice()
       next[action.index] = action.point
       return { ...state, placedPoints: next }
     }
     case 'CLEAR_POINTS':
-      return { ...state, placedPoints: [] }
+      return { ...state, placedPoints: [], placedAims: [], aimMode: false }
     case 'POP_POINT':
-      return { ...state, placedPoints: state.placedPoints.slice(0, -1) }
+      return {
+        ...state,
+        placedPoints: state.placedPoints.slice(0, -1),
+        placedAims: state.placedAims.slice(0, -1),
+        aimMode: false,
+      }
+    case 'SET_AIM': {
+      const next = state.placedAims.slice()
+      next[action.index] = action.point
+      return { ...state, placedAims: next, aimMode: false }
+    }
+    case 'AIM_MODE':
+      return { ...state, aimMode: action.on }
     case 'PIN_OVERRIDE':
       return { ...state, pinOverride: action.point }
     case 'TEE_OVERRIDE':
@@ -119,7 +150,13 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
     case 'SAVE_ERROR':
       return { ...state, saveError: action.message }
     case 'AFTER_SAVE':
-      return { ...state, reviewOpen: false, placedPoints: [] }
+      return {
+        ...state,
+        reviewOpen: false,
+        placedPoints: [],
+        placedAims: [],
+        aimMode: false,
+      }
   }
 }
 
@@ -157,6 +194,8 @@ export function RoundDetailPage() {
   const {
     activeHoleNumber,
     placedPoints,
+    placedAims,
+    aimMode,
     pinOverride,
     teeOverride,
     reviewOpen,
@@ -281,6 +320,10 @@ export function RoundDetailPage() {
         dispatchHoleView({ type: 'TEE_OVERRIDE', point: p }),
       onClearPoints: () => dispatchHoleView({ type: 'CLEAR_POINTS' }),
       onUndoPoint: () => dispatchHoleView({ type: 'POP_POINT' }),
+      onSetAim: (idx: number, point: PlacedPoint | null) =>
+        dispatchHoleView({ type: 'SET_AIM', index: idx, point }),
+      onToggleAimMode: (on: boolean) =>
+        dispatchHoleView({ type: 'AIM_MODE', on }),
       onDoneWithHole: () => dispatchHoleView({ type: 'OPEN_REVIEW' }),
       onDoneEditing: () => {
         dispatchHoleView({ type: 'EDIT_ON_MAP', editing: false })
@@ -380,6 +423,7 @@ export function RoundDetailPage() {
 
       for (const row of rows) {
         const isPuttRow = row.lieType === 'green' || row.club === 'putter'
+        const aim = placedAims[row.shotNumber - 1] ?? null
         await createShot.mutateAsync({
           hole_score_id: hs.id,
           user_id: user.id,
@@ -388,8 +432,8 @@ export function RoundDetailPage() {
           start_lng: row.startLng,
           end_lat: row.endLat,
           end_lng: row.endLng,
-          aim_lat: null,
-          aim_lng: null,
+          aim_lat: aim?.lat ?? null,
+          aim_lng: aim?.lng ?? null,
           distance_to_target: isPuttRow ? null : Math.round(row.distanceToPin),
           club: row.club,
           lie_type: row.lieType,
@@ -563,6 +607,8 @@ export function RoundDetailPage() {
           activeHoleGeo={activeHoleGeo}
           existingShots={activeHoleShots}
           placedPoints={placedPoints}
+          placedAims={placedAims}
+          aimMode={aimMode}
           pinOverride={pinOverride}
           teeOverride={teeOverride}
           handlers={placeHandlers}
@@ -731,6 +777,8 @@ interface MapViewProps {
   activeHoleGeo: HoleGeo | null
   existingShots: ExistingShot[]
   placedPoints: PlacedPoint[]
+  placedAims: (PlacedPoint | null)[]
+  aimMode: boolean
   pinOverride: PlacedPoint | null
   teeOverride: PlacedPoint | null
   handlers: {
@@ -740,6 +788,8 @@ interface MapViewProps {
     onMoveTee: (p: PlacedPoint) => void
     onClearPoints: () => void
     onUndoPoint: () => void
+    onSetAim: (idx: number, p: PlacedPoint | null) => void
+    onToggleAimMode: (on: boolean) => void
     onDoneWithHole: () => void
     onDoneEditing: () => void
   }
@@ -755,6 +805,8 @@ function MapView({
   activeHoleGeo,
   existingShots,
   placedPoints,
+  placedAims,
+  aimMode,
   pinOverride,
   teeOverride,
   handlers,
@@ -796,6 +848,13 @@ function MapView({
           editing={editingOnMap}
           shotsPlaced={placedPoints.length}
           remainingToPin={remainingToPin}
+          aimMode={aimMode}
+          aimsSet={placedAims.filter((a) => a != null).length}
+          onToggleAimMode={handlers.onToggleAimMode}
+          onClearLastAim={() => {
+            const idx = placedAims.length - 1
+            if (idx >= 0) handlers.onSetAim(idx, null)
+          }}
           onUndo={handlers.onUndoPoint}
           onClear={handlers.onClearPoints}
           onDone={handlers.onDoneWithHole}
@@ -817,6 +876,8 @@ function MapView({
             hole={activeHoleGeo}
             existingShots={existingShots}
             placedPoints={placedPoints}
+            placedAims={placedAims}
+            aimMode={aimMode}
             pinOverride={pinOverride}
             teeOverride={teeOverride}
             tapToPlaceDisabled={editingOnMap}
@@ -824,6 +885,7 @@ function MapView({
             onMovePoint={handlers.onMovePoint}
             onMovePin={handlers.onMovePin}
             onMoveTee={handlers.onMoveTee}
+            onSetAim={handlers.onSetAim}
           />
         </Suspense>
         {reviewSheet}

--- a/apps/web/src/pages/settings/BagPage.tsx
+++ b/apps/web/src/pages/settings/BagPage.tsx
@@ -355,7 +355,7 @@ export function BagPage() {
       <ConfirmDialog
         open={confirmReset}
         title="Reset to default bag?"
-        message="This deletes every club you've added and seeds the default 15-club bag."
+        message="This deletes every club you've added and seeds the default 14-club bag."
         confirmLabel="Reset"
         destructive
         onConfirm={() => {

--- a/apps/web/src/pages/settings/BagPage.tsx
+++ b/apps/web/src/pages/settings/BagPage.tsx
@@ -1,9 +1,8 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
+  CANONICAL_CLUBS_BY_CATEGORY,
   CLUB_CATEGORIES,
   CLUB_CATEGORY_LABELS,
-  CLUBS,
-  DEFAULT_BAG,
   clubCategoryFor,
   type ClubCategory,
 } from '@oga/core'
@@ -48,20 +47,6 @@ const EMPTY_DRAFT: AddClubDraft = {
   clubType: '7i',
   loft: '',
   typicalDistance: '',
-}
-
-// Maps the picklist category to the canonical CLUBS subset that matches.
-// Utility = "anything not covered above"; we let the user enter a free
-// club_type value when they pick utility (mini driver, chipper, attack
-// wedge, etc).
-const CANONICAL_CLUBS_BY_CATEGORY: Record<ClubCategory, readonly string[]> = {
-  driver: ['driver'],
-  wood: CLUBS.filter((c) => /^[357]w$/.test(c)),
-  hybrid: CLUBS.filter((c) => /^[345]h$/.test(c)),
-  iron: CLUBS.filter((c) => /^[2-9]i$/.test(c)),
-  wedge: ['pw', 'gw', 'sw', 'lw'],
-  putter: ['putter'],
-  utility: [],
 }
 
 export function BagPage() {
@@ -696,10 +681,19 @@ function AddClubForm({
     () => CANONICAL_CLUBS_BY_CATEGORY[draft.category],
     [draft.category],
   )
+  // Custom mode lets the user enter a free-text club_type for non-utility
+  // categories (e.g. an "attack wedge" the canonical wedge list doesn't
+  // mention). Toggled by the "Custom…" sentinel option in the dropdown.
+  const [customMode, setCustomMode] = useState(false)
+  const CUSTOM_VALUE = '__custom__'
+  const showFreeText = draft.category === 'utility' || customMode
 
   // When category changes, jump club_type to the first canonical option
   // for that category if the current type doesn't fit. Skip for utility.
+  // Switching category also resets custom mode so the user starts from
+  // canonical options for the new category.
   useEffect(() => {
+    setCustomMode(false)
     if (draft.category === 'utility') return
     if (!canonicalOptions.includes(draft.clubType)) {
       onChange({ ...draft, clubType: canonicalOptions[0] ?? '' })
@@ -744,11 +738,11 @@ function AddClubForm({
         </label>
         <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
           <span className="kicker">Club type</span>
-          {draft.category === 'utility' ? (
+          {showFreeText ? (
             <input
               value={draft.clubType}
               onChange={(e) => onChange({ ...draft, clubType: e.target.value })}
-              placeholder="e.g. chipper, mini_driver, aw"
+              placeholder="e.g. chipper, attack wedge, 1.5 hybrid"
               style={{
                 padding: '8px 10px',
                 fontSize: 14,
@@ -759,8 +753,19 @@ function AddClubForm({
             />
           ) : (
             <select
-              value={draft.clubType}
-              onChange={(e) => onChange({ ...draft, clubType: e.target.value })}
+              value={
+                canonicalOptions.includes(draft.clubType)
+                  ? draft.clubType
+                  : canonicalOptions[0] ?? ''
+              }
+              onChange={(e) => {
+                if (e.target.value === CUSTOM_VALUE) {
+                  setCustomMode(true)
+                  onChange({ ...draft, clubType: '' })
+                  return
+                }
+                onChange({ ...draft, clubType: e.target.value })
+              }}
               style={{
                 padding: '8px 10px',
                 fontSize: 14,
@@ -774,7 +779,28 @@ function AddClubForm({
                   {c}
                 </option>
               ))}
+              <option value={CUSTOM_VALUE}>Custom…</option>
             </select>
+          )}
+          {customMode && draft.category !== 'utility' && (
+            <button
+              type="button"
+              onClick={() => {
+                setCustomMode(false)
+                onChange({ ...draft, clubType: canonicalOptions[0] ?? '' })
+              }}
+              className="text-caddie-ink-dim"
+              style={{
+                fontSize: 12,
+                textAlign: 'left',
+                background: 'transparent',
+                border: 'none',
+                padding: 0,
+                marginTop: 2,
+              }}
+            >
+              ← Back to {CLUB_CATEGORY_LABELS[draft.category]} list
+            </button>
           )}
         </label>
         <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>

--- a/apps/web/src/pages/settings/BagPage.tsx
+++ b/apps/web/src/pages/settings/BagPage.tsx
@@ -78,6 +78,9 @@ export function BagPage() {
   const [confirmDelete, setConfirmDelete] = useState<UserClub | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [localOrder, setLocalOrder] = useState<UserClub[] | null>(null)
+  // Single-row inline edit. Holds the id of the club currently being
+  // edited; null when no row is in edit mode.
+  const [editingId, setEditingId] = useState<string | null>(null)
   // Set on drag-start, cleared after the order mutation settles. Guards
   // the localOrder<-server sync below so a refetch mid-drag (or a fast
   // second drag right after the first) can't stomp on what the user is
@@ -154,21 +157,28 @@ export function BagPage() {
     [upsertClub],
   )
 
-  const onRename = useCallback(
-    (id: string, name: string) => {
+  const onSaveEdit = useCallback(
+    (
+      id: string,
+      patch: { name: string; loft: number | null; typicalDistance: number | null },
+    ) => {
       const c = clubsRef.current.find((x) => x.id === id)
       if (!c) return
+      setError(null)
       upsertClub.mutate(
         {
           id: c.id,
-          name,
+          name: patch.name,
           club_type: c.club_type,
-          loft: c.loft,
-          typical_distance_yards: c.typical_distance_yards,
+          loft: patch.loft,
+          typical_distance_yards: patch.typicalDistance,
           sort_order: c.sort_order,
           in_bag: c.in_bag,
         },
-        { onError: (err) => setError(toUserMessage(err)) },
+        {
+          onSuccess: () => setEditingId(null),
+          onError: (err) => setError(toUserMessage(err)),
+        },
       )
     },
     [upsertClub],
@@ -295,8 +305,12 @@ export function BagPage() {
                 <SortableClubRow
                   key={c.id}
                   club={c}
+                  editing={editingId === c.id}
+                  onStartEdit={() => setEditingId(c.id)}
+                  onCancelEdit={() => setEditingId(null)}
+                  onSaveEdit={onSaveEdit}
+                  saving={upsertClub.isPending}
                   onToggleInBag={onToggleInBag}
-                  onRename={onRename}
                   onDelete={onRequestDelete}
                 />
               ))}
@@ -389,22 +403,29 @@ export function BagPage() {
 
 interface SortableClubRowProps {
   club: UserClub
+  editing: boolean
+  saving: boolean
+  onStartEdit: () => void
+  onCancelEdit: () => void
+  onSaveEdit: (
+    id: string,
+    patch: { name: string; loft: number | null; typicalDistance: number | null },
+  ) => void
   onToggleInBag: (id: string) => void
-  onRename: (id: string, name: string) => void
   onDelete: (id: string) => void
 }
 
 const SortableClubRow = memo(function SortableClubRow({
   club,
+  editing,
+  saving,
+  onStartEdit,
+  onCancelEdit,
+  onSaveEdit,
   onToggleInBag,
-  onRename,
   onDelete,
 }: SortableClubRowProps) {
   const sortable = useSortable({ id: club.id })
-  const [editing, setEditing] = useState(false)
-  const [name, setName] = useState(club.name)
-
-  useEffect(() => setName(club.name), [club.name])
 
   const style = {
     transform: CSS.Transform.toString(sortable.transform),
@@ -412,99 +433,249 @@ const SortableClubRow = memo(function SortableClubRow({
     opacity: sortable.isDragging ? 0.5 : 1,
   }
 
-  function commitRename() {
-    setEditing(false)
-    if (name.trim() && name.trim() !== club.name) onRename(club.id, name.trim())
-    else setName(club.name)
-  }
-
   return (
     <div
       ref={sortable.setNodeRef}
       style={{
         ...style,
-        display: 'flex',
-        alignItems: 'center',
-        gap: 12,
         borderBottom: '1px solid #D9D2BF',
-        padding: '14px 4px',
       }}
     >
-      <button
-        type="button"
-        aria-label="Drag to reorder"
-        {...sortable.attributes}
-        {...sortable.listeners}
-        className="text-caddie-ink-mute"
-        style={{ cursor: 'grab', fontSize: 14, padding: '4px 8px' }}
-      >
-        ⠿
-      </button>
-      <div style={{ flex: 1 }}>
-        {editing ? (
-          <input
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            onBlur={commitRename}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') commitRename()
-              if (e.key === 'Escape') {
-                setName(club.name)
-                setEditing(false)
-              }
-            }}
-            autoFocus
-            className="bg-transparent text-caddie-ink"
-            style={{ fontSize: 15, border: '1px solid #D9D2BF', padding: '4px 6px', width: '100%' }}
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={() => setEditing(true)}
-            className="text-caddie-ink"
-            style={{ fontSize: 15, textAlign: 'left' }}
-          >
-            {club.name}
-          </button>
-        )}
-        <div
-          className="font-mono uppercase text-caddie-ink-mute"
-          style={{ fontSize: 10, letterSpacing: '0.14em', marginTop: 2 }}
-        >
-          {club.club_type}
-          {club.loft != null ? ` · ${club.loft}°` : ''}
-          {club.typical_distance_yards != null ? ` · ${club.typical_distance_yards} yd` : ''}
-        </div>
-      </div>
-      <button
-        type="button"
-        onClick={() => onToggleInBag(club.id)}
-        title="Benched clubs stay in your list but won't show up when logging shots."
-        className="font-mono uppercase"
+      <div
         style={{
-          fontSize: 10,
-          letterSpacing: '0.14em',
-          padding: '4px 10px',
-          borderRadius: 2,
-          border: '1px solid #D9D2BF',
-          color: club.in_bag ? '#F2EEE5' : '#5C6356',
-          background: club.in_bag ? '#1F3D2C' : 'transparent',
+          display: 'flex',
+          alignItems: 'center',
+          gap: 12,
+          padding: '14px 4px',
         }}
       >
-        {club.in_bag ? 'In bag' : 'Benched'}
-      </button>
-      <button
-        type="button"
-        onClick={() => onDelete(club.id)}
-        aria-label={`Delete ${club.name}`}
-        className="text-caddie-neg hover:underline"
-        style={{ fontSize: 12 }}
-      >
-        Delete
-      </button>
+        <button
+          type="button"
+          aria-label="Drag to reorder"
+          {...sortable.attributes}
+          {...sortable.listeners}
+          className="text-caddie-ink-mute"
+          style={{ cursor: 'grab', fontSize: 14, padding: '4px 8px' }}
+        >
+          ⠿
+        </button>
+        <div style={{ flex: 1 }}>
+          <div className="text-caddie-ink" style={{ fontSize: 15 }}>
+            {club.name}
+          </div>
+          <div
+            className="font-mono uppercase text-caddie-ink-mute"
+            style={{ fontSize: 10, letterSpacing: '0.14em', marginTop: 2 }}
+          >
+            {club.club_type}
+            {club.loft != null ? ` · ${club.loft}°` : ''}
+            {club.typical_distance_yards != null
+              ? ` · ${club.typical_distance_yards} yd`
+              : ''}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => onToggleInBag(club.id)}
+          title="Benched clubs stay in your list but won't show up when logging shots."
+          className="font-mono uppercase"
+          style={{
+            fontSize: 10,
+            letterSpacing: '0.14em',
+            padding: '4px 10px',
+            borderRadius: 2,
+            border: '1px solid #D9D2BF',
+            color: club.in_bag ? '#F2EEE5' : '#5C6356',
+            background: club.in_bag ? '#1F3D2C' : 'transparent',
+          }}
+        >
+          {club.in_bag ? 'In bag' : 'Benched'}
+        </button>
+        <button
+          type="button"
+          onClick={editing ? onCancelEdit : onStartEdit}
+          className="text-caddie-ink-dim hover:underline"
+          style={{ fontSize: 12 }}
+        >
+          {editing ? 'Close' : 'Edit'}
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(club.id)}
+          aria-label={`Delete ${club.name}`}
+          className="text-caddie-neg hover:underline"
+          style={{ fontSize: 12 }}
+        >
+          Delete
+        </button>
+      </div>
+      {editing && (
+        <ClubEditForm
+          club={club}
+          saving={saving}
+          onCancel={onCancelEdit}
+          onSave={(patch) => onSaveEdit(club.id, patch)}
+        />
+      )}
     </div>
   )
 })
+
+function ClubEditForm({
+  club,
+  saving,
+  onCancel,
+  onSave,
+}: {
+  club: UserClub
+  saving: boolean
+  onCancel: () => void
+  onSave: (patch: {
+    name: string
+    loft: number | null
+    typicalDistance: number | null
+  }) => void
+}) {
+  const [name, setName] = useState(club.name)
+  const [loft, setLoft] = useState(club.loft != null ? String(club.loft) : '')
+  const [typical, setTypical] = useState(
+    club.typical_distance_yards != null
+      ? String(club.typical_distance_yards)
+      : '',
+  )
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  useEffect(() => {
+    setName(club.name)
+    setLoft(club.loft != null ? String(club.loft) : '')
+    setTypical(
+      club.typical_distance_yards != null
+        ? String(club.typical_distance_yards)
+        : '',
+    )
+  }, [club.id, club.name, club.loft, club.typical_distance_yards])
+
+  function parseNumOrNull(s: string): number | null {
+    if (!s) return null
+    const n = Number(s)
+    return Number.isFinite(n) ? n : null
+  }
+
+  function submit() {
+    setLocalError(null)
+    if (!name.trim()) {
+      setLocalError('Name is required')
+      return
+    }
+    if (loft && !Number.isFinite(Number(loft))) {
+      setLocalError('Loft must be a number')
+      return
+    }
+    if (typical && !Number.isFinite(Number(typical))) {
+      setLocalError('Typical distance must be a number')
+      return
+    }
+    onSave({
+      name: name.trim(),
+      loft: parseNumOrNull(loft),
+      typicalDistance: parseNumOrNull(typical),
+    })
+  }
+
+  return (
+    <div
+      style={{
+        padding: '8px 4px 16px 40px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 10,
+      }}
+    >
+      <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <span className="kicker">Name</span>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="bg-caddie-bg text-caddie-ink"
+          style={{
+            border: '1px solid #D9D2BF',
+            borderRadius: 2,
+            padding: '8px 10px',
+            fontSize: 14,
+          }}
+        />
+      </label>
+      <div style={{ display: 'flex', gap: 12 }}>
+        <label
+          style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1 }}
+        >
+          <span className="kicker">Loft (°)</span>
+          <input
+            value={loft}
+            onChange={(e) => setLoft(e.target.value)}
+            inputMode="decimal"
+            placeholder="optional"
+            className="bg-caddie-bg text-caddie-ink"
+            style={{
+              border: '1px solid #D9D2BF',
+              borderRadius: 2,
+              padding: '8px 10px',
+              fontSize: 14,
+            }}
+          />
+        </label>
+        <label
+          style={{ display: 'flex', flexDirection: 'column', gap: 4, flex: 1 }}
+        >
+          <span className="kicker">Typical distance (yd)</span>
+          <input
+            value={typical}
+            onChange={(e) => setTypical(e.target.value)}
+            inputMode="numeric"
+            placeholder="optional"
+            className="bg-caddie-bg text-caddie-ink"
+            style={{
+              border: '1px solid #D9D2BF',
+              borderRadius: 2,
+              padding: '8px 10px',
+              fontSize: 14,
+            }}
+          />
+        </label>
+      </div>
+      {localError && (
+        <div className="text-caddie-neg" style={{ fontSize: 13 }}>
+          {localError}
+        </div>
+      )}
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button
+          type="button"
+          onClick={submit}
+          disabled={saving}
+          className="bg-caddie-accent text-caddie-accent-ink"
+          style={{
+            padding: '8px 14px',
+            fontSize: 13,
+            fontWeight: 600,
+            borderRadius: 2,
+            opacity: saving ? 0.7 : 1,
+          }}
+        >
+          {saving ? 'Saving…' : 'Save'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-caddie-ink-dim"
+          style={{ fontSize: 13 }}
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
 
 function AddClubForm({
   draft,

--- a/packages/core/src/__tests__/clubs.test.ts
+++ b/packages/core/src/__tests__/clubs.test.ts
@@ -38,12 +38,25 @@ describe('clubCategoryFor', () => {
     expect(clubCategoryFor('lw')).toBe('wedge')
   })
 
-  it('falls back to utility for non-canonical club_types', () => {
-    // Non-canonical entries from a user bag (utility category) all
-    // fall through to 'utility' so the picklist UI never crashes.
+  it('maps mini driver and extended fairway woods', () => {
+    expect(clubCategoryFor('mini_driver')).toBe('wood')
+    expect(clubCategoryFor('2w')).toBe('wood')
+    expect(clubCategoryFor('11w')).toBe('wood')
+  })
+
+  it('maps additional hybrids and irons', () => {
+    expect(clubCategoryFor('6h')).toBe('hybrid')
+    expect(clubCategoryFor('1i')).toBe('iron')
+  })
+
+  it('maps degree-named wedges and attack wedge', () => {
+    expect(clubCategoryFor('aw')).toBe('wedge')
+    expect(clubCategoryFor('46°')).toBe('wedge')
+    expect(clubCategoryFor('60°')).toBe('wedge')
+  })
+
+  it('falls back to utility for genuinely non-canonical club_types', () => {
     expect(clubCategoryFor('chipper')).toBe('utility')
-    expect(clubCategoryFor('mini_driver')).toBe('utility')
-    expect(clubCategoryFor('aw')).toBe('utility')
     expect(clubCategoryFor('')).toBe('utility')
   })
 
@@ -62,8 +75,8 @@ describe('clubCategoryFor', () => {
 })
 
 describe('DEFAULT_BAG', () => {
-  it('has 15 entries', () => {
-    expect(DEFAULT_BAG.length).toBe(15)
+  it('has 14 entries (the USGA legal max)', () => {
+    expect(DEFAULT_BAG.length).toBe(14)
   })
 
   it('every entry references a canonical CLUB', () => {
@@ -72,7 +85,7 @@ describe('DEFAULT_BAG', () => {
     }
   })
 
-  it('sort_order values are 0..14 in order', () => {
+  it('sort_order values are 0..13 in order', () => {
     DEFAULT_BAG.forEach((entry, idx) => {
       expect(entry.sort_order).toBe(idx)
     })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -112,10 +112,10 @@ export const CANONICAL_CLUBS_BY_CATEGORY: Record<ClubCategory, readonly string[]
   utility: [],
 }
 
-// Default 15-club starting bag seeded for new users when their bag is
-// empty. Standard tournament bag is 14 clubs — we ship 15 because the
-// 5-wood + 4h + 5h overlap is common in amateur bags. Players trim on
-// onboarding or in /settings/bag.
+// Default 14-club starting bag seeded for new users when their bag is
+// empty. 14 is the legal max under USGA rules; we drop the 4-hybrid
+// (most amateurs carry either the 5w or the 4h, not both — keeping
+// the 5w covers more bag profiles). Players can swap in /settings/bag.
 export interface DefaultBagEntry {
   club_type: string
   name: string
@@ -126,18 +126,17 @@ export const DEFAULT_BAG: readonly DefaultBagEntry[] = [
   { club_type: 'driver', name: 'Driver', sort_order: 0 },
   { club_type: '3w', name: '3 Wood', sort_order: 1 },
   { club_type: '5w', name: '5 Wood', sort_order: 2 },
-  { club_type: '4h', name: '4 Hybrid', sort_order: 3 },
-  { club_type: '5h', name: '5 Hybrid', sort_order: 4 },
-  { club_type: '5i', name: '5 Iron', sort_order: 5 },
-  { club_type: '6i', name: '6 Iron', sort_order: 6 },
-  { club_type: '7i', name: '7 Iron', sort_order: 7 },
-  { club_type: '8i', name: '8 Iron', sort_order: 8 },
-  { club_type: '9i', name: '9 Iron', sort_order: 9 },
-  { club_type: 'pw', name: 'Pitching Wedge', sort_order: 10 },
-  { club_type: 'gw', name: 'Gap Wedge', sort_order: 11 },
-  { club_type: 'sw', name: 'Sand Wedge', sort_order: 12 },
-  { club_type: 'lw', name: 'Lob Wedge', sort_order: 13 },
-  { club_type: 'putter', name: 'Putter', sort_order: 14 },
+  { club_type: '5h', name: '5 Hybrid', sort_order: 3 },
+  { club_type: '5i', name: '5 Iron', sort_order: 4 },
+  { club_type: '6i', name: '6 Iron', sort_order: 5 },
+  { club_type: '7i', name: '7 Iron', sort_order: 6 },
+  { club_type: '8i', name: '8 Iron', sort_order: 7 },
+  { club_type: '9i', name: '9 Iron', sort_order: 8 },
+  { club_type: 'pw', name: 'Pitching Wedge', sort_order: 9 },
+  { club_type: 'gw', name: 'Gap Wedge', sort_order: 10 },
+  { club_type: 'sw', name: 'Sand Wedge', sort_order: 11 },
+  { club_type: 'lw', name: 'Lob Wedge', sort_order: 12 },
+  { club_type: 'putter', name: 'Putter', sort_order: 13 },
 ] as const
 
 export const LIE_TYPES = [

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -59,17 +59,57 @@ export const CLUB_CATEGORY_LABELS: Record<ClubCategory, string> = {
 }
 
 // Map a canonical club_type to its category for the picklist UI. Anything
-// not matched here falls back to 'utility' — the catch-all for utility
-// irons / mini drivers / chippers / etc.
+// not matched here falls back to 'utility' — the catch-all for chippers,
+// truly custom one-offs, etc.
 export function clubCategoryFor(clubType: string): ClubCategory {
   if (clubType === 'driver') return 'driver'
   if (clubType === 'putter') return 'putter'
-  if (/^[357]w$/.test(clubType)) return 'wood'
-  if (/^[345]h$/.test(clubType)) return 'hybrid'
-  if (/^[2-9]i$/.test(clubType)) return 'iron'
-  if (clubType === 'pw' || clubType === 'gw' || clubType === 'sw' || clubType === 'lw')
+  if (clubType === 'mini_driver' || /^\d{1,2}w$/.test(clubType)) return 'wood'
+  if (/^\d{1,2}h$/.test(clubType)) return 'hybrid'
+  if (/^\d{1,2}i$/.test(clubType)) return 'iron'
+  if (
+    clubType === 'pw' ||
+    clubType === 'gw' ||
+    clubType === 'sw' ||
+    clubType === 'lw' ||
+    clubType === 'aw' ||
+    /^\d{2}°$/.test(clubType)
+  )
     return 'wedge'
   return 'utility'
+}
+
+// Canonical picklist options per category, surfaced by the bag UIs on
+// web and mobile. Lives here (not in app code) so both apps stay in
+// lockstep — adding a club_type to the picklist is a one-file edit.
+// Wedges are ordered by loft so the dropdown reads top-to-bottom from
+// pitch through lob; degree-named entries cover players who know their
+// wedges by loft rather than by name.
+export const CANONICAL_CLUBS_BY_CATEGORY: Record<ClubCategory, readonly string[]> = {
+  driver: ['driver'],
+  wood: ['mini_driver', '2w', '3w', '4w', '5w', '7w', '9w', '11w', '13w'],
+  hybrid: ['2h', '3h', '4h', '5h', '6h', '7h'],
+  iron: ['1i', '2i', '3i', '4i', '5i', '6i', '7i', '8i', '9i'],
+  wedge: [
+    '45°',
+    '46°',
+    '47°',
+    '48°',
+    'pw',
+    'gw',
+    'aw',
+    '50°',
+    '52°',
+    '54°',
+    '56°',
+    'sw',
+    '58°',
+    '60°',
+    '62°',
+    'lw',
+  ],
+  putter: ['putter'],
+  utility: [],
 }
 
 // Default 15-club starting bag seeded for new users when their bag is


### PR DESCRIPTION
## Summary

Ten fixes from web testing — sidebar active state, GPS prompt scope, post-round map shot numbering, distance labels + better connector visibility on the round map, inline club edit + expanded club options + custom-entry support, default bag trimmed to USGA-legal 14, post-round aim point capture on the web map, and tee marker style parity between web and mobile.

### Commits

1. `fix: My Bag sidebar active state uses exact path match` — `/settings/bag` no longer triggers `/settings` to highlight.
2. `fix: GPS only requested when Live mode selected` — past-round entry no longer prompts for location.
3. `fix: shot numbering after Done with hole` — existing-shot markers now render at start coords (matches CLAUDE.md spec).
4. `feat: distance labels between shots on web map` — JetBrains Mono pills at each segment midpoint.
5. `fix: shot connector line amber with better visibility` — 2.5px solid amber over a dark outline; works on both bright and dark satellite imagery.
6. `feat: inline club edit in bag settings` — name / loft / typical distance editable per row on web; bottom sheet on mobile. `club_type` stays canonical.
7. `feat: expanded club options + custom entry` — woods now include 2w/4w/9w/11w/13w/mini_driver, hybrids 2h/6h/7h, irons 1i, wedges by loft (45°–62°). New `CANONICAL_CLUBS_BY_CATEGORY` lives in `@oga/core` so web + mobile stay in lockstep. "Custom…" sentinel option in any category swaps the dropdown for free text.
8. `fix: default bag 14 clubs not 15` — drops the 4-hybrid (most amateurs carry the 5w or the 4h, not both). Onboarding copy + reset alerts updated.
9. `feat: aim point placement in post-round web map` — "Set aim" toggle in the instruction strip; next tap places the aim for the latest shot. Renders amber dot + dashed line + "AIM yyy" pill, persists `aim_lat`/`aim_lng`. Required for meaningful dispersion data.
10. `fix: tee marker style consistent web and mobile` — mobile now renders the same TEE pill (cream bg, ink-dim text, mono kicker) instead of a bare circle.

## Verification

- `pnpm typecheck` — 4/4 packages clean
- `pnpm test` — **242 / 242** passing (`packages/core`)
- `pnpm --filter web build` — succeeds
- `cd apps/mobile && npm run typecheck` — clean

## Test plan

- [ ] Sidebar: navigate to `/settings/bag`, confirm only "My Bag" is highlighted
- [ ] New round: choose "After the fact" — no GPS prompt; choose "Live" — GPS prompt fires once
- [ ] Round map: place 4 shots, tap "Done with hole", save, reopen — shot 1 marker at the tee, shots 2–4 at their start positions, line traces tee→pin in amber with dark outline
- [ ] Distance pills appear at each segment midpoint
- [ ] Settings → My Bag: tap Edit on a row, change name + loft + typical, Save
- [ ] Settings → My Bag: Add club → Wedges → "Custom…" → enter `vokey 56-12`
- [ ] Reset bag → 14 clubs, no 4 Hybrid in default
- [ ] Onboarding step 6 reads "Standard bags carry up to 14 clubs."
- [ ] Round map: place a shot, tap "Set aim", tap aim location — amber dot + dashed line + AIM distance pill render; "Clear aim" wipes it
- [ ] Mobile: hole map shows TEE pill instead of cream circle