### PR TITLE
fix: web past-round putting flow (sheet on tap, zoom on save)

### DIFF
--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -11,6 +11,7 @@ import {
   type ReviewedShotRow,
 } from '@oga/core'
 import type { PlacedPoint } from './RoundMap'
+import type { WebPuttData } from './WebPuttingSheet'
 import { useUnits } from '../../hooks/useUnits'
 import { useUserBag } from '../../hooks/useUserBag'
 
@@ -27,6 +28,11 @@ interface HoleReviewSheetProps {
    *  End-of-shot for shot N is marker N+1; for the final shot it is
    *  the pin (assumed holed). */
   placedPoints: PlacedPoint[]
+  /** Putt metadata pre-collected via the putting sheet at tap time.
+   *  Parallel to placedPoints. When the inferred row for that index
+   *  is a putt, this data overrides the defaults so the user doesn't
+   *  re-enter what they just answered. */
+  placedPutts?: (WebPuttData | null)[]
   saving: boolean
   /** "Edit on map" — close the sheet and let the user drag markers. */
   onEditOnMap: () => void
@@ -53,6 +59,7 @@ export function HoleReviewSheet({
   pinLat,
   pinLng,
   placedPoints,
+  placedPutts,
   saving,
   onEditOnMap,
   onSave,
@@ -61,9 +68,13 @@ export function HoleReviewSheet({
 
   // Read the latest placedPoints inside the effect via ref so the effect
   // doesn't re-fire (and clobber user edits) just because the parent
-  // returned a new array reference.
+  // returned a new array reference. Same trick for placedPutts so a
+  // stale inline-collected putt doesn't get re-merged after the user
+  // hand-edited the row.
   const placedPointsRef = useRef(placedPoints)
   placedPointsRef.current = placedPoints
+  const placedPuttsRef = useRef(placedPutts)
+  placedPuttsRef.current = placedPutts
 
   // Hydrate rows from the placed coordinates once per (hole, open). After
   // hydration the user's typing/dropdown choices are the source of truth —
@@ -81,8 +92,32 @@ export function HoleReviewSheet({
     }
     if (hydratedHoleRef.current === holeNumber) return
     hydratedHoleRef.current = holeNumber
+    const baseRows = buildInitialRows(
+      placedPointsRef.current,
+      par,
+      pinLat,
+      pinLng,
+    )
+    const putts = placedPuttsRef.current ?? []
+    // Merge any inline-collected putt data into the inferred rows so the
+    // player doesn't have to re-enter what they just answered in the
+    // putting sheet. Distance in feet maps to distanceYards / 3 so the
+    // sheet's edit display stays consistent.
     setRows(
-      buildInitialRows(placedPointsRef.current, par, pinLat, pinLng),
+      baseRows.map((row, idx) => {
+        const inline = putts[idx]
+        if (!inline) return row
+        return {
+          ...row,
+          puttMade: inline.puttMade,
+          puttDistanceResult: inline.puttDistanceResult,
+          puttDirectionResult: inline.puttDirectionResult,
+          distanceYards:
+            inline.puttDistanceFt != null
+              ? inline.puttDistanceFt / 3
+              : row.distanceYards,
+        }
+      }),
     )
   }, [open, holeNumber, par, pinLat, pinLng])
 

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -45,6 +45,9 @@ interface RoundMapProps {
   /** When true, the next map tap sets aim for the most recently placed
    *  shot instead of pushing a new shot start marker. */
   aimMode?: boolean
+  /** Monotonic counter — when it increments, fly to the pin at zoom 18
+   *  to frame the green for the next putt placement. */
+  focusGreenSignal?: number
   /** Local override for the pin and tee positions while the user is
    *  reviewing a hole. When set, these win over the values inside
    *  `hole.pinLat/pinLng` / `hole.teeLat/teeLng`. */
@@ -75,6 +78,7 @@ export function RoundMap({
   placedPoints,
   placedAims,
   aimMode,
+  focusGreenSignal,
   pinOverride,
   teeOverride,
   tapToPlaceDisabled,
@@ -153,6 +157,27 @@ export function RoundMap({
     if (!map || !center) return
     map.flyTo({ center, zoom: 17, speed: 1.4 })
   }, [center?.[0], center?.[1]])
+
+  // After a non-holed putt save the parent bumps focusGreenSignal —
+  // fly in tight on the green so the next putt placement lands on the
+  // right surface. The ref starts at the prop's initial value so the
+  // first render doesn't auto-fire (signal=0 matches; only later
+  // increments trigger the flyTo).
+  const lastSignalRef = useRef<number | undefined>(focusGreenSignal)
+  useEffect(() => {
+    if (focusGreenSignal == null) return
+    if (lastSignalRef.current === focusGreenSignal) return
+    lastSignalRef.current = focusGreenSignal
+    const map = mapRef.current
+    if (!map) return
+    if (!effectivePin) return
+    map.flyTo({
+      center: [effectivePin.lng, effectivePin.lat],
+      zoom: 18,
+      pitch: 0,
+      duration: 800,
+    })
+  }, [focusGreenSignal, effectivePin])
 
   // Wire a click handler for tap-to-place on holes that have no live shots.
   // When aimMode is on, the next click sets aim for the most recently

--- a/apps/web/src/components/round/WebPuttingSheet.tsx
+++ b/apps/web/src/components/round/WebPuttingSheet.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useState } from 'react'
+import type { PuttDirectionResult, PuttDistanceResult } from '@oga/core'
+
+export interface WebPuttData {
+  puttMade: boolean
+  puttDistanceFt: number | null
+  puttDistanceResult?: PuttDistanceResult
+  puttDirectionResult?: PuttDirectionResult
+}
+
+interface WebPuttingSheetProps {
+  open: boolean
+  shotNumber: number
+  /** Distance from the placed start to the pin in feet, used to seed
+   *  the distance input so the player only types in a correction. */
+  initialDistanceFt: number
+  initial?: WebPuttData | null
+  onSave: (value: WebPuttData) => void
+  onClose: () => void
+}
+
+const DISTANCE_OPTIONS: { value: PuttDistanceResult; label: string }[] = [
+  { value: 'short', label: 'Short' },
+  { value: 'long', label: 'Long' },
+]
+
+const DIRECTION_OPTIONS: { value: PuttDirectionResult; label: string }[] = [
+  { value: 'left', label: 'Missed left' },
+  { value: 'right', label: 'Missed right' },
+]
+
+// Minimum distance in feet a recorded putt can be — sub-1 ft tap-ins
+// stay at 1 ft so the SG baselines (which clamp to 3 ft anyway) get a
+// non-zero start length and the distance input doesn't read "0".
+const MIN_PUTT_FT = 1
+
+export function WebPuttingSheet({
+  open,
+  shotNumber,
+  initialDistanceFt,
+  initial,
+  onSave,
+  onClose,
+}: WebPuttingSheetProps) {
+  const [distanceText, setDistanceText] = useState('')
+  const [made, setMade] = useState<boolean>(false)
+  const [distanceResult, setDistanceResult] = useState<
+    PuttDistanceResult | undefined
+  >()
+  const [directionResult, setDirectionResult] = useState<
+    PuttDirectionResult | undefined
+  >()
+
+  // Re-seed the form whenever a new putt is opened. `open + shotNumber`
+  // is the right key — opening the sheet for shot 4 then shot 5 (without
+  // closing in between) should restart the form from the new shot's
+  // seed values, not retain shot 4's typed distance.
+  useEffect(() => {
+    if (!open) return
+    const seed = initial ?? null
+    setDistanceText(
+      String(
+        Math.max(
+          MIN_PUTT_FT,
+          seed?.puttDistanceFt ?? Math.round(initialDistanceFt),
+        ),
+      ),
+    )
+    setMade(seed?.puttMade ?? false)
+    setDistanceResult(seed?.puttDistanceResult)
+    setDirectionResult(seed?.puttDirectionResult)
+  }, [open, shotNumber, initialDistanceFt, initial])
+
+  function commit(makeOverride: boolean) {
+    const parsed = Number(distanceText)
+    const dist = Number.isFinite(parsed)
+      ? Math.max(MIN_PUTT_FT, Math.round(parsed))
+      : null
+    onSave({
+      puttMade: makeOverride,
+      puttDistanceFt: dist,
+      puttDistanceResult: makeOverride ? undefined : distanceResult,
+      puttDirectionResult: makeOverride ? undefined : directionResult,
+    })
+  }
+
+  if (!open) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-label={`Putt ${shotNumber}`}
+      style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: '#FBF8F1',
+        borderTop: '1px solid #9F9580',
+        borderTopLeftRadius: 12,
+        borderTopRightRadius: 12,
+        padding: '8px 22px 18px',
+        zIndex: 6,
+        maxHeight: '80%',
+        overflowY: 'auto',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'center',
+          paddingTop: 8,
+          marginBottom: 12,
+        }}
+      >
+        <div
+          aria-hidden
+          style={{
+            width: 32,
+            height: 4,
+            borderRadius: 2,
+            background: '#D9D2BF',
+          }}
+        />
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          paddingBottom: 12,
+          borderBottom: '1px solid #D9D2BF',
+        }}
+      >
+        <div>
+          <div className="kicker" style={{ marginBottom: 4 }}>
+            Putt {shotNumber}
+          </div>
+          <div
+            className="font-serif text-caddie-ink"
+            style={{ fontSize: 22, fontWeight: 500, fontStyle: 'italic' }}
+          >
+            On the green.
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="font-mono uppercase text-caddie-ink-mute hover:text-caddie-ink"
+          style={{
+            fontSize: 10,
+            letterSpacing: '0.14em',
+            background: 'transparent',
+            border: 'none',
+            padding: 8,
+          }}
+        >
+          Close
+        </button>
+      </div>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 14, marginTop: 14 }}>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <span className="kicker">Distance (ft)</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={MIN_PUTT_FT}
+            value={distanceText}
+            onChange={(e) => setDistanceText(e.target.value)}
+            className="bg-caddie-bg text-caddie-ink"
+            style={{
+              border: '1px solid #D9D2BF',
+              borderRadius: 2,
+              padding: '10px 12px',
+              fontSize: 15,
+              width: 120,
+            }}
+          />
+        </label>
+
+        <Section title="Distance result">
+          <RowChips
+            options={DISTANCE_OPTIONS}
+            value={made ? undefined : distanceResult}
+            disabled={made}
+            onSelect={(v) => {
+              setMade(false)
+              setDistanceResult((cur) => (cur === v ? undefined : v))
+            }}
+          />
+        </Section>
+
+        <Section title="Direction">
+          <RowChips
+            options={DIRECTION_OPTIONS}
+            value={made ? undefined : directionResult}
+            disabled={made}
+            onSelect={(v) => {
+              setMade(false)
+              setDirectionResult((cur) => (cur === v ? undefined : v))
+            }}
+          />
+        </Section>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          gap: 10,
+          marginTop: 18,
+          flexWrap: 'wrap',
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => commit(true)}
+          className="bg-caddie-accent text-caddie-accent-ink"
+          style={{
+            flex: 1,
+            minWidth: 160,
+            borderRadius: 2,
+            padding: '14px 18px',
+            fontSize: 14,
+            fontWeight: 600,
+            letterSpacing: '0.02em',
+          }}
+        >
+          Holed it{' '}
+          <span className="font-serif" style={{ fontStyle: 'italic' }}>
+            →
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={() => commit(false)}
+          className="text-caddie-accent"
+          style={{
+            flex: 1,
+            minWidth: 140,
+            border: '1px solid #1F3D2C',
+            background: 'transparent',
+            borderRadius: 2,
+            padding: '14px 18px',
+            fontSize: 14,
+            fontWeight: 600,
+            letterSpacing: '0.02em',
+          }}
+        >
+          Missed{' '}
+          <span className="font-serif" style={{ fontStyle: 'italic' }}>
+            →
+          </span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <div className="kicker" style={{ marginBottom: 8 }}>
+        {title}
+      </div>
+      {children}
+    </div>
+  )
+}
+
+function RowChips<V extends string>({
+  options,
+  value,
+  disabled,
+  onSelect,
+}: {
+  options: { value: V; label: string }[]
+  value: V | undefined
+  disabled?: boolean
+  onSelect: (v: V) => void
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      {options.map((opt) => {
+        const active = !disabled && value === opt.value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onSelect(opt.value)}
+            disabled={disabled}
+            aria-pressed={active}
+            style={{
+              background: active ? '#1F3D2C' : '#EBE5D6',
+              color: active ? '#F2EEE5' : '#1C211C',
+              border: 'none',
+              borderRadius: 2,
+              padding: '8px 14px',
+              fontSize: 13,
+              fontWeight: active ? 600 : 400,
+              opacity: disabled ? 0.4 : 1,
+              cursor: disabled ? 'not-allowed' : 'pointer',
+            }}
+          >
+            {opt.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -38,6 +38,10 @@ import {
   HoleReviewSheet,
   type ReviewedShotRow,
 } from '../../components/round/HoleReviewSheet'
+import {
+  WebPuttingSheet,
+  type WebPuttData,
+} from '../../components/round/WebPuttingSheet'
 import { useDeleteRound, useRound, useRounds } from '../../hooks/useRounds'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { useCourseTees, useHolesForCourse } from '../../hooks/useCourses'
@@ -66,9 +70,18 @@ interface HoleViewState {
    *  that shot. Aim point is what the player was aiming at when they
    *  hit shot N; required for meaningful dispersion analysis. */
   placedAims: (PlacedPoint | null)[]
+  /** Putt metadata per placed shot. Parallel to placedPoints. Set when
+   *  a tap landed within 30 yd of the pin and the user filled the
+   *  putting sheet. Null for non-putts. The data flows straight through
+   *  to saveReviewedHole so the player doesn't re-enter putt details
+   *  in the end-of-hole review. */
+  placedPutts: (WebPuttData | null)[]
   /** When true, the next map tap sets the aim point for the latest
    *  placed shot instead of dropping a new shot start marker. */
   aimMode: boolean
+  /** Index of the placed shot whose putting sheet is currently open;
+   *  null when the sheet is closed. */
+  puttingSheetForIdx: number | null
   pinOverride: PlacedPoint | null
   teeOverride: PlacedPoint | null
   reviewOpen: boolean
@@ -78,12 +91,15 @@ interface HoleViewState {
 
 type HoleViewAction =
   | { type: 'SWITCH_HOLE'; holeNumber: number }
-  | { type: 'PUSH_POINT'; point: PlacedPoint }
+  | { type: 'PUSH_POINT'; point: PlacedPoint; openPuttSheet?: boolean }
   | { type: 'MOVE_POINT'; index: number; point: PlacedPoint }
   | { type: 'CLEAR_POINTS' }
   | { type: 'POP_POINT' }
   | { type: 'SET_AIM'; index: number; point: PlacedPoint | null }
   | { type: 'AIM_MODE'; on: boolean }
+  | { type: 'OPEN_PUTT_SHEET'; index: number }
+  | { type: 'CLOSE_PUTT_SHEET' }
+  | { type: 'SET_PUTT'; index: number; data: WebPuttData }
   | { type: 'PIN_OVERRIDE'; point: PlacedPoint | null }
   | { type: 'TEE_OVERRIDE'; point: PlacedPoint | null }
   | { type: 'OPEN_REVIEW' }
@@ -96,7 +112,9 @@ const HOLE_VIEW_INITIAL: HoleViewState = {
   activeHoleNumber: 1,
   placedPoints: [],
   placedAims: [],
+  placedPutts: [],
   aimMode: false,
+  puttingSheetForIdx: null,
   pinOverride: null,
   teeOverride: null,
   reviewOpen: false,
@@ -108,28 +126,43 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
   switch (action.type) {
     case 'SWITCH_HOLE':
       return { ...HOLE_VIEW_INITIAL, activeHoleNumber: action.holeNumber }
-    case 'PUSH_POINT':
+    case 'PUSH_POINT': {
+      const newIdx = state.placedPoints.length
       return {
         ...state,
         placedPoints: [...state.placedPoints, action.point],
         placedAims: [...state.placedAims, null],
+        placedPutts: [...state.placedPutts, null],
         // Drop aim mode after placing a new shot — aim mode is sticky to
         // a specific shot, and pushing a new shot moves the cursor.
         aimMode: false,
+        // Auto-open the putting sheet for the new shot when this push
+        // landed within 30 yd of the pin (caller-controlled flag).
+        puttingSheetForIdx: action.openPuttSheet ? newIdx : state.puttingSheetForIdx,
       }
+    }
     case 'MOVE_POINT': {
       const next = state.placedPoints.slice()
       next[action.index] = action.point
       return { ...state, placedPoints: next }
     }
     case 'CLEAR_POINTS':
-      return { ...state, placedPoints: [], placedAims: [], aimMode: false }
+      return {
+        ...state,
+        placedPoints: [],
+        placedAims: [],
+        placedPutts: [],
+        aimMode: false,
+        puttingSheetForIdx: null,
+      }
     case 'POP_POINT':
       return {
         ...state,
         placedPoints: state.placedPoints.slice(0, -1),
         placedAims: state.placedAims.slice(0, -1),
+        placedPutts: state.placedPutts.slice(0, -1),
         aimMode: false,
+        puttingSheetForIdx: null,
       }
     case 'SET_AIM': {
       const next = state.placedAims.slice()
@@ -138,6 +171,15 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
     }
     case 'AIM_MODE':
       return { ...state, aimMode: action.on }
+    case 'OPEN_PUTT_SHEET':
+      return { ...state, puttingSheetForIdx: action.index }
+    case 'CLOSE_PUTT_SHEET':
+      return { ...state, puttingSheetForIdx: null }
+    case 'SET_PUTT': {
+      const next = state.placedPutts.slice()
+      next[action.index] = action.data
+      return { ...state, placedPutts: next, puttingSheetForIdx: null }
+    }
     case 'PIN_OVERRIDE':
       return { ...state, pinOverride: action.point }
     case 'TEE_OVERRIDE':
@@ -156,7 +198,9 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
         reviewOpen: false,
         placedPoints: [],
         placedAims: [],
+        placedPutts: [],
         aimMode: false,
+        puttingSheetForIdx: null,
       }
   }
 }
@@ -196,7 +240,9 @@ export function RoundDetailPage() {
     activeHoleNumber,
     placedPoints,
     placedAims,
+    placedPutts,
     aimMode,
+    puttingSheetForIdx,
     pinOverride,
     teeOverride,
     reviewOpen,
@@ -311,7 +357,20 @@ export function RoundDetailPage() {
 
   const placeHandlers = useMemo(
     () => ({
-      onPlace: (p: PlacedPoint) => dispatchHoleView({ type: 'PUSH_POINT', point: p }),
+      onPlace: (p: PlacedPoint) => {
+        // Auto-open the putting sheet for any tap within 30 yd of the
+        // pin so the user lands straight on putt entry instead of the
+        // generic shot detail row.
+        const isPutt =
+          effectivePin != null &&
+          haversineYards(p.lat, p.lng, effectivePin.lat, effectivePin.lng) <=
+            NEAR_GREEN_YARDS
+        dispatchHoleView({
+          type: 'PUSH_POINT',
+          point: p,
+          openPuttSheet: isPutt,
+        })
+      },
       onMovePoint: (idx: number, p: PlacedPoint) =>
         dispatchHoleView({ type: 'MOVE_POINT', index: idx, point: p }),
       onMovePin: (p: PlacedPoint) => {
@@ -331,7 +390,7 @@ export function RoundDetailPage() {
         dispatchHoleView({ type: 'OPEN_REVIEW' })
       },
     }),
-    [persistRoundPin],
+    [persistRoundPin, effectivePin],
   )
 
   const switchHole = useCallback((n: number) => {
@@ -630,6 +689,7 @@ export function RoundDetailPage() {
           placedPoints={placedPoints}
           placedAims={placedAims}
           aimMode={aimMode}
+          puttingOpen={puttingSheetForIdx != null}
           pinOverride={pinOverride}
           teeOverride={teeOverride}
           handlers={placeHandlers}
@@ -637,21 +697,51 @@ export function RoundDetailPage() {
           editingOnMap={editingOnMap}
           reviewSheet={
             activeHole ? (
-              <HoleReviewSheet
-                open={reviewOpen}
-                holeNumber={activeHole.number}
-                par={activeHole.par}
-                totalPar={holes.reduce((s, h) => s + h.par, 0)}
-                pinLat={effectivePin?.lat ?? null}
-                pinLng={effectivePin?.lng ?? null}
-                placedPoints={placedPoints}
-                saving={savingHole}
-                onEditOnMap={() => {
-                  dispatchHoleView({ type: 'CLOSE_REVIEW' })
-                  dispatchHoleView({ type: 'EDIT_ON_MAP', editing: true })
-                }}
-                onSave={saveReviewedHole}
-              />
+              <>
+                <HoleReviewSheet
+                  open={reviewOpen}
+                  holeNumber={activeHole.number}
+                  par={activeHole.par}
+                  totalPar={holes.reduce((s, h) => s + h.par, 0)}
+                  pinLat={effectivePin?.lat ?? null}
+                  pinLng={effectivePin?.lng ?? null}
+                  placedPoints={placedPoints}
+                  placedPutts={placedPutts}
+                  saving={savingHole}
+                  onEditOnMap={() => {
+                    dispatchHoleView({ type: 'CLOSE_REVIEW' })
+                    dispatchHoleView({ type: 'EDIT_ON_MAP', editing: true })
+                  }}
+                  onSave={saveReviewedHole}
+                />
+                {puttingSheetForIdx != null &&
+                  placedPoints[puttingSheetForIdx] &&
+                  effectivePin && (
+                    <WebPuttingSheet
+                      open
+                      shotNumber={puttingSheetForIdx + 1}
+                      initialDistanceFt={Math.round(
+                        haversineYards(
+                          placedPoints[puttingSheetForIdx]!.lat,
+                          placedPoints[puttingSheetForIdx]!.lng,
+                          effectivePin.lat,
+                          effectivePin.lng,
+                        ) * 3,
+                      )}
+                      initial={placedPutts[puttingSheetForIdx] ?? null}
+                      onSave={(data) =>
+                        dispatchHoleView({
+                          type: 'SET_PUTT',
+                          index: puttingSheetForIdx,
+                          data,
+                        })
+                      }
+                      onClose={() =>
+                        dispatchHoleView({ type: 'CLOSE_PUTT_SHEET' })
+                      }
+                    />
+                  )}
+              </>
             ) : null
           }
         />
@@ -800,6 +890,9 @@ interface MapViewProps {
   placedPoints: PlacedPoint[]
   placedAims: (PlacedPoint | null)[]
   aimMode: boolean
+  /** True while the putting sheet is open — suppresses tap-to-place so
+   *  taps that hit the map under the sheet don't drop new shots. */
+  puttingOpen: boolean
   pinOverride: PlacedPoint | null
   teeOverride: PlacedPoint | null
   handlers: {
@@ -828,6 +921,7 @@ function MapView({
   placedPoints,
   placedAims,
   aimMode,
+  puttingOpen,
   pinOverride,
   teeOverride,
   handlers,
@@ -901,7 +995,7 @@ function MapView({
             aimMode={aimMode}
             pinOverride={pinOverride}
             teeOverride={teeOverride}
-            tapToPlaceDisabled={editingOnMap}
+            tapToPlaceDisabled={editingOnMap || puttingOpen}
             onPlace={handlers.onPlace}
             onMovePoint={handlers.onMovePoint}
             onMovePin={handlers.onMovePin}

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -82,6 +82,11 @@ interface HoleViewState {
   /** Index of the placed shot whose putting sheet is currently open;
    *  null when the sheet is closed. */
   puttingSheetForIdx: number | null
+  /** Monotonic counter the map watches to fly to the green after a
+   *  saved putt. Bumped when the user saves a non-holed putt so
+   *  RoundMap can flyTo the pin at zoom 18 to frame the green for the
+   *  next putt placement. */
+  focusGreenSignal: number
   pinOverride: PlacedPoint | null
   teeOverride: PlacedPoint | null
   reviewOpen: boolean
@@ -115,6 +120,7 @@ const HOLE_VIEW_INITIAL: HoleViewState = {
   placedPutts: [],
   aimMode: false,
   puttingSheetForIdx: null,
+  focusGreenSignal: 0,
   pinOverride: null,
   teeOverride: null,
   reviewOpen: false,
@@ -125,7 +131,14 @@ const HOLE_VIEW_INITIAL: HoleViewState = {
 function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleViewState {
   switch (action.type) {
     case 'SWITCH_HOLE':
-      return { ...HOLE_VIEW_INITIAL, activeHoleNumber: action.holeNumber }
+      return {
+        ...HOLE_VIEW_INITIAL,
+        activeHoleNumber: action.holeNumber,
+        // Keep the focus-green counter monotonic across hole switches —
+        // resetting to 0 mid-session would re-fire RoundMap's flyTo
+        // effect (it watches the counter for changes).
+        focusGreenSignal: state.focusGreenSignal,
+      }
     case 'PUSH_POINT': {
       const newIdx = state.placedPoints.length
       return {
@@ -178,7 +191,17 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
     case 'SET_PUTT': {
       const next = state.placedPutts.slice()
       next[action.index] = action.data
-      return { ...state, placedPutts: next, puttingSheetForIdx: null }
+      return {
+        ...state,
+        placedPutts: next,
+        puttingSheetForIdx: null,
+        // A miss → frame the green for the follow-up putt. A holed
+        // putt ends the hole, so leave the camera where it is and let
+        // the player tap "Done with hole".
+        focusGreenSignal: action.data.puttMade
+          ? state.focusGreenSignal
+          : state.focusGreenSignal + 1,
+      }
     }
     case 'PIN_OVERRIDE':
       return { ...state, pinOverride: action.point }
@@ -243,6 +266,7 @@ export function RoundDetailPage() {
     placedPutts,
     aimMode,
     puttingSheetForIdx,
+    focusGreenSignal,
     pinOverride,
     teeOverride,
     reviewOpen,
@@ -689,6 +713,7 @@ export function RoundDetailPage() {
           placedPoints={placedPoints}
           placedAims={placedAims}
           aimMode={aimMode}
+          focusGreenSignal={focusGreenSignal}
           puttingOpen={puttingSheetForIdx != null}
           pinOverride={pinOverride}
           teeOverride={teeOverride}
@@ -893,6 +918,9 @@ interface MapViewProps {
   /** True while the putting sheet is open — suppresses tap-to-place so
    *  taps that hit the map under the sheet don't drop new shots. */
   puttingOpen: boolean
+  /** Bumped after a non-holed putt save so RoundMap zooms to the green
+   *  for the next putt placement. */
+  focusGreenSignal: number
   pinOverride: PlacedPoint | null
   teeOverride: PlacedPoint | null
   handlers: {
@@ -922,6 +950,7 @@ function MapView({
   placedAims,
   aimMode,
   puttingOpen,
+  focusGreenSignal,
   pinOverride,
   teeOverride,
   handlers,
@@ -993,6 +1022,7 @@ function MapView({
             placedPoints={placedPoints}
             placedAims={placedAims}
             aimMode={aimMode}
+            focusGreenSignal={focusGreenSignal}
             pinOverride={pinOverride}
             teeOverride={teeOverride}
             tapToPlaceDisabled={editingOnMap || puttingOpen}


### PR DESCRIPTION
## Summary

Two fixes that align the web past-round putting flow with the mobile live flow.

1. **Tap within 30 yd → putting sheet, not the generic shot row.** The `onPlace` handler in `RoundDetailPage` now measures `haversineYards(tap, pin)` against `NEAR_GREEN_YARDS` and sets a `openPuttSheet` flag on the `PUSH_POINT` action when the tap lands in the green ring. The reducer routes that flag into a new `puttingSheetForIdx` slice; a new `WebPuttingSheet` component (bottom sheet, mirrors mobile's distance / made / short / long / missed-L / missed-R controls minus the green diagram for v1) opens for that index. Saved data lives in `placedPutts` parallel to `placedPoints` and is merged into `HoleReviewSheet`'s rows so the player doesn't re-enter what they just answered. Tap-to-place is suppressed while the sheet is open so a stray click under the overlay doesn't drop a phantom shot.

2. **Map zooms to green after saving a non-holed putt.** `SET_PUTT` increments a monotonic `focusGreenSignal` only when the putt was a miss. `RoundMap` keeps a ref of the last seen signal value; when it changes it `flyTo`'s the pin at `zoom: 18, pitch: 0, duration: 800ms` — same framing the user spec'd. A holed putt leaves the camera alone so the existing "Done with hole" CTA in the strip stays in view.

## Verification

- `pnpm typecheck` — 4/4 packages clean
- `pnpm test` — 242 / 242 passing (`packages/core`)
- `pnpm --filter web build` — succeeds
- `cd apps/mobile && npm run typecheck` — clean

## Test plan

- [ ] Past round → Map view → tap on green inside ~30 yd of pin → putting sheet opens for that shot
- [ ] Sheet seeds the distance input from the haversine start-to-pin (× 3 for feet)
- [ ] Tap "Holed it" → sheet closes, camera does not pan, "Done with hole →" CTA visible in the strip
- [ ] Tap "Missed" → sheet closes, map flies in to pin at zoom 18, ready for next tap
- [ ] Place subsequent putt within 30 yd → sheet reopens for the new shot, distance reseeded
- [ ] Tap outside 30 yd → standard tap-to-place path (no sheet)
- [ ] After all shots placed, tap "Done with hole" → review sheet shows putt rows pre-filled with the inline-collected values; no re-entry needed