### PR TITLE
fix: synthetic hole progression + always-editable par

### DIFF
--- a/apps/mobile/components/round/Scorecard.tsx
+++ b/apps/mobile/components/round/Scorecard.tsx
@@ -173,7 +173,7 @@ export function ScorecardModal({
                 >
                   {h.number}
                 </Text>
-                {!h.yards && h.tee_lat == null && onChangePar ? (
+                {onChangePar ? (
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel={`Par ${h.par}, tap to change`}
@@ -187,10 +187,6 @@ export function ScorecardModal({
                       alignItems: 'flex-end',
                       paddingVertical: 2,
                       paddingHorizontal: 4,
-                      borderWidth: 1,
-                      borderStyle: 'dashed',
-                      borderColor: '#9F9580',
-                      borderRadius: 2,
                     }}
                   >
                     <Text
@@ -198,6 +194,9 @@ export function ScorecardModal({
                         fontSize: 15,
                         color: '#5C6356',
                         fontVariant: ['tabular-nums'],
+                        textDecorationLine: 'underline',
+                        textDecorationStyle: 'dotted',
+                        textDecorationColor: '#9F9580',
                       }}
                     >
                       {h.par}

--- a/apps/web/src/components/rounds/HoleScoreCard.tsx
+++ b/apps/web/src/components/rounds/HoleScoreCard.tsx
@@ -90,10 +90,9 @@ export function HoleScoreCard({
   const [putts, setPutts] = useState<string>(holeScore?.putts?.toString() ?? '')
   const [fairway, setFairway] = useState<boolean | null>(holeScore?.fairway_hit ?? null)
   const [gir, setGir] = useState<boolean | null>(holeScore?.gir ?? null)
-  // No yards + no tee coords = course had no layout data when this hole
-  // was loaded (or it was synthesized client-side). Lets the player
-  // override par per-hole instead of being stuck at the 4 default.
-  const isSyntheticHole = !hole.yards && hole.tee_lat == null
+  // Par is always editable on the scorecard — synthetic-fallback courses
+  // need it (par-4 default is wrong for the par 3s and 5s) and real
+  // courses occasionally have stale data the player wants to correct.
   const [parOverride, setParOverride] = useState<number | null>(null)
   const effectivePar = parOverride ?? hole.par
 
@@ -112,18 +111,17 @@ export function HoleScoreCard({
     setGir(holeScore.gir ?? null)
   }, [holeScore])
 
-  // Cycle par 3 → 4 → 5 → 3. Synthetic placeholders just keep the new
-  // par in local state — ensureRealHole reads it on the next hole_score
-  // save and seeds the materialized row. Real-but-no-layout rows (a hole
-  // exists in the DB but yards/coords are null) get an immediate UPDATE
-  // so the change is permanent course curation.
+  // Cycle par 3 → 4 → 5 → 3. Synthetic placeholders are materialized via
+  // ensureRealHole so the UPDATE has a real id to target; real holes
+  // short-circuit to a plain UPDATE. Either way the change is permanent
+  // course curation — every par tap improves the dataset over time.
   async function setPar(newPar: number) {
     setParOverride(newPar)
-    if (hole.id.startsWith('synthetic-')) return
+    const realHoleId = await ensureRealHole({ ...hole, par: newPar })
     const { error } = await supabase
       .from('holes')
       .update({ par: newPar })
-      .eq('id', hole.id)
+      .eq('id', realHoleId)
     if (error) {
       // Roll back the optimistic override so the UI doesn't lie about
       // what's persisted. The user re-tries by tapping again.
@@ -192,37 +190,32 @@ export function HoleScoreCard({
         >
           Hole {hole.number}
         </div>
-        {isSyntheticHole ? (
-          <button
-            type="button"
-            onClick={() => {
-              const next = effectivePar === 3 ? 4 : effectivePar === 4 ? 5 : 3
-              void setPar(next)
-            }}
-            aria-label={`Par ${effectivePar}, tap to change`}
-            className="font-serif text-caddie-ink"
-            style={{
-              marginTop: 2,
-              padding: '2px 8px',
-              fontSize: 17,
-              fontWeight: 500,
-              lineHeight: 1.2,
-              background: 'transparent',
-              border: '1px dashed #9F9580',
-              borderRadius: 2,
-              textAlign: 'left',
-            }}
-          >
-            Par {effectivePar}
-          </button>
-        ) : (
-          <div
-            className="font-serif text-caddie-ink"
-            style={{ fontSize: 17, fontWeight: 500, lineHeight: 1.2, marginTop: 2 }}
-          >
-            Par {hole.par}
-          </div>
-        )}
+        <button
+          type="button"
+          onClick={() => {
+            const next = effectivePar === 3 ? 4 : effectivePar === 4 ? 5 : 3
+            void setPar(next)
+          }}
+          aria-label={`Par ${effectivePar}, tap to change`}
+          title="Click to change par"
+          className="font-serif text-caddie-ink"
+          style={{
+            marginTop: 2,
+            padding: 0,
+            fontSize: 17,
+            fontWeight: 500,
+            lineHeight: 1.2,
+            background: 'transparent',
+            border: 'none',
+            textDecoration: 'underline dotted',
+            textDecorationColor: '#9F9580',
+            textUnderlineOffset: 4,
+            cursor: 'pointer',
+            textAlign: 'left',
+          }}
+        >
+          Par {effectivePar}
+        </button>
         {hole.yards && (
           <div
             className="font-mono tabular text-caddie-ink-mute"

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -123,7 +123,7 @@ type HoleViewAction =
   | { type: 'CLOSE_REVIEW' }
   | { type: 'EDIT_ON_MAP'; editing: boolean }
   | { type: 'SAVE_ERROR'; message: string | null }
-  | { type: 'AFTER_SAVE' }
+  | { type: 'AFTER_SAVE'; nextHoleNumber: number | null }
 
 const HOLE_VIEW_INITIAL: HoleViewState = {
   activeHoleNumber: 1,
@@ -234,11 +234,12 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
       return { ...state, saveError: action.message }
     case 'AFTER_SAVE': {
       // Auto-advance to the next hole on save so the player isn't stuck
-      // re-tapping the hole selector after every Done with hole. Hole 18
-      // is the last — stay put and just clear the placed-shot state so
-      // the player can review or edit.
-      const next = state.activeHoleNumber + 1
-      if (next > 18) {
+      // re-tapping the hole selector after every Done with hole. Caller
+      // decides how far we can advance — `nextHoleNumber == null` means
+      // we just saved the last hole on the course (caller compared
+      // against the course's expected hole count). In that case stay put
+      // and just clear the placed-shot state so the player can review.
+      if (action.nextHoleNumber == null) {
         return {
           ...state,
           reviewOpen: false,
@@ -251,7 +252,7 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
       }
       return {
         ...HOLE_VIEW_INITIAL,
-        activeHoleNumber: next,
+        activeHoleNumber: action.nextHoleNumber,
         focusGreenSignal: state.focusGreenSignal,
       }
     }
@@ -316,24 +317,32 @@ export function RoundDetailPage() {
   // Without this, every downstream feature gates on `activeHole` being
   // non-null and the round detail page locks up.
   //
-  // Once any hole is materialized via ensureRealHole, the query refetches
-  // and returns just that one row — but holes 2..18 still need synthetic
-  // placeholders so the player can navigate to them. Detect "synthetic
-  // mode" by checking whether every fetched row lacks layout data
-  // (yards null + tee_lat null = freshly-inserted placeholder), and pad
-  // to 18. Real courses with full layout (yards/coords populated) keep
-  // their fetched rows untouched so 9-hole-real-course rendering doesn't
-  // sprout phantom holes 10..18.
+  // Detection is length-based — once any hole is materialized via
+  // ensureRealHole, the query refetches with one row and the rest must
+  // still be synthesized. Predicate-based detection (yards/tee_lat null)
+  // breaks once `saveReviewedHole` seeds the new row with the player's
+  // teeOverride — that single populated tee_lat made every "is this
+  // synthetic?" check return false on the post-save refetch and holes
+  // 2..18 disappeared from the array. Length is the unambiguous signal:
+  // if fewer rows than the course expects, fill the gap.
+  //
+  // Expected count comes from `course_tees.par` when present (≤36 = 9,
+  // else 18); falls back to 18 when no tees row exists. 9-hole real
+  // courses with no course_tees row would over-pad — that combination
+  // is rare enough to leave for a follow-up.
   type HSWithJoin = HoleScoreRow & {
     holes?: { number?: number | null; par?: number | null } | null
   }
+  const expectedHoleCount = useMemo(() => {
+    const tees = teesQuery.data ?? []
+    const totalPar = tees[0]?.par
+    if (totalPar != null && totalPar <= 36) return 9
+    return 18
+  }, [teesQuery.data])
   const holes = useMemo<HoleRow[]>(() => {
     const fetched = holesQuery.data ?? []
     const roundData = round.data
-    const allSynthetic =
-      fetched.length === 0 ||
-      fetched.every((h) => !h.yards && h.tee_lat == null)
-    if (!allSynthetic) return fetched
+    if (fetched.length >= expectedHoleCount) return fetched
     if (!roundData) return fetched
     // Index real rows + score-derived rows by hole number for a 1..18
     // merge. Real wins over score-derived, score-derived wins over a
@@ -356,7 +365,7 @@ export function RoundDetailPage() {
         })
       }
     }
-    return Array.from({ length: 18 }, (_, i) => {
+    return Array.from({ length: expectedHoleCount }, (_, i) => {
       const num = i + 1
       const real = realByNumber.get(num)
       if (real) return real
@@ -388,7 +397,7 @@ export function RoundDetailPage() {
         pin_lng: null,
       }
     })
-  }, [holesQuery.data, round.data])
+  }, [holesQuery.data, round.data, expectedHoleCount])
   const rawScores: Array<HoleScoreRow & { holes?: HoleRow | null }> = useMemo(
     () => holeScoresQuery.data ?? [],
     [holeScoresQuery.data],
@@ -766,7 +775,13 @@ export function RoundDetailPage() {
           notes: null,
         })
       }
-      dispatchHoleView({ type: 'AFTER_SAVE' })
+      // Cap auto-advance to the course's expected hole count — passing
+      // null on the last hole keeps the player put with a cleared state.
+      const nextHole =
+        activeHole.number + 1 <= expectedHoleCount
+          ? activeHole.number + 1
+          : null
+      dispatchHoleView({ type: 'AFTER_SAVE', nextHoleNumber: nextHole })
     } catch (err) {
       dispatchHoleView({ type: 'SAVE_ERROR', message: toUserMessage(err) })
     } finally {

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -232,16 +232,29 @@ function holeViewReducer(state: HoleViewState, action: HoleViewAction): HoleView
       return { ...state, editingOnMap: action.editing }
     case 'SAVE_ERROR':
       return { ...state, saveError: action.message }
-    case 'AFTER_SAVE':
-      return {
-        ...state,
-        reviewOpen: false,
-        placedPoints: [],
-        placedAims: [],
-        placedPutts: [],
-        aimMode: false,
-        puttingSheetForIdx: null,
+    case 'AFTER_SAVE': {
+      // Auto-advance to the next hole on save so the player isn't stuck
+      // re-tapping the hole selector after every Done with hole. Hole 18
+      // is the last — stay put and just clear the placed-shot state so
+      // the player can review or edit.
+      const next = state.activeHoleNumber + 1
+      if (next > 18) {
+        return {
+          ...state,
+          reviewOpen: false,
+          placedPoints: [],
+          placedAims: [],
+          placedPutts: [],
+          aimMode: false,
+          puttingSheetForIdx: null,
+        }
       }
+      return {
+        ...HOLE_VIEW_INITIAL,
+        activeHoleNumber: next,
+        focusGreenSignal: state.focusGreenSignal,
+      }
+    }
   }
 }
 
@@ -301,43 +314,80 @@ export function RoundDetailPage() {
   // Synthetic fallback when the course has no rows in the `holes` table
   // (typical for OSM-imported courses that never went through enrichment).
   // Without this, every downstream feature gates on `activeHole` being
-  // non-null and the round detail page locks up: scorecard renders no
-  // rows, map placement buttons hide, review sheet can't open. Synthesize
-  // either from hole_scores (real hole_ids + joined par survive a
-  // refresh) or as 18 par-4 placeholders so the UI is at least usable.
-  type HSWithJoin = HoleScoreRow & { holes?: { par?: number | null } | null }
+  // non-null and the round detail page locks up.
+  //
+  // Once any hole is materialized via ensureRealHole, the query refetches
+  // and returns just that one row — but holes 2..18 still need synthetic
+  // placeholders so the player can navigate to them. Detect "synthetic
+  // mode" by checking whether every fetched row lacks layout data
+  // (yards null + tee_lat null = freshly-inserted placeholder), and pad
+  // to 18. Real courses with full layout (yards/coords populated) keep
+  // their fetched rows untouched so 9-hole-real-course rendering doesn't
+  // sprout phantom holes 10..18.
+  type HSWithJoin = HoleScoreRow & {
+    holes?: { number?: number | null; par?: number | null } | null
+  }
   const holes = useMemo<HoleRow[]>(() => {
     const fetched = holesQuery.data ?? []
-    if (fetched.length > 0) return fetched
     const roundData = round.data
-    if (!roundData) return []
-    const scores = (roundData as { hole_scores?: HSWithJoin[] }).hole_scores
-    if (scores && scores.length > 0) {
-      return scores.map((hs, i) => ({
-        id: hs.hole_id,
+    const allSynthetic =
+      fetched.length === 0 ||
+      fetched.every((h) => !h.yards && h.tee_lat == null)
+    if (!allSynthetic) return fetched
+    if (!roundData) return fetched
+    // Index real rows + score-derived rows by hole number for a 1..18
+    // merge. Real wins over score-derived, score-derived wins over a
+    // generic par-4 placeholder. score-derived carries the real hole_id
+    // (FK already valid) so the upsert path doesn't need ensureRealHole.
+    const realByNumber = new Map<number, HoleRow>()
+    for (const h of fetched) realByNumber.set(h.number, h)
+    const scores =
+      (roundData as { hole_scores?: HSWithJoin[] }).hole_scores ?? []
+    const scoredByNumber = new Map<
+      number,
+      { id: string; par: number | null }
+    >()
+    for (const hs of scores) {
+      const num = hs.holes?.number ?? null
+      if (num != null) {
+        scoredByNumber.set(num, {
+          id: hs.hole_id,
+          par: hs.holes?.par ?? null,
+        })
+      }
+    }
+    return Array.from({ length: 18 }, (_, i) => {
+      const num = i + 1
+      const real = realByNumber.get(num)
+      if (real) return real
+      const scored = scoredByNumber.get(num)
+      if (scored) {
+        return {
+          id: scored.id,
+          course_id: roundData.course_id,
+          number: num,
+          par: scored.par ?? 4,
+          yards: null,
+          stroke_index: num,
+          tee_lat: null,
+          tee_lng: null,
+          pin_lat: null,
+          pin_lng: null,
+        }
+      }
+      return {
+        id: `synthetic-${roundData.id}-hole-${num}`,
         course_id: roundData.course_id,
-        number: i + 1,
-        par: hs.holes?.par ?? 4,
+        number: num,
+        par: 4,
         yards: null,
-        stroke_index: i + 1,
+        stroke_index: num,
         tee_lat: null,
         tee_lng: null,
         pin_lat: null,
         pin_lng: null,
-      }))
-    }
-    return Array.from({ length: 18 }, (_, i) => ({
-      id: `synthetic-${roundData.id}-hole-${i + 1}`,
-      course_id: roundData.course_id,
-      number: i + 1,
-      par: 4,
-      yards: null,
-      stroke_index: i + 1,
-      tee_lat: null,
-      tee_lng: null,
-      pin_lat: null,
-      pin_lng: null,
-    }))
+      }
+    })
   }, [holesQuery.data, round.data])
   const rawScores: Array<HoleScoreRow & { holes?: HoleRow | null }> = useMemo(
     () => holeScoresQuery.data ?? [],


### PR DESCRIPTION
## Summary

Three commits. The first two were the original spec, the third addresses a root cause that diagnosis surfaced after the spec was written.

**`d16ae15` — hole progression auto-advances**
- `AFTER_SAVE` reducer auto-advances `activeHoleNumber` instead of just clearing placed-shot state. Caller passes `nextHoleNumber` (or `null` if we just saved the last hole on the course); reducer either applies it or stays put with a cleared state.

**`c83d0b6` — par always editable**
- Dropped the `isSyntheticHole` gate in `HoleScoreCard.tsx`. Par renders as a dotted-underline button on every hole.
- `setPar` always: optimistic `setParOverride` → `ensureRealHole({...hole, par: newPar})` (short-circuits real ids, materializes synthetic) → `UPDATE holes SET par WHERE id = realId` → invalidate `['holes', course_id]`. Rolls back on error.
- Same gate drop in mobile `Scorecard.tsx`.

**`7732028` — synthetic detection survives place-tee + save (the actual root cause)**

A debug-hunter agent traced why BUG 2's `isSyntheticHole = !hole.yards && hole.tee_lat == null` gate never fired in user testing. Confirmed root cause: `saveReviewedHole` calls `ensureRealHole` with `{teeLat: teeOverride?.lat, ...}`. When the player has used the "Place tee box" button (PR #174), `teeOverride` is set — the new `holes` row gets inserted with `tee_lat != null`. On the next refetch, every predicate-based "is synthetic?" check returns false.

The same root cause was hiding inside `d16ae15`'s BUG 1 fix: my `allSynthetic = fetched.every(h => !h.yards && h.tee_lat == null)` had identical wording, so on the first Done-with-hole save where the player had placed a tee, `fetched.length === 1` but `allSynthetic === false` → returned fetched as-is → holes 2..18 silently disappeared → BUG 1 still broken in that scenario.

Fix: switch detection to length-based. Compute `expectedHoleCount` from `course_tees.par` (≤36 = 9, else 18; default 18 when no tees row). If `fetched.length < expectedHoleCount`, pad. Detection survives any mix of populated coords on the materialized row. Threaded into AFTER_SAVE's auto-advance cap so 9-hole courses don't try to advance to hole 10.

Known limitation: 9-hole real courses with no `course_tees` row default to expected=18 → would phantom-pad 10..18. Rare combination; left for follow-up.

## Test plan
- [ ] Coord-less course → Place tee box → place shots → Done with hole → app advances to hole 2; holes 2..18 still navigable in selector.
- [ ] Tap par on any hole → cycles 3→4→5; reload confirms persistence.
- [ ] Hole 18 save (or hole 9 on a 9-hole course with tees) → stays put, placed state cleared.
- [ ] Real 18-hole course unchanged.
- [ ] `pnpm typecheck`, `pnpm --filter web build`, mobile `npm run typecheck` all pass.