### PR TITLE
fix: replace auto-putting trigger with confirmation + units in shot UI

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -148,6 +148,16 @@ export default function HoleScreen() {
   // yet, the round will be discarded") without changing the meaning of
   // the in-round Delete dialog.
   const [confirmExit, setConfirmExit] = useState(false)
+  // "On the green?" confirmation. Opened when the player marks ball
+  // within PUTTING_RADIUS_YARDS of the pin instead of auto-switching to
+  // putting mode — device testing showed the auto-switch was wrong
+  // often enough (chipping from rough at 25 yd, fringe lie at 8 yd)
+  // that the prompt is the safer default.
+  const [onGreenPromptOpen, setOnGreenPromptOpen] = useState(false)
+  // Seed lie type that gets passed to ShotLogger when it opens. Used
+  // to pre-fill 'green' for the YES path on the prompt and 'rough' for
+  // NO so the player isn't picking a lie chip from scratch every time.
+  const [loggerInitial, setLoggerInitial] = useState<ShotLoggerValue>({})
 
   // Synthetic-holes fallback. Mirrors the web pattern documented in
   // CLAUDE.md: when the course has fewer real `holes` rows than the
@@ -508,6 +518,7 @@ export default function HoleScreen() {
       // location — which on test builds (or anywhere far from where the
       // ball actually lies) jumped the marker miles off the course.
       setLoggerOpen(false)
+      setLoggerInitial({})
       setRoundState('PLACE_BALL')
       // Background sync — don't await.
       syncPendingShots().catch(() => undefined)
@@ -639,17 +650,34 @@ export default function HoleScreen() {
     // committed to, not anything an in-flight GPS callback wrote.
     setBall(ballSnapshot)
     setAim(null)
-    // Auto-switch to the putting flow when the player has marked their
-    // position within ~30 yd of the pin — bypasses SET_AIM (long-press
-    // line) and SHOT_DETAIL (club/lie/result), since none of those
-    // matter on a putt. Falls back to the standard aim flow if no pin
-    // is known.
+    // Within ~30 yd of the pin, ask first instead of auto-switching to
+    // putting. Wrong half the time on chips/bunker shots near the
+    // green; player decides. Falls back to the standard aim flow when
+    // no pin is known or the prompt is declined.
     const pinTarget = roundPin ?? storedPin ?? null
     if (pinTarget && distanceYards(ballSnapshot, pinTarget) <= PUTTING_RADIUS_YARDS) {
-      setRoundState('PUTTING')
+      setOnGreenPromptOpen(true)
       return
     }
     setRoundState('SET_AIM')
+  }
+
+  function handleOnGreenYes() {
+    setOnGreenPromptOpen(false)
+    setLoggerInitial({ lieType: 'green', club: 'putter' })
+    setRoundState('SHOT_DETAIL')
+    setLoggerOpen(true)
+  }
+
+  function handleOnGreenNo() {
+    setOnGreenPromptOpen(false)
+    // 'rough' is the safest near-green default — fairway/fringe/sand
+    // are common but rough is the modal answer for "near green but
+    // not putting". Player overrides in ShotLogger; this just saves a
+    // tap on the most likely choice.
+    setLoggerInitial({ lieType: 'rough' })
+    setRoundState('SHOT_DETAIL')
+    setLoggerOpen(true)
   }
 
   function confirmAim() {
@@ -666,6 +694,7 @@ export default function HoleScreen() {
 
   function closeLogger() {
     setLoggerOpen(false)
+    setLoggerInitial({})
     setRoundState('PLACE_BALL')
   }
 
@@ -1296,6 +1325,7 @@ export default function HoleScreen() {
             ? Math.round(distanceYards(ball, roundPin ?? storedPin ?? ball) * 3)
             : undefined
         }
+        initial={loggerInitial}
         onSave={(v) => persistShot(v)}
         onSkip={() => persistShot(null)}
         onClose={closeLogger}
@@ -1363,6 +1393,16 @@ export default function HoleScreen() {
         busy={ending}
         onConfirm={handleEndRound}
         onCancel={() => setConfirmEnd(false)}
+      />
+
+      <ConfirmDialog
+        visible={onGreenPromptOpen}
+        title="On the green?"
+        message="Within 30 yd of the pin — were you putting, or chipping/in a bunker?"
+        confirmLabel="Yes, I'm putting"
+        cancelLabel="No"
+        onConfirm={handleOnGreenYes}
+        onCancel={handleOnGreenNo}
       />
 
       <Modal

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -11,6 +11,7 @@ import {
 import type {
   BreakDirection,
   GreenSpeed,
+  LieType,
   PuttDirectionResult,
   PuttDistanceResult,
 } from '@oga/core'
@@ -35,6 +36,14 @@ interface PuttingSheetProps {
   initial?: PuttingValue
   onSave: (value: PuttingValue) => void
   onClose: () => void
+  /**
+   * Optional escape from putting mode without closing the sheet. When
+   * provided, renders a "Not a putt?" link that hands the lie back to
+   * the parent so it can swap to the regular shot logger UI. Used by
+   * ShotLogger when its internal `lieType === 'green'` branch wants to
+   * let the player undo an incorrect on-the-green prompt response.
+   */
+  onChangeLie?: (lie: LieType) => void
 }
 
 const KICKER: import('react-native').TextStyle = {
@@ -76,6 +85,7 @@ export function PuttingSheet({
   initial,
   onSave,
   onClose,
+  onChangeLie,
 }: PuttingSheetProps) {
   const { unit } = useUnits()
   const [value, setValue] = useState<PuttingValue>({
@@ -199,6 +209,26 @@ export function PuttingSheet({
           >
             On the green.
           </Text>
+          {onChangeLie && (
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Not a putt — switch to chip or bunker shot"
+              onPress={() => onChangeLie('rough')}
+              hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+              style={{ marginTop: 4 }}
+            >
+              <Text
+                style={{
+                  color: '#A66A1F',
+                  fontSize: 12,
+                  fontWeight: '500',
+                  letterSpacing: 0.2,
+                }}
+              >
+                Not a putt? Chip / bunker →
+              </Text>
+            </Pressable>
+          )}
         </View>
         <Pressable
           accessibilityRole="button"

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -8,12 +8,13 @@ import {
   TextInput,
   View,
 } from 'react-native'
-import type {
-  BreakDirection,
-  GreenSpeed,
-  LieType,
-  PuttDirectionResult,
-  PuttDistanceResult,
+import {
+  FEET_TO_CM,
+  type BreakDirection,
+  type GreenSpeed,
+  type LieType,
+  type PuttDirectionResult,
+  type PuttDistanceResult,
 } from '@oga/core'
 import { GreenDiagram } from './GreenDiagram'
 import { useUnits } from '../../hooks/useUnits'
@@ -88,6 +89,16 @@ export function PuttingSheet({
   onChangeLie,
 }: PuttingSheetProps) {
   const { unit } = useUnits()
+  const isMetric = unit === 'meters'
+  const inputUnit = isMetric ? 'cm' : 'ft'
+  // Storage stays in feet so SG baselines line up; the input field
+  // echoes the unit on the player's profile and converts on the way in
+  // and out. The previous label said "m" while the input still parsed
+  // feet — a metric player typing "5" stored 5 ft (1.5 m), not 5 m.
+  const feetToInput = (feet: number): number =>
+    isMetric ? Math.round(feet * FEET_TO_CM) : Math.round(feet)
+  const inputToFeet = (n: number): number =>
+    isMetric ? n / FEET_TO_CM : n
   const [value, setValue] = useState<PuttingValue>({
     puttDistanceFt: initial?.puttDistanceFt ?? initialDistanceFt ?? 0,
     puttMade: initial?.puttMade,
@@ -100,23 +111,23 @@ export function PuttingSheet({
     notes: initial?.notes,
   })
   const [distanceText, setDistanceText] = useState(
-    String(initial?.puttDistanceFt ?? initialDistanceFt ?? 0),
+    String(feetToInput(initial?.puttDistanceFt ?? initialDistanceFt ?? 0)),
   )
 
   useEffect(() => {
     if (initialDistanceFt != null && initial?.puttDistanceFt == null) {
       setValue((v) => ({ ...v, puttDistanceFt: initialDistanceFt }))
-      setDistanceText(String(initialDistanceFt))
+      setDistanceText(String(feetToInput(initialDistanceFt)))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialDistanceFt])
+  }, [initialDistanceFt, unit])
 
   function commitDistance(text: string) {
     setDistanceText(text)
     const n = parseFloat(text)
     setValue((v) => ({
       ...v,
-      puttDistanceFt: Number.isFinite(n) ? n : undefined,
+      puttDistanceFt: Number.isFinite(n) ? inputToFeet(n) : undefined,
     }))
   }
 
@@ -251,7 +262,7 @@ export function PuttingSheet({
 
         <View style={{ marginTop: 14 }}>
           <Text style={{ ...KICKER, marginBottom: 6 }}>
-            Distance override ({unit === 'meters' ? 'm' : 'ft'})
+            Distance override ({inputUnit})
           </Text>
           <TextInput
             keyboardType="numeric"

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -144,6 +144,16 @@ export function ShotLogger({
               })
             }
             onClose={onClose}
+            onChangeLie={(lie) =>
+              setValue((prev) => ({
+                ...prev,
+                lieType: lie,
+                // Drop putter when switching off the green — the player
+                // is logging a chip / bunker shot now and the club
+                // chip row will let them pick the right club.
+                club: prev.club === 'putter' ? undefined : prev.club,
+              }))
+            }
           />
         ) : (
         <View

--- a/apps/web/src/components/round/WebPuttingSheet.tsx
+++ b/apps/web/src/components/round/WebPuttingSheet.tsx
@@ -1,5 +1,10 @@
 import { useEffect, useState } from 'react'
-import type { PuttDirectionResult, PuttDistanceResult } from '@oga/core'
+import {
+  FEET_TO_CM,
+  type PuttDirectionResult,
+  type PuttDistanceResult,
+} from '@oga/core'
+import { useUnits } from '../../hooks/useUnits'
 
 export interface WebPuttData {
   puttMade: boolean
@@ -42,6 +47,17 @@ export function WebPuttingSheet({
   onSave,
   onClose,
 }: WebPuttingSheetProps) {
+  const { unit } = useUnits()
+  const isMetric = unit === 'meters'
+  const inputUnit = isMetric ? 'cm' : 'ft'
+  // Helpers for input ↔ storage conversion. Storage is always feet so
+  // SG baselines stay correct; the input echoes whatever unit the
+  // player has set on their profile.
+  const feetToInput = (feet: number): number =>
+    isMetric ? Math.round(feet * FEET_TO_CM) : Math.round(feet)
+  const inputToFeet = (n: number): number =>
+    isMetric ? n / FEET_TO_CM : n
+  const minInput = feetToInput(MIN_PUTT_FT)
   const [distanceText, setDistanceText] = useState('')
   const [made, setMade] = useState<boolean>(false)
   const [distanceResult, setDistanceResult] = useState<
@@ -58,23 +74,24 @@ export function WebPuttingSheet({
   useEffect(() => {
     if (!open) return
     const seed = initial ?? null
-    setDistanceText(
-      String(
-        Math.max(
-          MIN_PUTT_FT,
-          seed?.puttDistanceFt ?? Math.round(initialDistanceFt),
-        ),
-      ),
+    const seedFt = Math.max(
+      MIN_PUTT_FT,
+      seed?.puttDistanceFt ?? Math.round(initialDistanceFt),
     )
+    setDistanceText(String(feetToInput(seedFt)))
     setMade(seed?.puttMade ?? false)
     setDistanceResult(seed?.puttDistanceResult)
     setDirectionResult(seed?.puttDirectionResult)
-  }, [open, shotNumber, initialDistanceFt, initial])
+    // feetToInput depends on `unit` which is captured in the closure;
+    // eslint can't see the dependency and would request a useCallback.
+    // Keeping it inline keeps the seed logic in one place.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, shotNumber, initialDistanceFt, initial, unit])
 
   function commit(makeOverride: boolean) {
     const parsed = Number(distanceText)
     const dist = Number.isFinite(parsed)
-      ? Math.max(MIN_PUTT_FT, Math.round(parsed))
+      ? Math.max(MIN_PUTT_FT, Math.round(inputToFeet(parsed)))
       : null
     onSave({
       puttMade: makeOverride,
@@ -161,11 +178,11 @@ export function WebPuttingSheet({
 
       <div style={{ display: 'flex', flexDirection: 'column', gap: 14, marginTop: 14 }}>
         <label style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-          <span className="kicker">Distance (ft)</span>
+          <span className="kicker">Distance ({inputUnit})</span>
           <input
             type="number"
             inputMode="numeric"
-            min={MIN_PUTT_FT}
+            min={minInput}
             value={distanceText}
             onChange={(e) => setDistanceText(e.target.value)}
             className="bg-caddie-bg text-caddie-ink"

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -7,9 +7,11 @@ import {
   SHOT_RESULTS,
   SHOT_RESULT_LABELS,
   combinedPuttResult,
+  formatPuttDistance,
   legacySlopeToAxes,
   type BreakDirection,
   type Club,
+  type DistanceUnit,
   type GreenSpeed,
   type LieSlopeForward,
   type LieSlopeSide,
@@ -404,7 +406,7 @@ export function ShotEntryModal({
                         className="text-caddie-ink-dim"
                         style={{ fontSize: 12, marginTop: 2 }}
                       >
-                        {formatShotSummary(s)}
+                        {formatShotSummary(s, units.unit)}
                       </div>
                     </div>
                     <div className="flex" style={{ gap: 4 }}>
@@ -792,7 +794,7 @@ export function ShotEntryModal({
 // their putt_result label + distance; everything else gets the
 // shot_result label. Falls back to the raw value when the column has
 // something unexpected, and to '—' when both are null.
-function formatShotSummary(s: ShotRow): string {
+function formatShotSummary(s: ShotRow, unit: DistanceUnit): string {
   if (s.lie_type === 'green' || s.club === 'putter') {
     const result =
       (s.putt_result &&
@@ -800,7 +802,9 @@ function formatShotSummary(s: ShotRow): string {
       s.putt_result ??
       null
     const distance =
-      s.putt_distance_ft != null ? `${Math.round(s.putt_distance_ft)} ft` : null
+      s.putt_distance_ft != null
+        ? formatPuttDistance(s.putt_distance_ft, unit)
+        : null
     const parts = [result, distance].filter(Boolean) as string[]
     return parts.length ? parts.join(' · ') : '—'
   }

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -281,6 +281,12 @@ export function RoundDetailPage() {
   const allRounds = useRounds(50)
   const queryClient = useQueryClient()
   const [confirmDelete, setConfirmDelete] = useState(false)
+  // "On the green?" confirmation. Holds the placed point while the
+  // dialog is open. Cleared on either response — Yes pushes with the
+  // putting sheet, No pushes without it.
+  const [onGreenPrompt, setOnGreenPrompt] = useState<PlacedPoint | null>(
+    null,
+  )
 
   const [shotsModalFor, setShotsModalFor] = useState<{
     holeScoreId: string
@@ -575,17 +581,23 @@ export function RoundDetailPage() {
   const placeHandlers = useMemo(
     () => ({
       onPlace: (p: PlacedPoint) => {
-        // Auto-open the putting sheet for any tap within 30 yd of the
-        // pin so the user lands straight on putt entry instead of the
-        // generic shot detail row.
-        const isPutt =
+        // Within ~30 yd of the pin, ask before opening the putting
+        // sheet — the prior auto-switch was wrong on chips, bunkers,
+        // and fringe lies, and forced the player to back out and re-
+        // place to log a non-putt. The point goes into a holding cell
+        // until the prompt resolves.
+        const nearGreen =
           effectivePin != null &&
           haversineYards(p.lat, p.lng, effectivePin.lat, effectivePin.lng) <=
             NEAR_GREEN_YARDS
+        if (nearGreen) {
+          setOnGreenPrompt(p)
+          return
+        }
         dispatchHoleView({
           type: 'PUSH_POINT',
           point: p,
-          openPuttSheet: isPutt,
+          openPuttSheet: false,
         })
       },
       onMovePoint: (idx: number, p: PlacedPoint) =>
@@ -880,6 +892,34 @@ export function RoundDetailPage() {
         busy={deleteMutation.isPending}
         onConfirm={handleDelete}
         onCancel={() => setConfirmDelete(false)}
+      />
+
+      <ConfirmDialog
+        open={onGreenPrompt != null}
+        title="On the green?"
+        message="Within 30 yd of the pin — were you putting, or chipping/in a bunker?"
+        confirmLabel="Yes, I'm putting"
+        cancelLabel="No"
+        onConfirm={() => {
+          if (onGreenPrompt) {
+            dispatchHoleView({
+              type: 'PUSH_POINT',
+              point: onGreenPrompt,
+              openPuttSheet: true,
+            })
+          }
+          setOnGreenPrompt(null)
+        }}
+        onCancel={() => {
+          if (onGreenPrompt) {
+            dispatchHoleView({
+              type: 'PUSH_POINT',
+              point: onGreenPrompt,
+              openPuttSheet: false,
+            })
+          }
+          setOnGreenPrompt(null)
+        }}
       />
 
       {completeError && (


### PR DESCRIPTION
## Summary
Two related live-round fixes plus a backlog ticket for the long-term direction.

### 1. Replace auto-putting trigger with on-the-green confirmation
Within 30 yd of the pin, the app used to auto-switch into putting mode and skip aim/shot detail entirely. Wrong half the time on chips, bunker shots, and fringe lies — player had to back out of the putting sheet, re-place the ball, and start over.

Now, marking the ball within `PUTTING_RADIUS_YARDS` (mobile) / `NEAR_GREEN_YARDS` (web) opens a confirm dialog:

> **On the green?**
> Within 30 yd of the pin — were you putting, or chipping/in a bunker?
> [No] [Yes, I'm putting]

- **Yes** → opens ShotLogger (mobile) / putting sheet (web) with `lieType: 'green'` pre-set
- **No** → opens ShotLogger / shot detail with `lieType: 'rough'` pre-set as the modal near-green non-putt default; player can override

Mobile: dialog reuses the existing `ConfirmDialog`. Yes/No flow funnels through `ShotLogger` (which internally renders `PuttingSheet` when `lieType === 'green'`), unifying the prior split flow.

Mobile `PuttingSheet` also gains an inline "Not a putt? Chip / bunker →" link (only visible when ShotLogger passes the `onChangeLie` callback) so a player who tapped Yes by mistake can flip to chip/bunker mode without backing all the way out. Web's `ShotEntryModal` already has reactive `isPutt = lieType === 'green'`, so the existing chip row handles the same case there.

### 2. Shot distances respect unit preference
- `ShotEntryModal.formatShotSummary` (web) now takes a `DistanceUnit` and uses `formatPuttDistance` instead of a hardcoded `${ft} ft` template.
- `WebPuttingSheet` (web) and `PuttingSheet` (mobile) now label the distance override input with the user's display unit (`ft` or `cm`) and convert input ↔ feet on entry/save. The mobile label previously said "m" while the input was still parsed as feet — a metric player typing 5 stored 5 ft (1.5 m), not 5 m. Storage is still always feet so SG baselines line up.

Other distance displays in the round/review/scorecard surfaces already routed through `useUnits().toDisplay` / `toDisplayFt` and stay unchanged.

### Backlog
Filed #187 for the long-term direction: per-cell lie type mapping via H3 grid (depends on #125). Eventually the "On the green?" prompt becomes unnecessary because GPS position + community-contributed cell tags resolves the lie automatically.

## Test plan
- [ ] Mobile: place ball >30 yd from pin → SET_AIM as before, no prompt
- [ ] Mobile: place ball within 30 yd → "On the green?" dialog opens; Yes seeds putting UI; No seeds rough lie + ShotLogger
- [ ] Mobile: open putting sheet via Yes, tap "Not a putt? Chip / bunker →" → ShotLogger view with lie chips visible, putter cleared
- [ ] Web round detail map: tap within 30 yd of pin → "On the green?" dialog; Yes opens WebPuttingSheet; No opens regular ShotEntryModal flow
- [ ] Web settings → Metres → ShotEntryModal completed-shot summary line shows e.g. `…  · 152 cm` (not "5 ft")
- [ ] Web Metres → WebPuttingSheet input labelled "Distance (cm)"; typing 152 saves as 1.52 m worth of feet (5.0 ft)
- [ ] Mobile Metres → PuttingSheet override labelled "Distance override (cm)"; typing 152 saves as ~5 ft
- [ ] `pnpm typecheck`, `pnpm --filter web build`, mobile `npm run typecheck` all pass