### PR TITLE
feat: editable par on scorecard for courses without hole data

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -1225,6 +1225,23 @@ export default function HoleScreen() {
               router.replace(`/(app)/round/${id}/hole/${n}`)
             }
           }}
+          onChangePar={async (holeId, newPar) => {
+            // Optimistic update so the cell reflects the tap immediately.
+            // Roll back if the DB write fails so the UI doesn't lie.
+            const prev = holes.find((h) => h.id === holeId)?.par ?? 4
+            setHoles((cur) =>
+              cur.map((h) => (h.id === holeId ? { ...h, par: newPar } : h)),
+            )
+            const { error: parErr } = await supabase
+              .from('holes')
+              .update({ par: newPar })
+              .eq('id', holeId)
+            if (parErr) {
+              setHoles((cur) =>
+                cur.map((h) => (h.id === holeId ? { ...h, par: prev } : h)),
+              )
+            }
+          }}
           onClose={() => setScorecardOpen(false)}
         />
       </Modal>

--- a/apps/mobile/components/round/Scorecard.tsx
+++ b/apps/mobile/components/round/Scorecard.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
 import type { Database } from '@oga/supabase'
 
@@ -18,6 +18,11 @@ interface ScorecardModalProps {
   holeScores: HoleScoreRow[]
   currentHoleNumber: number
   onJumpToHole: (n: number) => void
+  /** Tap-to-cycle par 3 → 4 → 5 → 3 for holes that came back with no
+   *  layout data (yards null + tee coords null — typical OSM-only rows).
+   *  Optional so callers that don't yet wire the update can still mount
+   *  the modal read-only. */
+  onChangePar?: (holeId: string, newPar: number) => void
   onClose: () => void
 }
 
@@ -26,6 +31,7 @@ export function ScorecardModal({
   holeScores,
   currentHoleNumber,
   onJumpToHole,
+  onChangePar,
   onClose,
 }: ScorecardModalProps) {
   const scoresByHoleId = useMemo(
@@ -36,6 +42,10 @@ export function ScorecardModal({
     () => [...holes].sort((a, b) => a.number - b.number),
     [holes],
   )
+  const hasSyntheticHoles = sorted.some(
+    (h) => !h.yards && h.tee_lat == null,
+  )
+  const [hintDismissed, setHintDismissed] = useState(false)
   let runningTotal = 0
   let runningPar = 0
   return (
@@ -71,6 +81,33 @@ export function ScorecardModal({
         >
           Scorecard
         </Text>
+        {hasSyntheticHoles && !hintDismissed && onChangePar && (
+          <View
+            style={{
+              marginBottom: 10,
+              paddingHorizontal: 12,
+              paddingVertical: 8,
+              borderWidth: 1,
+              borderColor: '#D9D2BF',
+              borderRadius: 2,
+              flexDirection: 'row',
+              alignItems: 'flex-start',
+              gap: 12,
+            }}
+          >
+            <Text style={{ flex: 1, fontSize: 13, color: '#5C6356', lineHeight: 18 }}>
+              No course layout found. Par defaults to 4 — tap to edit.
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Dismiss notice"
+              onPress={() => setHintDismissed(true)}
+              hitSlop={8}
+            >
+              <Text style={{ ...KICKER, color: '#8A8B7E' }}>Dismiss</Text>
+            </Pressable>
+          </View>
+        )}
         <ScrollView
           style={{ maxHeight: '90%' }}
           showsVerticalScrollIndicator={false}
@@ -136,17 +173,49 @@ export function ScorecardModal({
                 >
                   {h.number}
                 </Text>
-                <Text
-                  style={{
-                    width: 44,
-                    textAlign: 'right',
-                    fontSize: 15,
-                    color: '#5C6356',
-                    fontVariant: ['tabular-nums'],
-                  }}
-                >
-                  {h.par}
-                </Text>
+                {!h.yards && h.tee_lat == null && onChangePar ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={`Par ${h.par}, tap to change`}
+                    onPress={() => {
+                      const next = h.par === 3 ? 4 : h.par === 4 ? 5 : 3
+                      onChangePar(h.id, next)
+                    }}
+                    hitSlop={6}
+                    style={{
+                      width: 44,
+                      alignItems: 'flex-end',
+                      paddingVertical: 2,
+                      paddingHorizontal: 4,
+                      borderWidth: 1,
+                      borderStyle: 'dashed',
+                      borderColor: '#9F9580',
+                      borderRadius: 2,
+                    }}
+                  >
+                    <Text
+                      style={{
+                        fontSize: 15,
+                        color: '#5C6356',
+                        fontVariant: ['tabular-nums'],
+                      }}
+                    >
+                      {h.par}
+                    </Text>
+                  </Pressable>
+                ) : (
+                  <Text
+                    style={{
+                      width: 44,
+                      textAlign: 'right',
+                      fontSize: 15,
+                      color: '#5C6356',
+                      fontVariant: ['tabular-nums'],
+                    }}
+                  >
+                    {h.par}
+                  </Text>
+                )}
                 <Text
                   style={{
                     width: 56,

--- a/apps/web/src/components/rounds/HoleScoreCard.tsx
+++ b/apps/web/src/components/rounds/HoleScoreCard.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
 import type { Database } from '@oga/supabase'
 import { useUpsertHoleScore } from '../../hooks/useHoleScores'
 import { useUnits } from '../../hooks/useUnits'
+import { supabase } from '../../lib/supabase'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
@@ -82,11 +84,18 @@ export function HoleScoreCard({
   onEditShots,
 }: HoleScoreCardProps) {
   const upsert = useUpsertHoleScore(roundId)
+  const queryClient = useQueryClient()
   const { toDisplay } = useUnits()
   const [score, setScore] = useState<string>(holeScore?.score?.toString() ?? '')
   const [putts, setPutts] = useState<string>(holeScore?.putts?.toString() ?? '')
   const [fairway, setFairway] = useState<boolean | null>(holeScore?.fairway_hit ?? null)
   const [gir, setGir] = useState<boolean | null>(holeScore?.gir ?? null)
+  // No yards + no tee coords = course had no layout data when this hole
+  // was loaded (or it was synthesized client-side). Lets the player
+  // override par per-hole instead of being stuck at the 4 default.
+  const isSyntheticHole = !hole.yards && hole.tee_lat == null
+  const [parOverride, setParOverride] = useState<number | null>(null)
+  const effectivePar = parOverride ?? hole.par
 
   // Hydrate the form from server state once per holeScore.id. Subsequent
   // refetches (after our own save, or another tab) must not clobber what
@@ -103,6 +112,31 @@ export function HoleScoreCard({
     setGir(holeScore.gir ?? null)
   }, [holeScore])
 
+  // Cycle par 3 → 4 → 5 → 3. Synthetic placeholders just keep the new
+  // par in local state — ensureRealHole reads it on the next hole_score
+  // save and seeds the materialized row. Real-but-no-layout rows (a hole
+  // exists in the DB but yards/coords are null) get an immediate UPDATE
+  // so the change is permanent course curation.
+  async function setPar(newPar: number) {
+    setParOverride(newPar)
+    if (hole.id.startsWith('synthetic-')) return
+    const { error } = await supabase
+      .from('holes')
+      .update({ par: newPar })
+      .eq('id', hole.id)
+    if (error) {
+      // Roll back the optimistic override so the UI doesn't lie about
+      // what's persisted. The user re-tries by tapping again.
+      setParOverride(null)
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[HoleScoreCard/setPar]', error)
+      }
+      return
+    }
+    queryClient.invalidateQueries({ queryKey: ['holes', hole.course_id] })
+  }
+
   async function persist(next: {
     score?: number | null
     putts?: number | null
@@ -113,8 +147,11 @@ export function HoleScoreCard({
       next.score !== undefined ? next.score : score ? Number(score) : null
     if (!numericScore) return
     // Materialize the synthetic hole before the upsert (FK on hole_id).
-    // No-op for real holes — short-circuits and returns the existing id.
-    const realHoleId = await ensureRealHole(hole)
+    // Pass the par override so the new holes row reflects the user's
+    // pick rather than the par-4 placeholder default.
+    const holeForEnsure =
+      parOverride != null ? { ...hole, par: parOverride } : hole
+    const realHoleId = await ensureRealHole(holeForEnsure)
     upsert.mutate({
       id: holeScore?.id,
       round_id: roundId,
@@ -127,7 +164,7 @@ export function HoleScoreCard({
             ? null
             : Number(putts),
       fairway_hit:
-        hole.par <= 3
+        effectivePar <= 3
           ? null
           : next.fairway_hit !== undefined
             ? next.fairway_hit
@@ -136,8 +173,8 @@ export function HoleScoreCard({
     })
   }
 
-  const isPar3 = hole.par === 3
-  const bubble = bubbleStyle(holeScore?.score, hole.par)
+  const isPar3 = effectivePar === 3
+  const bubble = bubbleStyle(holeScore?.score, effectivePar)
 
   return (
     <div
@@ -155,12 +192,37 @@ export function HoleScoreCard({
         >
           Hole {hole.number}
         </div>
-        <div
-          className="font-serif text-caddie-ink"
-          style={{ fontSize: 17, fontWeight: 500, lineHeight: 1.2, marginTop: 2 }}
-        >
-          Par {hole.par}
-        </div>
+        {isSyntheticHole ? (
+          <button
+            type="button"
+            onClick={() => {
+              const next = effectivePar === 3 ? 4 : effectivePar === 4 ? 5 : 3
+              void setPar(next)
+            }}
+            aria-label={`Par ${effectivePar}, tap to change`}
+            className="font-serif text-caddie-ink"
+            style={{
+              marginTop: 2,
+              padding: '2px 8px',
+              fontSize: 17,
+              fontWeight: 500,
+              lineHeight: 1.2,
+              background: 'transparent',
+              border: '1px dashed #9F9580',
+              borderRadius: 2,
+              textAlign: 'left',
+            }}
+          >
+            Par {effectivePar}
+          </button>
+        ) : (
+          <div
+            className="font-serif text-caddie-ink"
+            style={{ fontSize: 17, fontWeight: 500, lineHeight: 1.2, marginTop: 2 }}
+          >
+            Par {hole.par}
+          </div>
+        )}
         {hole.yards && (
           <div
             className="font-mono tabular text-caddie-ink-mute"

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -1010,11 +1010,52 @@ function ScorecardView({
   ensureRealHole,
   onEditShots,
 }: ScorecardViewProps) {
+  const hasSyntheticHoles = holes.some(
+    (h) => !h.yards && h.tee_lat == null,
+  )
+  const [hintDismissed, setHintDismissed] = useState(false)
   return (
     <div style={{ borderTop: '1px solid #D9D2BF', paddingTop: 14 }}>
       <div className="kicker" style={{ marginBottom: 14 }}>
         Scorecard
       </div>
+      {hasSyntheticHoles && !hintDismissed && (
+        <div
+          role="status"
+          style={{
+            marginBottom: 14,
+            padding: '10px 14px',
+            background: '#FBF8F1',
+            border: '1px solid #D9D2BF',
+            borderRadius: 2,
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 14,
+          }}
+        >
+          <div
+            className="text-caddie-ink-dim"
+            style={{ flex: 1, fontSize: 13, lineHeight: 1.4 }}
+          >
+            No course layout found. Par defaults to 4 — tap to edit.
+          </div>
+          <button
+            type="button"
+            onClick={() => setHintDismissed(true)}
+            aria-label="Dismiss notice"
+            className="font-mono uppercase text-caddie-ink-mute hover:text-caddie-ink"
+            style={{
+              fontSize: 10,
+              letterSpacing: '0.14em',
+              background: 'transparent',
+              border: 'none',
+              padding: 4,
+            }}
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
       <div
         style={{
           borderTop: '1px solid #D9D2BF',


### PR DESCRIPTION
## Summary
Web + mobile: scorecard par cell becomes a tap-to-cycle button (3 → 4 → 5 → 3) for any hole loaded without layout data (`yards == null && tee_lat == null`). Style: dashed border to signal it's editable.

**Web (`HoleScoreCard.tsx`)**
- Synthetic placeholders (id `synthetic-…`) keep the new par in local state (`parOverride`); `ensureRealHole` reads it on the next save and seeds the materialized row's par.
- Real-but-no-layout rows get an immediate `UPDATE holes SET par` and invalidate `['holes', course_id]` so the change is permanent course curation. Optimistic update with rollback on error.
- `effectivePar` flows through bubble computation, `isPar3` (drives FH disabled), and the upsert payload.

**Web (`RoundDetailPage.tsx ScorecardView`)**
- One-line dismissable hint above the table when any hole is synthetic: "No course layout found. Par defaults to 4 — tap to edit."

**Mobile (`Scorecard.tsx`, `hole/[number].tsx`)**
- `ScorecardModal` accepts an optional `onChangePar(holeId, newPar)`. When set + the hole has no layout, the par cell renders as a `Pressable` with the same dashed-border treatment.
- Hint banner mirrors web copy + dismiss behavior.
- Parent wires `onChangePar` to an optimistic `setHoles` + `supabase.from('holes').update({par})`, with rollback on error.

## Test plan
- [ ] Open a round on a coord-less course → scorecard rows show dashed-bordered par; tap cycles 3→4→5.
- [ ] Enter a score on a synthetic hole → `ensureRealHole` writes the new row with the user's par, not the par-4 default.
- [ ] Open a real hole with null `yards`/`tee_lat`; cycle par → DB updates immediately, refetch confirms persistence.
- [ ] Hint appears once, dismissable, doesn't reappear until reopen.
- [ ] Mobile: tap par cell — cycles without also jumping to that hole.
- [ ] Course with full layout (yards + tee_lat populated) shows static par text, no UI change.
- [ ] `pnpm typecheck`, `pnpm --filter web build`, mobile `npm run typecheck` all pass.