### PR TITLE
fix: map flies to course coords when hole data unavailable

### DIFF
--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -94,26 +94,6 @@ export function RoundMap({
   onMoveTee,
   onSetAim,
 }: RoundMapProps) {
-  // Top-of-component log so we can confirm RoundMap mounts at all and
-  // see the props actually arriving — the previous in-effect log only
-  // fires after the first render, and a missing log there couldn't tell
-  // us whether the component never rendered or just rendered with the
-  // wrong inputs.
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log('[RoundMap] component rendering, props:', {
-      holeId: hole?.id ?? null,
-      holeNumber: hole?.number ?? null,
-      teeLat: hole?.teeLat ?? null,
-      teeLng: hole?.teeLng ?? null,
-      pinLat: hole?.pinLat ?? null,
-      pinLng: hole?.pinLng ?? null,
-      courseLat: hole?.courseLat ?? null,
-      courseLng: hole?.courseLng ?? null,
-      placedPointsCount: placedPoints.length,
-      existingShotsCount: existingShots.length,
-    })
-  }
   const { toDisplay } = useUnits()
   // Memoized so downstream effects can dep on the object directly without
   // thrashing on every parent render — coords are the only meaningful
@@ -139,45 +119,51 @@ export function RoundMap({
   const hasExistingShots = existingShots.some(
     (s) => s.endLat != null && s.endLng != null,
   )
-  // Prefer tee over pin so a fresh past-round map opens looking down the
-  // hole (where shot 1 starts) rather than zoomed straight at the green.
-  // Falls back to pin, then to course-level coordinates so a course
-  // without per-hole layout data still shows the property — the player
-  // can still tap to place shots manually.
-  const courseFallback = useMemo<[number, number] | null>(() => {
-    if (hole?.courseLat == null || hole?.courseLng == null) return null
-    return [hole.courseLng, hole.courseLat]
-  }, [hole?.courseLat, hole?.courseLng])
-  const center = useMemo<[number, number] | null>(() => {
-    if (effectiveTee) return [effectiveTee.lng, effectiveTee.lat]
-    if (effectivePin) return [effectivePin.lng, effectivePin.lat]
-    return courseFallback
-  }, [effectivePin, effectiveTee, courseFallback])
-  const hasHoleLayout = effectiveTee != null || effectivePin != null
-  // Per-hole layout missing → zoom out so the whole course is visible;
-  // with layout, frame the hole tightly.
-  const targetZoom = hasHoleLayout ? 17 : 15
+  // Single camera target with priority order: hole tee → hole pin →
+  // course centroid → hard-coded OKC default. Course rows missing
+  // lat/lng entirely fall to OKC zoom 11 so the player isn't stranded
+  // at the world view if every tier comes back null. useMemo gives a
+  // stable identity when the underlying coords don't change, so the
+  // camera effect below only fires when something actually moved.
+  const cameraTarget = useMemo<{
+    center: [number, number]
+    zoom: number
+  }>(() => {
+    if (effectiveTee) {
+      return { center: [effectiveTee.lng, effectiveTee.lat], zoom: 17 }
+    }
+    if (effectivePin) {
+      return { center: [effectivePin.lng, effectivePin.lat], zoom: 15 }
+    }
+    if (hole?.courseLat != null && hole?.courseLng != null) {
+      return { center: [hole.courseLng, hole.courseLat], zoom: 15 }
+    }
+    return { center: [-97.5, 35.5], zoom: 11 }
+  }, [
+    effectiveTee?.lat,
+    effectiveTee?.lng,
+    effectivePin?.lat,
+    effectivePin?.lng,
+    hole?.courseLat,
+    hole?.courseLng,
+  ])
 
-  // Initialize the map once on mount.
+  const initialPositionDoneRef = useRef(false)
+
+  // Initialize at a neutral world view. The reactive camera effect
+  // below positions it as soon as any priority tier resolves —
+  // decoupling init from positioning fixes a race where the map
+  // captured a stale center on mount (before useCourse / the joined
+  // courses field returned) and then never re-flew because the
+  // dependent useMemo identity didn't change.
   useEffect(() => {
     if (!containerRef.current || !MAPBOX_TOKEN_PRESENT) return
     if (mapRef.current) return
-    if (import.meta.env.DEV) {
-      // eslint-disable-next-line no-console
-      console.log('[RoundMap] init center', {
-        center,
-        targetZoom,
-        teeLat: hole?.teeLat,
-        pinLat: hole?.pinLat,
-        courseLat: hole?.courseLat,
-        courseLng: hole?.courseLng,
-      })
-    }
     const map = new mapboxgl.Map({
       container: containerRef.current,
       style: 'mapbox://styles/mapbox/satellite-streets-v12',
-      center: center ?? [-97.5, 35.5],
-      zoom: center ? targetZoom : 12,
+      center: [0, 0],
+      zoom: 1,
       attributionControl: false,
     })
     map.addControl(
@@ -197,14 +183,28 @@ export function RoundMap({
     }
   }, [])
 
-  // Fly to the active hole when it changes. Zoom adapts to whether
-  // per-hole layout data is available — when only the course centroid
-  // is known, frame wider so the player can still see the property.
+  // Reactive camera positioning. First valid target snaps the camera
+  // into place (jumpTo, no animation) so a fresh map doesn't spend a
+  // second flying in from the world view. Subsequent target changes
+  // (hole switch, course coords arriving late, focus-on-green after a
+  // putt) animate so the change is visible.
   useEffect(() => {
     const map = mapRef.current
-    if (!map || !center) return
-    map.flyTo({ center, zoom: targetZoom, speed: 1.4 })
-  }, [center?.[0], center?.[1], targetZoom])
+    if (!map) return
+    if (!initialPositionDoneRef.current) {
+      map.jumpTo({
+        center: cameraTarget.center,
+        zoom: cameraTarget.zoom,
+      })
+      initialPositionDoneRef.current = true
+      return
+    }
+    map.flyTo({
+      center: cameraTarget.center,
+      zoom: cameraTarget.zoom,
+      speed: 1.4,
+    })
+  }, [cameraTarget])
 
   // After a non-holed putt save the parent bumps focusGreenSignal —
   // fly in tight on the green so the next putt placement lands on the

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -342,20 +342,6 @@ export function RoundDetailPage() {
   const courseRow = courseQuery.data ?? null
   const courseFallbackLat = courseRow?.lat ?? joinedCourse?.lat ?? null
   const courseFallbackLng = courseRow?.lng ?? joinedCourse?.lng ?? null
-  if (import.meta.env.DEV) {
-    // eslint-disable-next-line no-console
-    console.log('[RoundDetail] course from useCourse:', courseRow)
-    // eslint-disable-next-line no-console
-    console.log('[RoundDetail] round.course (joined):', joinedCourse)
-    // eslint-disable-next-line no-console
-    console.log('[RoundDetail] resolved fallback coords:', {
-      lat: courseFallbackLat,
-      lng: courseFallbackLng,
-      activeHoleNumber,
-      teeLat: activeHole?.tee_lat ?? null,
-      pinLat: activeHole?.pin_lat ?? null,
-    })
-  }
   const activeHoleGeo: HoleGeo | null = activeHole
     ? {
         id: activeHole.id,


### PR DESCRIPTION
## Summary

Decouples Mapbox initialization from camera positioning so the camera reliably tracks asynchronously-resolved coords. The map now mounts at a neutral world view (\`[0,0]\` zoom 1) and a single reactive effect positions it whenever any priority tier resolves:

| Priority | Source | Zoom |
|---|---|---|
| 1 | active hole tee_lat / tee_lng | 17 |
| 2 | active hole pin_lat / pin_lng | 15 |
| 3 | course lat / lng (course centroid) | 15 |
| 4 | OKC default \`[-97.5, 35.5]\` | 11 |

\`useMemo\` returns a \`cameraTarget\` object that's stable when underlying coords don't change, and the effect deps directly on it. First valid target uses \`jumpTo\` (instant — initial paint isn't animated from the world view); subsequent changes (hole switch, course coords arriving late, focus-on-green after a putt) animate via \`flyTo\`.

### Why the previous structure missed for Oak Tree

PR #169 widened \`getRound\`'s embedded \`courses(...)\` to include lat/lng, and PR #170 added a standalone \`useCourse(courseId)\` to read the same data without depending on the join shape. Both data paths worked under happy-path testing.

What broke for Oak Tree National was the *order of operations*:

1. \`MapView\` rendered as soon as \`round.isLoading\` settled — before \`courseQuery\` had resolved.
2. \`RoundMap\` mounted; the constructor's \`center\` argument resolved to \`null\` (no tee, no pin, no course-from-join, no course-from-useCourse yet) and fell through to \`[-97.5, 35.5]\` zoom 12.
3. When \`useCourse\` resolved, the \`center\` \`useMemo\` re-identified to course coords. The follow-up \`flyTo\` effect *should* have fired (deps on \`center?.[0]\` / \`center?.[1]\`).
4. But: the joined \`courses(...)\` field on \`getRound\` came back without lat/lng for this row in production (likely a PostgREST shape edge case the typed DB inference doesn't catch), so even after both queries settled the underlying inputs stayed null. \`center\` never moved off the OKC fallback and the flyTo never fired.

The new structure fixes this two ways: the \`cameraTarget\` memo always returns a valid target (OKC last resort instead of \`null\`), and the effect uses \`jumpTo\` for the first apply so the initial paint is the right place even if data is still loading. When real coords arrive later the effect runs again and \`flyTo\` animates to them.

### Cleanup

Drops the DEV-only \`console.log\` calls added in PRs #170 / #171 — they were tree-shaken out of the prod bundle (which is why you couldn't see them) and the structural fix makes them moot. Both \`useCourse\` and the joined-course path stay so the camera priority chain has two independent sources for course lat/lng.

## Verification

- \`pnpm typecheck\` — 4/4 packages clean
- \`pnpm --filter web build\` — succeeds

## Test plan

- [ ] Open a round at Oak Tree National → map snaps to course coords at zoom 15, no OKC default frame
- [ ] Open a round at a course with full layout → map snaps to active hole tee at zoom 17
- [ ] Switch to a different hole on the same course → flyTo animates to the new tee
- [ ] Mid-round, save a non-holed putt → flyTo animates to pin at zoom 18 (focus-green effect untouched)
- [ ] Open a round at a course where \`courses.lat\` is null in the DB → map lands on OKC default at zoom 11 (last-resort fallback, not silent world view)