### PR TITLE
fix: graceful fallback for courses with no hole layout

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -98,6 +98,7 @@ export default function HoleScreen() {
   const { toDisplay } = useUnits()
 
   const [round, setRound] = useState<RoundRow | null>(null)
+  const [courseCenter, setCourseCenter] = useState<LatLng | null>(null)
   const [holes, setHoles] = useState<HoleRow[]>([])
   const [holeScores, setHoleScores] = useState<HoleScoreRow[]>([])
   const [loading, setLoading] = useState(true)
@@ -167,24 +168,37 @@ export default function HoleScreen() {
 
   // Camera anchors on the tee box — the player's starting point. Pin/green
   // is intentionally NOT a fallback; it would mis-frame the hole every time.
+  // Course centroid is the next-best landing if no per-hole layout exists,
+  // and the hard-coded US-center FALLBACK_CENTER is the absolute last
+  // resort (course rows missing lat/lng entirely).
   const center: LatLng = useMemo(() => {
     if (tee) return tee
     if (ball) return ball
+    if (courseCenter) return courseCenter
     return FALLBACK_CENTER
-  }, [tee?.lat, tee?.lng, ball?.lat, ball?.lng])
+  }, [tee?.lat, tee?.lng, ball?.lat, ball?.lng, courseCenter?.lat, courseCenter?.lng])
 
   const loadAll = useCallback(async () => {
     if (!id) return
     setLoading(true)
     setError(null)
     try {
+      // Joining course lat/lng so HoleMap has a fallback camera target
+      // when this hole has no tee/pin coords (most courses pre-OSM
+      // import). Without it the map flew to FALLBACK_CENTER (US
+      // middle), which felt broken.
       const { data: r, error: rErr } = await supabase
         .from('rounds')
-        .select('*')
+        .select('*, courses(lat, lng)')
         .eq('id', id)
         .single()
       if (rErr || !r) throw rErr ?? new Error('Round not found')
       setRound(r)
+      setCourseCenter(
+        r.courses && r.courses.lat != null && r.courses.lng != null
+          ? { lat: r.courses.lat, lng: r.courses.lng }
+          : null,
+      )
 
       const [hRes, hsRes] = await Promise.all([
         supabase.from('holes').select('*').eq('course_id', r.course_id).order('number'),
@@ -825,6 +839,7 @@ export default function HoleScreen() {
           aim={aim}
           ball={ball}
           previousShots={previousShots}
+          missingHoleLayout={tee == null && storedPin == null && roundPin == null}
           phase={
             pinPlacementOpen
               ? 'PIN'

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -44,6 +44,13 @@ interface HoleMapProps {
    */
   previousShots?: LatLng[]
   phase?: HoleMapPhase
+  /**
+   * True when this hole has no tee or pin coordinates in the DB —
+   * surfaces a small banner under the top hint so the player knows
+   * the missing distance pill / no auto-putt switch is data-driven,
+   * not a bug.
+   */
+  missingHoleLayout?: boolean
   onSetAim: (loc: LatLng) => void
   onSetBall: (loc: LatLng) => void
   onPlacePin?: (loc: LatLng) => void
@@ -71,6 +78,7 @@ export function HoleMap({
   ball,
   previousShots,
   phase = 'PLACE_BALL',
+  missingHoleLayout = false,
   onSetAim,
   onSetBall,
   onPlacePin,
@@ -557,6 +565,35 @@ export function HoleMap({
                 : 'Drag the ball to refine, then tap Mark ball here'}
           </Text>
         </View>
+
+        {missingHoleLayout && !isPinMode && (
+          <View
+            style={{
+              position: 'absolute',
+              top: 48,
+              left: 12,
+              right: 12,
+              backgroundColor: 'rgba(28,33,28,0.78)',
+              borderWidth: 1,
+              borderColor: 'rgba(217,210,191,0.4)',
+              borderRadius: 2,
+              paddingHorizontal: 10,
+              paddingVertical: 6,
+            }}
+          >
+            <Text
+              style={{
+                color: '#F2EEE5',
+                fontSize: 11,
+                lineHeight: 14,
+              }}
+            >
+              No hole layout for this course. Place shots manually — the
+              distance pill and putting auto-switch stay off until tee /
+              pin coords land.
+            </Text>
+          </View>
+        )}
 
         {!isPinMode && pinDistance !== null && (
           <View

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -13,6 +13,12 @@ export interface HoleGeo {
   teeLng: number | null
   pinLat: number | null
   pinLng: number | null
+  /** Course-level fallback coordinates. Used as the camera target when
+   *  the hole has no tee/pin coords (most courses pre-OSM-import). The
+   *  map zooms out to ~15 in that case so the player sees the whole
+   *  property and can still tap to place shots manually. */
+  courseLat?: number | null
+  courseLng?: number | null
 }
 
 export interface ExistingShot {
@@ -115,13 +121,22 @@ export function RoundMap({
   )
   // Prefer tee over pin so a fresh past-round map opens looking down the
   // hole (where shot 1 starts) rather than zoomed straight at the green.
-  // Falls back to pin only when tee coords are missing — same behaviour
-  // as mobile's PLACE_BALL camera frame.
+  // Falls back to pin, then to course-level coordinates so a course
+  // without per-hole layout data still shows the property — the player
+  // can still tap to place shots manually.
+  const courseFallback = useMemo<[number, number] | null>(() => {
+    if (hole?.courseLat == null || hole?.courseLng == null) return null
+    return [hole.courseLng, hole.courseLat]
+  }, [hole?.courseLat, hole?.courseLng])
   const center = useMemo<[number, number] | null>(() => {
     if (effectiveTee) return [effectiveTee.lng, effectiveTee.lat]
     if (effectivePin) return [effectivePin.lng, effectivePin.lat]
-    return null
-  }, [effectivePin, effectiveTee])
+    return courseFallback
+  }, [effectivePin, effectiveTee, courseFallback])
+  const hasHoleLayout = effectiveTee != null || effectivePin != null
+  // Per-hole layout missing → zoom out so the whole course is visible;
+  // with layout, frame the hole tightly.
+  const targetZoom = hasHoleLayout ? 17 : 15
 
   // Initialize the map once on mount.
   useEffect(() => {
@@ -131,7 +146,7 @@ export function RoundMap({
       container: containerRef.current,
       style: 'mapbox://styles/mapbox/satellite-streets-v12',
       center: center ?? [-97.5, 35.5],
-      zoom: center ? 17 : 12,
+      zoom: center ? targetZoom : 12,
       attributionControl: false,
     })
     map.addControl(
@@ -151,12 +166,14 @@ export function RoundMap({
     }
   }, [])
 
-  // Fly to the active hole when it changes.
+  // Fly to the active hole when it changes. Zoom adapts to whether
+  // per-hole layout data is available — when only the course centroid
+  // is known, frame wider so the player can still see the property.
   useEffect(() => {
     const map = mapRef.current
     if (!map || !center) return
-    map.flyTo({ center, zoom: 17, speed: 1.4 })
-  }, [center?.[0], center?.[1]])
+    map.flyTo({ center, zoom: targetZoom, speed: 1.4 })
+  }, [center?.[0], center?.[1], targetZoom])
 
   // After a non-holed putt save the parent bumps focusGreenSignal —
   // fly in tight on the green so the next putt placement lands on the
@@ -456,6 +473,9 @@ interface RoundMapInstructionStripProps {
   editing?: boolean
   shotsPlaced: number
   remainingToPin: number | null
+  /** False when this hole has no pin coordinates — drives the "— to
+   *  pin" placeholder instead of just hiding the distance silently. */
+  pinAvailable?: boolean
   /** Aim mode: next tap sets aim for the latest placed shot. */
   aimMode?: boolean
   /** Number of placed shots that already have an aim point. */
@@ -477,6 +497,7 @@ export function RoundMapInstructionStrip({
   editing,
   shotsPlaced,
   remainingToPin,
+  pinAvailable = true,
   aimMode = false,
   aimsSet = 0,
   onToggleAimMode,
@@ -546,7 +567,9 @@ export function RoundMapInstructionStrip({
                   }${
                     remainingToPin != null
                       ? ` · ${toDisplay(remainingToPin)} to pin`
-                      : ''
+                      : pinAvailable
+                        ? ''
+                        : ' · — to pin'
                   }.`}
             </div>
           </>

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -2,6 +2,7 @@ import {
   Suspense,
   lazy,
   useCallback,
+  useEffect,
   useMemo,
   useReducer,
   useState,
@@ -325,6 +326,10 @@ export function RoundDetailPage() {
     (activeHole?.tee_lat != null && activeHole?.tee_lng != null
       ? { lat: activeHole.tee_lat, lng: activeHole.tee_lng }
       : null)
+  // Course-level lat/lng pulled off the joined courses row. Used as the
+  // map's fallback camera target when this hole has no tee/pin coords —
+  // most courses imported pre-OSM still lack per-hole layout data.
+  const courseRow = round.data?.courses ?? null
   const activeHoleGeo: HoleGeo | null = activeHole
     ? {
         id: activeHole.id,
@@ -335,8 +340,17 @@ export function RoundDetailPage() {
         teeLng: effectiveTee?.lng ?? null,
         pinLat: effectivePin?.lat ?? null,
         pinLng: effectivePin?.lng ?? null,
+        courseLat: courseRow?.lat ?? null,
+        courseLng: courseRow?.lng ?? null,
       }
     : null
+  // True when the active hole has no per-hole layout in the DB. Drives
+  // the dismissable notice banner above the map and the "— yd to pin"
+  // strip text so the player understands why distances are missing.
+  const missingHoleLayout =
+    activeHole != null &&
+    activeHole.tee_lat == null &&
+    activeHole.pin_lat == null
   const activeHoleShots = useMemo<ExistingShot[]>(() => {
     if (!activeHoleScore) return []
     return (shotsQuery.data ?? [])
@@ -713,6 +727,7 @@ export function RoundDetailPage() {
           placedPoints={placedPoints}
           placedAims={placedAims}
           aimMode={aimMode}
+          missingHoleLayout={missingHoleLayout}
           focusGreenSignal={focusGreenSignal}
           puttingOpen={puttingSheetForIdx != null}
           pinOverride={pinOverride}
@@ -915,6 +930,9 @@ interface MapViewProps {
   placedPoints: PlacedPoint[]
   placedAims: (PlacedPoint | null)[]
   aimMode: boolean
+  /** True when the active hole has neither tee nor pin coordinates in
+   *  the DB — drives the dismissable notice banner above the map. */
+  missingHoleLayout: boolean
   /** True while the putting sheet is open — suppresses tap-to-place so
    *  taps that hit the map under the sheet don't drop new shots. */
   puttingOpen: boolean
@@ -949,6 +967,7 @@ function MapView({
   placedPoints,
   placedAims,
   aimMode,
+  missingHoleLayout,
   puttingOpen,
   focusGreenSignal,
   pinOverride,
@@ -958,6 +977,13 @@ function MapView({
   editingOnMap,
   reviewSheet,
 }: MapViewProps) {
+  // Notice banner sits above the map when the active hole has no tee
+  // or pin coords. Dismiss state resets on every hole switch so the
+  // player isn't surprised by a missing-data hole later in the round.
+  const [noticeDismissed, setNoticeDismissed] = useState(false)
+  useEffect(() => {
+    setNoticeDismissed(false)
+  }, [activeHoleNumber])
   const hasExistingShots = existingShots.some(
     (s) => s.endLat != null && s.endLng != null,
   )
@@ -986,12 +1012,56 @@ function MapView({
         activeNumber={activeHoleNumber}
         onSelect={onSwitchHole}
       />
+      {missingHoleLayout && !noticeDismissed && (
+        <div
+          role="status"
+          style={{
+            marginTop: 14,
+            padding: '10px 14px',
+            background: '#FBF8F1',
+            border: '1px solid #D9D2BF',
+            borderRadius: 2,
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 14,
+          }}
+        >
+          <div style={{ flex: 1 }}>
+            <div className="kicker" style={{ marginBottom: 4 }}>
+              No hole layout
+            </div>
+            <div
+              className="text-caddie-ink-dim"
+              style={{ fontSize: 13, lineHeight: 1.4 }}
+            >
+              No hole layout data for this course. You can still place
+              shots manually.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => setNoticeDismissed(true)}
+            aria-label="Dismiss notice"
+            className="font-mono uppercase text-caddie-ink-mute hover:text-caddie-ink"
+            style={{
+              fontSize: 10,
+              letterSpacing: '0.14em',
+              background: 'transparent',
+              border: 'none',
+              padding: 4,
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
       <div style={{ marginTop: 14 }}>
         <RoundMapInstructionStrip
           hasExistingShots={hasExistingShots}
           editing={editingOnMap}
           shotsPlaced={placedPoints.length}
           remainingToPin={remainingToPin}
+          pinAvailable={effectivePin != null}
           aimMode={aimMode}
           aimsSet={placedAims.filter((a) => a != null).length}
           onToggleAimMode={handlers.onToggleAimMode}

--- a/packages/supabase/src/queries/rounds.ts
+++ b/packages/supabase/src/queries/rounds.ts
@@ -33,7 +33,7 @@ export function getRound(
   return client
     .from('rounds')
     .select(
-      `${ROUND_COLUMNS}, courses(name, city, state), hole_scores(*, holes(*), shots(${SHOT_COLUMNS}))`,
+      `${ROUND_COLUMNS}, courses(name, city, state, lat, lng), hole_scores(*, holes(*), shots(${SHOT_COLUMNS}))`,
     )
     .eq('id', roundId)
     .eq('user_id', userId)

--- a/scripts/import-osm-course.ts
+++ b/scripts/import-osm-course.ts
@@ -10,6 +10,13 @@
  * tee_lat/lng + pin_lat/lng. Re-running is safe: the course is
  * matched by name and holes are upserted on (course_id, number).
  *
+ * Pass --update-existing to refuse creating a new course row and
+ * instead delete-then-replace holes for the matching course. Useful
+ * when re-importing layout for a course that already exists in the
+ * DB; without this flag a stale hole that's no longer in OSM would
+ * remain because the upsert is keyed on (course_id, number) and
+ * doesn't drop missing rows.
+ *
  * Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (read from .env via
  * dotenv/config or the shell).
  */
@@ -37,6 +44,7 @@ interface Args {
   lat: number
   lng: number
   radius: number
+  updateExisting: boolean
 }
 
 function parseArgs(argv: string[]): Args {
@@ -44,6 +52,7 @@ function parseArgs(argv: string[]): Args {
   let lat: number | undefined
   let lng: number | undefined
   let radius: number | undefined
+  let updateExisting = false
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     const next = argv[i + 1]
@@ -59,17 +68,19 @@ function parseArgs(argv: string[]): Args {
     } else if (a === '--radius' && next != null) {
       radius = Number(next)
       i++
+    } else if (a === '--update-existing') {
+      updateExisting = true
     }
   }
   if (!name || lat == null || lng == null || radius == null) {
     throw new Error(
-      'Usage: tsx scripts/import-osm-course.ts --name "<Course Name>" --lat <lat> --lng <lng> --radius <meters>',
+      'Usage: tsx scripts/import-osm-course.ts --name "<Course Name>" --lat <lat> --lng <lng> --radius <meters> [--update-existing]',
     )
   }
   if (!Number.isFinite(lat) || !Number.isFinite(lng) || !Number.isFinite(radius)) {
     throw new Error('--lat, --lng, --radius must be numeric')
   }
-  return { name, lat, lng, radius }
+  return { name, lat, lng, radius, updateExisting }
 }
 
 // ---------------------------------------------------------------------------
@@ -351,6 +362,7 @@ function matchHoles(
 async function upsertCourse(
   name: string,
   centroid: LatLon,
+  updateExisting: boolean,
 ): Promise<{ id: string; created: boolean }> {
   const { data: existing, error: lookupErr } = await supabase
     .from('courses')
@@ -366,6 +378,16 @@ async function upsertCourse(
     if (updateErr) throw updateErr
     return { id: existing.id, created: false }
   }
+  // --update-existing means "operate on a known course only" — bail
+  // out with a clear error rather than silently inserting a duplicate
+  // row when the name match misses (e.g. punctuation drift between
+  // the DB row and the OSM tag).
+  if (updateExisting) {
+    throw new Error(
+      `--update-existing was set but no course matching "${name}" exists. ` +
+        `Re-run without the flag to create it, or fix the --name argument to match the existing row.`,
+    )
+  }
 
   const { data, error } = await supabase
     .from('courses')
@@ -374,6 +396,23 @@ async function upsertCourse(
     .single()
   if (error || !data) throw error ?? new Error('course insert failed')
   return { id: data.id, created: true }
+}
+
+async function deleteHolesForCourse(courseId: string): Promise<number> {
+  // Count first so we can report what was wiped — Supabase delete()
+  // doesn't return the affected row count without a `count: 'exact'`
+  // header, and a separate count keeps the log line accurate.
+  const { count, error: countErr } = await supabase
+    .from('holes')
+    .select('*', { count: 'exact', head: true })
+    .eq('course_id', courseId)
+  if (countErr) throw countErr
+  const { error } = await supabase
+    .from('holes')
+    .delete()
+    .eq('course_id', courseId)
+  if (error) throw error
+  return count ?? 0
 }
 
 async function upsertHoles(courseId: string, holes: MatchedHole[]): Promise<void> {
@@ -420,7 +459,22 @@ async function main() {
   const courseCentroid = centroid(
     matched.flatMap((h) => [h.tee, h.pin]),
   )
-  const { id, created } = await upsertCourse(args.name, courseCentroid)
+  const { id, created } = await upsertCourse(
+    args.name,
+    courseCentroid,
+    args.updateExisting,
+  )
+  // --update-existing wipes the existing holes before inserting fresh
+  // ones, so a hole that's been removed from OSM upstream doesn't
+  // linger in the DB. Default flow (upsert-only) keeps any holes not
+  // present in the new import — desirable for a partial re-import,
+  // but a footgun when the goal is "reset this course's layout".
+  if (args.updateExisting && !created) {
+    const wiped = await deleteHolesForCourse(id)
+    if (wiped > 0) {
+      console.log(`✓ Cleared ${wiped} existing hole row${wiped === 1 ? '' : 's'} on this course`)
+    }
+  }
   await upsertHoles(id, matched)
 
   const greenHits = matched.filter((h) => h.hasGreenMatch).length


### PR DESCRIPTION
## Summary

Most courses in the DB have a course-level lat/lng but no per-hole tee/pin coordinates. Logging a round at one of those courses used to render a near-empty map (no markers, camera flying to FALLBACK_CENTER on mobile, or stuck at zoom 12 anywhere on web). Two fixes plus a tooling improvement so the layout can be backfilled per course.

### 1. Web + mobile: fall through to course centroid

**Web (`apps/web/src/components/round/RoundMap.tsx`, `apps/web/src/pages/rounds/RoundDetailPage.tsx`):**
- `HoleGeo` now carries optional `courseLat` / `courseLng`, threaded off the joined `courses` row in `getRound` (extended `select` to include lat/lng).
- Camera fallback: tee → pin → course centroid. Zoom adapts (17 with per-hole layout, 15 with only the centroid) so the property is visible at the wider frame.
- A dismissable notice banner (`caddie-surface` bg, mono kicker, ink-dim copy) sits above the instruction strip when both `tee_lat` and `pin_lat` are null on the active hole. Dismiss state resets on every hole switch.
- Strip text reads `… · — to pin` instead of going silent when shots are placed but no pin exists. Threaded via a new `pinAvailable` prop on `RoundMapInstructionStrip`.
- 30-yd putt auto-trigger already gated on `effectivePin != null` so it stays off when no pin.

**Mobile (`apps/mobile/components/round/HoleMap.tsx`, `apps/mobile/app/(app)/round/[id]/hole/[number].tsx`):**
- `HoleMap` accepts a `missingHoleLayout` flag and renders a small notice under the existing top hint.
- The hole screen loads `courses(lat, lng)` alongside the round and threads it as the third-tier camera fallback before the hard-coded `FALLBACK_CENTER`.
- Putting auto-switch already gates on `pinTarget` so it stays off when no pin coords exist.

### 2. `scripts/import-osm-course.ts --update-existing`

New flag for refreshing layout on a course that already exists:
- Refuses to create a new row — errors out with a hint to fix `--name` if the lookup misses.
- Deletes all existing holes for the matched course before the upsert, so a hole that's been removed upstream doesn't linger in the DB.
- Default flow (no flag) keeps current upsert-only behaviour, useful for partial / additive re-imports.

Usage:
```
npx tsx scripts/import-osm-course.ts \\
  --name 'Oak Tree National' \\
  --lat <lat> --lng <lng> --radius <m> \\
  --update-existing
```

## Verification

- `pnpm typecheck` — 4/4 packages clean
- `pnpm test` — 242 / 242 passing
- `pnpm --filter web build` — succeeds
- `cd apps/mobile && npm run typecheck` — clean

## Test plan

- [ ] Pick a course in the DB with no per-hole tee/pin (most of them) → open Map view → camera frames the property at zoom 15, no TEE / pin markers, notice banner above the strip
- [ ] Tap to place shots → markers drop, line renders, distance pill says `— to pin`
- [ ] Switch to a hole with full layout (e.g. one imported via `import-osm-course.ts`) → notice banner gone, normal zoom 17, markers + pin distance restored
- [ ] Mobile live round on a no-layout course → camera lands on the course centroid (not the US-middle FALLBACK_CENTER), notice banner under the top hint, putting auto-switch stays off
- [ ] `npx tsx scripts/import-osm-course.ts --name 'Existing Course' --lat ... --lng ... --radius 1500 --update-existing` — confirms existing-hole delete count, then upserts the fresh set
- [ ] Same command with a name that doesn't match → errors out with the "no course matching" message instead of inserting a duplicate