### PR TITLE
fix(mobile): seven device-test fixes (Learn tab, markers, pin, aim ghosts, camera, putting handle, resume banner)

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -211,7 +211,7 @@ export default function AppLayout() {
           ),
         }}
       />
-      <Tabs.Screen name="learn" options={{ href: null }} />
+      <Tabs.Screen name="learn/index" options={{ href: null }} />
       <Tabs.Screen name="learn/[article]" options={{ href: null }} />
       <Tabs.Screen name="bag" options={{ href: null }} />
       <Tabs.Screen name="rounds" options={{ href: null }} />

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -46,6 +46,7 @@ const KICKER: import('react-native').TextStyle = {
   color: '#8A8B7E',
   fontSize: 10,
   fontWeight: '500',
+  fontFamily: 'JetBrainsMono-Medium',
   letterSpacing: 1.4,
   textTransform: 'uppercase',
 }
@@ -255,7 +256,7 @@ export default function Home() {
               borderRadius: 2,
               paddingVertical: 14,
               paddingHorizontal: 16,
-              paddingLeft: 20,
+              paddingLeft: 18,
               marginBottom: 14,
               backgroundColor: '#FBF8F1',
               flexDirection: 'row',
@@ -284,7 +285,6 @@ export default function Home() {
                   ...KICKER,
                   color: '#A66A1F',
                   marginBottom: 4,
-                  fontFamily: 'JetBrainsMono-Medium',
                 }}
               >
                 Active round
@@ -295,6 +295,7 @@ export default function Home() {
                   fontSize: 15,
                   fontWeight: '500',
                   fontFamily: 'Fraunces-Medium',
+                  fontStyle: 'italic',
                 }}
               >
                 {activeRound.courseName} · Hole {activeRound.currentHole}

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -191,8 +191,8 @@ export default function Home() {
     }
     pulse.value = withRepeat(
       withSequence(
-        withTiming(0.4, { duration: 1000 }),
-        withTiming(1, { duration: 1000 }),
+        withTiming(0.4, { duration: 1500 }),
+        withTiming(1, { duration: 1500 }),
       ),
       -1,
       false,

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -3,6 +3,14 @@ import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-na
 import { Link, useRouter } from 'expo-router'
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
 import { Swipeable } from 'react-native-gesture-handler'
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated'
 import { formatSG } from '@oga/core'
 import { deleteRound, getProfile, getRecentSGData } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
@@ -170,6 +178,31 @@ export default function Home() {
   // unrelated parent re-renders (delete sync, window resize) don't
   // re-walk the array four times for the SG averages and once more for
   // the trend points.
+  // Pulsing left border on the active-round banner — slow 1s in / 1s out
+  // breath so the player notices the live state without it nagging.
+  // Cancel on unmount or when activeRound clears so we don't leak a
+  // running worklet on Android.
+  const pulse = useSharedValue(1)
+  useEffect(() => {
+    if (!activeRound) {
+      cancelAnimation(pulse)
+      pulse.value = 1
+      return
+    }
+    pulse.value = withRepeat(
+      withSequence(
+        withTiming(0.4, { duration: 1000 }),
+        withTiming(1, { duration: 1000 }),
+      ),
+      -1,
+      false,
+    )
+    return () => {
+      cancelAnimation(pulse)
+    }
+  }, [activeRound, pulse])
+  const pulseStyle = useAnimatedStyle(() => ({ opacity: pulse.value }))
+
   const { breakdown, maxAbs, trend } = useMemo(() => {
     const bd = SG_KEYS.map((c) => {
       const values = rounds.map((r) => r[c.key]).filter((v): v is number => v !== null)
@@ -219,20 +252,41 @@ export default function Home() {
               )
             }
             style={{
-              borderWidth: 1,
-              borderColor: '#A66A1F',
               borderRadius: 2,
               paddingVertical: 14,
               paddingHorizontal: 16,
+              paddingLeft: 20,
               marginBottom: 14,
               backgroundColor: '#FBF8F1',
               flexDirection: 'row',
               alignItems: 'center',
               justifyContent: 'space-between',
+              position: 'relative',
+              overflow: 'hidden',
             }}
           >
+            <Animated.View
+              style={[
+                {
+                  position: 'absolute',
+                  left: 0,
+                  top: 0,
+                  bottom: 0,
+                  width: 4,
+                  backgroundColor: '#A66A1F',
+                },
+                pulseStyle,
+              ]}
+            />
             <View>
-              <Text style={{ ...KICKER, color: '#A66A1F', marginBottom: 4 }}>
+              <Text
+                style={{
+                  ...KICKER,
+                  color: '#A66A1F',
+                  marginBottom: 4,
+                  fontFamily: 'JetBrainsMono-Medium',
+                }}
+              >
                 Active round
               </Text>
               <Text
@@ -240,6 +294,7 @@ export default function Home() {
                   color: '#1C211C',
                   fontSize: 15,
                   fontWeight: '500',
+                  fontFamily: 'Fraunces-Medium',
                 }}
               >
                 {activeRound.courseName} · Hole {activeRound.currentHole}

--- a/apps/mobile/components/round/GreenDiagram.tsx
+++ b/apps/mobile/components/round/GreenDiagram.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useCallback } from 'react'
 import { Text, View } from 'react-native'
 import Svg, { Circle, Ellipse, Line, Path } from 'react-native-svg'
 import {
@@ -56,7 +56,6 @@ export function GreenDiagram({
   breakDirection = 'straight',
   onAimChange,
 }: GreenDiagramProps) {
-  const layoutRef = useRef<{ width: number } | null>(null)
   const { toDisplayFt } = useUnits()
 
   // Drag is driven entirely by Reanimated shared values so the SVG
@@ -82,18 +81,20 @@ export function GreenDiagram({
   const handleY = 150
   const trajectoryEndY = pinY + 60
 
-  function commitWithTranslation(translationX: number) {
-    const w = layoutRef.current?.width ?? SVG_WIDTH
-    const pxPerSvgX = w / SVG_WIDTH
-    const svgDelta = translationX / pxPerSvgX
-    const targetCx = clamp(
-      CENTER_X + aimOffsetInches * PX_PER_INCH + svgDelta,
-      HANDLE_MIN_X,
-      HANDLE_MAX_X,
-    )
-    const next = Math.round((targetCx - CENTER_X) / PX_PER_INCH)
-    if (next !== aimOffsetInches) onAimChange(next)
-  }
+  // The committed offset is derived entirely inside the worklet from
+  // `startOffset.value` (snapshotted at gesture begin) and the current
+  // shared values, then handed to the parent via runOnJS. Computing the
+  // final value in the worklet avoids a stale-closure pitfall: if the
+  // parent re-renders mid-gesture, the prior JS-thread commit function
+  // captured an outdated `aimOffsetInches` and the committed value
+  // could disagree with the visible handle position. The worklet path
+  // always reads the freshest shared values.
+  const commitOffset = useCallback(
+    (next: number) => {
+      onAimChange(next)
+    },
+    [onAimChange],
+  )
 
   const pan = Gesture.Pan()
     .activeOffsetX([-2, 2])
@@ -114,7 +115,15 @@ export function GreenDiagram({
     })
     .onEnd((e) => {
       'worklet'
-      runOnJS(commitWithTranslation)(e.translationX)
+      const pxPerSvgX = layoutWidth.value / SVG_WIDTH
+      const svgDelta = e.translationX / pxPerSvgX
+      const targetCx = clampWorklet(
+        CENTER_X + startOffset.value * PX_PER_INCH + svgDelta,
+        HANDLE_MIN_X,
+        HANDLE_MAX_X,
+      )
+      const next = Math.round((targetCx - CENTER_X) / PX_PER_INCH)
+      runOnJS(commitOffset)(next)
       offsetX.value = 0
     })
 
@@ -193,7 +202,6 @@ export function GreenDiagram({
       <GestureDetector gesture={pan}>
         <View
           onLayout={(e) => {
-            layoutRef.current = { width: e.nativeEvent.layout.width }
             layoutWidth.value = e.nativeEvent.layout.width
           }}
           style={{ aspectRatio: SVG_WIDTH / SVG_HEIGHT, width: '100%' }}
@@ -256,11 +264,8 @@ export function GreenDiagram({
   )
 }
 
-function clamp(n: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, n))
-}
-
-// Same as clamp but flagged as a worklet so it can run on the UI thread.
+// Worklet-flagged clamp so the Pan onEnd / useAnimatedProps math can
+// run on the UI thread without bouncing through JS.
 function clampWorklet(n: number, min: number, max: number): number {
   'worklet'
   return Math.min(max, Math.max(min, n))

--- a/apps/mobile/components/round/GreenDiagram.tsx
+++ b/apps/mobile/components/round/GreenDiagram.tsx
@@ -97,6 +97,12 @@ export function GreenDiagram({
 
   const pan = Gesture.Pan()
     .activeOffsetX([-2, 2])
+    // The diagram is rendered inside a ScrollView in PuttingSheet.
+    // Without `failOffsetY`, RNGH races the parent ScrollView for the
+    // initial touch and a slightly-diagonal drag can be claimed by the
+    // ScrollView, never activating the handle. Yield to vertical scroll
+    // only once the drag exceeds 5px vertical before 2px horizontal.
+    .failOffsetY([-5, 5])
     .onBegin(() => {
       'worklet'
       startOffset.value = aimOffsetInches

--- a/apps/mobile/components/round/GreenDiagram.tsx
+++ b/apps/mobile/components/round/GreenDiagram.tsx
@@ -36,6 +36,15 @@ const KICKER: import('react-native').TextStyle = {
 const SVG_WIDTH = 300
 const SVG_HEIGHT = 240
 const PX_PER_INCH = 3
+const CENTER_X = 150
+// Handle visual range, in SVG units. Stays inside the green trapezoid
+// (front edge 30→270). Both the worklet handle position and the
+// committed offset clamp against this range so they can't disagree —
+// the previous code clamped commit at ±50 in but pinned handle cx to
+// [50, 250] (±33 in), so dragging past the visual edge silently kept
+// updating the stored value while the handle stopped, producing drift.
+const HANDLE_MIN_X = 50
+const HANDLE_MAX_X = 250
 
 // Editorial perspective view from behind the ball, mobile flavor.
 // Drag the amber handle horizontally to bias aim left/right of the
@@ -76,10 +85,13 @@ export function GreenDiagram({
   function commitWithTranslation(translationX: number) {
     const w = layoutRef.current?.width ?? SVG_WIDTH
     const pxPerSvgX = w / SVG_WIDTH
-    const offsetInchesDelta = translationX / pxPerSvgX / PX_PER_INCH
-    const next = Math.round(
-      clamp(aimOffsetInches + offsetInchesDelta, -50, 50),
+    const svgDelta = translationX / pxPerSvgX
+    const targetCx = clamp(
+      CENTER_X + aimOffsetInches * PX_PER_INCH + svgDelta,
+      HANDLE_MIN_X,
+      HANDLE_MAX_X,
     )
+    const next = Math.round((targetCx - CENTER_X) / PX_PER_INCH)
     if (next !== aimOffsetInches) onAimChange(next)
   }
 
@@ -105,26 +117,26 @@ export function GreenDiagram({
   const handleProps = useAnimatedProps(() => {
     'worklet'
     const pxPerSvgX = layoutWidth.value / SVG_WIDTH
-    const deltaInches = offsetX.value / pxPerSvgX / PX_PER_INCH
+    const svgDelta = offsetX.value / pxPerSvgX
     const cx = clampWorklet(
-      150 + (startOffset.value + deltaInches) * PX_PER_INCH,
-      50,
-      250,
+      CENTER_X + startOffset.value * PX_PER_INCH + svgDelta,
+      HANDLE_MIN_X,
+      HANDLE_MAX_X,
     )
     return { cx }
   })
   const trajectoryProps = useAnimatedProps(() => {
     'worklet'
     const pxPerSvgX = layoutWidth.value / SVG_WIDTH
-    const deltaInches = offsetX.value / pxPerSvgX / PX_PER_INCH
+    const svgDelta = offsetX.value / pxPerSvgX
     const handleX = clampWorklet(
-      150 + (startOffset.value + deltaInches) * PX_PER_INCH,
-      50,
-      250,
+      CENTER_X + startOffset.value * PX_PER_INCH + svgDelta,
+      HANDLE_MIN_X,
+      HANDLE_MAX_X,
     )
-    const curveControlX = handleX * 0.6 + 150 * 0.4
+    const curveControlX = handleX * 0.6 + CENTER_X * 0.4
     return {
-      d: `M${ballX} ${ballY} Q ${curveControlX} ${handleY} 150 ${trajectoryEndY}`,
+      d: `M${ballX} ${ballY} Q ${curveControlX} ${handleY} ${CENTER_X} ${trajectoryEndY}`,
     }
   })
 

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -369,7 +369,12 @@ export function HoleMap({
                 id={`prev-shot-${i}`}
                 coordinate={toCoord(p)}
               >
-                <Marker color="#A66A1F" border="#FBF8F1" size={9} />
+                <NumberedMarker
+                  color="#A66A1F"
+                  border="#FBF8F1"
+                  size={20}
+                  number={i + 1}
+                />
               </Mapbox.PointAnnotation>
             ))}
 
@@ -668,6 +673,45 @@ function Marker({ color, border, size }: MarkerProps) {
         borderColor: border,
       }}
     />
+  )
+}
+
+type NumberedMarkerProps = MarkerProps & { number: number; opacity?: number }
+
+function NumberedMarker({
+  color,
+  border,
+  size,
+  number,
+  opacity = 1,
+}: NumberedMarkerProps) {
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: color,
+        borderWidth: 2,
+        borderColor: border,
+        alignItems: 'center',
+        justifyContent: 'center',
+        opacity,
+      }}
+    >
+      <Text
+        style={{
+          color: '#FBF8F1',
+          fontSize: size * 0.55,
+          fontWeight: '700',
+          fontVariant: ['tabular-nums'],
+          lineHeight: size,
+          textAlign: 'center',
+        }}
+      >
+        {number}
+      </Text>
+    </View>
   )
 }
 

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -126,11 +126,16 @@ export function HoleMap({
   }, [phase])
   // Hole change is signalled by previousShots resetting to empty (the
   // parent re-mounts a new hole with no prior shot starts). Clear ghosts
-  // so they don't bleed across holes.
+  // so they don't bleed across holes. Guarded on `aimGhosts.length > 0`
+  // so the initial mount (where prevShotsLen and aimGhosts.length are
+  // both 0) doesn't schedule a no-op state update.
   const prevShotsLen = previousShots?.length ?? 0
+  const ghostCount = aimGhosts.length
   useEffect(() => {
-    if (prevShotsLen === 0) setAimGhosts([])
-  }, [prevShotsLen])
+    if (prevShotsLen === 0 && ghostCount > 0) {
+      setAimGhosts([])
+    }
+  }, [prevShotsLen, ghostCount])
 
   // Mapbox's onLongPress wasn't firing reliably on Android (single-tap
   // onPress works fine, but long-press never reaches JS). Detect it via

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -234,14 +234,9 @@ export function HoleMap({
   }, [ball?.lat, ball?.lng, phase])
 
   // SET_AIM: rotate the camera so direction-of-play (ball → pin) is
-  // toward the top of the screen, zoom to fit the shot ahead, and
-  // tilt for a first-person-ish perspective. The 1.2s duration is
-  // the satisfying UX moment that signals "now aim".
-  //
-  // Zoom adapts to ball→pin distance so a 90-yd wedge frames the
-  // green tightly while a 380-yd par 5 still shows fairway + green.
-  // Fixed zoom 15 was too far out for short approaches and too close
-  // on long par 5s.
+  // toward the top of the screen and add a subtle tilt. Fixed zoom 15
+  // and pitch 20 — device testing showed adaptive zoom + 30° pitch was
+  // too aggressive and disorienting on the SET_AIM transition.
   useEffect(() => {
     if (!isAimPhase) return
     if (!cameraRef.current) return
@@ -257,19 +252,10 @@ export function HoleMap({
       ? (Math.atan2(target.lng - ball.lng, target.lat - ball.lat) * 180) /
         Math.PI
       : 0
-    const distYd = target ? distanceYards(ball, target) : null
-    const zoom =
-      distYd == null
-        ? 15
-        : distYd < 150
-          ? 16
-          : distYd <= 300
-            ? 15
-            : 14
     cameraRef.current.setCamera({
       centerCoordinate: toCoord(focus),
-      zoomLevel: zoom,
-      pitch: 30,
+      zoomLevel: 15,
+      pitch: 20,
       heading: bearing,
       animationDuration: 1200,
     })

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -97,6 +97,41 @@ export function HoleMap({
   const isAimPhase = phase === 'SET_AIM'
   const isPlaceBallPhase = phase === 'PLACE_BALL'
 
+  // Aim ghosts: prior shots' aim point + ball-start, retained as faded
+  // markers + dotted lines so the player can see intended direction vs
+  // actual result across the whole hole. Captured locally in HoleMap so
+  // the parent doesn't have to thread historical aim coords through.
+  const [aimGhosts, setAimGhosts] = useState<{ ball: LatLng; aim: LatLng }[]>(
+    [],
+  )
+  const lastAimSnapshotRef = useRef<{ ball: LatLng; aim: LatLng } | null>(null)
+  // While in SET_AIM, snapshot the current ball + aim pair so we can
+  // promote it to a ghost the moment the phase exits SET_AIM (i.e. shot
+  // was saved or aim was abandoned for ball placement again).
+  useEffect(() => {
+    if (isAimPhase && ball && aim) {
+      lastAimSnapshotRef.current = { ball, aim }
+    }
+  }, [isAimPhase, ball?.lat, ball?.lng, aim?.lat, aim?.lng])
+  const ghostPhaseRef = useRef<HoleMapPhase>(phase)
+  useEffect(() => {
+    if (ghostPhaseRef.current === 'SET_AIM' && phase !== 'SET_AIM') {
+      const snap = lastAimSnapshotRef.current
+      if (snap) {
+        setAimGhosts((prev) => [...prev, snap])
+        lastAimSnapshotRef.current = null
+      }
+    }
+    ghostPhaseRef.current = phase
+  }, [phase])
+  // Hole change is signalled by previousShots resetting to empty (the
+  // parent re-mounts a new hole with no prior shot starts). Clear ghosts
+  // so they don't bleed across holes.
+  const prevShotsLen = previousShots?.length ?? 0
+  useEffect(() => {
+    if (prevShotsLen === 0) setAimGhosts([])
+  }, [prevShotsLen])
+
   // Mapbox's onLongPress wasn't firing reliably on Android (single-tap
   // onPress works fine, but long-press never reaches JS). Detect it via
   // react-native-gesture-handler instead, then translate the screen
@@ -277,6 +312,21 @@ export function HoleMap({
     return { lat: (ball.lat + aim.lat) / 2, lng: (ball.lng + aim.lng) / 2 }
   }, [isAimPhase, ball, aim])
 
+  const aimGhostFeatures = useMemo(() => {
+    if (aimGhosts.length === 0) return null
+    return {
+      type: 'FeatureCollection' as const,
+      features: aimGhosts.map((g, i) => ({
+        type: 'Feature' as const,
+        properties: { id: i },
+        geometry: {
+          type: 'LineString' as const,
+          coordinates: [toCoord(g.ball), toCoord(g.aim)],
+        },
+      })),
+    }
+  }, [aimGhosts])
+
   // Breadcrumb line through every previous shot start, with a final
   // segment to the current ball so the most recent leg is visible too.
   // Filtered to require at least 2 points so the LineString geometry
@@ -407,6 +457,33 @@ export function HoleMap({
                   >
                     {toDisplay(seg.yards)}
                   </Text>
+                </View>
+              </Mapbox.PointAnnotation>
+            ))}
+
+          {styleLoaded && !isPinMode && aimGhostFeatures && (
+            <Mapbox.ShapeSource id="aimGhostsLine" shape={aimGhostFeatures}>
+              <Mapbox.LineLayer
+                id="aimGhostsLineLayer"
+                style={{
+                  lineColor: '#A66A1F',
+                  lineWidth: 1.2,
+                  lineDasharray: [3, 3],
+                  lineOpacity: 0.4,
+                }}
+              />
+            </Mapbox.ShapeSource>
+          )}
+
+          {!isPinMode &&
+            aimGhosts.map((g, i) => (
+              <Mapbox.PointAnnotation
+                key={`aim-ghost-${i}`}
+                id={`aim-ghost-${i}`}
+                coordinate={toCoord(g.aim)}
+              >
+                <View style={{ opacity: 0.4 }}>
+                  <Marker color="#A66A1F" border="#FBF8F1" size={9} />
                 </View>
               </Mapbox.PointAnnotation>
             ))}

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -520,7 +520,21 @@ export function HoleMap({
                 if (c) onPlacePin?.(c)
               }}
             >
-              <Flag tone={roundPin ? 'strong' : 'dim'} />
+              {/* 44pt transparent hit area in PIN mode so the flag is
+                  comfortable to drag — matches the ball/aim marker
+                  pattern (Apple HIG minimum target). Outside PIN mode
+                  the visual flag is the entire annotation; the halo
+                  has no behavioral effect. */}
+              <View
+                style={{
+                  width: 44,
+                  height: 44,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Flag tone={roundPin ? 'strong' : 'dim'} />
+              </View>
             </Mapbox.PointAnnotation>
           )}
 

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -239,9 +239,10 @@ export function HoleMap({
   }, [ball?.lat, ball?.lng, phase])
 
   // SET_AIM: rotate the camera so direction-of-play (ball → pin) is
-  // toward the top of the screen and add a subtle tilt. Fixed zoom 15
-  // and pitch 20 — device testing showed adaptive zoom + 30° pitch was
-  // too aggressive and disorienting on the SET_AIM transition.
+  // toward the top of the screen, add a subtle 20° tilt, and pick zoom
+  // by ball→pin distance so a wedge frames the green tightly while a
+  // par-5 still shows fairway + green. Fixed zoom 15 was too loose for
+  // short approaches (≤120 yd compressed the shot into a tiny band).
   useEffect(() => {
     if (!isAimPhase) return
     if (!cameraRef.current) return
@@ -257,9 +258,12 @@ export function HoleMap({
       ? (Math.atan2(target.lng - ball.lng, target.lat - ball.lat) * 180) /
         Math.PI
       : 0
+    const distYd = target ? distanceYards(ball, target) : null
+    const zoom =
+      distYd == null ? 15 : distYd >= 250 ? 14 : distYd >= 120 ? 15 : 16
     cameraRef.current.setCamera({
       centerCoordinate: toCoord(focus),
-      zoomLevel: 15,
+      zoomLevel: zoom,
       pitch: 20,
       heading: bearing,
       animationDuration: 1200,

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -431,20 +431,24 @@ export function HoleMap({
             </Mapbox.PointAnnotation>
           )}
 
-          {/* Stored hole pin: dim flag, only when no per-round pin.
-              Hidden in PIN mode so the annotation doesn't intercept the
-              tap that's supposed to place a new flag. */}
-          {!isPinMode && !roundPin && pin && (
-            <Mapbox.PointAnnotation id="pin" coordinate={toCoord(pin)}>
-              <Flag tone="dim" />
-            </Mapbox.PointAnnotation>
-          )}
-
-          {/* Per-round pin: prominent flag. Hidden in PIN mode for the
-              same reason — taps need to reach the map below. */}
-          {!isPinMode && roundPin && (
-            <Mapbox.PointAnnotation id="roundPin" coordinate={toCoord(roundPin)}>
-              <Flag tone="strong" />
+          {/* Single flag at effectivePin (roundPin > pin). Strong tone
+              when this round's pin is set, dim when only the stored
+              hole pin is known. In PIN mode the annotation is draggable
+              so the player can move it directly; tap-on-map (handled
+              below in handleTap) still places a fresh flag if dragging
+              isn't ergonomic. */}
+          {effectivePin && (
+            <Mapbox.PointAnnotation
+              id="effectivePin"
+              coordinate={toCoord(effectivePin)}
+              draggable={isPinMode}
+              onDragEnd={(e: unknown) => {
+                if (!isPinMode) return
+                const c = extractCoord(e)
+                if (c) onPlacePin?.(c)
+              }}
+            >
+              <Flag tone={roundPin ? 'strong' : 'dim'} />
             </Mapbox.PointAnnotation>
           )}
 
@@ -715,44 +719,56 @@ function NumberedMarker({
   )
 }
 
-// Simple flag glyph: vertical pole with a triangular cloth at the top.
-// "dim" = stored course pin (course default, may be wrong); "strong" =
-// today's actual flag position captured this round. Sized large enough
-// to read at zoom 17 against satellite imagery — the previous 16x22
-// version was disappearing into the green on real device tests.
+// Simple flag glyph: vertical pole with a rectangular cloth at the top
+// and a small base disk. PointAnnotation measures children via normal
+// flex layout — the previous absolutely-positioned version sometimes
+// rendered as a zero-size annotation on Android, leaving no visible
+// flag at all. This version uses an explicit-size column so the
+// annotation always has positive bounds.
 function Flag({ tone }: { tone: 'dim' | 'strong' }) {
   const flagColor = tone === 'strong' ? '#A33A2A' : 'rgba(163,58,42,0.85)'
-  const poleColor = tone === 'strong' ? '#FBF8F1' : '#FBF8F1'
+  const poleColor = '#FBF8F1'
   return (
-    <View style={{ width: 26, height: 36, alignItems: 'flex-start' }}>
+    <View
+      style={{
+        width: 28,
+        height: 38,
+        alignItems: 'flex-start',
+        justifyContent: 'flex-start',
+      }}
+    >
+      {/* Cloth + pole top section */}
+      <View style={{ flexDirection: 'row', alignItems: 'flex-start' }}>
+        <View
+          style={{
+            width: 3,
+            height: 12,
+            backgroundColor: poleColor,
+          }}
+        />
+        <View
+          style={{
+            width: 15,
+            height: 11,
+            backgroundColor: flagColor,
+            borderTopRightRadius: 1,
+          }}
+        />
+      </View>
+      {/* Pole shaft */}
       <View
         style={{
-          position: 'absolute',
-          left: 6,
-          top: 0,
           width: 3,
-          height: 36,
+          height: 22,
           backgroundColor: poleColor,
         }}
       />
+      {/* Base disk */}
       <View
         style={{
-          position: 'absolute',
-          left: 9,
-          top: 1,
-          width: 15,
-          height: 11,
-          backgroundColor: flagColor,
-          borderTopRightRadius: 1,
-        }}
-      />
-      <View
-        style={{
-          position: 'absolute',
-          left: 4,
-          top: 33,
-          width: 7,
+          width: 9,
           height: 3,
+          marginLeft: -3,
           borderRadius: 1.5,
           backgroundColor: poleColor,
         }}


### PR DESCRIPTION
## Summary
Device-testing pass on `dev`. Seven discrete fixes (one commit each) plus five audit-followup commits applied after running specialist review against the diff.

### Original 7 fixes
- **Learn tab routing**: `Tabs.Screen name="learn"` → `learn/index` so Expo Router v3 matches `app/(app)/learn/index.tsx`. Previous form raised `No route named "learn" exists in nested children`.
- **Shot marker numbers**: breadcrumb dots now show shot number centered (1, 2, 3...). Bumped 9px → 20px to fit text.
- **Pin/flag rendering**: single flag at `effectivePin`, draggable in PIN mode. Rewrote `Flag` from `position: absolute` children to flex column so `@rnmapbox/maps` PointAnnotation measures correctly on Android (prior version sometimes rendered zero-size and disappeared).
- **Aim ghost persistence**: every prior shot's ball→aim line + aim point persists for the rest of the hole as 40% opacity amber dotted line + faint marker. Cleared on hole change. Local state in `HoleMap`; parent untouched.
- **SET_AIM camera retune**: pitch 30 → pitch 20. Less aggressive transition.
- **Putting aim handle**: unified clamp on the SVG handle range (`HANDLE_MIN_X/MAX_X`). Visual handle and committed offset now share the same range — drift gone.
- **Resume round banner**: pulsing left bar (Reanimated `withRepeat(withSequence(withTiming, withTiming), -1)`) on the active-round home banner. `cancelAnimation` on cleanup and when `activeRound` clears.

### Audit-followup commits
- **GreenDiagram pan / ScrollView coexist**: added `.failOffsetY([-5, 5])` so a slightly-diagonal aim drag isn't claimed by the parent ScrollView.
- **Aim ghost reset guard**: skips no-op `setAimGhosts([])` on initial mount when ghosts already empty.
- **Adaptive SET_AIM zoom restored**: distance-banded zoom 14/15/16 by ball→pin yards (≥250 → 14, 120–250 → 15, <120 → 16). Pitch stays at 20. Fixed zoom 15 was framing wedge approaches too loose.
- **Pulse cadence 3 s**: `withTiming` duration 1000 → 1500 per phase. Slower breath better matches the editorial yardage-book aesthetic.
- **GreenDiagram commit from worklet**: `onEnd` now derives the final committed offset entirely inside the worklet using `startOffset.value` and `layoutWidth.value`, then `runOnJS`'s the resulting integer to the parent. Eliminates a stale-closure pitfall where a parent re-render mid-gesture could leave the JS-thread commit function reading an outdated `aimOffsetInches`.

## Tuning concern to monitor on device
**Breadcrumb markers grew from 9px to 20px** to fit shot numbers — they may visually merge when adjacent shots are <6 yd apart (re-tees, tap-ins, lipped putts). Acceptable trade-off for shot-number visibility, but watch on a real round.

## Test plan
- [ ] Open app → Learn link no longer crashes the tab tree
- [ ] Live round: numbers visible inside breadcrumb circles for shots 1..N
- [ ] Live round: flag renders at hole pin; can drag in PIN mode to reposition
- [ ] Live round: after saving shot 1, set up shot 2 — prior aim line + marker remain as 40% opacity ghost
- [ ] Live round: walk to next hole — all aim ghosts cleared
- [ ] Live round: SET_AIM transitions feel right at <120 yd, 120–250 yd, and 250+ yd; pitch 20 is gentle
- [ ] Putting sheet: drag aim handle — handle tracks finger precisely; commit value matches visible handle position at edges
- [ ] Putting sheet: vertical scroll still works; aim drag still activates from any starting angle
- [ ] Home: with an active round started <24 h ago, banner shows above "Start live round" CTA with pulsing left bar at ~3 s cycle; tap navigates to current hole
- [ ] `pnpm typecheck` and mobile `npm run typecheck` pass