### PR TITLE
fix(mobile): hole-not-found trap — synthesize holes + escape route

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -143,10 +143,52 @@ export default function HoleScreen() {
   const [confirmLeave, setConfirmLeave] = useState(false)
   const [confirmEnd, setConfirmEnd] = useState(false)
   const [ending, setEnding] = useState(false)
+  // Separate confirm state from the menu-triggered delete dialog so the
+  // error-screen Exit button can use friendlier copy ("nothing logged
+  // yet, the round will be discarded") without changing the meaning of
+  // the in-round Delete dialog.
+  const [confirmExit, setConfirmExit] = useState(false)
+
+  // Synthetic-holes fallback. Mirrors the web pattern documented in
+  // CLAUDE.md: when the course has fewer real `holes` rows than the
+  // expected count (18 here — mobile doesn't query course_tees yet),
+  // pad with par-4 placeholders keyed `synthetic-${roundId}-hole-${n}`
+  // so the UI can render and the player isn't trapped on a "Hole not
+  // found" screen. Going-forward, `round/new.tsx` materializes 18 real
+  // placeholder rows on first round at the course, so this branch only
+  // catches rounds created before that fix or while a partial holes
+  // ingest is in flight. UPDATEs against synthetic hole_scores will
+  // fail server-side; that's acceptable here because the only path
+  // that reaches synthetic mode is rounds with no logged scores, and
+  // the player can use the in-screen Exit Round button to bail.
+  const expectedHoleCount = 18
+  const effectiveHoles = useMemo<HoleRow[]>(() => {
+    if (!round) return holes
+    if (holes.length >= expectedHoleCount) return holes
+    const realByNumber = new Map<number, HoleRow>()
+    for (const h of holes) realByNumber.set(h.number, h)
+    return Array.from({ length: expectedHoleCount }, (_, i) => {
+      const num = i + 1
+      const real = realByNumber.get(num)
+      if (real) return real
+      return {
+        id: `synthetic-${round.id}-hole-${num}`,
+        course_id: round.course_id,
+        number: num,
+        par: 4,
+        yards: null,
+        stroke_index: num,
+        tee_lat: null,
+        tee_lng: null,
+        pin_lat: null,
+        pin_lng: null,
+      } as HoleRow
+    })
+  }, [holes, round])
 
   const currentHole = useMemo(
-    () => holes.find((h) => h.number === holeNumber) ?? null,
-    [holes, holeNumber],
+    () => effectiveHoles.find((h) => h.number === holeNumber) ?? null,
+    [effectiveHoles, holeNumber],
   )
   const currentHoleScore = useMemo(
     () => holeScores.find((hs) => hs.hole_id === currentHole?.id) ?? null,
@@ -713,6 +755,36 @@ export default function HoleScreen() {
     }
   }
 
+  // Escape hatch from the error screen. If we have a round row but
+  // can't render it (no holes / no hole_scores / etc.), discard it so
+  // the resume banner on home doesn't drag the player back into the
+  // same trap. If round is null we just navigate home — nothing to
+  // delete.
+  async function handleExitFromError() {
+    if (round && user) {
+      setDeleting(true)
+      try {
+        const { error: delErr } = await deleteRound(
+          supabase,
+          round.id,
+          user.id,
+        )
+        if (delErr) {
+          // eslint-disable-next-line no-console
+          console.error('[hole/exitFromError]', delErr.message)
+          Alert.alert('Could not discard round', delErr.message)
+          return
+        }
+      } finally {
+        setDeleting(false)
+        setConfirmExit(false)
+      }
+    } else {
+      setConfirmExit(false)
+    }
+    router.replace('/(app)')
+  }
+
   if (loading) {
     return (
       <View
@@ -728,6 +800,12 @@ export default function HoleScreen() {
     )
   }
   if (error || !round || !currentHole || !currentHoleScore) {
+    const headline = error
+      ? 'Something went wrong loading this round.'
+      : `Hole ${holeNumber} isn't set up for this round yet.`
+    const subline = error
+      ? 'Check your connection and try again, or exit to clear the round.'
+      : 'This usually means the course was created without per-hole layout data. Exit to discard the round and start fresh.'
     return (
       <View
         style={{
@@ -735,12 +813,90 @@ export default function HoleScreen() {
           alignItems: 'center',
           justifyContent: 'center',
           backgroundColor: '#F2EEE5',
-          padding: 18,
+          padding: 22,
         }}
       >
-        <Text style={{ color: '#A33A2A', fontSize: 13 }}>
-          {error ?? `Hole ${holeNumber} not found for this round.`}
+        <Text
+          style={{
+            color: '#1C211C',
+            fontSize: 20,
+            fontStyle: 'italic',
+            fontWeight: '500',
+            fontFamily: 'Fraunces-MediumItalic',
+            textAlign: 'center',
+            marginBottom: 10,
+          }}
+        >
+          {headline}
         </Text>
+        <Text
+          style={{
+            color: '#5C6356',
+            fontSize: 13,
+            lineHeight: 18,
+            textAlign: 'center',
+            marginBottom: 22,
+          }}
+        >
+          {subline}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Try again"
+          onPress={loadAll}
+          style={{
+            borderWidth: 1,
+            borderColor: '#1F3D2C',
+            borderRadius: 2,
+            paddingVertical: 12,
+            paddingHorizontal: 22,
+            marginBottom: 10,
+          }}
+        >
+          <Text
+            style={{
+              color: '#1F3D2C',
+              fontSize: 13,
+              fontWeight: '600',
+              letterSpacing: 0.3,
+            }}
+          >
+            Try again
+          </Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Exit round and discard"
+          onPress={() => setConfirmExit(true)}
+          style={{
+            backgroundColor: '#A33A2A',
+            borderRadius: 2,
+            paddingVertical: 14,
+            paddingHorizontal: 24,
+          }}
+        >
+          <Text
+            style={{
+              color: '#F2EEE5',
+              fontSize: 14,
+              fontWeight: '600',
+              letterSpacing: 0.3,
+            }}
+          >
+            Exit round
+          </Text>
+        </Pressable>
+        <ConfirmDialog
+          visible={confirmExit}
+          title="Leave this round?"
+          message="Nothing's been logged yet, so the round will be discarded."
+          confirmLabel="Leave round"
+          cancelLabel="Stay"
+          destructive
+          busy={deleting}
+          onConfirm={handleExitFromError}
+          onCancel={() => setConfirmExit(false)}
+        />
       </View>
     )
   }

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -154,16 +154,39 @@ export default function NewRound() {
       })
       if (roundError || !round) throw roundError ?? new Error('Round insert failed')
 
-      const { data: holes, error: holesError } = await supabase
+      const { data: existingHoles, error: holesError } = await supabase
         .from('holes')
         .select('id, number, par')
         .eq('course_id', courseId)
         .order('number')
       if (holesError) throw holesError
 
+      // Most courses (private clubs, anything not OSM-mapped) have zero
+      // rows in `holes`. Without holes there are no FK targets for
+      // hole_scores, the hole screen hits "Hole not found", and the
+      // resume banner traps the user. Materialize 18 par-4 placeholders
+      // for the course on the first round there — subsequent rounds at
+      // the same course inherit them, and any later enrichment / shot
+      // logging upgrades the rows in place via tee_lat / pin_lat fills.
+      let holes = existingHoles ?? []
+      if (holes.length === 0) {
+        const placeholders = Array.from({ length: 18 }, (_, i) => ({
+          course_id: courseId,
+          number: i + 1,
+          par: 4,
+          stroke_index: i + 1,
+        }))
+        const { data: inserted, error: phErr } = await supabase
+          .from('holes')
+          .insert(placeholders)
+          .select('id, number, par')
+        if (phErr) throw phErr
+        holes = inserted ?? []
+      }
+
       // Single batch insert beats 18 sequential round-trips; round was just
       // created so there's nothing to conflict against.
-      const holeScoreRows = (holes ?? []).map((h) => ({
+      const holeScoreRows = holes.map((h) => ({
         round_id: round.id,
         hole_id: h.id,
         score: 0,


### PR DESCRIPTION
## Summary
Two changes that together remove the "Hole 1 not found" dead-end the player hit when starting a round at a course with no per-hole layout (most private clubs, anything not OSM-mapped).

### Root cause: rounds were created without hole_scores
`apps/mobile/app/(app)/round/new.tsx` queried the `holes` table for the course and only inserted `hole_scores` rows when matching holes existed. For a course with zero rows in `holes`, no `hole_scores` were created, the hole screen rendered "Hole N not found", and the resume banner re-trapped the user every time they returned home.

**Fix**: when the `holes` query comes back empty, materialize 18 par-4 placeholder rows for the course (`number`, `par: 4`, `stroke_index`) before the `hole_scores` insert. The placeholders upgrade in place over time as the player drops shots and the synthetic-holes code path fills `tee_lat` / `pin_lat`.

### Defense: synthesis fallback + Exit button
`apps/mobile/app/(app)/round/[id]/hole/[number].tsx` is now defensive about rounds created before the root-cause fix (or while a partial holes ingest is running):

- **Length-based synthetic-holes fallback** mirrors the web pattern (CLAUDE.md): when `holes.length < 18`, pad with placeholders keyed `synthetic-${roundId}-hole-${n}`. `currentHole` derives from this; the screen renders.
- **"Hole not set up" error screen** replaces the bare-text dead-end. It shows headline + subline explaining the situation, plus two affordances:
  - **Try again** — re-runs `loadAll`
  - **Exit round** — confirm dialog ("Leave this round? Nothing's been logged yet, so the round will be discarded."), then deletes the round and navigates home. The home screen's `useFocusEffect` from PR #184 then re-checks active-round and the resume banner clears.
- The exit handler also handles the case where `round` itself is null (round-not-found) — falls through to `router.replace('/(app)')` without trying to delete a non-existent row.

`handleExitFromError` is separate from the in-round `handleDeleteRound` so the friendlier "nothing logged yet" copy doesn't change the meaning of the in-round Delete dialog (which warns about losing scored hole data).

## Related
- Splash screen ticket filed: #185
- Resume banner refresh on tab focus: #184 (already merged or in flight)

## Test plan
- [ ] Start a round at a private course with no holes-table rows → land on hole 1 with the map and shot logger working (no "Hole not found")
- [ ] Existing pre-fix broken round in the wild → return to that round → "Hole not set up" screen with Try again + Exit round buttons
- [ ] Tap Exit round → confirm dialog → confirm → round deleted → returned home → no resume banner
- [ ] Tap Try again with a flaky network → loadAll re-runs; succeeds when network returns
- [ ] Round with intact data → renders normally, no synthesis kick in
- [ ] `pnpm typecheck` and mobile `npm run typecheck` pass