### PR TITLE
fix: map centers on course coords using load event

### DIFF
--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -38,6 +38,12 @@ export interface PlacedPoint {
 
 interface RoundMapProps {
   hole: HoleGeo | null
+  /** Course-level lat/lng — direct prop, independent of `hole`.
+   *  Surfaces course centroid even when `hole` is null (e.g. courses
+   *  with no rows in the holes table). HoleGeo.courseLat/courseLng
+   *  is still honoured but only as a secondary read. */
+  courseLat?: number | null
+  courseLng?: number | null
   /** Pre-existing shots (live-tracked or previously saved). */
   existingShots: ExistingShot[]
   /** Tap-placed points for the active hole when no existing shots are
@@ -80,6 +86,8 @@ const MARKER_COLORS = {
 
 export function RoundMap({
   hole,
+  courseLat,
+  courseLng,
   existingShots,
   placedPoints,
   placedAims,
@@ -119,6 +127,14 @@ export function RoundMap({
   const hasExistingShots = existingShots.some(
     (s) => s.endLat != null && s.endLng != null,
   )
+  // Course centroid resolves from a direct prop first (so a course
+  // with zero rows in the holes table — and therefore a null `hole`
+  // — still drops the camera on the property), and only falls back
+  // to the optional HoleGeo.courseLat/Lng for callers that haven't
+  // adopted the direct props yet.
+  const effectiveCourseLat = courseLat ?? hole?.courseLat ?? null
+  const effectiveCourseLng = courseLng ?? hole?.courseLng ?? null
+
   // Single camera target with priority order: hole tee → hole pin →
   // course centroid → hard-coded OKC default. Course rows missing
   // lat/lng entirely fall to OKC zoom 11 so the player isn't stranded
@@ -135,8 +151,8 @@ export function RoundMap({
     if (effectivePin) {
       return { center: [effectivePin.lng, effectivePin.lat], zoom: 15 }
     }
-    if (hole?.courseLat != null && hole?.courseLng != null) {
-      return { center: [hole.courseLng, hole.courseLat], zoom: 15 }
+    if (effectiveCourseLat != null && effectiveCourseLng != null) {
+      return { center: [effectiveCourseLng, effectiveCourseLat], zoom: 15 }
     }
     return { center: [-97.5, 35.5], zoom: 11 }
   }, [
@@ -144,18 +160,17 @@ export function RoundMap({
     effectiveTee?.lng,
     effectivePin?.lat,
     effectivePin?.lng,
-    hole?.courseLat,
-    hole?.courseLng,
+    effectiveCourseLat,
+    effectiveCourseLng,
   ])
 
   const initialPositionDoneRef = useRef(false)
+  const [mapLoaded, setMapLoaded] = useState(false)
 
-  // Initialize at a neutral world view. The reactive camera effect
-  // below positions it as soon as any priority tier resolves —
-  // decoupling init from positioning fixes a race where the map
-  // captured a stale center on mount (before useCourse / the joined
-  // courses field returned) and then never re-flew because the
-  // dependent useMemo identity didn't change.
+  // Initialize at a neutral world view. The camera positioning waits
+  // for the 'load' event below — Mapbox happily queues jumpTo on a
+  // mid-load map, but a load gate makes the timing explicit and
+  // matches what production was actually doing under the hood.
   useEffect(() => {
     if (!containerRef.current || !MAPBOX_TOKEN_PRESENT) return
     if (mapRef.current) return
@@ -176,19 +191,23 @@ export function RoundMap({
       new mapboxgl.NavigationControl({ showCompass: false }),
       'bottom-right',
     )
+    map.on('load', () => setMapLoaded(true))
     mapRef.current = map
     return () => {
       map.remove()
       mapRef.current = null
+      setMapLoaded(false)
     }
   }, [])
 
-  // Reactive camera positioning. First valid target snaps the camera
-  // into place (jumpTo, no animation) so a fresh map doesn't spend a
-  // second flying in from the world view. Subsequent target changes
-  // (hole switch, course coords arriving late, focus-on-green after a
-  // putt) animate so the change is visible.
+  // Reactive camera positioning. Gated on `mapLoaded` so we never call
+  // jumpTo against an instance whose style hasn't finished initializing
+  // — which is the failure mode the OKC-stuck bug was hitting in
+  // production. First valid target after load snaps (jumpTo, instant);
+  // subsequent target changes (hole switch, course coords arriving
+  // late, focus-on-green after a putt) animate via flyTo.
   useEffect(() => {
+    if (!mapLoaded) return
     const map = mapRef.current
     if (!map) return
     if (!initialPositionDoneRef.current) {
@@ -204,7 +223,7 @@ export function RoundMap({
       zoom: cameraTarget.zoom,
       speed: 1.4,
     })
-  }, [cameraTarget])
+  }, [mapLoaded, cameraTarget])
 
   // After a non-holed putt save the parent bumps focusGreenSignal —
   // fly in tight on the green so the next putt placement lands on the

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -735,6 +735,8 @@ export function RoundDetailPage() {
           activeHoleNumber={activeHoleNumber}
           onSwitchHole={switchHole}
           activeHoleGeo={activeHoleGeo}
+          courseLat={courseFallbackLat}
+          courseLng={courseFallbackLng}
           existingShots={activeHoleShots}
           placedPoints={placedPoints}
           placedAims={placedAims}
@@ -938,6 +940,11 @@ interface MapViewProps {
   activeHoleNumber: number
   onSwitchHole: (n: number) => void
   activeHoleGeo: HoleGeo | null
+  /** Course-level lat/lng — passed to RoundMap as a direct prop so the
+   *  camera can fall back to the course centroid even when activeHoleGeo
+   *  is null (course rows with no entries in the holes table). */
+  courseLat: number | null
+  courseLng: number | null
   existingShots: ExistingShot[]
   placedPoints: PlacedPoint[]
   placedAims: (PlacedPoint | null)[]
@@ -975,6 +982,8 @@ function MapView({
   activeHoleNumber,
   onSwitchHole,
   activeHoleGeo,
+  courseLat,
+  courseLng,
   existingShots,
   placedPoints,
   placedAims,
@@ -1100,6 +1109,8 @@ function MapView({
         <Suspense fallback={<MapLoading />}>
           <RoundMap
             hole={activeHoleGeo}
+            courseLat={courseLat}
+            courseLng={courseLng}
             existingShots={existingShots}
             placedPoints={placedPoints}
             placedAims={placedAims}


### PR DESCRIPTION
## Summary

Two changes that should finally close the OKC-stuck loop for courses with no per-hole layout (Oak Tree National being the test case).

### 1. \`courseLat\` / \`courseLng\` are direct props on \`RoundMap\`

PR #169 + #170 + #172 all threaded the course centroid through \`HoleGeo.courseLat\` / \`courseLng\`. That works when the active hole exists. **But when the \`holes\` table has zero rows for the course** (true for several OSM-only imports — the course row exists with \`lat\`/\`lng\`, no holes are attached), \`holes.find(…)\` returns undefined → \`activeHole\` is null → \`activeHoleGeo\` is null → \`hole?.courseLat\` inside \`RoundMap\` is undefined → \`cameraTarget\` falls through to the OKC last-resort.

That matches the user-reported center of \`~35.46, -97.51\` exactly: it's the literal \`[-97.5, 35.5]\` zoom 11 from the cameraTarget OKC fallback, not a misframe of the actual course.

\`RoundMap\` now accepts \`courseLat\` / \`courseLng\` as direct props that survive a null \`hole\`. \`MapView\` and \`RoundDetailPage\` thread them straight from \`courseFallbackLat\` / \`courseFallbackLng\` (which already merges \`useCourse\` + the joined \`courses(...)\` field). \`HoleGeo.courseLat\` / \`courseLng\` is still honoured as a secondary read — only consulted if the direct prop is null — so we don't break callers that haven't been migrated.

### 2. Camera positioning gates on \`map.on('load')\`

Mapbox documents that \`jumpTo\` / \`flyTo\` are safe to call before style load — they queue. In practice the previous structure relied on that, and the camera moves were silently dropped in this specific failure mode. Now explicit:

\`\`\`ts
const [mapLoaded, setMapLoaded] = useState(false)
…
map.on('load', () => setMapLoaded(true))
…
useEffect(() => {
  if (!mapLoaded) return
  …  // jumpTo first time, flyTo after
}, [mapLoaded, cameraTarget])
\`\`\`

First valid \`cameraTarget\` after load snaps (jumpTo, instant — initial paint isn't animated from the world view); subsequent target changes animate.

## Verification

- \`pnpm typecheck\` — 4/4 packages clean
- \`pnpm --filter web build\` — succeeds

## Test plan

- [ ] Open Oak Tree National round → map snaps to \`(35.7192, -97.5054)\` zoom 15. Confirms direct prop reached the camera even with zero hole rows.
- [ ] Open a round at a course with a populated holes table and full per-hole layout → map snaps to active hole tee at zoom 17.
- [ ] Switch to a different hole on the same course → flyTo animates to the new tee.
- [ ] Save a non-holed putt → flyTo animates to pin at zoom 18 (focus-green effect untouched).
- [ ] Open a round at a course where \`courses.lat\` is null in the DB → map lands on OKC zoom 11 last resort.