### PR TITLE
feat: how-to-practice article (web + mobile)

### DIFF
--- a/apps/mobile/app/(app)/learn/[article].tsx
+++ b/apps/mobile/app/(app)/learn/[article].tsx
@@ -1,4 +1,5 @@
-import { Pressable, ScrollView, Text, View } from 'react-native'
+import { useState } from 'react'
+import { Linking, Pressable, ScrollView, Text, View } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { AppBar } from '../../../components/ui/AppBar'
 import { findArticle } from '../../../components/learn/sections'
@@ -96,6 +97,8 @@ function LiveArticle({ id }: { id: string }) {
       return <BenchmarksArticle />
     case 'glossary':
       return <GlossaryArticle />
+    case 'how-to-practice':
+      return <HowToPracticeArticle />
     default:
       return <StubBody title="Article" />
   }
@@ -251,6 +254,616 @@ const GLOSSARY = [
     kicker: 'Dispersion',
     title: 'Reading the pattern.',
     body: 'The inner ellipse covers 68 percent of your shots — your typical window. The outer one covers 95. A pattern shifted right of centre means a fade bias; the aim correction tip moves the centre back over your target.',
+  },
+]
+
+function HowToPracticeArticle() {
+  return (
+    <View>
+      <Text style={{ ...KICKER, marginBottom: 10 }}>Improving your game · Draft</Text>
+      <Text style={TITLE}>How to practice.</Text>
+
+      <WipBanner />
+
+      <H3>The uncomfortable truth</H3>
+      <Para>
+        Most golfers practice in a way that feels productive but isn't. They
+        hit a bucket of balls, stripe a few drives, feel good, and leave.
+        Their handicap doesn't move.
+      </Para>
+      <Para>
+        This isn't laziness. It's that no one ever explained what practice
+        is actually for — or that there's a difference between hitting balls
+        and getting better.
+      </Para>
+      <Para>
+        There's nothing wrong with going to the range to unwind, enjoy the
+        weather, or just swing a club. That's a legitimate and enjoyable
+        thing to do. But if your goal is to improve, that's a different
+        activity and it requires a different approach.
+      </Para>
+
+      <Divider />
+
+      <H3>What practice is actually for</H3>
+      <Para>
+        Practice exists to change your behavior on the golf course. Not to
+        feel good on the range. Not to hit your best shots. To change what
+        you do under pressure, on uneven lies, with something at stake.
+      </Para>
+      <Para>
+        If your practice doesn't eventually show up on the course, it wasn't
+        practice — it was entertainment. Which, again, is fine. Just know
+        which one you're doing.
+      </Para>
+
+      <Divider />
+
+      <H3>The four types of practice</H3>
+
+      <H4>Block practice</H4>
+      <KV label="What it is">
+        Repeating the same shot over and over. 50 7-irons in a row to the
+        same target.
+      </KV>
+      <KV label="Good for">
+        Learning a brand new movement. If you're working on a swing change
+        with your coach, some repetition helps establish the new pattern.
+        Use it sparingly and early.
+      </KV>
+      <KV label="Not good for">
+        Building skills that transfer to the course. Research consistently
+        shows that improvement during block practice doesn't stick. You get
+        better within the session and worse by the next round.
+      </KV>
+      <KV label="The trap">
+        Block practice feels like learning because you do get better within
+        the session. That feeling is misleading. It is one of the most
+        well-replicated findings in motor learning research.
+      </KV>
+      <Note variant="research">
+        Research basis: Robert Bjork (UCLA) — contextual interference
+        effect. See also: "Make It Stick" by Brown, Roediger, McDaniel.
+      </Note>
+      <Note variant="todo">TODO: Add specific study citations</Note>
+
+      <H4>Random practice</H4>
+      <KV label="What it is">
+        Varying every shot. 7-iron, driver, wedge, 5-iron — never hitting
+        the same club twice in a row.
+      </KV>
+      <KV label="Good for">
+        Building skills that actually transfer to the course. The research
+        on this is consistent across many studies. Random practice feels
+        harder and messier but produces dramatically better retention.
+      </KV>
+      <KV label="Why it works">
+        Each time you pick up a different club, your brain has to fully
+        reconstruct the motor pattern from scratch. That reconstruction
+        process is where learning happens.
+      </KV>
+      <KV label="Not good for">
+        Learning a brand new movement. Don't randomize before you have a
+        basic pattern to work with.
+      </KV>
+      <Note variant="research">
+        Research basis: Contextual interference effect, Battig (1979),
+        confirmed in many subsequent studies.
+      </Note>
+      <Note variant="todo">
+        TODO: Verify whether the beginner exception is well-established or
+        still debated
+      </Note>
+
+      <H4>Variable practice</H4>
+      <KV label="What it is">
+        Same club, different conditions. 9-iron from 100 yards, then 90,
+        then uphill, then into wind, then from a downslope.
+      </KV>
+      <KV label="Good for">
+        Building adaptability. Golf never gives you the same shot twice.
+        Variable practice trains you for that reality.
+      </KV>
+      <KV label="Combine it with">
+        Random practice for maximum transfer.
+      </KV>
+
+      <H4>Pressure practice</H4>
+      <KV label="What it is">
+        Creating consequences in practice. Something is at stake on each
+        shot.
+      </KV>
+      <Bullets
+        items={[
+          'Make 5 putts in a row from 6 feet or start over from 0',
+          'Last ball in your bucket must hit a specific target',
+          'Play a simulated 9 holes on the range — pick targets, keep score',
+          'Clock drill: 12 balls around the hole at 3 feet (clock positions), make all 12 in a row or start over',
+        ]}
+      />
+      <KV label="Good for">
+        Training your nervous system to perform under pressure. If you've
+        never practiced with consequences, your body hasn't learned how to
+        handle them on the course.
+      </KV>
+      <Note variant="research">
+        Research basis: Dr. Sian Beilock — "Choke" (2010). Bob Rotella —
+        "Golf Is Not a Game of Perfect" (1995).
+      </Note>
+      <Note variant="todo">
+        TODO: Add more specific pressure practice examples from tour player
+        documented routines
+      </Note>
+
+      <Divider />
+
+      <H3>How to structure a session</H3>
+      <Para>
+        A well-structured session has a flow. Adjust based on your time and
+        current focus area.
+      </Para>
+      <SessionRows />
+      <Note variant="todo">
+        TODO: Review these time allocations with a teaching professional.
+        The short game / full swing split in particular (Dave Pelz suggests
+        ~60% short game) needs more exploration.
+      </Note>
+
+      <Divider />
+
+      <H3>Having a goal for the session</H3>
+      <Para>
+        Before you hit a single ball, decide what you're trying to
+        accomplish today.
+      </Para>
+      <Bullets
+        items={[
+          'Bad goal: Work on my irons.',
+          'Better goal: Work on my ball striking.',
+          'Good goal: Hit 7 of 10 approach shots within 20 yards of the target from 150 yards.',
+        ]}
+      />
+      <Para>
+        The difference is measurability. If you can't tell whether you
+        achieved your goal, it wasn't a goal — it was a vague intention.
+      </Para>
+      <Para>
+        Your OGA strokes gained data tells you exactly where to focus. If
+        you're losing 1.2 strokes per round on approach shots, that's your
+        focus area. Your practice goal should be specific to that weakness.
+      </Para>
+      <H4>How to quantify your practice</H4>
+      <Bullets
+        items={[
+          'Track your success rate on pressure games over time',
+          'Note which club and distance you practiced',
+          'Write down what you worked on and what changed',
+          'Connect practice focus to round data over time',
+        ]}
+      />
+
+      <Divider />
+
+      <H3>What bad practice looks like</H3>
+
+      <H4>The range bucket spiral</H4>
+      <Para>
+        Buy a large bucket. Hit wedges, feel good. Move to 7-iron, stripe a
+        few. Pull out the driver. Spend 45 minutes hitting drivers because
+        that's the most fun. Leave feeling like you worked hard. Nothing
+        about your game changed.
+      </Para>
+
+      <H4>Same shot, same target, same lie</H4>
+      <Para>
+        You struggle with your 6-iron so you hit 60 6-irons to the same
+        target from a flat lie. On the course you face a 6-iron from a
+        downslope with water left. These are completely different skills.
+      </Para>
+
+      <H4>Practicing your strengths</H4>
+      <Para>
+        You putt well so you skip the green. You hit your driver well so
+        you spend an hour on the tee line. Improvement comes from
+        addressing weaknesses, not reinforcing strengths.
+      </Para>
+
+      <H4>No target, no feedback</H4>
+      <Para>
+        Hitting shots without a specific target or any way to evaluate the
+        result is exercise, not practice. Useful and enjoyable — but not
+        improvement.
+      </Para>
+
+      <H4>Working on technique under pressure</H4>
+      <Para>
+        The course is for playing. The range is for working on technique.
+        Working on a swing change during a round rarely ends well.
+      </Para>
+
+      <Divider />
+
+      <H3>Practice round vs scoring round</H3>
+      <Para>
+        Two completely different activities. Mixing them is one of the most
+        common mistakes amateurs make.
+      </Para>
+      <KV label="Practice round mode">
+        Experiment. Try the risky shot. Play from a bad lie on purpose. Hit
+        two balls. Explore. Score doesn't matter — you're gathering
+        information.
+      </KV>
+      <KV label="Scoring round mode">
+        Full pre-shot routine on every shot. Full commitment. No mulligans.
+        Track everything. This is performance mode.
+      </KV>
+      <Para>
+        The mistake is being half-committed to both — sort of practicing,
+        sort of scoring. You get the anxiety of performance without the
+        data of tracking, and the experimentation of practice without the
+        freedom of no consequences.
+      </Para>
+      <Para>
+        Before you tee off, decide which mode you're in and commit to it
+        fully.
+      </Para>
+
+      <Divider />
+
+      <H3>Resources</H3>
+      <Note variant="todo">
+        These are starting points for further research, not endorsements.
+        Verify all links are current before publishing.
+      </Note>
+
+      <H4>Books</H4>
+      {BOOKS.map((b) => (
+        <View
+          key={b.title}
+          style={{
+            borderTopWidth: 1,
+            borderColor: '#D9D2BF',
+            paddingVertical: 12,
+          }}
+        >
+          <Text
+            style={{
+              color: '#1C211C',
+              fontSize: 15,
+              fontStyle: 'italic',
+              fontWeight: '500',
+            }}
+          >
+            {b.title}
+            {b.by && (
+              <Text style={{ color: '#5C6356', fontStyle: 'normal', fontWeight: '400' }}>
+                {' '}— {b.by}
+              </Text>
+            )}
+          </Text>
+          <Text style={{ color: '#5C6356', fontSize: 14, lineHeight: 20, marginTop: 4 }}>
+            {b.note}
+          </Text>
+        </View>
+      ))}
+
+      <H4>Research worth knowing</H4>
+      <Bullets
+        items={[
+          'Robert Bjork — contextual interference, desirable difficulties (UCLA)',
+          'Anders Ericsson — deliberate practice and expert performance',
+          'Gabriele Wulf — attentional focus research showing external focus cues outperform internal focus cues',
+          'Sian Beilock — choking under pressure',
+        ]}
+      />
+
+      <H4>Online resources</H4>
+      <ResourceLink label="TPI (Titleist Performance Institute)" url="https://mytpi.com" />
+      <ResourceLink label="Robert Bjork's lab" url="https://bjorklab.psych.ucla.edu" />
+      <Note variant="todo" inline>
+        TODO: Verify Bjork lab URL is current
+      </Note>
+
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderColor: '#D9D2BF',
+          paddingTop: 18,
+          marginTop: 22,
+        }}
+      >
+        <Text
+          style={{
+            ...KICKER,
+            color: '#8A8B7E',
+            lineHeight: 14,
+          }}
+        >
+          Last reviewed May 2026 · Draft, needs instructor review · Edit
+          docs/learn/how-to-practice.md to contribute
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+function WipBanner() {
+  const [dismissed, setDismissed] = useState(false)
+  if (dismissed) return null
+  return (
+    <View
+      style={{
+        backgroundColor: '#FBF8F1',
+        borderLeftWidth: 3,
+        borderLeftColor: '#A66A1F',
+        borderTopWidth: 1,
+        borderRightWidth: 1,
+        borderBottomWidth: 1,
+        borderColor: '#D9D2BF',
+        borderRadius: 2,
+        padding: 14,
+        marginBottom: 18,
+        flexDirection: 'row',
+        gap: 12,
+      }}
+    >
+      <View style={{ flex: 1 }}>
+        <Text style={{ ...KICKER, color: '#A66A1F', marginBottom: 6 }}>
+          Work in progress
+        </Text>
+        <Text style={{ color: '#1C211C', fontSize: 14, lineHeight: 20 }}>
+          This guide is being reviewed for accuracy. Treat specific
+          technique advice as provisional until the notice is removed.
+        </Text>
+      </View>
+      <Pressable
+        onPress={() => setDismissed(true)}
+        style={{
+          borderWidth: 1,
+          borderColor: '#D9D2BF',
+          borderRadius: 2,
+          paddingHorizontal: 10,
+          paddingVertical: 6,
+          alignSelf: 'flex-start',
+        }}
+      >
+        <Text style={{ ...KICKER, color: '#5C6356' }}>Dismiss</Text>
+      </Pressable>
+    </View>
+  )
+}
+
+function H3({ children }: { children: string }) {
+  return (
+    <Text
+      style={{
+        color: '#1C211C',
+        fontSize: 22,
+        fontStyle: 'italic',
+        fontWeight: '500',
+        lineHeight: 28,
+        marginTop: 20,
+        marginBottom: 12,
+      }}
+    >
+      {children}
+    </Text>
+  )
+}
+
+function H4({ children }: { children: string }) {
+  return (
+    <Text
+      style={{
+        color: '#1C211C',
+        fontSize: 17,
+        fontStyle: 'italic',
+        fontWeight: '500',
+        marginTop: 16,
+        marginBottom: 6,
+      }}
+    >
+      {children}
+    </Text>
+  )
+}
+
+function Para({ children }: { children: React.ReactNode }) {
+  return (
+    <Text
+      style={{
+        color: '#1C211C',
+        fontSize: 15,
+        lineHeight: 22,
+        marginBottom: 12,
+      }}
+    >
+      {children}
+    </Text>
+  )
+}
+
+function KV({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <Text
+      style={{
+        color: '#1C211C',
+        fontSize: 15,
+        lineHeight: 22,
+        marginBottom: 10,
+      }}
+    >
+      <Text
+        style={{
+          fontStyle: 'italic',
+          fontWeight: '500',
+          color: '#1C211C',
+        }}
+      >
+        {label}.{' '}
+      </Text>
+      {children}
+    </Text>
+  )
+}
+
+function Bullets({ items }: { items: string[] }) {
+  return (
+    <View style={{ marginBottom: 12 }}>
+      {items.map((item) => (
+        <View
+          key={item}
+          style={{
+            flexDirection: 'row',
+            marginBottom: 6,
+          }}
+        >
+          <Text style={{ color: '#1C211C', fontSize: 15, lineHeight: 22, marginRight: 6 }}>
+            •
+          </Text>
+          <Text
+            style={{
+              color: '#1C211C',
+              fontSize: 15,
+              lineHeight: 22,
+              flex: 1,
+            }}
+          >
+            {item}
+          </Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+function Divider() {
+  return (
+    <View
+      style={{
+        borderTopWidth: 1,
+        borderColor: '#D9D2BF',
+        marginVertical: 18,
+      }}
+    />
+  )
+}
+
+function SessionRows() {
+  const rows = [
+    { phase: 'Warm up', dur: '10–15 min', why: 'Easy wedges, get body ready. Not practice time.' },
+    { phase: 'Skill work', dur: '20–30 min', why: 'Current focus area. Deliberate, with feedback.' },
+    { phase: 'Random / variable', dur: '20–30 min', why: 'Whole bag, random clubs, real targets.' },
+    { phase: 'Pressure games', dur: '10–15 min', why: 'Consequences on every shot. Keep score.' },
+    { phase: 'Short game', dur: '15–20 min', why: 'Chipping and pitching. Don’t skip.' },
+    { phase: 'Putting', dur: '10–15 min', why: 'Always end on the green. End by holing putts.' },
+  ]
+  return (
+    <View style={{ borderTopWidth: 1, borderColor: '#D9D2BF', marginBottom: 14 }}>
+      {rows.map((r) => (
+        <View
+          key={r.phase}
+          style={{
+            paddingVertical: 12,
+            borderBottomWidth: 1,
+            borderColor: '#D9D2BF',
+          }}
+        >
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 4 }}>
+            <Text style={{ color: '#1C211C', fontSize: 15, fontStyle: 'italic', fontWeight: '500' }}>
+              {r.phase}
+            </Text>
+            <Text style={{ color: '#5C6356', fontSize: 12, fontVariant: ['tabular-nums'] }}>
+              {r.dur}
+            </Text>
+          </View>
+          <Text style={{ color: '#5C6356', fontSize: 14, lineHeight: 20 }}>{r.why}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+function Note({
+  variant,
+  inline,
+  children,
+}: {
+  variant: 'research' | 'todo'
+  inline?: boolean
+  children: React.ReactNode
+}) {
+  if (!__DEV__) return null
+  const tone = variant === 'research' ? '#1F3D2C' : '#A66A1F'
+  const label = variant === 'research' ? 'Source' : 'Todo'
+  if (inline) {
+    return (
+      <Text style={{ ...KICKER, color: tone, marginTop: 4 }}>
+        [{label}] {children}
+      </Text>
+    )
+  }
+  return (
+    <View
+      style={{
+        backgroundColor: '#EBE5D6',
+        borderLeftWidth: 3,
+        borderLeftColor: tone,
+        padding: 12,
+        marginBottom: 12,
+      }}
+    >
+      <Text style={{ ...KICKER, color: tone, marginBottom: 4 }}>
+        {label} · dev only
+      </Text>
+      <Text style={{ color: '#5C6356', fontSize: 13, fontStyle: 'italic', lineHeight: 19 }}>
+        {children}
+      </Text>
+    </View>
+  )
+}
+
+function ResourceLink({ label, url }: { label: string; url: string }) {
+  return (
+    <Pressable onPress={() => Linking.openURL(url)} style={{ paddingVertical: 8 }}>
+      <Text style={{ color: '#1C211C', fontSize: 15, lineHeight: 22 }}>
+        {label}:{' '}
+        <Text style={{ color: '#1F3D2C', textDecorationLine: 'underline' }}>{url}</Text>
+      </Text>
+    </Pressable>
+  )
+}
+
+const BOOKS = [
+  {
+    title: '"Make It Stick"',
+    by: 'Brown, Roediger, McDaniel.',
+    note: 'Best plain-language summary of learning science. Not golf-specific but directly applicable.',
+  },
+  {
+    title: '"Golf Is Not a Game of Perfect"',
+    by: 'Bob Rotella.',
+    note: 'Standard text on golf psychology and performance.',
+  },
+  {
+    title: '"Dave Pelz\'s Short Game Bible"',
+    by: '',
+    note: 'Research-based approach to practice from inside 100 yards.',
+  },
+  {
+    title: '"Harvey Penick\'s Little Red Book"',
+    by: '',
+    note: 'The most beloved golf instruction book ever written. Simple, wise, feel-based.',
+  },
+  {
+    title: '"Peak"',
+    by: 'Anders Ericsson.',
+    note: 'His own account of deliberate practice research. Better than the Gladwell version.',
+  },
+  {
+    title: '"Choke"',
+    by: 'Sian Beilock.',
+    note: 'Accessible neuroscience of performance under pressure.',
   },
 ]
 

--- a/apps/mobile/components/learn/sections.ts
+++ b/apps/mobile/components/learn/sections.ts
@@ -39,7 +39,7 @@ export const LEARN_SECTIONS: LearnSection[] = [
     number: 'Section three',
     title: 'Improving your game',
     articles: [
-      { id: 'how-to-practice', title: 'How to practice effectively', status: 'stub' },
+      { id: 'how-to-practice', title: 'How to practice effectively', status: 'live' },
       { id: 'practice-modes', title: 'Block, random, and pressure practice', status: 'stub' },
       { id: 'measurable-goals', title: 'Creating measurable practice goals', status: 'stub' },
       { id: 'skill-and-pressure-games', title: 'Skill games and pressure games', status: 'stub' },

--- a/apps/web/src/pages/learn/LearnPage.tsx
+++ b/apps/web/src/pages/learn/LearnPage.tsx
@@ -3,6 +3,7 @@ import { useDetailedStats } from '../../hooks/useDetailedStats'
 import { useProfile } from '../../hooks/useProfile'
 import { useUnits } from '../../hooks/useUnits'
 import type { DetailedStats } from '@oga/core'
+import { HowToPracticeArticle } from './articles/HowToPracticeArticle'
 
 interface ArticleStub {
   id: string
@@ -43,7 +44,7 @@ const LEARN_SECTIONS: LearnSection[] = [
     number: 'Section three',
     title: 'Improving your game',
     articles: [
-      { id: 'how-to-practice', title: 'How to practice effectively', status: 'stub' },
+      { id: 'how-to-practice', title: 'How to practice effectively', status: 'live' },
       { id: 'practice-modes', title: 'Block, random, and pressure practice', status: 'stub' },
       { id: 'measurable-goals', title: 'Creating measurable practice goals', status: 'stub' },
       { id: 'skill-and-pressure-games', title: 'Skill games and pressure games', status: 'stub' },
@@ -228,13 +229,13 @@ export function LearnPage() {
             number={section.number}
             title={section.title}
           />
-          {section.articles.map((article) => (
-            <StubEntry
-              key={article.id}
-              id={article.id}
-              title={article.title}
-            />
-          ))}
+          {section.articles.map((article) =>
+            article.status === 'live' ? (
+              <LiveArticle key={article.id} id={article.id} title={article.title} />
+            ) : (
+              <StubEntry key={article.id} id={article.id} title={article.title} />
+            ),
+          )}
         </div>
       ))}
 
@@ -1490,6 +1491,15 @@ function ArticleAnchor({
       </h3>
     </section>
   )
+}
+
+function LiveArticle({ id, title }: { id: string; title: string }) {
+  switch (id) {
+    case 'how-to-practice':
+      return <HowToPracticeArticle />
+    default:
+      return <StubEntry id={id} title={title} />
+  }
 }
 
 function StubEntry({ id, title }: { id: string; title: string }) {

--- a/apps/web/src/pages/learn/articles/HowToPracticeArticle.tsx
+++ b/apps/web/src/pages/learn/articles/HowToPracticeArticle.tsx
@@ -1,0 +1,706 @@
+import { useEffect, useState } from 'react'
+
+const DEV = import.meta.env.DEV
+const WIP_KEY = 'oga.learn.how-to-practice.wip-dismissed'
+
+export function HowToPracticeArticle() {
+  return (
+    <article
+      id="how-to-practice"
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 22,
+        marginBottom: 32,
+      }}
+    >
+      <div className="kicker" style={{ marginBottom: 14 }}>
+        Improving your game · Draft
+      </div>
+      <h2
+        className="font-serif text-caddie-ink"
+        style={{
+          fontSize: 28,
+          fontWeight: 500,
+          fontStyle: 'italic',
+          letterSpacing: '-0.015em',
+          lineHeight: 1.15,
+          marginBottom: 18,
+        }}
+      >
+        How to practice.
+      </h2>
+
+      <WipBanner />
+
+      <H3>The uncomfortable truth</H3>
+      <P>
+        Most golfers practice in a way that feels productive but
+        isn't. They hit a bucket of balls, stripe a few drives, feel
+        good, and leave. Their handicap doesn't move.
+      </P>
+      <P>
+        This isn't laziness. It's that no one ever explained what
+        practice is actually for — or that there's a difference
+        between hitting balls and getting better.
+      </P>
+      <P>
+        There's nothing wrong with going to the range to unwind, enjoy
+        the weather, or just swing a club. That's a legitimate and
+        enjoyable thing to do. But if your goal is to improve, that's
+        a different activity and it requires a different approach.
+      </P>
+
+      <Hr />
+
+      <H3>What practice is actually for</H3>
+      <P>
+        Practice exists to change your behavior on the golf course.
+        Not to feel good on the range. Not to hit your best shots. To
+        change what you do under pressure, on uneven lies, with
+        something at stake.
+      </P>
+      <P>
+        If your practice doesn't eventually show up on the course, it
+        wasn't practice — it was entertainment. Which, again, is
+        fine. Just know which one you're doing.
+      </P>
+
+      <Hr />
+
+      <H3>The four types of practice</H3>
+
+      <H4>Block practice</H4>
+      <Kv label="What it is">
+        Repeating the same shot over and over. 50 7-irons in a row to
+        the same target.
+      </Kv>
+      <Kv label="Good for">
+        Learning a brand new movement. If you're working on a swing
+        change with your coach, some repetition helps establish the
+        new pattern. Use it sparingly and early.
+      </Kv>
+      <Kv label="Not good for">
+        Building skills that transfer to the course. Research
+        consistently shows that improvement during block practice
+        doesn't stick. You get better within the session and worse
+        by the next round.
+      </Kv>
+      <Kv label="The trap">
+        Block practice feels like learning because you do get better
+        within the session. That feeling is misleading. It is one of
+        the most well-replicated findings in motor learning research.
+      </Kv>
+      <EditorialNote variant="research">
+        Research basis: Robert Bjork (UCLA) — contextual interference
+        effect. See also: "Make It Stick" by Brown, Roediger,
+        McDaniel.
+      </EditorialNote>
+      <EditorialNote variant="todo">
+        TODO: Add specific study citations
+      </EditorialNote>
+
+      <H4>Random practice</H4>
+      <Kv label="What it is">
+        Varying every shot. 7-iron, driver, wedge, 5-iron — never
+        hitting the same club twice in a row.
+      </Kv>
+      <Kv label="Good for">
+        Building skills that actually transfer to the course. The
+        research on this is consistent across many studies. Random
+        practice feels harder and messier but produces dramatically
+        better retention.
+      </Kv>
+      <Kv label="Why it works">
+        Each time you pick up a different club, your brain has to
+        fully reconstruct the motor pattern from scratch. That
+        reconstruction process is where learning happens.
+      </Kv>
+      <Kv label="Not good for">
+        Learning a brand new movement. Don't randomize before you
+        have a basic pattern to work with.
+      </Kv>
+      <EditorialNote variant="research">
+        Research basis: Contextual interference effect, Battig
+        (1979), confirmed in many subsequent studies.
+      </EditorialNote>
+      <EditorialNote variant="todo">
+        TODO: Verify whether the beginner exception is
+        well-established or still debated
+      </EditorialNote>
+
+      <H4>Variable practice</H4>
+      <Kv label="What it is">
+        Same club, different conditions. 9-iron from 100 yards, then
+        90, then uphill, then into wind, then from a downslope.
+      </Kv>
+      <Kv label="Good for">
+        Building adaptability. Golf never gives you the same shot
+        twice. Variable practice trains you for that reality.
+      </Kv>
+      <Kv label="Combine it with">
+        Random practice for maximum transfer.
+      </Kv>
+
+      <H4>Pressure practice</H4>
+      <Kv label="What it is">
+        Creating consequences in practice. Something is at stake on
+        each shot.
+      </Kv>
+      <Kv label="Examples">
+        <ul style={UL_STYLE}>
+          <li>Make 5 putts in a row from 6 feet or start over from 0</li>
+          <li>Last ball in your bucket must hit a specific target</li>
+          <li>
+            Play a simulated 9 holes on the range — pick targets, keep
+            score
+          </li>
+          <li>
+            Clock drill: 12 balls around the hole at 3 feet (clock
+            positions), make all 12 in a row or start over
+          </li>
+        </ul>
+      </Kv>
+      <Kv label="Good for">
+        Training your nervous system to perform under pressure. If
+        you've never practiced with consequences, your body hasn't
+        learned how to handle them on the course.
+      </Kv>
+      <EditorialNote variant="research">
+        Research basis: Dr. Sian Beilock — "Choke" (2010). Bob Rotella
+        — "Golf Is Not a Game of Perfect" (1995).
+      </EditorialNote>
+      <EditorialNote variant="todo">
+        TODO: Add more specific pressure practice examples from tour
+        player documented routines
+      </EditorialNote>
+
+      <Hr />
+
+      <H3>How to structure a session</H3>
+      <P>
+        A well-structured session has a flow. Adjust based on your
+        time and current focus area.
+      </P>
+      <SessionTable />
+      <EditorialNote variant="todo">
+        TODO: Review these time allocations with a teaching
+        professional. The short game / full swing split in
+        particular (Dave Pelz suggests ~60% short game) needs more
+        exploration.
+      </EditorialNote>
+
+      <Hr />
+
+      <H3>Having a goal for the session</H3>
+      <P>
+        Before you hit a single ball, decide what you're trying to
+        accomplish today.
+      </P>
+      <ul style={UL_STYLE}>
+        <li>
+          <strong>Bad goal:</strong> Work on my irons.
+        </li>
+        <li>
+          <strong>Better goal:</strong> Work on my ball striking.
+        </li>
+        <li>
+          <strong>Good goal:</strong> Hit 7 of 10 approach shots
+          within 20 yards of the target from 150 yards.
+        </li>
+      </ul>
+      <P>
+        The difference is measurability. If you can't tell whether
+        you achieved your goal, it wasn't a goal — it was a vague
+        intention.
+      </P>
+      <P>
+        Your OGA strokes gained data tells you exactly where to
+        focus. If you're losing 1.2 strokes per round on approach
+        shots, that's your focus area. Your practice goal should be
+        specific to that weakness.
+      </P>
+      <H4>How to quantify your practice</H4>
+      <ul style={UL_STYLE}>
+        <li>Track your success rate on pressure games over time</li>
+        <li>Note which club and distance you practiced</li>
+        <li>Write down what you worked on and what changed</li>
+        <li>Connect practice focus to round data over time</li>
+      </ul>
+
+      <Hr />
+
+      <H3>What bad practice looks like</H3>
+
+      <H4>The range bucket spiral</H4>
+      <P>
+        Buy a large bucket. Hit wedges, feel good. Move to 7-iron,
+        stripe a few. Pull out the driver. Spend 45 minutes hitting
+        drivers because that's the most fun. Leave feeling like you
+        worked hard. Nothing about your game changed.
+      </P>
+
+      <H4>Same shot, same target, same lie</H4>
+      <P>
+        You struggle with your 6-iron so you hit 60 6-irons to the
+        same target from a flat lie. On the course you face a 6-iron
+        from a downslope with water left. These are completely
+        different skills.
+      </P>
+
+      <H4>Practicing your strengths</H4>
+      <P>
+        You putt well so you skip the green. You hit your driver well
+        so you spend an hour on the tee line. Improvement comes from
+        addressing weaknesses, not reinforcing strengths.
+      </P>
+
+      <H4>No target, no feedback</H4>
+      <P>
+        Hitting shots without a specific target or any way to evaluate
+        the result is exercise, not practice. Useful and enjoyable —
+        but not improvement.
+      </P>
+
+      <H4>Working on technique under pressure</H4>
+      <P>
+        The course is for playing. The range is for working on
+        technique. Working on a swing change during a round rarely
+        ends well.
+      </P>
+
+      <Hr />
+
+      <H3>Practice round vs scoring round</H3>
+      <P>
+        Two completely different activities. Mixing them is one of
+        the most common mistakes amateurs make.
+      </P>
+      <Kv label="Practice round mode">
+        Experiment. Try the risky shot. Play from a bad lie on
+        purpose. Hit two balls. Explore. Score doesn't matter —
+        you're gathering information.
+      </Kv>
+      <Kv label="Scoring round mode">
+        Full pre-shot routine on every shot. Full commitment. No
+        mulligans. Track everything. This is performance mode.
+      </Kv>
+      <P>
+        The mistake is being half-committed to both — sort of
+        practicing, sort of scoring. You get the anxiety of
+        performance without the data of tracking, and the
+        experimentation of practice without the freedom of no
+        consequences.
+      </P>
+      <P>
+        Before you tee off, decide which mode you're in and commit to
+        it fully.
+      </P>
+
+      <Hr />
+
+      <H3>Resources</H3>
+      <EditorialNote variant="todo">
+        These are starting points for further research, not
+        endorsements. Verify all links are current before publishing.
+      </EditorialNote>
+
+      <H4>Books</H4>
+      <ResourceList
+        items={[
+          {
+            title: '"Make It Stick"',
+            by: 'Brown, Roediger, McDaniel.',
+            note: 'Best plain-language summary of learning science. Not golf-specific but directly applicable.',
+          },
+          {
+            title: '"Golf Is Not a Game of Perfect"',
+            by: 'Bob Rotella.',
+            note: 'Standard text on golf psychology and performance.',
+          },
+          {
+            title: '"Dave Pelz\'s Short Game Bible"',
+            note: 'Research-based approach to practice from inside 100 yards.',
+          },
+          {
+            title: '"Harvey Penick\'s Little Red Book"',
+            note: 'The most beloved golf instruction book ever written. Simple, wise, feel-based.',
+          },
+          {
+            title: '"Peak"',
+            by: 'Anders Ericsson.',
+            note: 'His own account of deliberate practice research. Better than the Gladwell version.',
+          },
+          {
+            title: '"Choke"',
+            by: 'Sian Beilock.',
+            note: 'Accessible neuroscience of performance under pressure.',
+          },
+        ]}
+      />
+
+      <H4>Research worth knowing</H4>
+      <ul style={UL_STYLE}>
+        <li>
+          Robert Bjork — contextual interference, desirable
+          difficulties (UCLA)
+        </li>
+        <li>
+          Anders Ericsson — deliberate practice and expert performance
+        </li>
+        <li>
+          Gabriele Wulf — attentional focus research showing external
+          focus cues outperform internal focus cues
+        </li>
+        <li>Sian Beilock — choking under pressure</li>
+      </ul>
+
+      <H4>Online resources</H4>
+      <ul style={UL_STYLE}>
+        <li>
+          TPI (Titleist Performance Institute):{' '}
+          <a
+            href="https://mytpi.com"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: '#1F3D2C', textDecoration: 'underline' }}
+          >
+            mytpi.com
+          </a>
+        </li>
+        <li>
+          Robert Bjork's lab:{' '}
+          <a
+            href="https://bjorklab.psych.ucla.edu"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: '#1F3D2C', textDecoration: 'underline' }}
+          >
+            bjorklab.psych.ucla.edu
+          </a>
+          <EditorialNote variant="todo" inline>
+            TODO: Verify this URL is current
+          </EditorialNote>
+        </li>
+      </ul>
+
+      <Footer />
+    </article>
+  )
+}
+
+// ===========================================================================
+// Components
+// ===========================================================================
+
+function WipBanner() {
+  const [dismissed, setDismissed] = useState(false)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (window.sessionStorage.getItem(WIP_KEY) === '1') setDismissed(true)
+  }, [])
+  if (dismissed) return null
+  return (
+    <div
+      role="note"
+      style={{
+        background: '#FBF8F1',
+        borderLeft: '3px solid #A66A1F',
+        borderTop: '1px solid #D9D2BF',
+        borderRight: '1px solid #D9D2BF',
+        borderBottom: '1px solid #D9D2BF',
+        borderRadius: 2,
+        padding: '14px 18px',
+        marginBottom: 22,
+        display: 'flex',
+        gap: 14,
+        alignItems: 'flex-start',
+      }}
+    >
+      <div style={{ flex: 1 }}>
+        <div className="kicker" style={{ marginBottom: 6, color: '#A66A1F' }}>
+          Work in progress
+        </div>
+        <p
+          className="text-caddie-ink"
+          style={{ fontSize: 14, lineHeight: 1.55 }}
+        >
+          This guide is being reviewed for accuracy. Treat specific
+          technique advice as provisional until the notice is removed.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          window.sessionStorage.setItem(WIP_KEY, '1')
+          setDismissed(true)
+        }}
+        className="font-mono uppercase"
+        style={{
+          background: 'transparent',
+          border: '1px solid #D9D2BF',
+          padding: '6px 10px',
+          fontSize: 10,
+          letterSpacing: '0.14em',
+          color: '#5C6356',
+          cursor: 'pointer',
+          borderRadius: 2,
+        }}
+      >
+        Dismiss
+      </button>
+    </div>
+  )
+}
+
+function H3({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 22,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        letterSpacing: '-0.01em',
+        lineHeight: 1.2,
+        marginTop: 22,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </h3>
+  )
+}
+
+function H4({ children }: { children: React.ReactNode }) {
+  return (
+    <h4
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 17,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        marginTop: 18,
+        marginBottom: 8,
+      }}
+    >
+      {children}
+    </h4>
+  )
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="text-caddie-ink"
+      style={{
+        fontSize: 15,
+        lineHeight: 1.6,
+        maxWidth: 680,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </p>
+  )
+}
+
+function Kv({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 12, maxWidth: 680 }}>
+      <span
+        className="font-serif text-caddie-ink"
+        style={{
+          fontSize: 15,
+          fontWeight: 500,
+          fontStyle: 'italic',
+        }}
+      >
+        {label}.
+      </span>{' '}
+      <span
+        className="text-caddie-ink"
+        style={{ fontSize: 15, lineHeight: 1.6 }}
+      >
+        {children}
+      </span>
+    </div>
+  )
+}
+
+function Hr() {
+  return (
+    <div
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        margin: '22px 0',
+      }}
+    />
+  )
+}
+
+const UL_STYLE: React.CSSProperties = {
+  listStyle: 'disc',
+  paddingLeft: 20,
+  margin: '8px 0 14px',
+  fontSize: 15,
+  lineHeight: 1.7,
+  color: '#1C211C',
+  maxWidth: 680,
+}
+
+function SessionTable() {
+  const rows = [
+    { phase: 'Warm up', dur: '10–15 min', why: 'Easy wedges, get body ready. Not practice time.' },
+    { phase: 'Skill work', dur: '20–30 min', why: 'Current focus area. Deliberate, with feedback.' },
+    { phase: 'Random / variable', dur: '20–30 min', why: 'Whole bag, random clubs, real targets.' },
+    { phase: 'Pressure games', dur: '10–15 min', why: 'Consequences on every shot. Keep score.' },
+    { phase: 'Short game', dur: '15–20 min', why: 'Chipping and pitching. Don’t skip.' },
+    { phase: 'Putting', dur: '10–15 min', why: 'Always end on the green. End by holing putts.' },
+  ]
+  return (
+    <div style={{ borderTop: '1px solid #D9D2BF', marginTop: 14, marginBottom: 18 }}>
+      {rows.map((r) => (
+        <div
+          key={r.phase}
+          className="grid grid-cols-1 sm:grid-cols-[1.2fr_0.8fr_2.5fr]"
+          style={{
+            gap: 14,
+            padding: '12px 0',
+            borderBottom: '1px solid #D9D2BF',
+            alignItems: 'baseline',
+          }}
+        >
+          <div
+            className="font-serif text-caddie-ink"
+            style={{ fontSize: 15, fontWeight: 500, fontStyle: 'italic' }}
+          >
+            {r.phase}
+          </div>
+          <div
+            className="font-mono tabular text-caddie-ink-dim"
+            style={{ fontSize: 12, letterSpacing: '0.05em' }}
+          >
+            {r.dur}
+          </div>
+          <div className="text-caddie-ink-dim" style={{ fontSize: 14, lineHeight: 1.5 }}>
+            {r.why}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+interface ResourceItem {
+  title: string
+  by?: string
+  note: string
+}
+
+function ResourceList({ items }: { items: ResourceItem[] }) {
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 14px', maxWidth: 680 }}>
+      {items.map((r) => (
+        <li
+          key={r.title}
+          style={{
+            padding: '12px 0',
+            borderTop: '1px solid #D9D2BF',
+          }}
+        >
+          <div
+            className="font-serif text-caddie-ink"
+            style={{ fontSize: 15, fontWeight: 500, fontStyle: 'italic' }}
+          >
+            {r.title}
+            {r.by && (
+              <span className="text-caddie-ink-dim" style={{ fontStyle: 'normal', fontWeight: 400 }}>
+                {' '}— {r.by}
+              </span>
+            )}
+          </div>
+          <div className="text-caddie-ink-dim" style={{ fontSize: 14, lineHeight: 1.55, marginTop: 4 }}>
+            {r.note}
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function EditorialNote({
+  variant,
+  inline,
+  children,
+}: {
+  variant: 'research' | 'todo'
+  inline?: boolean
+  children: React.ReactNode
+}) {
+  if (!DEV) return null
+  const tone = variant === 'research' ? '#1F3D2C' : '#A66A1F'
+  const label = variant === 'research' ? 'Source' : 'Todo'
+  if (inline) {
+    return (
+      <span
+        className="font-mono uppercase"
+        style={{
+          fontSize: 10,
+          letterSpacing: '0.14em',
+          color: tone,
+          marginLeft: 8,
+        }}
+      >
+        [{label}: {children}]
+      </span>
+    )
+  }
+  return (
+    <div
+      style={{
+        background: '#EBE5D6',
+        borderLeft: `3px solid ${tone}`,
+        padding: '10px 14px',
+        marginBottom: 14,
+        maxWidth: 680,
+      }}
+    >
+      <div
+        className="font-mono uppercase"
+        style={{
+          fontSize: 10,
+          letterSpacing: '0.14em',
+          color: tone,
+          marginBottom: 4,
+        }}
+      >
+        {label} · dev only
+      </div>
+      <div
+        className="text-caddie-ink-dim"
+        style={{ fontSize: 13, lineHeight: 1.5, fontStyle: 'italic' }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Footer() {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 1.6,
+      }}
+    >
+      Last reviewed May 2026 · Draft, needs instructor review · Edit
+      docs/learn/how-to-practice.md to contribute
+    </div>
+  )
+}

--- a/docs/learn/how-to-practice.md
+++ b/docs/learn/how-to-practice.md
@@ -1,0 +1,291 @@
+---
+title: How to Practice
+section: Improving Your Game
+status: draft
+last_reviewed: 2026-05
+contributors: []
+content_warning: |
+  This article is a work in progress. The structure and core
+  ideas are established but individual sections need deeper
+  research, better resource links, and review by a qualified
+  golf instructor before being considered complete.
+  Do not treat any specific technique advice as authoritative
+  until this notice is removed.
+---
+
+# How to Practice
+
+> **Work in progress.** This article is being developed.
+> Core structure is in place but content needs review,
+> additional research, and input from qualified instructors.
+> Resource links are placeholders — verify before using.
+
+## The uncomfortable truth
+
+Most golfers practice in a way that feels productive but
+isn't. They hit a bucket of balls, stripe a few drives,
+feel good, and leave. Their handicap doesn't move.
+
+This isn't laziness. It's that no one ever explained what
+practice is actually for — or that there's a difference
+between hitting balls and getting better.
+
+There's nothing wrong with going to the range to unwind,
+enjoy the weather, or just swing a club. That's a
+legitimate and enjoyable thing to do. But if your goal is
+to improve, that's a different activity and it requires a
+different approach.
+
+---
+
+## What practice is actually for
+
+Practice exists to change your behavior on the golf course.
+Not to feel good on the range. Not to hit your best shots.
+To change what you do under pressure, on uneven lies, with
+something at stake.
+
+If your practice doesn't eventually show up on the course,
+it wasn't practice — it was entertainment. Which, again,
+is fine. Just know which one you're doing.
+
+---
+
+## The four types of practice
+
+### Block practice
+
+**What it is:** Repeating the same shot over and over.
+50 7-irons in a row to the same target.
+
+**Good for:** Learning a brand new movement. If you're
+working on a swing change with your coach, some repetition
+helps establish the new pattern. Use it sparingly and early.
+
+**Not good for:** Building skills that transfer to the
+course. Research consistently shows that improvement during
+block practice doesn't stick. You get better within the
+session and worse by the next round.
+
+**The trap:** Block practice feels like learning because
+you do get better within the session. That feeling is
+misleading. It is one of the most well-replicated findings
+in motor learning research.
+
+> 📚 *Research basis: Robert Bjork (UCLA) — contextual
+> interference effect. See also: "Make It Stick" by Brown,
+> Roediger, McDaniel.*
+> ⚠️ *TODO: Add specific study citations*
+
+---
+
+### Random practice
+
+**What it is:** Varying every shot. 7-iron, driver, wedge,
+5-iron — never hitting the same club twice in a row.
+
+**Good for:** Building skills that actually transfer to
+the course. The research on this is consistent across
+many studies. Random practice feels harder and messier
+but produces dramatically better retention.
+
+**Why it works:** Each time you pick up a different club,
+your brain has to fully reconstruct the motor pattern from
+scratch. That reconstruction process is where learning
+happens.
+
+**Not good for:** Learning a brand new movement. Don't
+randomize before you have a basic pattern to work with.
+
+> 📚 *Research basis: Contextual interference effect,
+> Battig (1979), confirmed in many subsequent studies.*
+> ⚠️ *TODO: Verify whether the beginner exception is
+> well-established or still debated*
+
+---
+
+### Variable practice
+
+**What it is:** Same club, different conditions. 9-iron
+from 100 yards, then 90, then uphill, then into wind,
+then from a downslope.
+
+**Good for:** Building adaptability. Golf never gives you
+the same shot twice. Variable practice trains you for
+that reality.
+
+**Combine it with:** Random practice for maximum transfer.
+
+---
+
+### Pressure practice
+
+**What it is:** Creating consequences in practice.
+Something is at stake on each shot.
+
+**Examples:**
+- Make 5 putts in a row from 6 feet or start over from 0
+- Last ball in your bucket must hit a specific target
+- Play a simulated 9 holes on the range — pick targets,
+  keep score
+- Clock drill: 12 balls around the hole at 3 feet (clock
+  positions), make all 12 in a row or start over
+
+**Good for:** Training your nervous system to perform
+under pressure. If you've never practiced with
+consequences, your body hasn't learned how to handle them
+on the course.
+
+> 📚 *Research basis: Dr. Sian Beilock — "Choke" (2010).
+> Bob Rotella — "Golf Is Not a Game of Perfect" (1995).*
+> ⚠️ *TODO: Add more specific pressure practice examples
+> from tour player documented routines*
+
+---
+
+## How to structure a session
+
+A well-structured session has a flow. Adjust based on
+your time and current focus area.
+
+| Phase | Duration | Purpose |
+|-------|----------|---------|
+| Warm up | 10-15 min | Easy wedges, get body ready. Not practice time. |
+| Skill work | 20-30 min | Current focus area. Deliberate, with feedback. |
+| Random / variable | 20-30 min | Whole bag, random clubs, real targets. |
+| Pressure games | 10-15 min | Consequences on every shot. Keep score. |
+| Short game | 15-20 min | Chipping and pitching. Don't skip. |
+| Putting | 10-15 min | Always end on the green. End by holing putts. |
+
+> ⚠️ *TODO: Review these time allocations with a teaching
+> professional. The short game / full swing split in
+> particular (Dave Pelz suggests ~60% short game) needs
+> more exploration.*
+
+---
+
+## Having a goal for the session
+
+Before you hit a single ball, decide what you're trying
+to accomplish today.
+
+**Bad goal:** Work on my irons.
+**Better goal:** Work on my ball striking.
+**Good goal:** Hit 7 of 10 approach shots within 20 yards
+of the target from 150 yards.
+
+The difference is measurability. If you can't tell whether
+you achieved your goal, it wasn't a goal — it was a
+vague intention.
+
+Your OGA strokes gained data tells you exactly where to
+focus. If you're losing 1.2 strokes per round on approach
+shots, that's your focus area. Your practice goal should
+be specific to that weakness.
+
+**How to quantify your practice:**
+- Track your success rate on pressure games over time
+- Note which club and distance you practiced
+- Write down what you worked on and what changed
+- Connect practice focus to round data over time
+
+---
+
+## What bad practice looks like
+
+### The range bucket spiral
+Buy a large bucket. Hit wedges, feel good. Move to 7-iron,
+stripe a few. Pull out the driver. Spend 45 minutes
+hitting drivers because that's the most fun. Leave feeling
+like you worked hard. Nothing about your game changed.
+
+### Same shot, same target, same lie
+You struggle with your 6-iron so you hit 60 6-irons to
+the same target from a flat lie. On the course you face
+a 6-iron from a downslope with water left. These are
+completely different skills.
+
+### Practicing your strengths
+You putt well so you skip the green. You hit your driver
+well so you spend an hour on the tee line. Improvement
+comes from addressing weaknesses, not reinforcing
+strengths.
+
+### No target, no feedback
+Hitting shots without a specific target or any way to
+evaluate the result is exercise, not practice. Useful
+and enjoyable — but not improvement.
+
+### Working on technique under pressure
+The course is for playing. The range is for working on
+technique. Working on a swing change during a round
+rarely ends well.
+
+---
+
+## Practice round vs scoring round
+
+Two completely different activities. Mixing them is one
+of the most common mistakes amateurs make.
+
+**Practice round mode:** Experiment. Try the risky shot.
+Play from a bad lie on purpose. Hit two balls. Explore.
+Score doesn't matter — you're gathering information.
+
+**Scoring round mode:** Full pre-shot routine on every
+shot. Full commitment. No mulligans. Track everything.
+This is performance mode.
+
+The mistake is being half-committed to both — sort of
+practicing, sort of scoring. You get the anxiety of
+performance without the data of tracking, and the
+experimentation of practice without the freedom of no
+consequences.
+
+Before you tee off, decide which mode you're in and
+commit to it fully.
+
+---
+
+## Resources
+
+> ⚠️ *These are starting points for further research,
+> not endorsements. Verify all links are current before
+> publishing.*
+
+### Books
+- **"Make It Stick"** — Brown, Roediger, McDaniel.
+  Best plain-language summary of learning science.
+  Not golf-specific but directly applicable.
+- **"Golf Is Not a Game of Perfect"** — Bob Rotella.
+  Standard text on golf psychology and performance.
+- **"Dave Pelz's Short Game Bible"** — Research-based
+  approach to practice from inside 100 yards.
+- **"Harvey Penick's Little Red Book"** — The most
+  beloved golf instruction book ever written.
+  Simple, wise, feel-based.
+- **"Peak"** — Anders Ericsson. His own account of
+  deliberate practice research. Better than the
+  Gladwell version.
+- **"Choke"** — Sian Beilock. Accessible neuroscience
+  of performance under pressure.
+
+### Research worth knowing
+- Robert Bjork — contextual interference, desirable
+  difficulties (UCLA)
+- Anders Ericsson — deliberate practice and expert
+  performance
+- Gabriele Wulf — attentional focus research showing
+  external focus cues outperform internal focus cues
+- Sian Beilock — choking under pressure
+
+### Online resources
+- TPI (Titleist Performance Institute): https://mytpi.com
+- Robert Bjork's lab: https://bjorklab.psych.ucla.edu
+  ⚠️ *TODO: Verify this URL is current*
+
+---
+
+*Last reviewed: May 2026*
+*Status: Draft — needs instructor review before publishing*
+*To contribute: open a PR editing docs/learn/how-to-practice.md*


### PR DESCRIPTION
## Summary
- Adds `docs/learn/how-to-practice.md` as the source-of-truth markdown for the "How to practice effectively" guide. Readable on GitHub directly; includes WIP frontmatter and editorial TODOs inline.
- Web: replaces the stub at `#how-to-practice` with a full JSX-rendered article in `apps/web/src/pages/learn/articles/HowToPracticeArticle.tsx`. Follows DESIGN.md (Fraunces headings, Inter body, mono kickers, hairline rules, no shadows/gradients). Includes a dismissable amber WIP banner; editorial 📚/⚠️ notes render as dev-only `EditorialNote` blocks (gated by `import.meta.env.DEV`).
- Mobile: adds the same article to `apps/mobile/app/(app)/learn/[article].tsx` keyed on `'how-to-practice'`. Same WIP banner pattern with per-mount `useState` dismiss; editorial notes gated by `__DEV__`. Mirrors the web structure (H3/H4, KV pairs, bullets, session table).
- Flips `how-to-practice` status from `stub` to `live` in both `LEARN_SECTIONS` arrays.

## Notes
Content is a first draft. Needs review by a qualified golf instructor before the WIP notice is removed. Resource links need verification. See `docs/learn/how-to-practice.md` for the source markdown — that file is the authoritative copy; PRs should edit the markdown and update the JSX in lockstep until we wire up an automated renderer.

## Test plan
- [ ] Web: `/learn` → click "How to practice effectively" in TOC → article anchor scrolls into view
- [ ] Web: WIP banner renders amber-bordered, dismiss persists for the session
- [ ] Web (dev): editorial Source/Todo notes render with subtle backgrounds; build a prod bundle and confirm they vanish
- [ ] Mobile: Learn → "How to practice effectively" row navigates to detail screen with full article + WIP banner
- [ ] Mobile: dismiss button hides banner for that screen
- [ ] Mobile (dev): editorial notes visible; verify they are stripped in a production build
- [ ] `pnpm typecheck` clean
- [ ] `pnpm --filter web build` clean
- [ ] `cd apps/mobile && npm run typecheck` clean