### PR TITLE
fix: web map past-round bugs (camera, putting, save dedupe)

### DIFF
--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   DEFAULT_BAG,
   LIE_TYPES,
+  NEAR_GREEN_YARDS,
   buildInitialRows,
   type Club,
   type LieType,
@@ -254,7 +255,15 @@ function ShotRow({
   row: ReviewedShotRow
   onChange: (next: ReviewedShotRow) => void
 }) {
-  const isPutt = row.lieType === 'green' || row.club === 'putter'
+  // Mirror mobile's PUTTING_RADIUS_YARDS — any shot starting within 30 yd
+  // of the pin gets the putt entry surface (made/short/long, miss left/
+  // right, distance in feet) rather than the standard club + lie row.
+  // Lie-type 'green' and club 'putter' still trigger it, so an explicit
+  // putt row stays a putt even if the start coords drifted past 30 yd.
+  const isPutt =
+    row.lieType === 'green' ||
+    row.club === 'putter' ||
+    row.distanceToPin <= NEAR_GREEN_YARDS
   const { toDisplay, toDisplayFt } = useUnits()
   const bag = useUserBag()
   // Source the club options from the user's bag, falling back to

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -109,9 +109,13 @@ export function RoundMap({
   const hasExistingShots = existingShots.some(
     (s) => s.endLat != null && s.endLng != null,
   )
+  // Prefer tee over pin so a fresh past-round map opens looking down the
+  // hole (where shot 1 starts) rather than zoomed straight at the green.
+  // Falls back to pin only when tee coords are missing — same behaviour
+  // as mobile's PLACE_BALL camera frame.
   const center = useMemo<[number, number] | null>(() => {
-    if (effectivePin) return [effectivePin.lng, effectivePin.lat]
     if (effectiveTee) return [effectiveTee.lng, effectiveTee.lat]
+    if (effectivePin) return [effectivePin.lng, effectivePin.lat]
     return null
   }, [effectivePin, effectiveTee])
 

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -23,6 +23,7 @@ import {
   DEFAULT_HANDICAP,
   getShotCategory,
   haversineYards,
+  NEAR_GREEN_YARDS,
 } from '@oga/core'
 import { toUserMessage } from '../../lib/errors'
 
@@ -406,8 +407,13 @@ export function RoundDetailPage() {
       // derived from the rows so the scorecard reflects what was placed
       // without needing a manual entry.
       const existing = scoresByHoleId.get(activeHole.id)
+      // Match HoleReviewSheet's isPutt — any shot starting within 30 yd
+      // of the pin counts as a putt for the scorecard's putt total.
       const puttCount = rows.filter(
-        (r) => r.lieType === 'green' || r.club === 'putter',
+        (r) =>
+          r.lieType === 'green' ||
+          r.club === 'putter' ||
+          r.distanceToPin <= NEAR_GREEN_YARDS,
       ).length
       const hsResult = await upsertHoleScore.mutateAsync({
         id: existing?.id,
@@ -422,7 +428,10 @@ export function RoundDetailPage() {
       if (!hs) throw new Error('hole_score upsert returned no row')
 
       for (const row of rows) {
-        const isPuttRow = row.lieType === 'green' || row.club === 'putter'
+        const isPuttRow =
+          row.lieType === 'green' ||
+          row.club === 'putter' ||
+          row.distanceToPin <= NEAR_GREEN_YARDS
         const aim = placedAims[row.shotNumber - 1] ?? null
         await createShot.mutateAsync({
           hole_score_id: hs.id,

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -427,6 +427,18 @@ export function RoundDetailPage() {
       const hs = hsResult ?? existing
       if (!hs) throw new Error('hole_score upsert returned no row')
 
+      // Replace-all save: drop any shots already attached to this
+      // hole_score before inserting the freshly reviewed rows. Without
+      // this, a re-save (e.g. after a partial-success error retry, or
+      // after editing the hole on the map) duplicated rows in the DB
+      // and surfaced as phantom shot markers + shifted shot numbers.
+      const { error: delErr } = await supabase
+        .from('shots')
+        .delete()
+        .eq('hole_score_id', hs.id)
+        .eq('user_id', user.id)
+      if (delErr) throw delErr
+
       for (const row of rows) {
         const isPuttRow =
           row.lieType === 'green' ||


### PR DESCRIPTION
## Summary

Three fixes for past-round shot logging on the web map.

1. **Camera opens on tee box, not the green.** `RoundMap` was preferring `effectivePin` over `effectiveTee` for the initial center, so a fresh map on hole 1 framed the cup instead of the tee. Flip the preference — tee first, pin fallback. Matches mobile's PLACE_BALL framing.
2. **Putting form auto-triggers within 30 yd.** `HoleReviewSheet` only treated rows as putts when `lieType === 'green'` (≤15 yd) or `club === 'putter'`, so a tap from 20 yd off the pin showed the standard club + lie row instead of the putt entry surface. Expanded the check to include `distanceToPin <= NEAR_GREEN_YARDS` (30 yd), matching mobile's `PUTTING_RADIUS_YARDS`. Updated the matching `puttCount` and `isPuttRow` calls in `RoundDetailPage.saveReviewedHole` so persisted putt fields stay in lockstep.
3. **Save is now replace-all per hole_score.** Re-saving (after a partial-success error retry, or after editing the hole on the map) used to leave the prior `INSERT`s in place — the loop ran again and produced duplicate `shots` rows, surfacing as phantom markers and shifted shot numbers. Added a `delete().eq('hole_score_id', hs.id).eq('user_id', user.id)` before the per-row insert loop, so each save lands as the canonical set of shots for that hole.

## Verification

- `pnpm typecheck` — 4/4 packages clean
- `pnpm test` — 242 / 242 passing (`packages/core`)
- `pnpm --filter web build` — succeeds
- `cd apps/mobile && npm run typecheck` — clean

## Test plan

- [ ] New round (after-the-fact) → open Map → camera frames the hole-1 tee box, not the green
- [ ] Switch holes — camera flies to each hole's tee box
- [ ] Tap a shot start within 25 yd of the pin → review sheet shows putt entry surface (made / short / long, missed left / right, distance in feet)
- [ ] Place 4 shots, Save hole, reopen the hole, edit on map, Save again → exactly 4 shots persisted (no duplicates), shot numbers 1-4 in order
- [ ] Existing logged holes still render correctly (PR #161 behaviour preserved)