### PR TITLE
fix(ux): live round polish — banner refresh, username validation, hide Start when active

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
-import { Link, useRouter } from 'expo-router'
+import { Link, useFocusEffect, useRouter } from 'expo-router'
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
 import { Swipeable } from 'react-native-gesture-handler'
 import Animated, {
@@ -127,53 +127,61 @@ export default function Home() {
   // the home screen forever. The current hole is the highest hole the
   // player has logged a score on, +1 (capped at 18) — so resuming
   // jumps back to where they left off, not hole 1.
-  useEffect(() => {
-    if (!user) return
-    let active = true
-    ;(async () => {
-      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
-        .toISOString()
-        .slice(0, 10)
-      const { data, error } = await supabase
-        .from('rounds')
-        .select('id, played_at, course_id, courses(name)')
-        .eq('user_id', user.id)
-        .is('total_score', null)
-        .gte('played_at', oneDayAgo)
-        .order('played_at', { ascending: false })
-        .limit(1)
-      if (!active || error || !data?.[0]) {
-        setActiveRound(null)
-        return
+  //
+  // Uses `useFocusEffect` so the query re-runs every time the home tab
+  // gains focus. Without this, deleting the active round from the
+  // hole/end-round screens left a stale banner showing on home until
+  // the app reloaded — there's no react-query cache here to invalidate.
+  useFocusEffect(
+    useCallback(() => {
+      if (!user) return
+      let active = true
+      ;(async () => {
+        const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+          .toISOString()
+          .slice(0, 10)
+        const { data, error } = await supabase
+          .from('rounds')
+          .select('id, played_at, course_id, courses(name)')
+          .eq('user_id', user.id)
+          .is('total_score', null)
+          .gte('played_at', oneDayAgo)
+          .order('played_at', { ascending: false })
+          .limit(1)
+        if (!active) return
+        if (error || !data?.[0]) {
+          setActiveRound(null)
+          return
+        }
+        const round = data[0] as {
+          id: string
+          played_at: string
+          course_id: string
+          courses?: { name: string | null } | null
+        }
+        const { data: hs } = await supabase
+          .from('hole_scores')
+          .select('score, holes(number)')
+          .eq('round_id', round.id)
+          .gt('score', 0)
+        if (!active) return
+        const maxHole = (hs ?? []).reduce<number>((acc, row) => {
+          const n = (row as { holes?: { number?: number | null } | null })
+            .holes?.number
+          return typeof n === 'number' && n > acc ? n : acc
+        }, 0)
+        const next = Math.min(18, Math.max(1, maxHole + 1))
+        setActiveRound({
+          id: round.id,
+          courseName: round.courses?.name ?? 'Round',
+          currentHole: next,
+        })
+      })()
+      return () => {
+        active = false
       }
-      const round = data[0] as {
-        id: string
-        played_at: string
-        course_id: string
-        courses?: { name: string | null } | null
-      }
-      const { data: hs } = await supabase
-        .from('hole_scores')
-        .select('score, holes(number)')
-        .eq('round_id', round.id)
-        .gt('score', 0)
-      if (!active) return
-      const maxHole = (hs ?? []).reduce<number>((acc, row) => {
-        const n = (row as { holes?: { number?: number | null } | null }).holes
-          ?.number
-        return typeof n === 'number' && n > acc ? n : acc
-      }, 0)
-      const next = Math.min(18, Math.max(1, maxHole + 1))
-      setActiveRound({
-        id: round.id,
-        courseName: round.courses?.name ?? 'Round',
-        currentHole: next,
-      })
-    })()
-    return () => {
-      active = false
-    }
-  }, [user?.id])
+    }, [user?.id]),
+  )
 
   // SG breakdown + trend are pure functions of `rounds` — memoize so
   // unrelated parent re-renders (delete sync, window resize) don't

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -322,40 +322,44 @@ export default function Home() {
           </Pressable>
         )}
 
-        <Link href="/(app)/round/new?mode=live" asChild>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Start live round"
-            style={{
-              backgroundColor: '#1F3D2C',
-              borderRadius: 2,
-              paddingVertical: 18,
-              alignItems: 'center',
-              marginBottom: 6,
-            }}
-          >
+        {!activeRound && (
+          <>
+            <Link href="/(app)/round/new?mode=live" asChild>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Start live round"
+                style={{
+                  backgroundColor: '#1F3D2C',
+                  borderRadius: 2,
+                  paddingVertical: 18,
+                  alignItems: 'center',
+                  marginBottom: 6,
+                }}
+              >
+                <Text
+                  style={{
+                    color: '#F2EEE5',
+                    fontSize: 16,
+                    fontWeight: '700',
+                    letterSpacing: 0.4,
+                  }}
+                >
+                  ▶  Start live round
+                </Text>
+              </Pressable>
+            </Link>
             <Text
               style={{
-                color: '#F2EEE5',
-                fontSize: 16,
-                fontWeight: '700',
-                letterSpacing: 0.4,
+                color: '#5C6356',
+                fontSize: 12,
+                textAlign: 'center',
+                marginBottom: 14,
               }}
             >
-              ▶  Start live round
+              Track shots in real time with GPS
             </Text>
-          </Pressable>
-        </Link>
-        <Text
-          style={{
-            color: '#5C6356',
-            fontSize: 12,
-            textAlign: 'center',
-            marginBottom: 14,
-          }}
-        >
-          Track shots in real time with GPS
-        </Text>
+          </>
+        )}
 
         <Link href="/(app)/round/new?mode=past" asChild>
           <Pressable

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -28,6 +28,30 @@ const KICKER: import('react-native').TextStyle = {
   textTransform: 'uppercase',
 }
 
+// Mirrors the server-side username constraint: alphanumerics, hyphen,
+// underscore; 3–32 chars. Empty string is also valid (username is
+// nullable). Inlined rather than lifted to @oga/core because it has
+// only two callers (web + mobile profile screens) — under the
+// 3-caller extraction rule.
+const USERNAME_PATTERN = /^[a-zA-Z0-9_-]{3,32}$/
+const USERNAME_HELPER =
+  '3–32 characters. Letters, numbers, - and _ only.'
+
+// PostgREST surfaces raw SQL constraint messages on save errors —
+// fine for `console.error` but not for an Alert. Map the common
+// failure modes to friendly copy; everything else falls back to a
+// neutral string.
+function humanizeProfileSaveError(message: string | undefined): string {
+  if (!message) return 'Could not save profile. Please try again.'
+  if (/duplicate key|unique/i.test(message)) {
+    return 'That username is already taken.'
+  }
+  if (/check constraint|violates/i.test(message)) {
+    return "One of the fields didn't pass validation."
+  }
+  return 'Could not save profile. Please try again.'
+}
+
 export default function ProfileTab() {
   const router = useRouter()
   const { user, loading: authLoading } = useAuth()
@@ -39,6 +63,12 @@ export default function ProfileTab() {
   const [facilities, setFacilities] = useState<string[]>([])
   const [unit, setUnit] = useState<'yards' | 'meters'>('yards')
   const [saving, setSaving] = useState(false)
+  const [usernameTouched, setUsernameTouched] = useState(false)
+
+  const trimmedUsername = username.trim()
+  const usernameInvalid =
+    trimmedUsername !== '' && !USERNAME_PATTERN.test(trimmedUsername)
+  const showUsernameError = usernameTouched && usernameInvalid
 
   // Hydrate form fields from the server once per signed-in user. After
   // hydration, only save() and the user's edits drive the form — a
@@ -74,6 +104,11 @@ export default function ProfileTab() {
 
   async function save() {
     if (!user) return
+    if (usernameInvalid) {
+      setUsernameTouched(true)
+      Alert.alert('Username invalid', USERNAME_HELPER)
+      return
+    }
     const numericHandicap = handicap === '' ? null : Number(handicap)
     if (handicap !== '' && Number.isNaN(numericHandicap)) {
       Alert.alert('Handicap must be a number')
@@ -85,7 +120,7 @@ export default function ProfileTab() {
     }
     setSaving(true)
     const { data, error } = await updateProfile(supabase, user.id, {
-      username: username || null,
+      username: trimmedUsername || null,
       handicap_index: numericHandicap,
       skill_level: skill,
       goal,
@@ -94,7 +129,9 @@ export default function ProfileTab() {
     })
     setSaving(false)
     if (error) {
-      Alert.alert('Save failed', error.message)
+      // eslint-disable-next-line no-console
+      console.error('[profile/save]', error.message)
+      Alert.alert('Save failed', humanizeProfileSaveError(error.message))
       return
     }
     if (data) setProfile(data)
@@ -152,10 +189,26 @@ export default function ProfileTab() {
         <Field label="Username">
           <TextInput
             autoCapitalize="none"
+            autoCorrect={false}
             value={username}
-            onChangeText={setUsername}
-            style={inputStyle}
+            onChangeText={(v) => {
+              setUsername(v)
+              setUsernameTouched(true)
+            }}
+            style={{
+              ...inputStyle,
+              borderColor: showUsernameError ? '#A33A2A' : '#D9D2BF',
+            }}
           />
+          <Text
+            style={{
+              color: showUsernameError ? '#A33A2A' : '#8A8B7E',
+              fontSize: 11,
+              marginTop: 6,
+            }}
+          >
+            {USERNAME_HELPER}
+          </Text>
         </Field>
 
         <Field label="Handicap index">
@@ -249,15 +302,16 @@ export default function ProfileTab() {
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={saving ? 'Saving profile' : 'Save profile changes'}
-          accessibilityState={{ disabled: saving }}
+          accessibilityState={{ disabled: saving || usernameInvalid }}
           onPress={save}
-          disabled={saving}
+          disabled={saving || usernameInvalid}
           style={{
             marginTop: 18,
             backgroundColor: '#1F3D2C',
             borderRadius: 2,
             paddingVertical: 14,
             alignItems: 'center',
+            opacity: saving || usernameInvalid ? 0.5 : 1,
           }}
         >
           <Text

--- a/apps/web/src/pages/rounds/NewRoundPage.tsx
+++ b/apps/web/src/pages/rounds/NewRoundPage.tsx
@@ -5,6 +5,7 @@ import { CourseSearch } from '../../components/courses/CourseSearch'
 import { TeeSelector } from '../../components/courses/TeeSelector'
 import { useCreateRound } from '../../hooks/useRounds'
 import { useAuth } from '../../hooks/useAuth'
+import { supabase } from '../../lib/supabase'
 import { toUserMessage } from '../../lib/errors'
 
 const TEE_COLORS = ['black', 'blue', 'white', 'gold', 'red'] as const
@@ -30,6 +31,28 @@ export function NewRoundPage() {
     if (!courseId) {
       setError('Pick a course first.')
       return
+    }
+    // Block accidental abandonment: if the user already has an
+    // unfinished round started in the last day, ask before starting a
+    // fresh live round on top of it. Past-round logging is fine — it
+    // doesn't compete for the "currently playing" slot.
+    if (mode === 'live') {
+      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10)
+      const { data: unfinished } = await supabase
+        .from('rounds')
+        .select('id')
+        .eq('user_id', user.id)
+        .is('total_score', null)
+        .gte('played_at', oneDayAgo)
+        .limit(1)
+      if (unfinished && unfinished.length > 0) {
+        const ok = window.confirm(
+          'You have an unfinished round. Starting a new one will leave it incomplete. Continue?',
+        )
+        if (!ok) return
+      }
     }
     try {
       const round = await createRoundMutation.mutateAsync({

--- a/apps/web/src/pages/settings/SettingsPage.tsx
+++ b/apps/web/src/pages/settings/SettingsPage.tsx
@@ -37,6 +37,15 @@ const FACILITY_LABELS: Record<Facility, string> = {
   sim: 'Sim',
 }
 
+// Mirrors the server-side username constraint: alphanumerics, hyphen,
+// underscore; 3–32 chars. Empty string is also valid (username is
+// nullable). Inlined rather than lifted to @oga/core because it has
+// only two callers (web + mobile profile screens) — under the
+// 3-caller extraction rule.
+const USERNAME_PATTERN = /^[a-zA-Z0-9_-]{3,32}$/
+const USERNAME_HELPER =
+  '3–32 characters. Letters, numbers, - and _ only.'
+
 export function SettingsPage() {
   const { data: profile } = useProfile()
   const updateProfile = useUpdateProfile()
@@ -47,7 +56,17 @@ export function SettingsPage() {
   const [goal, setGoal] = useState<Goal | null>(null)
   const [facilities, setFacilities] = useState<Facility[]>([])
   const [saved, setSaved] = useState(false)
+  const [usernameTouched, setUsernameTouched] = useState(false)
   const unit = profile?.distance_unit ?? 'yards'
+
+  // Only validate non-empty values — username is nullable in the DB so
+  // clearing it is allowed. `usernameTouched` keeps the error hidden
+  // until the user has actually started typing, so the field doesn't
+  // open in a red state when the page loads with a blank profile.
+  const trimmedUsername = username.trim()
+  const usernameInvalid =
+    trimmedUsername !== '' && !USERNAME_PATTERN.test(trimmedUsername)
+  const showUsernameError = usernameTouched && usernameInvalid
 
   // Hydrate form fields the first time profile loads. Refetches (our own
   // save, or background refresh) must not stomp on values the user is in
@@ -82,7 +101,11 @@ export function SettingsPage() {
   async function saveProfile() {
     setError(null)
     setSaved(false)
-    const trimmed = username.trim()
+    if (usernameInvalid) {
+      setUsernameTouched(true)
+      setError(USERNAME_HELPER)
+      return
+    }
     const numericHandicap = handicap === '' ? null : Number(handicap)
     if (handicap !== '' && Number.isNaN(numericHandicap)) {
       setError('Handicap must be a number')
@@ -94,7 +117,7 @@ export function SettingsPage() {
     }
     try {
       await updateProfile.mutateAsync({
-        username: trimmed || null,
+        username: trimmedUsername || null,
         handicap_index: numericHandicap,
         skill_level: skill,
         goal,
@@ -136,11 +159,26 @@ export function SettingsPage() {
             <input
               type="text"
               value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              onChange={(e) => {
+                setUsername(e.target.value)
+                setUsernameTouched(true)
+              }}
+              aria-invalid={showUsernameError || undefined}
               autoCapitalize="off"
               autoCorrect="off"
-              style={inputStyle}
+              style={{
+                ...inputStyle,
+                borderColor: showUsernameError ? '#A33A2A' : '#D9D2BF',
+              }}
             />
+            <span
+              style={{
+                fontSize: 11,
+                color: showUsernameError ? '#A33A2A' : '#8A8B7E',
+              }}
+            >
+              {USERNAME_HELPER}
+            </span>
           </label>
           <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
             <span className="kicker">Handicap index</span>
@@ -159,7 +197,7 @@ export function SettingsPage() {
             <button
               type="button"
               onClick={saveProfile}
-              disabled={updateProfile.isPending}
+              disabled={updateProfile.isPending || usernameInvalid}
               className="bg-caddie-accent text-caddie-accent-ink"
               style={{
                 border: 'none',
@@ -168,8 +206,12 @@ export function SettingsPage() {
                 fontSize: 13,
                 fontWeight: 600,
                 letterSpacing: '0.02em',
-                cursor: 'pointer',
-                opacity: updateProfile.isPending ? 0.5 : 1,
+                cursor:
+                  updateProfile.isPending || usernameInvalid
+                    ? 'not-allowed'
+                    : 'pointer',
+                opacity:
+                  updateProfile.isPending || usernameInvalid ? 0.5 : 1,
               }}
             >
               {updateProfile.isPending ? 'Saving…' : 'Save profile'}


### PR DESCRIPTION
## Summary
Three UX polish fixes from device testing.

### 1. Resume banner persists after deleting round
Mobile home reads active-round state via direct Supabase query into local `useState` — no react-query cache to invalidate. The query was firing only on `user?.id` change, so deleting an active round elsewhere (rounds list, hole screen) left a stale banner showing on home until the app reloaded.

Fix: convert the active-round effect to `useFocusEffect` so it re-runs every time the home tab gains focus. Returning to home after a delete clears the banner immediately.

`apps/mobile/app/(app)/index.tsx`

### 2. Username validation inline
Pattern `^[a-zA-Z0-9_-]{3,32}$` enforced at the input level on both web (`SettingsPage`) and mobile (`profile.tsx`):

- Helper text below the field — neutral copy when untouched/valid; red when invalid AND user has typed
- Red border when invalid AND user has typed
- Save button disabled when invalid (keeps the user from hitting a server-side reject)
- `usernameTouched` flag avoids opening the form in a red state for accounts loaded with a blank username

Web error text already collapses via `toUserMessage()` (DEV: raw, PROD: neutral). Mobile post-save error now passes through `humanizeProfileSaveError()` — maps `unique`/`duplicate key` to "That username is already taken." and `check constraint` to "One of the fields didn't pass validation." Raw message still goes to `console.error`.

The regex is inlined in both files (two callers, under the 3-caller extraction rule from CLAUDE.md). Server-side enforcement still applies on save.

`apps/web/src/pages/settings/SettingsPage.tsx`, `apps/mobile/app/(app)/profile.tsx`

### 3. Hide Start live round when active round exists
- **Mobile** (`apps/mobile/app/(app)/index.tsx`): when `activeRound` is set, hide the "Start live round" CTA + GPS helper text. Resume banner is the primary CTA in that state. "Log past round" stays visible — it doesn't compete for the live slot.
- **Web** (`apps/web/src/pages/rounds/NewRoundPage.tsx`): if the user submits Live mode while an unfinished round (≤24h old, `total_score IS NULL`) already exists, prompt with `window.confirm("You have an unfinished round. Starting a new one will leave it incomplete. Continue?")`. Cancel aborts; OK proceeds.

## Test plan
- [ ] Mobile: start a live round, return to home → banner shows. Delete the round from the rounds list / hole screen → return to home → banner gone (no app reload)
- [ ] Mobile: with active banner showing, "Start live round" CTA hidden. "Log past round" still visible
- [ ] Web Settings + Mobile Profile: type `ab` (too short) → red border + helper text + Save disabled
- [ ] Web Settings + Mobile Profile: type `valid_user-1` → neutral helper, Save enabled
- [ ] Web Settings + Mobile Profile: clear username entirely (empty) → no error, Save enabled
- [ ] Mobile Profile: save with a username already taken → Alert shows "That username is already taken." (not raw Postgres)
- [ ] Web new round with unfinished round in last 24h, mode=Live → confirm prompt appears; Cancel aborts, OK proceeds
- [ ] Web new round with no unfinished round, mode=Live → no prompt
- [ ] Web new round, mode=Past → no prompt regardless of unfinished state
- [ ] `pnpm typecheck`, `pnpm --filter web build`, mobile `npm run typecheck` pass