### PR TITLE
fix: map falls back to course coordinates when no hole data

### DIFF
--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -142,6 +142,17 @@ export function RoundMap({
   useEffect(() => {
     if (!containerRef.current || !MAPBOX_TOKEN_PRESENT) return
     if (mapRef.current) return
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.log('[RoundMap] init center', {
+        center,
+        targetZoom,
+        teeLat: hole?.teeLat,
+        pinLat: hole?.pinLat,
+        courseLat: hole?.courseLat,
+        courseLng: hole?.courseLng,
+      })
+    }
     const map = new mapboxgl.Map({
       container: containerRef.current,
       style: 'mapbox://styles/mapbox/satellite-streets-v12',

--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -10,6 +10,7 @@ import {
   createHoles,
   defaultHolesForCourse,
   getCourseByExternalId,
+  getCourseById,
   getCourseTees,
   getHolesForCourse,
   searchCourses,
@@ -52,6 +53,23 @@ export function useCourseSearch(query: string) {
         local: localRows,
         apiAvailable: api.status === 'fulfilled',
       }
+    },
+  })
+}
+
+// Direct course-row fetch by id. Used by RoundDetailPage to read
+// authoritative course lat/lng for the map's fallback camera target —
+// the joined courses(...) field on the round query has been
+// unreliable for the centroid lookup, so a separate direct read
+// avoids the join-shape ambiguity.
+export function useCourse(courseId: string | undefined) {
+  return useQuery({
+    queryKey: ['course', courseId],
+    enabled: !!courseId,
+    queryFn: async () => {
+      const { data, error } = await getCourseById(supabase, courseId!)
+      if (error) throw error
+      return data
     },
   })
 }

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -45,7 +45,11 @@ import {
 } from '../../components/round/WebPuttingSheet'
 import { useDeleteRound, useRound, useRounds } from '../../hooks/useRounds'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
-import { useCourseTees, useHolesForCourse } from '../../hooks/useCourses'
+import {
+  useCourse,
+  useCourseTees,
+  useHolesForCourse,
+} from '../../hooks/useCourses'
 import { useHoleScores, useUpsertHoleScore } from '../../hooks/useHoleScores'
 import { useCreateShot, useShotsForRound } from '../../hooks/useShots'
 import { useCompleteRound } from '../../hooks/useCompleteRound'
@@ -238,6 +242,10 @@ export function RoundDetailPage() {
   const courseId = round.data?.course_id
   const holesQuery = useHolesForCourse(courseId)
   const teesQuery = useCourseTees(courseId)
+  // Direct fetch — the joined courses(...) field on the round query has
+  // been intermittently flat (no lat/lng) for reasons that haven't
+  // panned out in PostgREST. A standalone course read is unambiguous.
+  const courseQuery = useCourse(courseId)
   const holeScoresQuery = useHoleScores(roundId)
   const shotsQuery = useShotsForRound(roundId)
   const upsertHoleScore = useUpsertHoleScore(roundId)
@@ -326,10 +334,14 @@ export function RoundDetailPage() {
     (activeHole?.tee_lat != null && activeHole?.tee_lng != null
       ? { lat: activeHole.tee_lat, lng: activeHole.tee_lng }
       : null)
-  // Course-level lat/lng pulled off the joined courses row. Used as the
-  // map's fallback camera target when this hole has no tee/pin coords —
-  // most courses imported pre-OSM still lack per-hole layout data.
-  const courseRow = round.data?.courses ?? null
+  // Course-level lat/lng pulled from the dedicated course query. The
+  // joined courses(...) field on the round query also exposes lat/lng,
+  // but reading both lets us pick whichever is non-null first — useful
+  // while the join shape stabilises across PostgREST behaviours.
+  const joinedCourse = round.data?.courses ?? null
+  const courseRow = courseQuery.data ?? null
+  const courseFallbackLat = courseRow?.lat ?? joinedCourse?.lat ?? null
+  const courseFallbackLng = courseRow?.lng ?? joinedCourse?.lng ?? null
   const activeHoleGeo: HoleGeo | null = activeHole
     ? {
         id: activeHole.id,
@@ -340,8 +352,8 @@ export function RoundDetailPage() {
         teeLng: effectiveTee?.lng ?? null,
         pinLat: effectivePin?.lat ?? null,
         pinLng: effectivePin?.lng ?? null,
-        courseLat: courseRow?.lat ?? null,
-        courseLng: courseRow?.lng ?? null,
+        courseLat: courseFallbackLat,
+        courseLng: courseFallbackLng,
       }
     : null
   // True when the active hole has no per-hole layout in the DB. Drives

--- a/packages/supabase/src/queries/courses.ts
+++ b/packages/supabase/src/queries/courses.ts
@@ -25,6 +25,14 @@ export function searchCourses(client: OgaSupabaseClient, query: string, limit = 
   })
 }
 
+export function getCourseById(client: OgaSupabaseClient, courseId: string) {
+  return client
+    .from('courses')
+    .select(COURSE_COLUMNS)
+    .eq('id', courseId)
+    .maybeSingle()
+}
+
 export function getHolesForCourse(client: OgaSupabaseClient, courseId: string) {
   return client
     .from('holes')


### PR DESCRIPTION
## Summary

Past-round map kept opening on the generic OKC fallback (`[-97.5, 35.5]`) for courses with no per-hole tee/pin coords, even though the `courses` row carried valid `lat/lng`. PR #169 widened `getRound`'s embedded `courses(...)` to include `lat, lng`, but the joined object has been intermittently flat in production — the field comes back without `lat/lng` and `courseRow?.lat` resolves to `undefined`.

Fix: stop relying on the join for the centroid lookup. Add `getCourseById` + a `useCourse(courseId)` hook and read course coords from the dedicated query in `RoundDetailPage`. The joined value stays as a fallback (still saves a round-trip for callers that only need the name), but the camera target now prefers the direct read.

DEV-only `console.log` in `RoundMap`'s init `useEffect` prints the resolved center, target zoom, and the per-hole / course coords that drove the decision — quick visual confirmation when the map lands somewhere unexpected.

## Verification

- `pnpm typecheck` — 4/4 packages clean
- `pnpm --filter web build` — succeeds

## Test plan

- [ ] Open a round at Oak Tree National (no per-hole tee/pin, but a populated `courses.lat/lng`) → map frames the property at zoom 15, not the OKC fallback at zoom 12
- [ ] Console (DEV build) shows `[RoundMap] init center` with the course coords and the chosen zoom
- [ ] Open a round at a course with full layout → map frames the active hole tee at zoom 17, course coords ignored
- [ ] Switch holes → flyTo fires with the new hole's tee, or stays on course centroid if the new hole also lacks layout