### PR TITLE
v0.2 cleanup: HoleMap + home extractions, mobile AuthContext, wedge naming

### DIFF
--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -423,7 +423,7 @@ export default function BagScreen() {
                       {CANONICAL_CLUBS_BY_CATEGORY[draft.category].map((c) => (
                         <Chip
                           key={c}
-                          label={c}
+                          label={c === 'custom_wedge' ? 'Custom (loft)' : c}
                           active={draft.clubType === c}
                           onPress={() =>
                             setDraft((d) => ({ ...d, clubType: c }))
@@ -431,7 +431,7 @@ export default function BagScreen() {
                         />
                       ))}
                       <Chip
-                        label="Custom…"
+                        label="Other…"
                         active={false}
                         onPress={() => {
                           setCustomMode(true)

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,46 +1,35 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
-import { Link, useFocusEffect, useRouter } from 'expo-router'
-import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
-import { Swipeable } from 'react-native-gesture-handler'
-import Animated, {
-  cancelAnimation,
-  useAnimatedStyle,
-  useSharedValue,
-  withRepeat,
-  withSequence,
-  withTiming,
-} from 'react-native-reanimated'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ScrollView, Text, View } from 'react-native'
 import { formatSG } from '@oga/core'
 import { deleteRound, getProfile, getRecentSGData } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useActiveRound } from '../../hooks/useActiveRound'
 import { syncPendingShots } from '../../lib/sync'
 import { pendingCount } from '../../lib/db'
 import { AppBar } from '../../components/ui/AppBar'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { ResumeRoundBanner } from '../../components/home/ResumeRoundBanner'
+import { SGBreakdown } from '../../components/home/SGBreakdown'
+import { SGTrendChart } from '../../components/home/SGTrendChart'
+import {
+  LogPastRoundCTA,
+  StartLiveRoundCTA,
+} from '../../components/home/RoundCTAs'
+import {
+  RecentRoundsList,
+  type RecentRoundRow,
+} from '../../components/home/RecentRoundsList'
 
 type Profile = Database['public']['Tables']['profiles']['Row']
 
-interface RecentRound {
-  id: string
-  played_at: string
-  total_score: number | null
+interface RecentRound extends RecentRoundRow {
   sg_off_tee: number | null
   sg_approach: number | null
   sg_around_green: number | null
   sg_putting: number | null
-  sg_total: number | null
-  courses?: { name: string | null } | null
 }
-
-const SG_KEYS = [
-  { key: 'sg_off_tee', label: 'Off tee' },
-  { key: 'sg_approach', label: 'Approach' },
-  { key: 'sg_around_green', label: 'Around green' },
-  { key: 'sg_putting', label: 'Putting' },
-] as const
 
 const KICKER: import('react-native').TextStyle = {
   color: '#8A8B7E',
@@ -51,26 +40,17 @@ const KICKER: import('react-native').TextStyle = {
   textTransform: 'uppercase',
 }
 
-interface ActiveRound {
-  id: string
-  courseName: string
-  currentHole: number
-}
-
 export default function Home() {
   const { user } = useAuth()
-  const router = useRouter()
   const [profile, setProfile] = useState<Profile | null>(null)
   const [rounds, setRounds] = useState<RecentRound[]>([])
-  const [activeRound, setActiveRound] = useState<ActiveRound | null>(null)
+  const activeRound = useActiveRound()
   const [pending, setPending] = useState(0)
   const [pendingDelete, setPendingDelete] = useState<{
     id: string
     name: string
   } | null>(null)
   const [deleting, setDeleting] = useState(false)
-  const swipeRefs = useRef<Map<string, Swipeable | null>>(new Map())
-  const { width: screenWidth } = useWindowDimensions()
 
   const handleDelete = useCallback(
     async (id: string) => {
@@ -83,7 +63,6 @@ export default function Home() {
       } finally {
         setDeleting(false)
         setPendingDelete(null)
-        swipeRefs.current.delete(id)
       }
     },
     [user],
@@ -122,113 +101,19 @@ export default function Home() {
       .catch(() => undefined)
   }, [])
 
-  // Active-round detection. Active = total_score IS NULL AND played_at
-  // within the last day, so a round abandoned a week ago doesn't haunt
-  // the home screen forever. The current hole is the highest hole the
-  // player has logged a score on, +1 (capped at 18) — so resuming
-  // jumps back to where they left off, not hole 1.
-  //
-  // Uses `useFocusEffect` so the query re-runs every time the home tab
-  // gains focus. Without this, deleting the active round from the
-  // hole/end-round screens left a stale banner showing on home until
-  // the app reloaded — there's no react-query cache here to invalidate.
-  useFocusEffect(
-    useCallback(() => {
-      if (!user) return
-      let active = true
-      ;(async () => {
-        const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
-          .toISOString()
-          .slice(0, 10)
-        const { data, error } = await supabase
-          .from('rounds')
-          .select('id, played_at, course_id, courses(name)')
-          .eq('user_id', user.id)
-          .is('total_score', null)
-          .gte('played_at', oneDayAgo)
-          .order('played_at', { ascending: false })
-          .limit(1)
-        if (!active) return
-        if (error || !data?.[0]) {
-          setActiveRound(null)
-          return
-        }
-        const round = data[0] as {
-          id: string
-          played_at: string
-          course_id: string
-          courses?: { name: string | null } | null
-        }
-        const { data: hs } = await supabase
-          .from('hole_scores')
-          .select('score, holes(number)')
-          .eq('round_id', round.id)
-          .gt('score', 0)
-        if (!active) return
-        const maxHole = (hs ?? []).reduce<number>((acc, row) => {
-          const n = (row as { holes?: { number?: number | null } | null })
-            .holes?.number
-          return typeof n === 'number' && n > acc ? n : acc
-        }, 0)
-        const next = Math.min(18, Math.max(1, maxHole + 1))
-        setActiveRound({
-          id: round.id,
-          courseName: round.courses?.name ?? 'Round',
-          currentHole: next,
-        })
-      })()
-      return () => {
-        active = false
-      }
-    }, [user?.id]),
+  const trend = useMemo(
+    () =>
+      [...rounds].reverse().map((r, i) => ({
+        x: i + 1,
+        y: r.sg_total ?? 0,
+      })),
+    [rounds],
   )
 
-  // SG breakdown + trend are pure functions of `rounds` — memoize so
-  // unrelated parent re-renders (delete sync, window resize) don't
-  // re-walk the array four times for the SG averages and once more for
-  // the trend points.
-  // Pulsing left border on the active-round banner — slow 1s in / 1s out
-  // breath so the player notices the live state without it nagging.
-  // Cancel on unmount or when activeRound clears so we don't leak a
-  // running worklet on Android.
-  const pulse = useSharedValue(1)
-  useEffect(() => {
-    if (!activeRound) {
-      cancelAnimation(pulse)
-      pulse.value = 1
-      return
-    }
-    pulse.value = withRepeat(
-      withSequence(
-        withTiming(0.4, { duration: 1500 }),
-        withTiming(1, { duration: 1500 }),
-      ),
-      -1,
-      false,
-    )
-    return () => {
-      cancelAnimation(pulse)
-    }
-  }, [activeRound, pulse])
-  const pulseStyle = useAnimatedStyle(() => ({ opacity: pulse.value }))
-
-  const { breakdown, maxAbs, trend } = useMemo(() => {
-    const bd = SG_KEYS.map((c) => {
-      const values = rounds.map((r) => r[c.key]).filter((v): v is number => v !== null)
-      const avg =
-        values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length
-      return { ...c, value: Number(avg.toFixed(2)) }
-    })
-    const maxAbsValue = Math.max(...bd.map((b) => Math.abs(b.value)), 0.5)
-    const trendPoints = [...rounds].reverse().map((r, i) => ({
-      x: i + 1,
-      y: r.sg_total ?? 0,
-    }))
-    return { breakdown: bd, maxAbs: maxAbsValue, trend: trendPoints }
-  }, [rounds])
-
   const eyebrow =
-    profile?.handicap_index != null ? `Handicap ${profile.handicap_index}` : 'Welcome'
+    profile?.handicap_index != null
+      ? `Handicap ${profile.handicap_index}`
+      : 'Welcome'
   const firstName = profile?.username?.split(/\s+/)[0]
 
   return (
@@ -251,142 +136,9 @@ export default function Home() {
           Last {rounds.length || 0} round{rounds.length === 1 ? '' : 's'}
         </Text>
 
-        {activeRound && (
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={`Resume active round at ${activeRound.courseName}, hole ${activeRound.currentHole}`}
-            onPress={() =>
-              router.push(
-                `/(app)/round/${activeRound.id}/hole/${activeRound.currentHole}?mode=live`,
-              )
-            }
-            style={{
-              borderRadius: 2,
-              paddingVertical: 14,
-              paddingHorizontal: 16,
-              paddingLeft: 18,
-              marginBottom: 14,
-              backgroundColor: '#FBF8F1',
-              flexDirection: 'row',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              position: 'relative',
-              overflow: 'hidden',
-            }}
-          >
-            <Animated.View
-              style={[
-                {
-                  position: 'absolute',
-                  left: 0,
-                  top: 0,
-                  bottom: 0,
-                  width: 4,
-                  backgroundColor: '#A66A1F',
-                },
-                pulseStyle,
-              ]}
-            />
-            <View>
-              <Text
-                style={{
-                  ...KICKER,
-                  color: '#A66A1F',
-                  marginBottom: 4,
-                }}
-              >
-                Active round
-              </Text>
-              <Text
-                style={{
-                  color: '#1C211C',
-                  fontSize: 15,
-                  fontWeight: '500',
-                  fontFamily: 'Fraunces-Medium',
-                  fontStyle: 'italic',
-                }}
-              >
-                {activeRound.courseName} · Hole {activeRound.currentHole}
-              </Text>
-            </View>
-            <Text
-              style={{
-                color: '#A66A1F',
-                fontSize: 14,
-                fontWeight: '600',
-                letterSpacing: 0.3,
-              }}
-            >
-              Resume →
-            </Text>
-          </Pressable>
-        )}
-
-        {!activeRound && (
-          <>
-            <Link href="/(app)/round/new?mode=live" asChild>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Start live round"
-                style={{
-                  backgroundColor: '#1F3D2C',
-                  borderRadius: 2,
-                  paddingVertical: 18,
-                  alignItems: 'center',
-                  marginBottom: 6,
-                }}
-              >
-                <Text
-                  style={{
-                    color: '#F2EEE5',
-                    fontSize: 16,
-                    fontWeight: '700',
-                    letterSpacing: 0.4,
-                  }}
-                >
-                  ▶  Start live round
-                </Text>
-              </Pressable>
-            </Link>
-            <Text
-              style={{
-                color: '#5C6356',
-                fontSize: 12,
-                textAlign: 'center',
-                marginBottom: 14,
-              }}
-            >
-              Track shots in real time with GPS
-            </Text>
-          </>
-        )}
-
-        <Link href="/(app)/round/new?mode=past" asChild>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Log past round"
-            style={{
-              borderWidth: 1,
-              borderColor: '#1F3D2C',
-              backgroundColor: 'transparent',
-              borderRadius: 2,
-              paddingVertical: 14,
-              alignItems: 'center',
-              marginBottom: 22,
-            }}
-          >
-            <Text
-              style={{
-                color: '#1F3D2C',
-                fontSize: 14,
-                fontWeight: '600',
-                letterSpacing: 0.3,
-              }}
-            >
-              +  Log past round
-            </Text>
-          </Pressable>
-        </Link>
+        {activeRound && <ResumeRoundBanner round={activeRound} />}
+        {!activeRound && <StartLiveRoundCTA />}
+        <LogPastRoundCTA />
 
         {pending > 0 && (
           <View
@@ -438,180 +190,15 @@ export default function Home() {
           </View>
         ) : (
           <>
-            <Section kicker="SG breakdown">
-              <View style={{ gap: 14 }}>
-                {breakdown.map((b) => (
-                  <SGBar key={b.key} label={b.label} value={b.value} max={maxAbs} />
-                ))}
-              </View>
-            </Section>
-
-            <Section kicker="SG total trend">
-              <VictoryChart
-                height={200}
-                width={screenWidth - 36}
-                padding={{ top: 12, right: 16, bottom: 28, left: 32 }}
-              >
-                <VictoryAxis
-                  style={{
-                    axis: { stroke: '#D9D2BF' },
-                    tickLabels: {
-                      fontSize: 9,
-                      fill: '#8A8B7E',
-                      fontFamily: 'JetBrainsMono-Medium',
-                    },
-                    grid: { stroke: 'transparent' },
-                  }}
-                />
-                <VictoryAxis
-                  dependentAxis
-                  style={{
-                    axis: { stroke: '#D9D2BF' },
-                    tickLabels: {
-                      fontSize: 9,
-                      fill: '#8A8B7E',
-                      fontFamily: 'JetBrainsMono-Medium',
-                    },
-                    grid: { stroke: '#EBE5D6', strokeDasharray: '0' },
-                  }}
-                />
-                <VictoryLine
-                  data={trend}
-                  style={{ data: { stroke: '#1F3D2C', strokeWidth: 1.5 } }}
-                />
-              </VictoryChart>
-            </Section>
+            <SGBreakdown rounds={rounds} />
+            <SGTrendChart data={trend} />
           </>
         )}
 
-        <Section kicker="Recent rounds">
-          {rounds.length === 0 ? (
-            <Text style={{ color: '#8A8B7E', fontSize: 13 }}>No rounds yet.</Text>
-          ) : (
-            <View style={{ borderTopWidth: 1, borderColor: '#D9D2BF' }}>
-              {rounds.slice(0, 5).map((r) => (
-                <Swipeable
-                  key={r.id}
-                  ref={(ref) => {
-                    swipeRefs.current.set(r.id, ref)
-                  }}
-                  renderRightActions={() => (
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel={`Delete round at ${r.courses?.name ?? 'this round'}`}
-                      onPress={() => {
-                        swipeRefs.current.get(r.id)?.close()
-                        setPendingDelete({
-                          id: r.id,
-                          name: r.courses?.name ?? 'this round',
-                        })
-                      }}
-                      style={{
-                        backgroundColor: '#A33A2A',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                        paddingHorizontal: 22,
-                      }}
-                    >
-                      <Text
-                        style={{
-                          color: '#F2EEE5',
-                          fontSize: 13,
-                          fontWeight: '600',
-                          letterSpacing: 0.3,
-                        }}
-                      >
-                        Delete
-                      </Text>
-                    </Pressable>
-                  )}
-                  overshootRight={false}
-                >
-                  <Link href={`/(app)/round/${r.id}`} asChild>
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel={`Open round at ${r.courses?.name ?? 'unknown course'} on ${r.played_at}`}
-                      style={{
-                        flexDirection: 'row',
-                        justifyContent: 'space-between',
-                        alignItems: 'center',
-                        paddingVertical: 14,
-                        paddingHorizontal: 4,
-                        borderBottomWidth: 1,
-                        borderColor: '#D9D2BF',
-                        backgroundColor: '#F2EEE5',
-                      }}
-                    >
-                      <View style={{ flex: 1, paddingRight: 12 }}>
-                        <Text
-                          style={{
-                            ...KICKER,
-                            color: '#8A8B7E',
-                            marginBottom: 4,
-                          }}
-                        >
-                          {r.played_at}
-                        </Text>
-                        <Text
-                          style={{
-                            color: '#1C211C',
-                            fontSize: 17,
-                            fontWeight: '500',
-                            fontStyle: 'italic',
-                          }}
-                        >
-                          {r.courses?.name ?? 'Round'}
-                        </Text>
-                      </View>
-                      <View
-                        style={{
-                          flexDirection: 'row',
-                          alignItems: 'baseline',
-                          gap: 14,
-                        }}
-                      >
-                        <Text
-                          style={{
-                            color: '#1C211C',
-                            fontSize: 22,
-                            fontWeight: '500',
-                            fontVariant: ['tabular-nums'],
-                          }}
-                        >
-                          {r.total_score ?? '—'}
-                        </Text>
-                        <SGValue value={r.sg_total} />
-                      </View>
-                    </Pressable>
-                  </Link>
-                </Swipeable>
-              ))}
-              {rounds.length > 5 && (
-                <Link href="/(app)/rounds" asChild>
-                  <Pressable
-                    accessibilityRole="link"
-                    accessibilityLabel="See all rounds"
-                    style={{
-                      paddingVertical: 14,
-                      paddingHorizontal: 4,
-                      alignItems: 'flex-end',
-                    }}
-                  >
-                    <Text
-                      style={{
-                        color: '#8A8B7E',
-                        fontSize: 13,
-                        fontWeight: '500',
-                      }}
-                    >
-                      See all rounds →
-                    </Text>
-                  </Pressable>
-                </Link>
-              )}
-            </View>
-          )}
-        </Section>
+        <RecentRoundsList
+          rounds={rounds}
+          onRequestDelete={(id, name) => setPendingDelete({ id, name })}
+        />
       </ScrollView>
       <ConfirmDialog
         visible={!!pendingDelete}
@@ -630,119 +217,5 @@ export default function Home() {
         onCancel={() => setPendingDelete(null)}
       />
     </View>
-  )
-}
-
-function Section({
-  kicker,
-  children,
-}: {
-  kicker: string
-  children: React.ReactNode
-}) {
-  return (
-    <View style={{ marginBottom: 28 }}>
-      <View
-        style={{
-          borderTopWidth: 1,
-          borderColor: '#D9D2BF',
-          paddingTop: 14,
-          marginBottom: 14,
-        }}
-      >
-        <Text style={KICKER}>{kicker}</Text>
-      </View>
-      {children}
-    </View>
-  )
-}
-
-function SGBar({
-  label,
-  value,
-  max,
-}: {
-  label: string
-  value: number
-  max: number
-}) {
-  const pct = Math.min(Math.abs(value) / max, 1) * 50
-  const isPositive = value > 0
-  const color = value > 0 ? '#1F3D2C' : value < 0 ? '#A33A2A' : '#8A8B7E'
-  return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-      <Text style={{ color: '#1C211C', fontSize: 13, width: 100 }}>{label}</Text>
-      <View
-        style={{
-          flex: 1,
-          height: 8,
-          position: 'relative',
-        }}
-      >
-        <View
-          style={{
-            position: 'absolute',
-            left: 0,
-            right: 0,
-            top: 4,
-            height: 1,
-            backgroundColor: '#D9D2BF',
-          }}
-        />
-        <View
-          style={{
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            left: '50%',
-            width: 1,
-            backgroundColor: '#9F9580',
-          }}
-        />
-        <View
-          style={{
-            position: 'absolute',
-            top: 1,
-            bottom: 1,
-            left: isPositive ? '50%' : `${50 - pct}%`,
-            width: `${pct}%`,
-            backgroundColor: color,
-          }}
-        />
-      </View>
-      <Text
-        style={{
-          color,
-          fontSize: 15,
-          fontStyle: 'italic',
-          fontWeight: '500',
-          width: 56,
-          textAlign: 'right',
-          fontVariant: ['tabular-nums'],
-        }}
-      >
-        {formatSG(value)}
-      </Text>
-    </View>
-  )
-}
-
-function SGValue({ value }: { value: number | null }) {
-  if (value === null) {
-    return <Text style={{ color: '#8A8B7E', fontSize: 17 }}>—</Text>
-  }
-  const color = value > 0 ? '#1F3D2C' : value < 0 ? '#A33A2A' : '#5C6356'
-  return (
-    <Text
-      style={{
-        color,
-        fontSize: 17,
-        fontStyle: 'italic',
-        fontWeight: '500',
-        fontVariant: ['tabular-nums'],
-      }}
-    >
-      {formatSG(value)}
-    </Text>
   )
 }

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import * as SplashScreen from 'expo-splash-screen'
 import { useFonts } from 'expo-font'
+import { AuthProvider } from '../contexts/AuthContext'
 import { useAuth } from '../hooks/useAuth'
 import { ErrorBoundary } from '../components/errors/ErrorBoundary'
 import '../global.css'
@@ -20,6 +21,14 @@ void SplashScreen.preventAutoHideAsync().catch(() => {
 })
 
 export default function RootLayout() {
+  return (
+    <AuthProvider>
+      <RootLayoutContent />
+    </AuthProvider>
+  )
+}
+
+function RootLayoutContent() {
   // Bundled Fraunces — `Fraunces9pt-SemiBold` upstream is the closest
   // 500-ish weight to "Medium" available as a static instance, so we
   // alias it under the family name the rest of the app references.

--- a/apps/mobile/components/home/RecentRoundsList.tsx
+++ b/apps/mobile/components/home/RecentRoundsList.tsx
@@ -1,0 +1,180 @@
+import { useRef } from 'react'
+import { Pressable, Text, View } from 'react-native'
+import { Link } from 'expo-router'
+import { Swipeable } from 'react-native-gesture-handler'
+import { formatSG } from '@oga/core'
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  fontFamily: 'JetBrainsMono-Medium',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+export interface RecentRoundRow {
+  id: string
+  played_at: string
+  total_score: number | null
+  sg_total: number | null
+  courses?: { name: string | null } | null
+}
+
+interface RecentRoundsListProps {
+  rounds: RecentRoundRow[]
+  onRequestDelete: (id: string, name: string) => void
+}
+
+export function RecentRoundsList({
+  rounds,
+  onRequestDelete,
+}: RecentRoundsListProps) {
+  const swipeRefs = useRef<Map<string, Swipeable | null>>(new Map())
+
+  return (
+    <View style={{ marginBottom: 28 }}>
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderColor: '#D9D2BF',
+          paddingTop: 14,
+          marginBottom: 14,
+        }}
+      >
+        <Text style={KICKER}>Recent rounds</Text>
+      </View>
+      {rounds.length === 0 ? (
+        <Text style={{ color: '#8A8B7E', fontSize: 13 }}>No rounds yet.</Text>
+      ) : (
+        <View style={{ borderTopWidth: 1, borderColor: '#D9D2BF' }}>
+          {rounds.slice(0, 5).map((r) => (
+            <Swipeable
+              key={r.id}
+              ref={(ref) => {
+                swipeRefs.current.set(r.id, ref)
+              }}
+              renderRightActions={() => (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Delete round at ${r.courses?.name ?? 'this round'}`}
+                  onPress={() => {
+                    swipeRefs.current.get(r.id)?.close()
+                    onRequestDelete(r.id, r.courses?.name ?? 'this round')
+                  }}
+                  style={{
+                    backgroundColor: '#A33A2A',
+                    justifyContent: 'center',
+                    alignItems: 'center',
+                    paddingHorizontal: 22,
+                  }}
+                >
+                  <Text
+                    style={{
+                      color: '#F2EEE5',
+                      fontSize: 13,
+                      fontWeight: '600',
+                      letterSpacing: 0.3,
+                    }}
+                  >
+                    Delete
+                  </Text>
+                </Pressable>
+              )}
+              overshootRight={false}
+            >
+              <Link href={`/(app)/round/${r.id}`} asChild>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open round at ${r.courses?.name ?? 'unknown course'} on ${r.played_at}`}
+                  style={{
+                    flexDirection: 'row',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    paddingVertical: 14,
+                    paddingHorizontal: 4,
+                    borderBottomWidth: 1,
+                    borderColor: '#D9D2BF',
+                    backgroundColor: '#F2EEE5',
+                  }}
+                >
+                  <View style={{ flex: 1, paddingRight: 12 }}>
+                    <Text style={{ ...KICKER, color: '#8A8B7E', marginBottom: 4 }}>
+                      {r.played_at}
+                    </Text>
+                    <Text
+                      style={{
+                        color: '#1C211C',
+                        fontSize: 17,
+                        fontWeight: '500',
+                        fontStyle: 'italic',
+                      }}
+                    >
+                      {r.courses?.name ?? 'Round'}
+                    </Text>
+                  </View>
+                  <View
+                    style={{
+                      flexDirection: 'row',
+                      alignItems: 'baseline',
+                      gap: 14,
+                    }}
+                  >
+                    <Text
+                      style={{
+                        color: '#1C211C',
+                        fontSize: 22,
+                        fontWeight: '500',
+                        fontVariant: ['tabular-nums'],
+                      }}
+                    >
+                      {r.total_score ?? '—'}
+                    </Text>
+                    <SGValue value={r.sg_total} />
+                  </View>
+                </Pressable>
+              </Link>
+            </Swipeable>
+          ))}
+          {rounds.length > 5 && (
+            <Link href="/(app)/rounds" asChild>
+              <Pressable
+                accessibilityRole="link"
+                accessibilityLabel="See all rounds"
+                style={{
+                  paddingVertical: 14,
+                  paddingHorizontal: 4,
+                  alignItems: 'flex-end',
+                }}
+              >
+                <Text style={{ color: '#8A8B7E', fontSize: 13, fontWeight: '500' }}>
+                  See all rounds →
+                </Text>
+              </Pressable>
+            </Link>
+          )}
+        </View>
+      )}
+    </View>
+  )
+}
+
+function SGValue({ value }: { value: number | null }) {
+  if (value === null) {
+    return <Text style={{ color: '#8A8B7E', fontSize: 17 }}>—</Text>
+  }
+  const color = value > 0 ? '#1F3D2C' : value < 0 ? '#A33A2A' : '#5C6356'
+  return (
+    <Text
+      style={{
+        color,
+        fontSize: 17,
+        fontStyle: 'italic',
+        fontWeight: '500',
+        fontVariant: ['tabular-nums'],
+      }}
+    >
+      {formatSG(value)}
+    </Text>
+  )
+}

--- a/apps/mobile/components/home/RecentRoundsList.tsx
+++ b/apps/mobile/components/home/RecentRoundsList.tsx
@@ -60,6 +60,7 @@ export function RecentRoundsList({
                   accessibilityLabel={`Delete round at ${r.courses?.name ?? 'this round'}`}
                   onPress={() => {
                     swipeRefs.current.get(r.id)?.close()
+                    swipeRefs.current.delete(r.id)
                     onRequestDelete(r.id, r.courses?.name ?? 'this round')
                   }}
                   style={{

--- a/apps/mobile/components/home/ResumeRoundBanner.tsx
+++ b/apps/mobile/components/home/ResumeRoundBanner.tsx
@@ -1,0 +1,116 @@
+import { useEffect } from 'react'
+import { Pressable, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import Animated, {
+  cancelAnimation,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated'
+import type { ActiveRound } from '../../hooks/useActiveRound'
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  fontFamily: 'JetBrainsMono-Medium',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+// Pulsing left border on the active-round banner — slow 1.5s in / 1.5s
+// out breath so the player notices the live state without it nagging.
+// Cancel on unmount so we don't leak a running worklet on Android.
+export function ResumeRoundBanner({ round }: { round: ActiveRound }) {
+  const router = useRouter()
+  const pulse = useSharedValue(1)
+
+  useEffect(() => {
+    pulse.value = withRepeat(
+      withSequence(
+        withTiming(0.4, { duration: 1500 }),
+        withTiming(1, { duration: 1500 }),
+      ),
+      -1,
+      false,
+    )
+    return () => {
+      cancelAnimation(pulse)
+    }
+  }, [pulse])
+
+  const pulseStyle = useAnimatedStyle(() => ({ opacity: pulse.value }))
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`Resume active round at ${round.courseName}, hole ${round.currentHole}`}
+      onPress={() =>
+        router.push(
+          `/(app)/round/${round.id}/hole/${round.currentHole}?mode=live`,
+        )
+      }
+      style={{
+        borderRadius: 2,
+        paddingVertical: 14,
+        paddingHorizontal: 16,
+        paddingLeft: 18,
+        marginBottom: 14,
+        backgroundColor: '#FBF8F1',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <Animated.View
+        style={[
+          {
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            width: 4,
+            backgroundColor: '#A66A1F',
+          },
+          pulseStyle,
+        ]}
+      />
+      <View>
+        <Text
+          style={{
+            ...KICKER,
+            color: '#A66A1F',
+            marginBottom: 4,
+          }}
+        >
+          Active round
+        </Text>
+        <Text
+          style={{
+            color: '#1C211C',
+            fontSize: 15,
+            fontWeight: '500',
+            fontFamily: 'Fraunces-Medium',
+            fontStyle: 'italic',
+          }}
+        >
+          {round.courseName} · Hole {round.currentHole}
+        </Text>
+      </View>
+      <Text
+        style={{
+          color: '#A66A1F',
+          fontSize: 14,
+          fontWeight: '600',
+          letterSpacing: 0.3,
+        }}
+      >
+        Resume →
+      </Text>
+    </Pressable>
+  )
+}

--- a/apps/mobile/components/home/RoundCTAs.tsx
+++ b/apps/mobile/components/home/RoundCTAs.tsx
@@ -1,0 +1,74 @@
+import { Pressable, Text } from 'react-native'
+import { Link } from 'expo-router'
+
+export function StartLiveRoundCTA() {
+  return (
+    <>
+      <Link href="/(app)/round/new?mode=live" asChild>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Start live round"
+          style={{
+            backgroundColor: '#1F3D2C',
+            borderRadius: 2,
+            paddingVertical: 18,
+            alignItems: 'center',
+            marginBottom: 6,
+          }}
+        >
+          <Text
+            style={{
+              color: '#F2EEE5',
+              fontSize: 16,
+              fontWeight: '700',
+              letterSpacing: 0.4,
+            }}
+          >
+            ▶  Start live round
+          </Text>
+        </Pressable>
+      </Link>
+      <Text
+        style={{
+          color: '#5C6356',
+          fontSize: 12,
+          textAlign: 'center',
+          marginBottom: 14,
+        }}
+      >
+        Track shots in real time with GPS
+      </Text>
+    </>
+  )
+}
+
+export function LogPastRoundCTA() {
+  return (
+    <Link href="/(app)/round/new?mode=past" asChild>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Log past round"
+        style={{
+          borderWidth: 1,
+          borderColor: '#1F3D2C',
+          backgroundColor: 'transparent',
+          borderRadius: 2,
+          paddingVertical: 14,
+          alignItems: 'center',
+          marginBottom: 22,
+        }}
+      >
+        <Text
+          style={{
+            color: '#1F3D2C',
+            fontSize: 14,
+            fontWeight: '600',
+            letterSpacing: 0.3,
+          }}
+        >
+          +  Log past round
+        </Text>
+      </Pressable>
+    </Link>
+  )
+}

--- a/apps/mobile/components/home/SGBreakdown.tsx
+++ b/apps/mobile/components/home/SGBreakdown.tsx
@@ -1,0 +1,131 @@
+import { useMemo } from 'react'
+import { Text, View } from 'react-native'
+import { formatSG } from '@oga/core'
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  fontFamily: 'JetBrainsMono-Medium',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+const SG_KEYS = [
+  { key: 'sg_off_tee', label: 'Off tee' },
+  { key: 'sg_approach', label: 'Approach' },
+  { key: 'sg_around_green', label: 'Around green' },
+  { key: 'sg_putting', label: 'Putting' },
+] as const
+
+interface SGRow {
+  sg_off_tee: number | null
+  sg_approach: number | null
+  sg_around_green: number | null
+  sg_putting: number | null
+}
+
+// Average each SG category across the rounds, then render a diverging
+// bar per category with the value floated at the bar end.
+export function SGBreakdown({ rounds }: { rounds: SGRow[] }) {
+  const { breakdown, maxAbs } = useMemo(() => {
+    const bd = SG_KEYS.map((c) => {
+      const values = rounds
+        .map((r) => r[c.key])
+        .filter((v): v is number => v !== null)
+      const avg =
+        values.length === 0
+          ? 0
+          : values.reduce((a, b) => a + b, 0) / values.length
+      return { ...c, value: Number(avg.toFixed(2)) }
+    })
+    const maxAbsValue = Math.max(...bd.map((b) => Math.abs(b.value)), 0.5)
+    return { breakdown: bd, maxAbs: maxAbsValue }
+  }, [rounds])
+
+  return (
+    <View style={{ marginBottom: 28 }}>
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderColor: '#D9D2BF',
+          paddingTop: 14,
+          marginBottom: 14,
+        }}
+      >
+        <Text style={KICKER}>SG breakdown</Text>
+      </View>
+      <View style={{ gap: 14 }}>
+        {breakdown.map((b) => (
+          <SGBar key={b.key} label={b.label} value={b.value} max={maxAbs} />
+        ))}
+      </View>
+    </View>
+  )
+}
+
+function SGBar({
+  label,
+  value,
+  max,
+}: {
+  label: string
+  value: number
+  max: number
+}) {
+  const pct = Math.min(Math.abs(value) / max, 1) * 50
+  const isPositive = value > 0
+  const color = value > 0 ? '#1F3D2C' : value < 0 ? '#A33A2A' : '#8A8B7E'
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+      <Text style={{ color: '#1C211C', fontSize: 13, width: 100 }}>
+        {label}
+      </Text>
+      <View style={{ flex: 1, height: 8, position: 'relative' }}>
+        <View
+          style={{
+            position: 'absolute',
+            left: 0,
+            right: 0,
+            top: 4,
+            height: 1,
+            backgroundColor: '#D9D2BF',
+          }}
+        />
+        <View
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: '50%',
+            width: 1,
+            backgroundColor: '#9F9580',
+          }}
+        />
+        <View
+          style={{
+            position: 'absolute',
+            top: 1,
+            bottom: 1,
+            left: isPositive ? '50%' : `${50 - pct}%`,
+            width: `${pct}%`,
+            backgroundColor: color,
+          }}
+        />
+      </View>
+      <Text
+        style={{
+          color,
+          fontSize: 15,
+          fontStyle: 'italic',
+          fontWeight: '500',
+          width: 56,
+          textAlign: 'right',
+          fontVariant: ['tabular-nums'],
+        }}
+      >
+        {formatSG(value)}
+      </Text>
+    </View>
+  )
+}

--- a/apps/mobile/components/home/SGTrendChart.tsx
+++ b/apps/mobile/components/home/SGTrendChart.tsx
@@ -1,0 +1,66 @@
+import { Text, View, useWindowDimensions } from 'react-native'
+import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  fontFamily: 'JetBrainsMono-Medium',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+interface SGTrendChartProps {
+  data: { x: number; y: number }[]
+}
+
+export function SGTrendChart({ data }: SGTrendChartProps) {
+  const { width: screenWidth } = useWindowDimensions()
+  return (
+    <View style={{ marginBottom: 28 }}>
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderColor: '#D9D2BF',
+          paddingTop: 14,
+          marginBottom: 14,
+        }}
+      >
+        <Text style={KICKER}>SG total trend</Text>
+      </View>
+      <VictoryChart
+        height={200}
+        width={screenWidth - 36}
+        padding={{ top: 12, right: 16, bottom: 28, left: 32 }}
+      >
+        <VictoryAxis
+          style={{
+            axis: { stroke: '#D9D2BF' },
+            tickLabels: {
+              fontSize: 9,
+              fill: '#8A8B7E',
+              fontFamily: 'JetBrainsMono-Medium',
+            },
+            grid: { stroke: 'transparent' },
+          }}
+        />
+        <VictoryAxis
+          dependentAxis
+          style={{
+            axis: { stroke: '#D9D2BF' },
+            tickLabels: {
+              fontSize: 9,
+              fill: '#8A8B7E',
+              fontFamily: 'JetBrainsMono-Medium',
+            },
+            grid: { stroke: '#EBE5D6', strokeDasharray: '0' },
+          }}
+        />
+        <VictoryLine
+          data={data}
+          style={{ data: { stroke: '#1F3D2C', strokeWidth: 1.5 } }}
+        />
+      </VictoryChart>
+    </View>
+  )
+}

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -1,27 +1,27 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import { Text, View } from 'react-native'
 import Mapbox from '@rnmapbox/maps'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import { runOnJS } from 'react-native-reanimated'
 import { distanceYards, ensureMapboxInitialized } from '../../lib/maps'
 import { useUnits } from '../../hooks/useUnits'
+import { Marker } from './markers/Marker'
+import { FlagMarker } from './markers/FlagMarker'
+import { AimGhostLayers, useAimGhosts } from './markers/AimGhost'
+import { BreadcrumbLayers } from './markers/BreadcrumbLayers'
+import { AimDistancePill } from './markers/AimDistancePill'
+import { useHoleCamera } from './hooks/useHoleCamera'
+import {
+  MissingLayoutBanner,
+  PinDistancePill,
+  TeeBadge,
+  TopHint,
+} from './HoleMapOverlays'
+import type { HoleMapPhase, LatLng } from './HoleMap.types'
 
 ensureMapboxInitialized()
 
-export interface LatLng {
-  lat: number
-  lng: number
-}
-
-/**
- * `PLACE_BALL` — ball draggable, tap places ball, no aim interaction.
- * `SET_AIM`    — ball locked, long-press drops aim, camera rotates so
- *                play direction is up.
- * `PIN`        — pin placement modality (orthogonal to the shot flow).
- * Kept lowercase ('shot') for back-compat but new callers use the
- * three-phase form.
- */
-export type HoleMapPhase = 'PLACE_BALL' | 'SET_AIM' | 'PIN'
+export type { HoleMapPhase, LatLng }
 
 interface HoleMapProps {
   center: LatLng
@@ -84,9 +84,7 @@ export function HoleMap({
   onPlacePin,
 }: HoleMapProps) {
   const { toDisplay } = useUnits()
-  const cameraRef = useRef<Mapbox.Camera>(null)
   const mapViewRef = useRef<Mapbox.MapView>(null)
-  const cameraInitialized = useRef(false)
   // Native side fires "Source X is not in style" when a ShapeSource /
   // LineLayer mounts before the satellite style has finished loading.
   // Gate every source behind this flag so React never renders them
@@ -97,45 +95,15 @@ export function HoleMap({
   const isAimPhase = phase === 'SET_AIM'
   const isPlaceBallPhase = phase === 'PLACE_BALL'
 
-  // Aim ghosts: prior shots' aim point + ball-start, retained as faded
-  // markers + dotted lines so the player can see intended direction vs
-  // actual result across the whole hole. Captured locally in HoleMap so
-  // the parent doesn't have to thread historical aim coords through.
-  const [aimGhosts, setAimGhosts] = useState<{ ball: LatLng; aim: LatLng }[]>(
-    [],
-  )
-  const lastAimSnapshotRef = useRef<{ ball: LatLng; aim: LatLng } | null>(null)
-  // While in SET_AIM, snapshot the current ball + aim pair so we can
-  // promote it to a ghost the moment the phase exits SET_AIM (i.e. shot
-  // was saved or aim was abandoned for ball placement again).
-  useEffect(() => {
-    if (isAimPhase && ball && aim) {
-      lastAimSnapshotRef.current = { ball, aim }
-    }
-  }, [isAimPhase, ball?.lat, ball?.lng, aim?.lat, aim?.lng])
-  const ghostPhaseRef = useRef<HoleMapPhase>(phase)
-  useEffect(() => {
-    if (ghostPhaseRef.current === 'SET_AIM' && phase !== 'SET_AIM') {
-      const snap = lastAimSnapshotRef.current
-      if (snap) {
-        setAimGhosts((prev) => [...prev, snap])
-        lastAimSnapshotRef.current = null
-      }
-    }
-    ghostPhaseRef.current = phase
-  }, [phase])
-  // Hole change is signalled by previousShots resetting to empty (the
-  // parent re-mounts a new hole with no prior shot starts). Clear ghosts
-  // so they don't bleed across holes. Guarded on `aimGhosts.length > 0`
-  // so the initial mount (where prevShotsLen and aimGhosts.length are
-  // both 0) doesn't schedule a no-op state update.
-  const prevShotsLen = previousShots?.length ?? 0
-  const ghostCount = aimGhosts.length
-  useEffect(() => {
-    if (prevShotsLen === 0 && ghostCount > 0) {
-      setAimGhosts([])
-    }
-  }, [prevShotsLen, ghostCount])
+  const cameraRef = useHoleCamera({ center, ball, pin, roundPin, phase })
+
+  const previousShotsLen = previousShots?.length ?? 0
+  const { aimGhosts, aimGhostFeatures } = useAimGhosts({
+    ball,
+    aim,
+    phase,
+    previousShotsLen,
+  })
 
   // Mapbox's onLongPress wasn't firing reliably on Android (single-tap
   // onPress works fine, but long-press never reaches JS). Detect it via
@@ -175,109 +143,6 @@ export function HoleMap({
     [dropAimFromScreenPoint, isAimPhase],
   )
 
-  // Center the camera once on first valid coords. Subsequent center changes
-  // (e.g. GPS deltas while standing on the tee) should not retrigger
-  // setCamera — the style was reloading and the satellite tiles would flash
-  // back to a black canvas every time.
-  //
-  // PLACE_BALL is flat top-down (pitch 0) — tilt only happens on the
-  // SET_AIM transition below. A tilted tee-box camera was disorienting
-  // on the device because it framed grass at an angle before the player
-  // had even decided what they were aiming at.
-  useEffect(() => {
-    if (cameraInitialized.current) return
-    if (!cameraRef.current) return
-    cameraRef.current.setCamera({
-      centerCoordinate: toCoord(center),
-      zoomLevel: 17,
-      pitch: 0,
-      animationDuration: 400,
-    })
-    cameraInitialized.current = true
-  }, [center.lat, center.lng])
-
-  // When entering pin mode, zoom in on the stored pin so the user is
-  // looking at the green.
-  useEffect(() => {
-    if (!isPinMode) return
-    if (!cameraRef.current) return
-    const target = roundPin ?? pin ?? null
-    if (!target) return
-    cameraRef.current.setCamera({
-      centerCoordinate: toCoord(target),
-      zoomLevel: 19,
-      animationDuration: 400,
-    })
-  }, [isPinMode, roundPin?.lat, roundPin?.lng, pin?.lat, pin?.lng])
-
-  // Mark whether we owe the camera a PLACE_BALL re-frame on the next
-  // ball update. Set on phase transitions INTO PLACE_BALL (e.g. after
-  // saving a shot) so the camera flies back to the closer tee-style view
-  // once GPS settles on the new ball position.
-  const prevPhaseRef = useRef<HoleMapPhase>(phase)
-  const reframePlaceBallRef = useRef(false)
-  useEffect(() => {
-    if (phase === 'PLACE_BALL' && prevPhaseRef.current !== 'PLACE_BALL') {
-      reframePlaceBallRef.current = true
-    }
-    prevPhaseRef.current = phase
-  }, [phase])
-
-  useEffect(() => {
-    if (!reframePlaceBallRef.current) return
-    if (phase !== 'PLACE_BALL') return
-    if (!cameraRef.current) return
-    if (!ball) return
-    cameraRef.current.setCamera({
-      centerCoordinate: toCoord(ball),
-      zoomLevel: 17,
-      pitch: 0,
-      heading: 0,
-      animationDuration: 800,
-    })
-    reframePlaceBallRef.current = false
-  }, [ball?.lat, ball?.lng, phase])
-
-  // SET_AIM: rotate the camera so direction-of-play (ball → pin) is
-  // toward the top of the screen, add a subtle 20° tilt, and pick zoom
-  // by ball→pin distance so a wedge frames the green tightly while a
-  // par-5 still shows fairway + green. Fixed zoom 15 was too loose for
-  // short approaches (≤120 yd compressed the shot into a tiny band).
-  useEffect(() => {
-    if (!isAimPhase) return
-    if (!cameraRef.current) return
-    if (!ball) return
-    const target = roundPin ?? pin ?? null
-    const focus = target
-      ? {
-          lat: (ball.lat + target.lat) / 2,
-          lng: (ball.lng + target.lng) / 2,
-        }
-      : ball
-    const bearing = target
-      ? (Math.atan2(target.lng - ball.lng, target.lat - ball.lat) * 180) /
-        Math.PI
-      : 0
-    const distYd = target ? distanceYards(ball, target) : null
-    const zoom =
-      distYd == null ? 15 : distYd >= 250 ? 14 : distYd >= 120 ? 15 : 16
-    cameraRef.current.setCamera({
-      centerCoordinate: toCoord(focus),
-      zoomLevel: zoom,
-      pitch: 20,
-      heading: bearing,
-      animationDuration: 1200,
-    })
-  }, [
-    isAimPhase,
-    ball?.lat,
-    ball?.lng,
-    roundPin?.lat,
-    roundPin?.lng,
-    pin?.lat,
-    pin?.lng,
-  ])
-
   const effectivePin = roundPin ?? pin ?? null
   const pinDistance = useMemo(() => {
     if (!effectivePin || !ball) return null
@@ -307,21 +172,6 @@ export function HoleMap({
     return { lat: (ball.lat + aim.lat) / 2, lng: (ball.lng + aim.lng) / 2 }
   }, [isAimPhase, ball, aim])
 
-  const aimGhostFeatures = useMemo(() => {
-    if (aimGhosts.length === 0) return null
-    return {
-      type: 'FeatureCollection' as const,
-      features: aimGhosts.map((g, i) => ({
-        type: 'Feature' as const,
-        properties: { id: i },
-        geometry: {
-          type: 'LineString' as const,
-          coordinates: [toCoord(g.ball), toCoord(g.aim)],
-        },
-      })),
-    }
-  }, [aimGhosts])
-
   // Breadcrumb line through every previous shot start, with a final
   // segment to the current ball so the most recent leg is visible too.
   // Filtered to require at least 2 points so the LineString geometry
@@ -341,9 +191,8 @@ export function HoleMap({
   }, [previousShots, ball?.lat, ball?.lng])
 
   // Per-segment midpoint + distance for the small labels rendered along
-  // the breadcrumb line. Excludes the trailing ball→nothing segment when
-  // ball is the only point. Only segments between fully-resolved waypoint
-  // pairs are kept (the current ball position is included as the final
+  // the breadcrumb. Only segments between fully-resolved waypoint pairs
+  // are kept (the current ball position is included as the final
   // waypoint so the latest leg also gets a label).
   const previousShotSegments = useMemo(() => {
     const pts: LatLng[] = [...(previousShots ?? [])]
@@ -394,94 +243,21 @@ export function HoleMap({
             }}
           />
 
-          {styleLoaded && !isPinMode && previousShotsLine && (
-            <Mapbox.ShapeSource id="prevShotsLine" shape={previousShotsLine}>
-              <Mapbox.LineLayer
-                id="prevShotsLineLayer"
-                style={{
-                  lineColor: '#A66A1F',
-                  lineWidth: 1.5,
-                  lineOpacity: 0.7,
-                }}
-              />
-            </Mapbox.ShapeSource>
-          )}
+          <BreadcrumbLayers
+            previousShots={previousShots ?? []}
+            previousShotsLine={previousShotsLine}
+            segments={previousShotSegments}
+            styleLoaded={styleLoaded}
+            isPinMode={isPinMode}
+            toDisplay={toDisplay}
+          />
 
-          {!isPinMode &&
-            (previousShots ?? []).map((p, i) => (
-              <Mapbox.PointAnnotation
-                key={`prev-shot-${i}`}
-                id={`prev-shot-${i}`}
-                coordinate={toCoord(p)}
-              >
-                <NumberedMarker
-                  color="#A66A1F"
-                  border="#FBF8F1"
-                  size={20}
-                  number={i + 1}
-                />
-              </Mapbox.PointAnnotation>
-            ))}
-
-          {/* Small distance label between every pair of consecutive
-              waypoints on the breadcrumb. Smaller / more muted than the
-              aim distance pill so it reads as supporting info, not the
-              primary callout. */}
-          {!isPinMode &&
-            previousShotSegments.map((seg) => (
-              <Mapbox.PointAnnotation
-                key={seg.id}
-                id={seg.id}
-                coordinate={toCoord(seg.midpoint)}
-              >
-                <View
-                  style={{
-                    backgroundColor: 'rgba(28,33,28,0.65)',
-                    borderRadius: 999,
-                    paddingHorizontal: 7,
-                    paddingVertical: 2,
-                  }}
-                >
-                  <Text
-                    style={{
-                      color: '#F2EEE5',
-                      fontSize: 10,
-                      fontWeight: '500',
-                      fontVariant: ['tabular-nums'],
-                    }}
-                  >
-                    {toDisplay(seg.yards)}
-                  </Text>
-                </View>
-              </Mapbox.PointAnnotation>
-            ))}
-
-          {styleLoaded && !isPinMode && aimGhostFeatures && (
-            <Mapbox.ShapeSource id="aimGhostsLine" shape={aimGhostFeatures}>
-              <Mapbox.LineLayer
-                id="aimGhostsLineLayer"
-                style={{
-                  lineColor: '#A66A1F',
-                  lineWidth: 1.2,
-                  lineDasharray: [3, 3],
-                  lineOpacity: 0.4,
-                }}
-              />
-            </Mapbox.ShapeSource>
-          )}
-
-          {!isPinMode &&
-            aimGhosts.map((g, i) => (
-              <Mapbox.PointAnnotation
-                key={`aim-ghost-${i}`}
-                id={`aim-ghost-${i}`}
-                coordinate={toCoord(g.aim)}
-              >
-                <View style={{ opacity: 0.4 }}>
-                  <Marker color="#A66A1F" border="#FBF8F1" size={9} />
-                </View>
-              </Mapbox.PointAnnotation>
-            ))}
+          <AimGhostLayers
+            aimGhosts={aimGhosts}
+            aimGhostFeatures={aimGhostFeatures}
+            styleLoaded={styleLoaded}
+            isPinMode={isPinMode}
+          />
 
           {styleLoaded && aimLine && (
             <Mapbox.ShapeSource id="aimLine" shape={aimLine}>
@@ -533,7 +309,7 @@ export function HoleMap({
                   justifyContent: 'center',
                 }}
               >
-                <Flag tone={roundPin ? 'strong' : 'dim'} />
+                <FlagMarker tone={roundPin ? 'strong' : 'dim'} />
               </View>
             </Mapbox.PointAnnotation>
           )}
@@ -567,35 +343,11 @@ export function HoleMap({
             </Mapbox.PointAnnotation>
           )}
 
-          {/* Distance pill at midpoint of the aim line. Sized + colored
-              for outdoor readability — large white serif numerals on a
-              dark, semi-opaque pill. */}
           {aimMidpoint && aimDistanceYards !== null && (
-            <Mapbox.PointAnnotation
-              id="aimDistance"
-              coordinate={toCoord(aimMidpoint)}
-            >
-              <View
-                style={{
-                  backgroundColor: 'rgba(28,33,28,0.85)',
-                  borderRadius: 999,
-                  paddingHorizontal: 14,
-                  paddingVertical: 6,
-                }}
-              >
-                <Text
-                  style={{
-                    color: '#F2EEE5',
-                    fontFamily: 'Fraunces-Medium',
-                    fontSize: 26,
-                    fontWeight: '600',
-                    fontVariant: ['tabular-nums'],
-                  }}
-                >
-                  {toDisplay(aimDistanceYards)}
-                </Text>
-              </View>
-            </Mapbox.PointAnnotation>
+            <AimDistancePill
+              midpoint={aimMidpoint}
+              display={toDisplay(aimDistanceYards)}
+            />
           )}
 
           {!isPinMode && ball && (
@@ -630,235 +382,12 @@ export function HoleMap({
           )}
         </Mapbox.MapView>
 
-        <View
-          style={{
-            position: 'absolute',
-            top: 12,
-            left: 12,
-            right: 12,
-            backgroundColor: isPinMode
-              ? 'rgba(166,106,31,0.92)'
-              : 'rgba(28,33,28,0.78)',
-            borderRadius: 2,
-            paddingHorizontal: 10,
-            paddingVertical: 6,
-          }}
-        >
-          <Text
-            style={{
-              color: '#F2EEE5',
-              fontSize: 10,
-              fontWeight: '600',
-              letterSpacing: 1.4,
-              textTransform: 'uppercase',
-            }}
-          >
-            {isPinMode
-              ? 'Pin mode — tap to place flag'
-              : isAimPhase
-                ? 'Long-press to set aim point'
-                : 'Drag the ball to refine, then tap Mark ball here'}
-          </Text>
-        </View>
-
-        {missingHoleLayout && !isPinMode && (
-          <View
-            style={{
-              position: 'absolute',
-              top: 48,
-              left: 12,
-              right: 12,
-              backgroundColor: 'rgba(28,33,28,0.78)',
-              borderWidth: 1,
-              borderColor: 'rgba(217,210,191,0.4)',
-              borderRadius: 2,
-              paddingHorizontal: 10,
-              paddingVertical: 6,
-            }}
-          >
-            <Text
-              style={{
-                color: '#F2EEE5',
-                fontSize: 11,
-                lineHeight: 14,
-              }}
-            >
-              No hole layout for this course. Place shots manually — the
-              distance pill and putting auto-switch stay off until tee /
-              pin coords land.
-            </Text>
-          </View>
-        )}
-
+        <TopHint isPinMode={isPinMode} isAimPhase={isAimPhase} />
+        {missingHoleLayout && !isPinMode && <MissingLayoutBanner />}
         {!isPinMode && pinDistance !== null && (
-          <View
-            style={{
-              position: 'absolute',
-              right: 12,
-              bottom: 12,
-              backgroundColor: 'rgba(28,33,28,0.78)',
-              borderRadius: 2,
-              paddingHorizontal: 12,
-              paddingVertical: 6,
-            }}
-          >
-            <Text
-              style={{
-                color: '#F2EEE5',
-                fontSize: 12,
-                fontWeight: '500',
-                fontVariant: ['tabular-nums'],
-              }}
-            >
-              {toDisplay(pinDistance)} to pin
-            </Text>
-          </View>
+          <PinDistancePill display={toDisplay(pinDistance)} />
         )}
       </View>
     </GestureDetector>
-  )
-}
-
-// Small "TEE" pill — kept visually identical to the web map's tee
-// marker so the satellite view reads the same on both platforms. The
-// previous bare cream circle was indistinguishable from a ball at the
-// same zoom.
-function TeeBadge() {
-  return (
-    <View
-      style={{
-        backgroundColor: '#FBF8F1',
-        borderWidth: 1,
-        borderColor: '#5C6356',
-        borderRadius: 2,
-        paddingHorizontal: 6,
-        paddingVertical: 3,
-      }}
-    >
-      <Text
-        style={{
-          color: '#5C6356',
-          fontSize: 9,
-          fontWeight: '500',
-          letterSpacing: 1.4,
-        }}
-      >
-        TEE
-      </Text>
-    </View>
-  )
-}
-
-type MarkerProps = { color: string; border: string; size: number }
-
-function Marker({ color, border, size }: MarkerProps) {
-  return (
-    <View
-      style={{
-        width: size,
-        height: size,
-        borderRadius: size / 2,
-        backgroundColor: color,
-        borderWidth: 2,
-        borderColor: border,
-      }}
-    />
-  )
-}
-
-type NumberedMarkerProps = MarkerProps & { number: number; opacity?: number }
-
-function NumberedMarker({
-  color,
-  border,
-  size,
-  number,
-  opacity = 1,
-}: NumberedMarkerProps) {
-  return (
-    <View
-      style={{
-        width: size,
-        height: size,
-        borderRadius: size / 2,
-        backgroundColor: color,
-        borderWidth: 2,
-        borderColor: border,
-        alignItems: 'center',
-        justifyContent: 'center',
-        opacity,
-      }}
-    >
-      <Text
-        style={{
-          color: '#FBF8F1',
-          fontSize: size * 0.55,
-          fontWeight: '700',
-          fontVariant: ['tabular-nums'],
-          lineHeight: size,
-          textAlign: 'center',
-        }}
-      >
-        {number}
-      </Text>
-    </View>
-  )
-}
-
-// Simple flag glyph: vertical pole with a rectangular cloth at the top
-// and a small base disk. PointAnnotation measures children via normal
-// flex layout — the previous absolutely-positioned version sometimes
-// rendered as a zero-size annotation on Android, leaving no visible
-// flag at all. This version uses an explicit-size column so the
-// annotation always has positive bounds.
-function Flag({ tone }: { tone: 'dim' | 'strong' }) {
-  const flagColor = tone === 'strong' ? '#A33A2A' : 'rgba(163,58,42,0.85)'
-  const poleColor = '#FBF8F1'
-  return (
-    <View
-      style={{
-        width: 28,
-        height: 38,
-        alignItems: 'flex-start',
-        justifyContent: 'flex-start',
-      }}
-    >
-      {/* Cloth + pole top section */}
-      <View style={{ flexDirection: 'row', alignItems: 'flex-start' }}>
-        <View
-          style={{
-            width: 3,
-            height: 12,
-            backgroundColor: poleColor,
-          }}
-        />
-        <View
-          style={{
-            width: 15,
-            height: 11,
-            backgroundColor: flagColor,
-            borderTopRightRadius: 1,
-          }}
-        />
-      </View>
-      {/* Pole shaft */}
-      <View
-        style={{
-          width: 3,
-          height: 22,
-          backgroundColor: poleColor,
-        }}
-      />
-      {/* Base disk */}
-      <View
-        style={{
-          width: 9,
-          height: 3,
-          marginLeft: -3,
-          borderRadius: 1.5,
-          backgroundColor: poleColor,
-        }}
-      />
-    </View>
   )
 }

--- a/apps/mobile/components/round/HoleMap.types.ts
+++ b/apps/mobile/components/round/HoleMap.types.ts
@@ -1,0 +1,12 @@
+export interface LatLng {
+  lat: number
+  lng: number
+}
+
+/**
+ * `PLACE_BALL` — ball draggable, tap places ball, no aim interaction.
+ * `SET_AIM`    — ball locked, long-press drops aim, camera rotates so
+ *                play direction is up.
+ * `PIN`        — pin placement modality (orthogonal to the shot flow).
+ */
+export type HoleMapPhase = 'PLACE_BALL' | 'SET_AIM' | 'PIN'

--- a/apps/mobile/components/round/HoleMapOverlays.tsx
+++ b/apps/mobile/components/round/HoleMapOverlays.tsx
@@ -1,0 +1,118 @@
+import { Text, View } from 'react-native'
+
+interface TopHintProps {
+  isPinMode: boolean
+  isAimPhase: boolean
+}
+
+export function TopHint({ isPinMode, isAimPhase }: TopHintProps) {
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        top: 12,
+        left: 12,
+        right: 12,
+        backgroundColor: isPinMode
+          ? 'rgba(166,106,31,0.92)'
+          : 'rgba(28,33,28,0.78)',
+        borderRadius: 2,
+        paddingHorizontal: 10,
+        paddingVertical: 6,
+      }}
+    >
+      <Text
+        style={{
+          color: '#F2EEE5',
+          fontSize: 10,
+          fontWeight: '600',
+          letterSpacing: 1.4,
+          textTransform: 'uppercase',
+        }}
+      >
+        {isPinMode
+          ? 'Pin mode — tap to place flag'
+          : isAimPhase
+            ? 'Long-press to set aim point'
+            : 'Drag the ball to refine, then tap Mark ball here'}
+      </Text>
+    </View>
+  )
+}
+
+export function MissingLayoutBanner() {
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        top: 48,
+        left: 12,
+        right: 12,
+        backgroundColor: 'rgba(28,33,28,0.78)',
+        borderWidth: 1,
+        borderColor: 'rgba(217,210,191,0.4)',
+        borderRadius: 2,
+        paddingHorizontal: 10,
+        paddingVertical: 6,
+      }}
+    >
+      <Text style={{ color: '#F2EEE5', fontSize: 11, lineHeight: 14 }}>
+        No hole layout for this course. Place shots manually — the distance
+        pill and putting auto-switch stay off until tee / pin coords land.
+      </Text>
+    </View>
+  )
+}
+
+export function PinDistancePill({ display }: { display: string }) {
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        right: 12,
+        bottom: 12,
+        backgroundColor: 'rgba(28,33,28,0.78)',
+        borderRadius: 2,
+        paddingHorizontal: 12,
+        paddingVertical: 6,
+      }}
+    >
+      <Text
+        style={{
+          color: '#F2EEE5',
+          fontSize: 12,
+          fontWeight: '500',
+          fontVariant: ['tabular-nums'],
+        }}
+      >
+        {display} to pin
+      </Text>
+    </View>
+  )
+}
+
+export function TeeBadge() {
+  return (
+    <View
+      style={{
+        backgroundColor: '#FBF8F1',
+        borderWidth: 1,
+        borderColor: '#5C6356',
+        borderRadius: 2,
+        paddingHorizontal: 6,
+        paddingVertical: 3,
+      }}
+    >
+      <Text
+        style={{
+          color: '#5C6356',
+          fontSize: 9,
+          fontWeight: '500',
+          letterSpacing: 1.4,
+        }}
+      >
+        TEE
+      </Text>
+    </View>
+  )
+}

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { Modal, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import Svg, { Circle, Line as SvgLine } from 'react-native-svg'
 import {
   DEFAULT_BAG,
   LIE_TYPES,
   SHOT_RESULTS,
+  formatClubLabel,
   type BreakDirection,
   type Club,
   type GreenSpeed,
@@ -44,6 +45,12 @@ interface ShotLoggerProps {
   onSkip: () => void
   onClose: () => void
 }
+
+const LIE_TYPE_OPTIONS = LIE_TYPES.map((l) => ({ value: l, label: l }))
+const SHOT_RESULT_OPTIONS = SHOT_RESULTS.map((r) => ({
+  value: r,
+  label: r.replace(/_/g, ' '),
+}))
 
 const SLOPE_FORWARD_ROW: LieSlopeForward[] = ['uphill', 'level', 'downhill']
 const SLOPE_SIDE_ROW: (LieSlopeSide | 'spacer')[] = [
@@ -94,8 +101,14 @@ export function ShotLogger({
   // while the bag is loading or if the user trimmed it to nothing — never
   // show an empty picker.
   const { bag } = useUserBag()
-  const clubOptions: readonly string[] =
-    bag.length > 0 ? bag.map((c) => c.club_type) : DEFAULT_BAG.map((c) => c.club_type)
+  const clubOptions = useMemo<{ value: string; label: string }[]>(
+    () =>
+      (bag.length > 0 ? bag : DEFAULT_BAG).map((c) => ({
+        value: c.club_type,
+        label: formatClubLabel(c),
+      })),
+    [bag],
+  )
 
   const isOnGreen = value.lieType === 'green'
 
@@ -235,7 +248,7 @@ export function ShotLogger({
             <Section title="Lie type">
               <ChipRow
                 value={value.lieType}
-                options={LIE_TYPES}
+                options={LIE_TYPE_OPTIONS}
                 onChange={(v) => set('lieType', v)}
               />
             </Section>
@@ -330,7 +343,7 @@ export function ShotLogger({
             <Section title="Shot result">
               <ChipRow
                 value={value.shotResult}
-                options={SHOT_RESULTS}
+                options={SHOT_RESULT_OPTIONS}
                 onChange={(v) => set('shotResult', v)}
               />
             </Section>
@@ -527,7 +540,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 interface ChipRowProps<T extends string> {
   value: T | undefined
-  options: readonly T[]
+  options: readonly { value: T; label: string }[]
   onChange: (v: T) => void
 }
 
@@ -535,15 +548,15 @@ function ChipRow<T extends string>({ value, options, onChange }: ChipRowProps<T>
   return (
     <ScrollView horizontal showsHorizontalScrollIndicator={false}>
       <View style={{ flexDirection: 'row', gap: 6 }}>
-        {options.map((opt) => {
-          const active = value === opt
+        {options.map(({ value: optValue, label }) => {
+          const active = value === optValue
           return (
             <Pressable
-              key={opt}
+              key={optValue}
               accessibilityRole="radio"
-              accessibilityLabel={opt.replace(/_/g, ' ')}
+              accessibilityLabel={label}
               accessibilityState={{ selected: active }}
-              onPress={() => onChange(opt)}
+              onPress={() => onChange(optValue)}
               style={{
                 paddingHorizontal: 10,
                 paddingVertical: 8,
@@ -558,7 +571,7 @@ function ChipRow<T extends string>({ value, options, onChange }: ChipRowProps<T>
                   fontWeight: active ? '500' : '400',
                 }}
               >
-                {opt.replace(/_/g, ' ')}
+                {label}
               </Text>
             </Pressable>
           )

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -1,0 +1,137 @@
+import { useEffect, useRef } from 'react'
+import Mapbox from '@rnmapbox/maps'
+import { distanceYards } from '../../../lib/maps'
+import type { HoleMapPhase, LatLng } from '../HoleMap.types'
+
+function toCoord(l: LatLng): [number, number] {
+  return [l.lng, l.lat]
+}
+
+interface UseHoleCameraOpts {
+  center: LatLng
+  ball?: LatLng | null
+  pin?: LatLng | null
+  roundPin?: LatLng | null
+  phase: HoleMapPhase
+}
+
+// Owns every camera positioning side-effect for HoleMap. The hook
+// returns the camera ref so HoleMap can mount it on the Mapbox.Camera
+// instance; all flyTo / setCamera scheduling is internal.
+export function useHoleCamera({
+  center,
+  ball,
+  pin,
+  roundPin,
+  phase,
+}: UseHoleCameraOpts) {
+  const cameraRef = useRef<Mapbox.Camera>(null)
+  const cameraInitialized = useRef(false)
+  const isPinMode = phase === 'PIN'
+  const isAimPhase = phase === 'SET_AIM'
+
+  // Center the camera once on first valid coords. Subsequent center changes
+  // (e.g. GPS deltas while standing on the tee) should not retrigger
+  // setCamera — the style was reloading and the satellite tiles would flash
+  // back to a black canvas every time.
+  //
+  // PLACE_BALL is flat top-down (pitch 0) — tilt only happens on the
+  // SET_AIM transition below. A tilted tee-box camera was disorienting
+  // on the device because it framed grass at an angle before the player
+  // had even decided what they were aiming at.
+  useEffect(() => {
+    if (cameraInitialized.current) return
+    if (!cameraRef.current) return
+    cameraRef.current.setCamera({
+      centerCoordinate: toCoord(center),
+      zoomLevel: 17,
+      pitch: 0,
+      animationDuration: 400,
+    })
+    cameraInitialized.current = true
+  }, [center.lat, center.lng])
+
+  // When entering pin mode, zoom in on the stored pin so the user is
+  // looking at the green.
+  useEffect(() => {
+    if (!isPinMode) return
+    if (!cameraRef.current) return
+    const target = roundPin ?? pin ?? null
+    if (!target) return
+    cameraRef.current.setCamera({
+      centerCoordinate: toCoord(target),
+      zoomLevel: 19,
+      animationDuration: 400,
+    })
+  }, [isPinMode, roundPin?.lat, roundPin?.lng, pin?.lat, pin?.lng])
+
+  // Mark whether we owe the camera a PLACE_BALL re-frame on the next
+  // ball update. Set on phase transitions INTO PLACE_BALL (e.g. after
+  // saving a shot) so the camera flies back to the closer tee-style view
+  // once GPS settles on the new ball position.
+  const prevPhaseRef = useRef<HoleMapPhase>(phase)
+  const reframePlaceBallRef = useRef(false)
+  useEffect(() => {
+    if (phase === 'PLACE_BALL' && prevPhaseRef.current !== 'PLACE_BALL') {
+      reframePlaceBallRef.current = true
+    }
+    prevPhaseRef.current = phase
+  }, [phase])
+
+  useEffect(() => {
+    if (!reframePlaceBallRef.current) return
+    if (phase !== 'PLACE_BALL') return
+    if (!cameraRef.current) return
+    if (!ball) return
+    cameraRef.current.setCamera({
+      centerCoordinate: toCoord(ball),
+      zoomLevel: 17,
+      pitch: 0,
+      heading: 0,
+      animationDuration: 800,
+    })
+    reframePlaceBallRef.current = false
+  }, [ball?.lat, ball?.lng, phase])
+
+  // SET_AIM: rotate the camera so direction-of-play (ball → pin) is
+  // toward the top of the screen, add a subtle 20° tilt, and pick zoom
+  // by ball→pin distance so a wedge frames the green tightly while a
+  // par-5 still shows fairway + green. Fixed zoom 15 was too loose for
+  // short approaches (≤120 yd compressed the shot into a tiny band).
+  useEffect(() => {
+    if (!isAimPhase) return
+    if (!cameraRef.current) return
+    if (!ball) return
+    const target = roundPin ?? pin ?? null
+    const focus = target
+      ? {
+          lat: (ball.lat + target.lat) / 2,
+          lng: (ball.lng + target.lng) / 2,
+        }
+      : ball
+    const bearing = target
+      ? (Math.atan2(target.lng - ball.lng, target.lat - ball.lat) * 180) /
+        Math.PI
+      : 0
+    const distYd = target ? distanceYards(ball, target) : null
+    const zoom =
+      distYd == null ? 15 : distYd >= 250 ? 14 : distYd >= 120 ? 15 : 16
+    cameraRef.current.setCamera({
+      centerCoordinate: toCoord(focus),
+      zoomLevel: zoom,
+      pitch: 20,
+      heading: bearing,
+      animationDuration: 1200,
+    })
+  }, [
+    isAimPhase,
+    ball?.lat,
+    ball?.lng,
+    roundPin?.lat,
+    roundPin?.lng,
+    pin?.lat,
+    pin?.lng,
+  ])
+
+  return cameraRef
+}

--- a/apps/mobile/components/round/markers/AimDistancePill.tsx
+++ b/apps/mobile/components/round/markers/AimDistancePill.tsx
@@ -1,0 +1,41 @@
+import { Text, View } from 'react-native'
+import Mapbox from '@rnmapbox/maps'
+import type { LatLng } from '../HoleMap.types'
+
+function toCoord(l: LatLng): [number, number] {
+  return [l.lng, l.lat]
+}
+
+interface AimDistancePillProps {
+  midpoint: LatLng
+  display: string
+}
+
+// Sized + colored for outdoor readability — large white serif numerals
+// on a dark, semi-opaque pill, anchored at the aim line midpoint.
+export function AimDistancePill({ midpoint, display }: AimDistancePillProps) {
+  return (
+    <Mapbox.PointAnnotation id="aimDistance" coordinate={toCoord(midpoint)}>
+      <View
+        style={{
+          backgroundColor: 'rgba(28,33,28,0.85)',
+          borderRadius: 999,
+          paddingHorizontal: 14,
+          paddingVertical: 6,
+        }}
+      >
+        <Text
+          style={{
+            color: '#F2EEE5',
+            fontFamily: 'Fraunces-Medium',
+            fontSize: 26,
+            fontWeight: '600',
+            fontVariant: ['tabular-nums'],
+          }}
+        >
+          {display}
+        </Text>
+      </View>
+    </Mapbox.PointAnnotation>
+  )
+}

--- a/apps/mobile/components/round/markers/AimGhost.tsx
+++ b/apps/mobile/components/round/markers/AimGhost.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { View } from 'react-native'
+import Mapbox from '@rnmapbox/maps'
+import type { HoleMapPhase, LatLng } from '../HoleMap.types'
+import { Marker } from './Marker'
+
+function toCoord(l: LatLng): [number, number] {
+  return [l.lng, l.lat]
+}
+
+interface AimGhostHookOpts {
+  ball: LatLng | null | undefined
+  aim: LatLng | null | undefined
+  phase: HoleMapPhase
+  previousShotsLen: number
+}
+
+interface AimGhostHookResult {
+  aimGhosts: { ball: LatLng; aim: LatLng }[]
+  aimGhostFeatures: GeoJSON.FeatureCollection | null
+}
+
+// Aim ghosts: prior shots' aim point + ball-start, retained as faded
+// markers + dotted lines so the player can see intended direction vs
+// actual result across the whole hole. Captured locally in the map so
+// the parent doesn't have to thread historical aim coords through.
+export function useAimGhosts({
+  ball,
+  aim,
+  phase,
+  previousShotsLen,
+}: AimGhostHookOpts): AimGhostHookResult {
+  const [aimGhosts, setAimGhosts] = useState<
+    { ball: LatLng; aim: LatLng }[]
+  >([])
+  const lastAimSnapshotRef = useRef<{ ball: LatLng; aim: LatLng } | null>(null)
+  const isAimPhase = phase === 'SET_AIM'
+
+  // While in SET_AIM, snapshot the current ball + aim pair so we can
+  // promote it to a ghost the moment the phase exits SET_AIM (i.e. shot
+  // was saved or aim was abandoned for ball placement again).
+  useEffect(() => {
+    if (isAimPhase && ball && aim) {
+      lastAimSnapshotRef.current = { ball, aim }
+    }
+  }, [isAimPhase, ball?.lat, ball?.lng, aim?.lat, aim?.lng])
+
+  const ghostPhaseRef = useRef<HoleMapPhase>(phase)
+  useEffect(() => {
+    if (ghostPhaseRef.current === 'SET_AIM' && phase !== 'SET_AIM') {
+      const snap = lastAimSnapshotRef.current
+      if (snap) {
+        setAimGhosts((prev) => [...prev, snap])
+        lastAimSnapshotRef.current = null
+      }
+    }
+    ghostPhaseRef.current = phase
+  }, [phase])
+
+  // Hole change is signalled by previousShots resetting to empty (the
+  // parent re-mounts a new hole with no prior shot starts). Clear ghosts
+  // so they don't bleed across holes. Guarded on aimGhosts.length > 0
+  // so the initial mount (where prevShotsLen and aimGhosts.length are
+  // both 0) doesn't schedule a no-op state update.
+  const ghostCount = aimGhosts.length
+  useEffect(() => {
+    if (previousShotsLen === 0 && ghostCount > 0) {
+      setAimGhosts([])
+    }
+  }, [previousShotsLen, ghostCount])
+
+  const aimGhostFeatures = useMemo<GeoJSON.FeatureCollection | null>(() => {
+    if (aimGhosts.length === 0) return null
+    return {
+      type: 'FeatureCollection' as const,
+      features: aimGhosts.map((g, i) => ({
+        type: 'Feature' as const,
+        properties: { id: i },
+        geometry: {
+          type: 'LineString' as const,
+          coordinates: [toCoord(g.ball), toCoord(g.aim)],
+        },
+      })),
+    }
+  }, [aimGhosts])
+
+  return { aimGhosts, aimGhostFeatures }
+}
+
+interface AimGhostLayersProps {
+  aimGhosts: { ball: LatLng; aim: LatLng }[]
+  aimGhostFeatures: GeoJSON.FeatureCollection | null
+  styleLoaded: boolean
+  isPinMode: boolean
+}
+
+// Renders the dotted breadcrumb between past ball→aim pairs and a small
+// faded aim marker at each historical aim point. Mounted as a child of
+// MapView; both the ShapeSource and the PointAnnotations must render at
+// the map level, so the layers are factored out together.
+export function AimGhostLayers({
+  aimGhosts,
+  aimGhostFeatures,
+  styleLoaded,
+  isPinMode,
+}: AimGhostLayersProps) {
+  if (isPinMode) return null
+  return (
+    <>
+      {styleLoaded && aimGhostFeatures && (
+        <Mapbox.ShapeSource id="aimGhostsLine" shape={aimGhostFeatures}>
+          <Mapbox.LineLayer
+            id="aimGhostsLineLayer"
+            style={{
+              lineColor: '#A66A1F',
+              lineWidth: 1.2,
+              lineDasharray: [3, 3],
+              lineOpacity: 0.4,
+            }}
+          />
+        </Mapbox.ShapeSource>
+      )}
+
+      {aimGhosts.map((g, i) => (
+        <Mapbox.PointAnnotation
+          key={`aim-ghost-${i}`}
+          id={`aim-ghost-${i}`}
+          coordinate={toCoord(g.aim)}
+        >
+          <View style={{ opacity: 0.4 }}>
+            <Marker color="#A66A1F" border="#FBF8F1" size={9} />
+          </View>
+        </Mapbox.PointAnnotation>
+      ))}
+    </>
+  )
+}

--- a/apps/mobile/components/round/markers/BreadcrumbLayers.tsx
+++ b/apps/mobile/components/round/markers/BreadcrumbLayers.tsx
@@ -1,0 +1,95 @@
+import { Text, View } from 'react-native'
+import Mapbox from '@rnmapbox/maps'
+import type { LatLng } from '../HoleMap.types'
+import { NumberedMarker } from './NumberedMarker'
+
+function toCoord(l: LatLng): [number, number] {
+  return [l.lng, l.lat]
+}
+
+interface BreadcrumbLayersProps {
+  previousShots: LatLng[]
+  previousShotsLine: GeoJSON.Feature | null
+  segments: { id: string; midpoint: LatLng; yards: number }[]
+  styleLoaded: boolean
+  isPinMode: boolean
+  toDisplay: (yards: number) => string
+}
+
+// Renders the orange line through prior shot starts, numbered markers
+// at each start, and small midpoint distance labels for each segment.
+// Mounted as a child of Mapbox.MapView so all sources / annotations
+// stay at the map level.
+export function BreadcrumbLayers({
+  previousShots,
+  previousShotsLine,
+  segments,
+  styleLoaded,
+  isPinMode,
+  toDisplay,
+}: BreadcrumbLayersProps) {
+  if (isPinMode) return null
+  return (
+    <>
+      {styleLoaded && previousShotsLine && (
+        <Mapbox.ShapeSource id="prevShotsLine" shape={previousShotsLine}>
+          <Mapbox.LineLayer
+            id="prevShotsLineLayer"
+            style={{
+              lineColor: '#A66A1F',
+              lineWidth: 1.5,
+              lineOpacity: 0.7,
+            }}
+          />
+        </Mapbox.ShapeSource>
+      )}
+
+      {previousShots.map((p, i) => (
+        <Mapbox.PointAnnotation
+          key={`prev-shot-${i}`}
+          id={`prev-shot-${i}`}
+          coordinate={toCoord(p)}
+        >
+          <NumberedMarker
+            color="#A66A1F"
+            border="#FBF8F1"
+            size={20}
+            number={i + 1}
+          />
+        </Mapbox.PointAnnotation>
+      ))}
+
+      {/* Small distance label between every pair of consecutive
+          waypoints on the breadcrumb. Smaller / more muted than the
+          aim distance pill so it reads as supporting info, not the
+          primary callout. */}
+      {segments.map((seg) => (
+        <Mapbox.PointAnnotation
+          key={seg.id}
+          id={seg.id}
+          coordinate={toCoord(seg.midpoint)}
+        >
+          <View
+            style={{
+              backgroundColor: 'rgba(28,33,28,0.65)',
+              borderRadius: 999,
+              paddingHorizontal: 7,
+              paddingVertical: 2,
+            }}
+          >
+            <Text
+              style={{
+                color: '#F2EEE5',
+                fontSize: 10,
+                fontWeight: '500',
+                fontVariant: ['tabular-nums'],
+              }}
+            >
+              {toDisplay(seg.yards)}
+            </Text>
+          </View>
+        </Mapbox.PointAnnotation>
+      ))}
+    </>
+  )
+}

--- a/apps/mobile/components/round/markers/FlagMarker.tsx
+++ b/apps/mobile/components/round/markers/FlagMarker.tsx
@@ -1,0 +1,55 @@
+import { View } from 'react-native'
+
+// Simple flag glyph: vertical pole with a rectangular cloth at the top
+// and a small base disk. PointAnnotation measures children via normal
+// flex layout — an absolutely-positioned version sometimes rendered as
+// a zero-size annotation on Android, leaving no visible flag at all.
+// This explicit-size column always has positive bounds.
+export function FlagMarker({ tone }: { tone: 'dim' | 'strong' }) {
+  const flagColor = tone === 'strong' ? '#A33A2A' : 'rgba(163,58,42,0.85)'
+  const poleColor = '#FBF8F1'
+  return (
+    <View
+      style={{
+        width: 28,
+        height: 38,
+        alignItems: 'flex-start',
+        justifyContent: 'flex-start',
+      }}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'flex-start' }}>
+        <View
+          style={{
+            width: 3,
+            height: 12,
+            backgroundColor: poleColor,
+          }}
+        />
+        <View
+          style={{
+            width: 15,
+            height: 11,
+            backgroundColor: flagColor,
+            borderTopRightRadius: 1,
+          }}
+        />
+      </View>
+      <View
+        style={{
+          width: 3,
+          height: 22,
+          backgroundColor: poleColor,
+        }}
+      />
+      <View
+        style={{
+          width: 9,
+          height: 3,
+          marginLeft: -3,
+          borderRadius: 1.5,
+          backgroundColor: poleColor,
+        }}
+      />
+    </View>
+  )
+}

--- a/apps/mobile/components/round/markers/Marker.tsx
+++ b/apps/mobile/components/round/markers/Marker.tsx
@@ -1,0 +1,22 @@
+import { View } from 'react-native'
+
+export interface MarkerProps {
+  color: string
+  border: string
+  size: number
+}
+
+export function Marker({ color, border, size }: MarkerProps) {
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: color,
+        borderWidth: 2,
+        borderColor: border,
+      }}
+    />
+  )
+}

--- a/apps/mobile/components/round/markers/NumberedMarker.tsx
+++ b/apps/mobile/components/round/markers/NumberedMarker.tsx
@@ -1,0 +1,46 @@
+import { Text, View } from 'react-native'
+
+interface NumberedMarkerProps {
+  color: string
+  border: string
+  size: number
+  number: number
+  opacity?: number
+}
+
+export function NumberedMarker({
+  color,
+  border,
+  size,
+  number,
+  opacity = 1,
+}: NumberedMarkerProps) {
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: color,
+        borderWidth: 2,
+        borderColor: border,
+        alignItems: 'center',
+        justifyContent: 'center',
+        opacity,
+      }}
+    >
+      <Text
+        style={{
+          color: '#FBF8F1',
+          fontSize: size * 0.55,
+          fontWeight: '700',
+          fontVariant: ['tabular-nums'],
+          lineHeight: size,
+          textAlign: 'center',
+        }}
+      >
+        {number}
+      </Text>
+    </View>
+  )
+}

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -5,12 +5,11 @@ import {
   useState,
   type ReactNode,
 } from 'react'
-import type { Session, User } from '@supabase/supabase-js'
+import type { User } from '@supabase/supabase-js'
 import { supabase } from '../lib/supabase'
 
 interface AuthState {
   user: User | null
-  session: Session | null
   loading: boolean
 }
 
@@ -23,7 +22,6 @@ const AuthContext = createContext<AuthState | null>(null)
 // the loading-flag race that bit the web app before it migrated.
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
-  const [session, setSession] = useState<Session | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -31,17 +29,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     supabase.auth.getSession().then(({ data }) => {
       if (!mounted) return
-      setSession(data.session ?? null)
       setUser(data.session?.user ?? null)
       setLoading(false)
     })
 
+    // Always flip loading off on the first auth event, including the
+    // synchronous INITIAL_SESSION the JS client emits on a warm
+    // session — getSession's resolve and the listener can race, and
+    // if getSession ever silently rejects we don't want the splash
+    // overlay to wedge.
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, nextSession) => {
       if (!mounted) return
-      setSession(nextSession ?? null)
       setUser(nextSession?.user ?? null)
+      setLoading(false)
     })
 
     return () => {
@@ -51,7 +53,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   return (
-    <AuthContext.Provider value={{ user, session, loading }}>
+    <AuthContext.Provider value={{ user, loading }}>
       {children}
     </AuthContext.Provider>
   )

--- a/apps/mobile/contexts/AuthContext.tsx
+++ b/apps/mobile/contexts/AuthContext.tsx
@@ -1,0 +1,66 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import type { Session, User } from '@supabase/supabase-js'
+import { supabase } from '../lib/supabase'
+
+interface AuthState {
+  user: User | null
+  session: Session | null
+  loading: boolean
+}
+
+const AuthContext = createContext<AuthState | null>(null)
+
+// Single source of truth for auth state on mobile. Mirrors the web
+// AuthContext (PR #159) — every call site of useAuth() shares one
+// onAuthStateChange subscription instead of each hook instance
+// installing its own. Eliminates the per-call subscription churn and
+// the loading-flag race that bit the web app before it migrated.
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [session, setSession] = useState<Session | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let mounted = true
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return
+      setSession(data.session ?? null)
+      setUser(data.session?.user ?? null)
+      setLoading(false)
+    })
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      if (!mounted) return
+      setSession(nextSession ?? null)
+      setUser(nextSession?.user ?? null)
+    })
+
+    return () => {
+      mounted = false
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  return (
+    <AuthContext.Provider value={{ user, session, loading }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuthContext(): AuthState {
+  const ctx = useContext(AuthContext)
+  if (ctx === null) {
+    throw new Error('useAuth must be called inside <AuthProvider>')
+  }
+  return ctx
+}

--- a/apps/mobile/hooks/useActiveRound.ts
+++ b/apps/mobile/hooks/useActiveRound.ts
@@ -1,0 +1,77 @@
+import { useCallback, useState } from 'react'
+import { useFocusEffect } from 'expo-router'
+import { supabase } from '../lib/supabase'
+import { useAuth } from './useAuth'
+
+export interface ActiveRound {
+  id: string
+  courseName: string
+  currentHole: number
+}
+
+// Active = total_score IS NULL AND played_at within the last day, so a
+// round abandoned a week ago doesn't haunt the home screen forever.
+// The current hole is the highest hole the player has logged a score
+// on, +1 (capped at 18) — so resuming jumps back to where they left
+// off, not hole 1.
+//
+// Re-runs every time the host screen gains focus. Without that,
+// deleting the active round from the hole/end-round screens left a
+// stale banner on home until the app reloaded.
+export function useActiveRound(): ActiveRound | null {
+  const { user } = useAuth()
+  const [activeRound, setActiveRound] = useState<ActiveRound | null>(null)
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!user) return
+      let active = true
+      ;(async () => {
+        const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000)
+          .toISOString()
+          .slice(0, 10)
+        const { data, error } = await supabase
+          .from('rounds')
+          .select('id, played_at, course_id, courses(name)')
+          .eq('user_id', user.id)
+          .is('total_score', null)
+          .gte('played_at', oneDayAgo)
+          .order('played_at', { ascending: false })
+          .limit(1)
+        if (!active) return
+        if (error || !data?.[0]) {
+          setActiveRound(null)
+          return
+        }
+        const round = data[0] as {
+          id: string
+          played_at: string
+          course_id: string
+          courses?: { name: string | null } | null
+        }
+        const { data: hs } = await supabase
+          .from('hole_scores')
+          .select('score, holes(number)')
+          .eq('round_id', round.id)
+          .gt('score', 0)
+        if (!active) return
+        const maxHole = (hs ?? []).reduce<number>((acc, row) => {
+          const n = (row as { holes?: { number?: number | null } | null })
+            .holes?.number
+          return typeof n === 'number' && n > acc ? n : acc
+        }, 0)
+        const next = Math.min(18, Math.max(1, maxHole + 1))
+        setActiveRound({
+          id: round.id,
+          courseName: round.courses?.name ?? 'Round',
+          currentHole: next,
+        })
+      })()
+      return () => {
+        active = false
+      }
+    }, [user?.id]),
+  )
+
+  return activeRound
+}

--- a/apps/mobile/hooks/useAuth.ts
+++ b/apps/mobile/hooks/useAuth.ts
@@ -1,32 +1,10 @@
-import { useEffect, useState } from 'react'
-import type { User } from '@supabase/supabase-js'
-import { supabase } from '../lib/supabase'
+import { useAuthContext } from '../contexts/AuthContext'
 
+// Thin wrapper around the AuthProvider context. All previous call
+// sites used `{ user, loading }` and that shape is preserved here.
+// The session is also exposed so any future caller that needs the raw
+// access token (signed URL hand-off, RPC headers) doesn't have to
+// re-query supabase.auth.getSession().
 export function useAuth() {
-  const [user, setUser] = useState<User | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  useEffect(() => {
-    let mounted = true
-
-    supabase.auth.getSession().then(({ data }) => {
-      if (!mounted) return
-      setUser(data.session?.user ?? null)
-      setLoading(false)
-    })
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (!mounted) return
-      setUser(session?.user ?? null)
-    })
-
-    return () => {
-      mounted = false
-      subscription.unsubscribe()
-    }
-  }, [])
-
-  return { user, loading }
+  return useAuthContext()
 }

--- a/apps/mobile/hooks/useAuth.ts
+++ b/apps/mobile/hooks/useAuth.ts
@@ -1,10 +1,7 @@
 import { useAuthContext } from '../contexts/AuthContext'
 
-// Thin wrapper around the AuthProvider context. All previous call
-// sites used `{ user, loading }` and that shape is preserved here.
-// The session is also exposed so any future caller that needs the raw
-// access token (signed URL hand-off, RPC headers) doesn't have to
-// re-query supabase.auth.getSession().
+// Thin wrapper around the AuthProvider context. All call sites used
+// `{ user, loading }` and that shape is preserved.
 export function useAuth() {
   return useAuthContext()
 }

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -4,6 +4,7 @@ import {
   LIE_TYPES,
   NEAR_GREEN_YARDS,
   buildInitialRows,
+  formatClubLabel,
   haversineYards,
   type Club,
   type LieType,
@@ -321,12 +322,18 @@ function ShotRow({
   // DEFAULT_BAG when empty/loading. Splice in the row's current `club`
   // when it isn't represented (custom utility club types from a bag
   // edit, or a legacy CLUBS-based row from before this PR) so the
-  // <select> always shows the value the user actually has.
-  const clubOptions = useMemo(() => {
-    const base = bag.data && bag.data.length > 0
-      ? bag.data.map((c) => c.club_type)
-      : DEFAULT_BAG.map((c) => c.club_type)
-    if (row.club && !base.includes(row.club)) return [row.club, ...base]
+  // <select> always shows the value the user actually has. Labels
+  // route through `formatClubLabel` so a custom_wedge entry reads as
+  // its loft (e.g. "58°") rather than the raw "custom_wedge" key.
+  const clubOptions = useMemo<{ value: string; label: string }[]>(() => {
+    const source = bag.data && bag.data.length > 0 ? bag.data : DEFAULT_BAG
+    const base = source.map((c) => ({
+      value: c.club_type,
+      label: formatClubLabel(c),
+    }))
+    if (row.club && !base.some((o) => o.value === row.club)) {
+      return [{ value: row.club, label: row.club }, ...base]
+    }
     return base
   }, [bag.data, row.club])
   return (
@@ -372,8 +379,8 @@ function ShotRow({
         }}
       >
         {clubOptions.map((c) => (
-          <option key={c} value={c}>
-            {c}
+          <option key={c.value} value={c.value}>
+            {c.label}
           </option>
         ))}
       </select>

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -7,6 +7,7 @@ import {
   SHOT_RESULTS,
   SHOT_RESULT_LABELS,
   combinedPuttResult,
+  formatClubLabel,
   formatPuttDistance,
   legacySlopeToAxes,
   type BreakDirection,
@@ -46,6 +47,13 @@ const BREAK_OPTIONS: {
 ]
 
 const SLOPE_INTENSITY_LABELS = ['Flat', 'Slight', 'Moderate', 'Strong', 'Severe']
+
+const LIE_TYPE_OPTIONS: { value: LieType; label: string }[] = LIE_TYPES.map(
+  (l) => ({ value: l, label: LIE_TYPE_LABELS[l] }),
+)
+
+const SHOT_RESULT_OPTIONS: { value: ShotResult; label: string }[] =
+  SHOT_RESULTS.map((r) => ({ value: r, label: SHOT_RESULT_LABELS[r] }))
 
 const GREEN_SPEEDS: { value: GreenSpeed; label: string }[] = [
   { value: 'slow', label: 'Slow' },
@@ -168,12 +176,15 @@ export function ShotEntryModal({
   // Fall back to DEFAULT_BAG while loading or if the user has trimmed
   // their bag to nothing — never show an empty club picker. Bag custom
   // club_types pass through as plain strings since `shots.club` is a
-  // text column.
-  const clubOptions: readonly string[] = useMemo(() => {
-    if (bag.data && bag.data.length > 0) {
-      return bag.data.map((c) => c.club_type)
-    }
-    return DEFAULT_BAG.map((c) => c.club_type)
+  // text column. The label routes through `formatClubLabel` so a
+  // custom_wedge entry reads as its loft (e.g. "58°"), not the raw
+  // "custom_wedge" club_type.
+  const clubOptions = useMemo<{ value: string; label: string }[]>(() => {
+    const source = bag.data && bag.data.length > 0 ? bag.data : DEFAULT_BAG
+    return source.map((c) => ({
+      value: c.club_type,
+      label: formatClubLabel(c),
+    }))
   }, [bag.data])
 
   const holeShots = useMemo(() => {
@@ -397,7 +408,13 @@ export function ShotEntryModal({
                         className="font-serif text-caddie-ink"
                         style={{ fontSize: 15, fontWeight: 500, marginTop: 2 }}
                       >
-                        {s.club ?? '—'}
+                        {s.club
+                          ? formatClubLabel(
+                              bag.data?.find((b) => b.club_type === s.club) ?? {
+                                club_type: s.club,
+                              },
+                            )
+                          : '—'}
                         {s.lie_type
                           ? ` · ${LIE_TYPE_LABELS[s.lie_type as LieType] ?? s.lie_type}`
                           : ''}
@@ -488,7 +505,7 @@ export function ShotEntryModal({
               <Field label="Lie type">
                 <ChipGroup
                   value={draft.lieType}
-                  options={LIE_TYPES}
+                  options={LIE_TYPE_OPTIONS}
                   onChange={(v) => setDraft((d) => ({ ...d, lieType: v }))}
                 />
               </Field>
@@ -665,7 +682,7 @@ export function ShotEntryModal({
                 <Field label="Shot result">
                   <ChipGroup
                     value={draft.shotResult}
-                    options={SHOT_RESULTS}
+                    options={SHOT_RESULT_OPTIONS}
                     onChange={(v) => setDraft((d) => ({ ...d, shotResult: v }))}
                   />
                 </Field>
@@ -858,7 +875,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 
 interface ChipGroupProps<T extends string> {
   value: T | undefined
-  options: readonly T[]
+  options: readonly { value: T; label: string }[]
   onChange: (v: T | undefined) => void
 }
 
@@ -877,14 +894,14 @@ function chipStyle(active: boolean): React.CSSProperties {
 function ChipGroup<T extends string>({ value, options, onChange }: ChipGroupProps<T>) {
   return (
     <div className="flex flex-wrap" style={{ gap: 6 }}>
-      {options.map((opt) => (
+      {options.map(({ value: optValue, label }) => (
         <button
-          key={opt}
+          key={optValue}
           type="button"
-          onClick={() => onChange(value === opt ? undefined : opt)}
-          style={chipStyle(value === opt)}
+          onClick={() => onChange(value === optValue ? undefined : optValue)}
+          style={chipStyle(value === optValue)}
         >
-          {opt.replace(/_/g, ' ')}
+          {label}
         </button>
       ))}
     </div>

--- a/apps/web/src/pages/settings/BagPage.tsx
+++ b/apps/web/src/pages/settings/BagPage.tsx
@@ -776,10 +776,10 @@ function AddClubForm({
             >
               {canonicalOptions.map((c) => (
                 <option key={c} value={c}>
-                  {c}
+                  {c === 'custom_wedge' ? 'Custom (loft)' : c}
                 </option>
               ))}
-              <option value={CUSTOM_VALUE}>Custom…</option>
+              <option value={CUSTOM_VALUE}>Other…</option>
             </select>
           )}
           {customMode && draft.category !== 'utility' && (

--- a/packages/core/src/__tests__/clubs.test.ts
+++ b/packages/core/src/__tests__/clubs.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import {
+  CANONICAL_CLUBS_BY_CATEGORY,
   CLUBS,
   CLUB_CATEGORIES,
   CLUB_CATEGORY_LABELS,
   DEFAULT_BAG,
   clubCategoryFor,
+  formatClubLabel,
 } from '../constants'
 
 describe('clubCategoryFor', () => {
@@ -49,10 +51,17 @@ describe('clubCategoryFor', () => {
     expect(clubCategoryFor('1i')).toBe('iron')
   })
 
-  it('maps degree-named wedges and attack wedge', () => {
+  it('maps approach wedge and the custom_wedge slot', () => {
     expect(clubCategoryFor('aw')).toBe('wedge')
-    expect(clubCategoryFor('46°')).toBe('wedge')
-    expect(clubCategoryFor('60°')).toBe('wedge')
+    expect(clubCategoryFor('custom_wedge')).toBe('wedge')
+  })
+
+  it('no longer treats raw degree strings as wedges', () => {
+    // Degree-named entries were removed from the picklist (issue #164).
+    // The custom_wedge slot + the loft field carry the same intent;
+    // a free-floating "60°" string falls through to utility now.
+    expect(clubCategoryFor('60°')).toBe('utility')
+    expect(clubCategoryFor('46°')).toBe('utility')
   })
 
   it('falls back to utility for genuinely non-canonical club_types', () => {
@@ -102,5 +111,60 @@ describe('DEFAULT_BAG', () => {
 
   it('includes a driver', () => {
     expect(DEFAULT_BAG.some((c) => c.club_type === 'driver')).toBe(true)
+  })
+})
+
+describe('CANONICAL_CLUBS_BY_CATEGORY.wedge', () => {
+  it('only contains the five traditional names plus custom_wedge', () => {
+    expect(CANONICAL_CLUBS_BY_CATEGORY.wedge).toEqual([
+      'pw',
+      'gw',
+      'aw',
+      'sw',
+      'lw',
+      'custom_wedge',
+    ])
+  })
+
+  it('contains no degree-based entries', () => {
+    for (const c of CANONICAL_CLUBS_BY_CATEGORY.wedge) {
+      expect(/°/.test(c)).toBe(false)
+    }
+  })
+})
+
+describe('formatClubLabel', () => {
+  it('returns club_type unchanged for non-custom entries', () => {
+    expect(formatClubLabel({ club_type: 'pw' })).toBe('pw')
+    expect(formatClubLabel({ club_type: '7i', loft: 34 })).toBe('7i')
+    expect(formatClubLabel({ club_type: 'driver', loft: 10.5 })).toBe('driver')
+  })
+
+  it('returns the loft as the label for custom_wedge', () => {
+    expect(formatClubLabel({ club_type: 'custom_wedge', loft: 58 })).toBe(
+      '58°',
+    )
+    expect(formatClubLabel({ club_type: 'custom_wedge', loft: 62 })).toBe(
+      '62°',
+    )
+  })
+
+  it('falls back to the user-set name when custom_wedge has no loft', () => {
+    expect(
+      formatClubLabel({ club_type: 'custom_wedge', name: 'lob v2' }),
+    ).toBe('lob v2')
+  })
+
+  it('falls back to literal "wedge" when custom_wedge has no loft and no name', () => {
+    expect(formatClubLabel({ club_type: 'custom_wedge' })).toBe('wedge')
+    expect(formatClubLabel({ club_type: 'custom_wedge', name: '   ' })).toBe(
+      'wedge',
+    )
+  })
+
+  it('rejects non-finite loft values', () => {
+    expect(
+      formatClubLabel({ club_type: 'custom_wedge', loft: Number.NaN }),
+    ).toBe('wedge')
   })
 })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -73,7 +73,7 @@ export function clubCategoryFor(clubType: string): ClubCategory {
     clubType === 'sw' ||
     clubType === 'lw' ||
     clubType === 'aw' ||
-    /^\d{2}°$/.test(clubType)
+    clubType === 'custom_wedge'
   )
     return 'wedge'
   return 'utility'
@@ -82,34 +82,39 @@ export function clubCategoryFor(clubType: string): ClubCategory {
 // Canonical picklist options per category, surfaced by the bag UIs on
 // web and mobile. Lives here (not in app code) so both apps stay in
 // lockstep — adding a club_type to the picklist is a one-file edit.
-// Wedges are ordered by loft so the dropdown reads top-to-bottom from
-// pitch through lob; degree-named entries cover players who know their
-// wedges by loft rather than by name.
+//
+// Wedges are name-based (pw → lw covers ~90% of players) plus a
+// `custom_wedge` slot for grinds outside the standard set. The user
+// captures the loft via the bag editor's loft field; the shot picker
+// reads loft via formatClubLabel below so a custom_wedge chip reads
+// "58°" rather than the raw "custom_wedge" string.
 export const CANONICAL_CLUBS_BY_CATEGORY: Record<ClubCategory, readonly string[]> = {
   driver: ['driver'],
   wood: ['mini_driver', '2w', '3w', '4w', '5w', '7w', '9w', '11w', '13w'],
   hybrid: ['2h', '3h', '4h', '5h', '6h', '7h'],
   iron: ['1i', '2i', '3i', '4i', '5i', '6i', '7i', '8i', '9i'],
-  wedge: [
-    '45°',
-    '46°',
-    '47°',
-    '48°',
-    'pw',
-    'gw',
-    'aw',
-    '50°',
-    '52°',
-    '54°',
-    '56°',
-    'sw',
-    '58°',
-    '60°',
-    '62°',
-    'lw',
-  ],
+  wedge: ['pw', 'gw', 'aw', 'sw', 'lw', 'custom_wedge'],
   putter: ['putter'],
   utility: [],
+}
+
+// Picker label for a bag entry. Plain club_type for everything except
+// `custom_wedge`, where the loft (e.g. "58°") is the meaningful label.
+// Falls back to the club's free-text name, then the literal club_type
+// when no loft is set, so the chip never reads as raw "custom_wedge"
+// in the shot picker.
+export function formatClubLabel(c: {
+  club_type: string
+  name?: string | null
+  loft?: number | null
+}): string {
+  if (c.club_type === 'custom_wedge') {
+    if (c.loft != null && Number.isFinite(c.loft)) return `${c.loft}°`
+    const trimmed = c.name?.trim()
+    if (trimmed) return trimmed
+    return 'wedge'
+  }
+  return c.club_type
 }
 
 // Default 14-club starting bag seeded for new users when their bag is


### PR DESCRIPTION
## Summary

Three v0.2 cleanup items, one per the original spec.

- **#39 — split large mobile components** (commits 1, 2). `HoleMap.tsx` 864 → 393 lines, `(app)/index.tsx` 749 → 221 lines. Pure extraction; no behavior change. Subcomponents and hooks pulled into `components/round/markers/`, `components/round/hooks/`, `components/home/`, and `hooks/useActiveRound.ts`.
- **#160 — collapse mobile auth into one context** (commit 3). Mirrors the web AuthContext pattern from PR #159. `AuthProvider` at the root layout owns the single `getSession` + `onAuthStateChange` subscription; `useAuth()` is a thin `useContext` wrapper. 14+ duplicated subscriptions across the app collapse to one.
- **#164 — standardize wedge naming** (commit 4). Drop degree-named entries (45° through 62°) from `CANONICAL_CLUBS_BY_CATEGORY.wedge`; keep traditional names (pw/gw/aw/sw/lw) plus a single `custom_wedge` slot for grinds outside that set. The bag editor's loft field captures the actual loft; new `formatClubLabel` helper in `@oga/core` renders that loft as the picker label.

A 5th commit applies fixes from a specialist audit (a swipe-ref leak in the new `RecentRoundsList`, a splash-overlay wedge condition in the new `AuthContext`, and a `session` field that was over-shipped).

Closes #39, #160, #164.

## Verification

- `pnpm typecheck` — passes (`@oga/core`, `@oga/supabase`, `@oga/web`)
- `pnpm test` — 250 tests pass (was 242, +8 new tests for `formatClubLabel` and the wedge picklist shape)
- `pnpm --filter web build` — clean build, 461 KB main bundle
- `apps/mobile && npx tsc --noEmit` — clean

## Tuning concerns surfaced in audit (follow-up, not blocking)

- **Single-caller extractions.** Most of the new files in `components/round/markers/` and `components/home/` have one caller. The 3-caller rule in `CLAUDE.md` says co-locate; the 864-line / 749-line parents trip the "genuinely unreadable" carve-out, but the rule literally fails. Worth a follow-up pass if any of these files stay one-caller for long.
- **`SGBreakdown.tsx` averaging math.** The per-category SG average + maxAbs calc lives in the UI component, not `@oga/core`. CLAUDE.md says all pure logic belongs in core. Small enough to argue inline (~6 lines), but the existing `sgAverages` in `packages/core/src/stats.ts` is the natural home if someone files it.
- **`useHoleCamera.ts` two-effect ref pattern.** The PLACE_BALL reframe writes `reframePlaceBallRef.current = true` in one effect and reads it in another. Both depend on `[phase]`. Currently fine because React batches commits in deterministic order, but fragile if the deps ever diverge.
- **`useActiveRound` calls `useAuth` internally.** Threading `user` as a parameter would defer the second auth subscription if a second caller appears. Harmless today (one caller, post-#160 there's only one subscription anyway).

## Test plan

- [ ] Live round on mobile — long-press to set aim, confirm aim ghosts persist across shots, breadcrumb labels render in the right units
- [ ] Home tab — Resume banner pulses while an active round exists, drops when the round is deleted (swipe-to-delete works, no orphaned refs)
- [ ] Cold start — splash overlay clears within ~400ms once auth resolves; doesn't wedge if Supabase is slow
- [ ] Bag editor — pick `Custom (loft)` from the wedge picklist, set loft 58, save; the chip label in the shot logger reads `58°` (not `custom_wedge`)
- [ ] Existing rounds with logged shots still render correctly under the new club-label formatter