### PR TITLE
fix: synthetic holes fallback unblocks rounds on coord-less courses

### DIFF
--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -4,6 +4,7 @@ import {
   LIE_TYPES,
   NEAR_GREEN_YARDS,
   buildInitialRows,
+  haversineYards,
   type Club,
   type LieType,
   type PuttDirectionResult,
@@ -86,18 +87,33 @@ export function HoleReviewSheet({
       hydratedHoleRef.current = null
       return
     }
-    if (pinLat == null || pinLng == null) {
-      setRows([])
-      return
-    }
     if (hydratedHoleRef.current === holeNumber) return
     hydratedHoleRef.current = holeNumber
-    const baseRows = buildInitialRows(
-      placedPointsRef.current,
-      par,
-      pinLat,
-      pinLng,
-    )
+    // When pin coords are unavailable (course has no OSM hole layout and
+    // the user hasn't manually placed a pin), build rows directly from
+    // placed points: end of shot N is the next placed point, last shot
+    // ends at itself, and distance-to-pin reads 0. The user picks club /
+    // lie manually since we can't infer them from a missing pin context.
+    const points = placedPointsRef.current
+    const baseRows: ReviewedShotRow[] =
+      pinLat != null && pinLng != null
+        ? buildInitialRows(points, par, pinLat, pinLng)
+        : points.map((p, idx) => {
+            const isLast = idx === points.length - 1
+            const next = isLast ? p : points[idx + 1]!
+            return {
+              shotNumber: idx + 1,
+              club: 'driver',
+              lieType: idx === 0 ? 'tee' : 'fairway',
+              startLat: p.lat,
+              startLng: p.lng,
+              endLat: next.lat,
+              endLng: next.lng,
+              distanceYards: haversineYards(p.lat, p.lng, next.lat, next.lng),
+              distanceToPin: 0,
+              isLastShot: isLast,
+            }
+          })
     const putts = placedPuttsRef.current ?? []
     // Merge any inline-collected putt data into the inferred rows so the
     // player doesn't have to re-enter what they just answered in the

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -296,7 +296,47 @@ export function RoundDetailPage() {
   } = holeView
   const [savingHole, setSavingHole] = useState(false)
 
-  const holes = useMemo(() => holesQuery.data ?? [], [holesQuery.data])
+  // Synthetic fallback when the course has no rows in the `holes` table
+  // (typical for OSM-imported courses that never went through enrichment).
+  // Without this, every downstream feature gates on `activeHole` being
+  // non-null and the round detail page locks up: scorecard renders no
+  // rows, map placement buttons hide, review sheet can't open. Synthesize
+  // either from hole_scores (real hole_ids + joined par survive a
+  // refresh) or as 18 par-4 placeholders so the UI is at least usable.
+  type HSWithJoin = HoleScoreRow & { holes?: { par?: number | null } | null }
+  const holes = useMemo<HoleRow[]>(() => {
+    const fetched = holesQuery.data ?? []
+    if (fetched.length > 0) return fetched
+    const roundData = round.data
+    if (!roundData) return []
+    const scores = (roundData as { hole_scores?: HSWithJoin[] }).hole_scores
+    if (scores && scores.length > 0) {
+      return scores.map((hs, i) => ({
+        id: hs.hole_id,
+        course_id: roundData.course_id,
+        number: i + 1,
+        par: hs.holes?.par ?? 4,
+        yards: null,
+        stroke_index: i + 1,
+        tee_lat: null,
+        tee_lng: null,
+        pin_lat: null,
+        pin_lng: null,
+      }))
+    }
+    return Array.from({ length: 18 }, (_, i) => ({
+      id: `synthetic-${roundData.id}-hole-${i + 1}`,
+      course_id: roundData.course_id,
+      number: i + 1,
+      par: 4,
+      yards: null,
+      stroke_index: i + 1,
+      tee_lat: null,
+      tee_lng: null,
+      pin_lat: null,
+      pin_lng: null,
+    }))
+  }, [holesQuery.data, round.data])
   const rawScores: Array<HoleScoreRow & { holes?: HoleRow | null }> = useMemo(
     () => holeScoresQuery.data ?? [],
     [holeScoresQuery.data],


### PR DESCRIPTION
## Summary
- `RoundDetailPage` synthesizes `holes` rows when `useHolesForCourse` returns empty. Prefers `round.hole_scores` (real `hole_id` + joined par survives a refresh); else generates 18 par-4 placeholders so brand-new rounds on coord-less courses still render.
- `HoleReviewSheet` no longer bails with empty rows when pin coords are unavailable. Builds rows directly from placed points (end of N = next placed point, last shot ends at itself, distance-to-pin = 0). Save is reachable.

Together these unwire the `activeHole != null` cascade that was blocking placement buttons, scorecard rows, shot markers, and the review sheet on courses with no rows in the `holes` table.

## Test plan
- [ ] Open a round on a course with zero rows in the `holes` table → scorecard renders 18 rows; map view shows placement buttons; shot markers from prior taps render.
- [ ] Place shots without setting a pin, click "Done with hole" → review sheet opens with rows populated, save button enabled.
- [ ] Course WITH normal hole layout still flows unchanged (no synthetic path triggered).
- [ ] `pnpm typecheck` and `pnpm --filter web build` pass.