### PR TITLE
feat: manual tee/pin placement for courses without hole data

### DIFF
--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -68,6 +68,10 @@ interface RoundMapProps {
   /** Suppress tap-to-place. Used in "Edit on map" mode so the user can
    *  drag existing markers without accidentally dropping new ones. */
   tapToPlaceDisabled?: boolean
+  /** When set, the next map tap places either the tee box or pin for
+   *  this hole instead of dropping a shot marker. Used for courses with
+   *  no hole layout in the DB so the player can mark them manually. */
+  placementMode?: 'tee' | 'pin' | null
   onPlace: (point: PlacedPoint) => void
   onMovePoint: (index: number, point: PlacedPoint) => void
   onMovePin?: (point: PlacedPoint) => void
@@ -96,6 +100,7 @@ export function RoundMap({
   pinOverride,
   teeOverride,
   tapToPlaceDisabled,
+  placementMode,
   onPlace,
   onMovePoint,
   onMovePin,
@@ -253,6 +258,17 @@ export function RoundMap({
     const map = mapRef.current
     if (!map) return
     function onClick(e: mapboxgl.MapMouseEvent) {
+      // Tee / pin placement wins over every other click outcome — even
+      // when shots already exist, the user explicitly entered placement
+      // mode from the strip and the next tap should land the marker.
+      if (placementMode === 'tee' && onMoveTee) {
+        onMoveTee({ lat: e.lngLat.lat, lng: e.lngLat.lng })
+        return
+      }
+      if (placementMode === 'pin' && onMovePin) {
+        onMovePin({ lat: e.lngLat.lat, lng: e.lngLat.lng })
+        return
+      }
       if (hasExistingShots) return
       if (tapToPlaceDisabled) return
       if (aimMode && onSetAim) {
@@ -275,6 +291,9 @@ export function RoundMap({
     aimMode,
     onSetAim,
     placedPoints.length,
+    placementMode,
+    onMoveTee,
+    onMovePin,
   ])
 
   const renderLayers = useCallback(() => {
@@ -530,6 +549,20 @@ interface RoundMapInstructionStripProps {
   aimMode?: boolean
   /** Number of placed shots that already have an aim point. */
   aimsSet?: number
+  /** Active hole number — surfaced in the manual-placement instruction
+   *  copy so the user knows which hole they're marking up. */
+  holeNumber?: number
+  /** True when no tee coordinate exists for this hole (DB null and no
+   *  session override). Drives the "Place tee box" entry button. */
+  needsTee?: boolean
+  /** True when no pin coordinate exists for this hole. */
+  needsPin?: boolean
+  /** Active manual-placement mode. When set, the strip switches to a
+   *  "tap to place …" prompt with a Cancel button. */
+  placementMode?: 'tee' | 'pin' | null
+  onStartPlaceTee?: () => void
+  onStartPlacePin?: () => void
+  onCancelPlacement?: () => void
   onToggleAimMode?: (on: boolean) => void
   onClearLastAim?: () => void
   onUndo: () => void
@@ -550,6 +583,13 @@ export function RoundMapInstructionStrip({
   pinAvailable = true,
   aimMode = false,
   aimsSet = 0,
+  holeNumber,
+  needsTee = false,
+  needsPin = false,
+  placementMode = null,
+  onStartPlaceTee,
+  onStartPlacePin,
+  onCancelPlacement,
   onToggleAimMode,
   onClearLastAim,
   onUndo,
@@ -559,6 +599,92 @@ export function RoundMapInstructionStrip({
 }: RoundMapInstructionStripProps) {
   const placingNumber = shotsPlaced + 1
   const { toDisplay } = useUnits()
+  if (placementMode) {
+    const holeLabel = holeNumber != null ? ` for hole ${holeNumber}` : ''
+    const targetLabel =
+      placementMode === 'tee' ? 'tee box' : 'pin'
+    return (
+      <div
+        style={{
+          background: '#FBF8F1',
+          border: '1px solid #D9D2BF',
+          borderRadius: 2,
+          padding: '10px 14px',
+          display: 'flex',
+          gap: 14,
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          flexWrap: 'wrap',
+        }}
+      >
+        <div style={{ minWidth: 200 }}>
+          <div className="kicker" style={{ marginBottom: 2 }}>
+            Place {targetLabel}
+          </div>
+          <div className="text-caddie-ink" style={{ fontSize: 13 }}>
+            Tap to place the {targetLabel}{holeLabel}.
+          </div>
+        </div>
+        {onCancelPlacement && (
+          <button
+            type="button"
+            onClick={onCancelPlacement}
+            className="text-caddie-ink-dim"
+            style={{
+              border: '1px solid #D9D2BF',
+              borderRadius: 2,
+              padding: '6px 10px',
+              fontSize: 12,
+              background: 'transparent',
+            }}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+    )
+  }
+  const placeButtons =
+    (needsTee && onStartPlaceTee) || (needsPin && onStartPlacePin) ? (
+      <>
+        {needsTee && onStartPlaceTee && (
+          <button
+            type="button"
+            onClick={onStartPlaceTee}
+            style={{
+              border: '1px solid #5C6356',
+              borderRadius: 2,
+              padding: '6px 10px',
+              fontSize: 12,
+              background: 'transparent',
+              color: '#5C6356',
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+            }}
+          >
+            Place tee box
+          </button>
+        )}
+        {needsPin && onStartPlacePin && (
+          <button
+            type="button"
+            onClick={onStartPlacePin}
+            style={{
+              border: '1px solid #A33A2A',
+              borderRadius: 2,
+              padding: '6px 10px',
+              fontSize: 12,
+              background: 'transparent',
+              color: '#A33A2A',
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+            }}
+          >
+            Place pin
+          </button>
+        )}
+      </>
+    ) : null
   return (
     <div
       style={{
@@ -626,22 +752,26 @@ export function RoundMapInstructionStrip({
         )}
       </div>
       {editing ? (
-        <button
-          type="button"
-          onClick={onDoneEditing}
-          className="bg-caddie-accent text-caddie-accent-ink"
-          style={{
-            borderRadius: 2,
-            padding: '6px 12px',
-            fontSize: 13,
-            fontWeight: 600,
-            letterSpacing: '0.02em',
-          }}
-        >
-          Done editing →
-        </button>
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {placeButtons}
+          <button
+            type="button"
+            onClick={onDoneEditing}
+            className="bg-caddie-accent text-caddie-accent-ink"
+            style={{
+              borderRadius: 2,
+              padding: '6px 12px',
+              fontSize: 13,
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+            }}
+          >
+            Done editing →
+          </button>
+        </div>
       ) : !hasExistingShots ? (
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {placeButtons}
           {onToggleAimMode && shotsPlaced > 0 && (
             <button
               type="button"
@@ -722,6 +852,10 @@ export function RoundMapInstructionStrip({
           >
             Done with hole →
           </button>
+        </div>
+      ) : placeButtons ? (
+        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+          {placeButtons}
         </div>
       ) : null}
     </div>

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -298,7 +298,12 @@ export function RoundMap({
 
   const renderLayers = useCallback(() => {
     const map = mapRef.current
-    if (!map || !hole) return
+    if (!map) return
+    // Markers, lines, distance pills, and aim ghosts render purely off
+    // shot/placed-point coordinates. Tee/pin/aim sub-blocks already
+    // null-check their own inputs (via effectiveTee, effectivePin) so
+    // a course with no row in the holes table still draws shots when
+    // their start/end coords are populated.
 
     // Clear old markers.
     for (const m of markerRefs.current) m.remove()

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -94,6 +94,11 @@ interface HoleViewState {
   focusGreenSignal: number
   pinOverride: PlacedPoint | null
   teeOverride: PlacedPoint | null
+  /** Manual tee/pin placement flow — when set, the next map tap drops
+   *  the corresponding marker instead of starting a shot. Used for
+   *  courses with no hole layout in the DB so the player can mark the
+   *  tee box and pin themselves. */
+  placementMode: 'tee' | 'pin' | null
   reviewOpen: boolean
   editingOnMap: boolean
   saveError: string | null
@@ -112,6 +117,7 @@ type HoleViewAction =
   | { type: 'SET_PUTT'; index: number; data: WebPuttData }
   | { type: 'PIN_OVERRIDE'; point: PlacedPoint | null }
   | { type: 'TEE_OVERRIDE'; point: PlacedPoint | null }
+  | { type: 'PLACEMENT_MODE'; mode: 'tee' | 'pin' | null }
   | { type: 'OPEN_REVIEW' }
   | { type: 'CLOSE_REVIEW' }
   | { type: 'EDIT_ON_MAP'; editing: boolean }
@@ -128,6 +134,7 @@ const HOLE_VIEW_INITIAL: HoleViewState = {
   focusGreenSignal: 0,
   pinOverride: null,
   teeOverride: null,
+  placementMode: null,
   reviewOpen: false,
   editingOnMap: false,
   saveError: null,
@@ -209,9 +216,13 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
       }
     }
     case 'PIN_OVERRIDE':
-      return { ...state, pinOverride: action.point }
+      // A pin write also exits placement mode so the next tap goes back
+      // to dropping shot markers instead of re-placing the pin.
+      return { ...state, pinOverride: action.point, placementMode: null }
     case 'TEE_OVERRIDE':
-      return { ...state, teeOverride: action.point }
+      return { ...state, teeOverride: action.point, placementMode: null }
+    case 'PLACEMENT_MODE':
+      return { ...state, placementMode: action.mode }
     case 'OPEN_REVIEW':
       return { ...state, reviewOpen: true }
     case 'CLOSE_REVIEW':
@@ -278,6 +289,7 @@ export function RoundDetailPage() {
     focusGreenSignal,
     pinOverride,
     teeOverride,
+    placementMode,
     reviewOpen,
     editingOnMap,
     saveError,
@@ -434,6 +446,12 @@ export function RoundDetailPage() {
         dispatchHoleView({ type: 'SET_AIM', index: idx, point }),
       onToggleAimMode: (on: boolean) =>
         dispatchHoleView({ type: 'AIM_MODE', on }),
+      onStartPlaceTee: () =>
+        dispatchHoleView({ type: 'PLACEMENT_MODE', mode: 'tee' }),
+      onStartPlacePin: () =>
+        dispatchHoleView({ type: 'PLACEMENT_MODE', mode: 'pin' }),
+      onCancelPlacement: () =>
+        dispatchHoleView({ type: 'PLACEMENT_MODE', mode: null }),
       onDoneWithHole: () => dispatchHoleView({ type: 'OPEN_REVIEW' }),
       onDoneEditing: () => {
         dispatchHoleView({ type: 'EDIT_ON_MAP', editing: false })
@@ -746,6 +764,7 @@ export function RoundDetailPage() {
           puttingOpen={puttingSheetForIdx != null}
           pinOverride={pinOverride}
           teeOverride={teeOverride}
+          placementMode={placementMode}
           handlers={placeHandlers}
           saveError={saveError}
           editingOnMap={editingOnMap}
@@ -960,6 +979,8 @@ interface MapViewProps {
   focusGreenSignal: number
   pinOverride: PlacedPoint | null
   teeOverride: PlacedPoint | null
+  /** Active manual-placement mode for courses missing hole layout. */
+  placementMode: 'tee' | 'pin' | null
   handlers: {
     onPlace: (p: PlacedPoint) => void
     onMovePoint: (idx: number, p: PlacedPoint) => void
@@ -969,6 +990,9 @@ interface MapViewProps {
     onUndoPoint: () => void
     onSetAim: (idx: number, p: PlacedPoint | null) => void
     onToggleAimMode: (on: boolean) => void
+    onStartPlaceTee: () => void
+    onStartPlacePin: () => void
+    onCancelPlacement: () => void
     onDoneWithHole: () => void
     onDoneEditing: () => void
   }
@@ -993,6 +1017,7 @@ function MapView({
   focusGreenSignal,
   pinOverride,
   teeOverride,
+  placementMode,
   handlers,
   saveError,
   editingOnMap,
@@ -1014,6 +1039,15 @@ function MapView({
     (activeHoleGeo?.pinLat != null && activeHoleGeo?.pinLng != null
       ? { lat: activeHoleGeo.pinLat, lng: activeHoleGeo.pinLng }
       : null)
+  const effectiveTee =
+    teeOverride ??
+    (activeHoleGeo?.teeLat != null && activeHoleGeo?.teeLng != null
+      ? { lat: activeHoleGeo.teeLat, lng: activeHoleGeo.teeLng }
+      : null)
+  // Manual placement entry points only render when the active hole has
+  // no coord for that target. Tee/pin both null = course w/o hole layout.
+  const needsTee = activeHoleGeo != null && effectiveTee == null
+  const needsPin = activeHoleGeo != null && effectivePin == null
   const remainingToPin =
     lastPoint && effectivePin
       ? Math.round(
@@ -1085,6 +1119,13 @@ function MapView({
           pinAvailable={effectivePin != null}
           aimMode={aimMode}
           aimsSet={placedAims.filter((a) => a != null).length}
+          holeNumber={activeHoleNumber}
+          needsTee={needsTee}
+          needsPin={needsPin}
+          placementMode={placementMode}
+          onStartPlaceTee={handlers.onStartPlaceTee}
+          onStartPlacePin={handlers.onStartPlacePin}
+          onCancelPlacement={handlers.onCancelPlacement}
           onToggleAimMode={handlers.onToggleAimMode}
           onClearLastAim={() => {
             const idx = placedAims.length - 1
@@ -1119,6 +1160,7 @@ function MapView({
             pinOverride={pinOverride}
             teeOverride={teeOverride}
             tapToPlaceDisabled={editingOnMap || puttingOpen}
+            placementMode={placementMode}
             onPlace={handlers.onPlace}
             onMovePoint={handlers.onMovePoint}
             onMovePin={handlers.onMovePin}


### PR DESCRIPTION
## Summary
- Add manual tee box + pin placement for courses with no rows in the `holes` table layout (tee_lat/pin_lat null). Buttons in the instruction strip enter a placement mode; the next map tap drops the marker. Pin persists via existing `hole_scores.pin_lat/pin_lng` write; tee stays as session override (no DB column).
- Shot markers, lines, distance pills, and aim ghosts now render purely off shot coords. Removed the `!hole` gate in `renderLayers` so placed shots draw on courses with no hole layout too.

## Test plan
- [ ] Open a round on a course with no hole coords → "Place tee box" + "Place pin" buttons appear; tap a location places each. Markers and instructions return to the normal shot flow afterward.
- [ ] Cancel button exits placement mode without dropping a marker.
- [ ] After placement, drag handles still work for tee + pin.
- [ ] Course with full hole data still flows normally (no buttons, taps drop shots).
- [ ] Place shots on a coord-less course → numbered markers + connecting lines + distance pills render as expected.
- [ ] `pnpm typecheck` and `pnpm --filter web build` pass.