### PR TITLE
debug: add diagnostic logs to trace course coordinate flow

### DIFF
--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -94,6 +94,26 @@ export function RoundMap({
   onMoveTee,
   onSetAim,
 }: RoundMapProps) {
+  // Top-of-component log so we can confirm RoundMap mounts at all and
+  // see the props actually arriving — the previous in-effect log only
+  // fires after the first render, and a missing log there couldn't tell
+  // us whether the component never rendered or just rendered with the
+  // wrong inputs.
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log('[RoundMap] component rendering, props:', {
+      holeId: hole?.id ?? null,
+      holeNumber: hole?.number ?? null,
+      teeLat: hole?.teeLat ?? null,
+      teeLng: hole?.teeLng ?? null,
+      pinLat: hole?.pinLat ?? null,
+      pinLng: hole?.pinLng ?? null,
+      courseLat: hole?.courseLat ?? null,
+      courseLng: hole?.courseLng ?? null,
+      placedPointsCount: placedPoints.length,
+      existingShotsCount: existingShots.length,
+    })
+  }
   const { toDisplay } = useUnits()
   // Memoized so downstream effects can dep on the object directly without
   // thrashing on every parent render — coords are the only meaningful

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -342,6 +342,20 @@ export function RoundDetailPage() {
   const courseRow = courseQuery.data ?? null
   const courseFallbackLat = courseRow?.lat ?? joinedCourse?.lat ?? null
   const courseFallbackLng = courseRow?.lng ?? joinedCourse?.lng ?? null
+  if (import.meta.env.DEV) {
+    // eslint-disable-next-line no-console
+    console.log('[RoundDetail] course from useCourse:', courseRow)
+    // eslint-disable-next-line no-console
+    console.log('[RoundDetail] round.course (joined):', joinedCourse)
+    // eslint-disable-next-line no-console
+    console.log('[RoundDetail] resolved fallback coords:', {
+      lat: courseFallbackLat,
+      lng: courseFallbackLng,
+      activeHoleNumber,
+      teeLat: activeHole?.tee_lat ?? null,
+      pinLat: activeHole?.pin_lat ?? null,
+    })
+  }
   const activeHoleGeo: HoleGeo | null = activeHole
     ? {
         id: activeHole.id,


### PR DESCRIPTION
## Summary

PR #170's init log never appeared on the prod deploy because it (and these new ones) gate on \`import.meta.env.DEV\`. Adds three more checkpoints so the next \`pnpm dev\` session can pin down whether the issue is RoundMap not mounting, props arriving empty, the standalone \`useCourse\` returning null, or the joined \`courses(...)\` field landing flat.

- \`[RoundMap] component rendering, props: …\` — top of component body. Fires every render, prints \`hole.id\`, \`teeLat\`, \`pinLat\`, \`courseLat\`, \`courseLng\`, plus shot counts. Confirms whether the component runs at all.
- \`[RoundDetail] course from useCourse: …\` — what the dedicated \`getCourseById\` query returns.
- \`[RoundDetail] round.course (joined): …\` — what the embedded \`courses(...)\` field on \`getRound\` returns.
- \`[RoundDetail] resolved fallback coords: …\` — final lat/lng threaded into \`HoleGeo\`, alongside the raw \`tee_lat\` / \`pin_lat\` on the active hole.

All four DEV-only — production tree-shakes the \`import.meta.env.DEV\` branches out, so this PR is safe to merge without leaking to prod consoles. Use \`pnpm dev --filter=web\` locally to see them.

## Verification

- \`pnpm typecheck\` — 4/4 packages clean
- \`pnpm --filter web build\` — succeeds

## Test plan

- [ ] \`pnpm dev --filter=web\`, open Oak Tree National round at \`/rounds/<id>?view=map\` in DevTools
- [ ] Confirm \`[RoundMap] component rendering, props\` prints. If absent, the map component isn't mounting at all.
- [ ] Compare \`[RoundDetail] course from useCourse\` vs \`[RoundDetail] round.course (joined)\` — first one should carry \`lat/lng\`; if both are null/empty the join + standalone fetch are both failing (RLS / dropped column / wrong courseId).
- [ ] If coords are present in the RoundDetail logs but \`courseLat/courseLng\` is null in the RoundMap log, the prop is being lost between parent and child.