### PR TITLE
fix: wedge picklist polish (cw + humanize underscores)

### DIFF
--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -14,6 +14,7 @@ import {
   CLUB_CATEGORIES,
   CLUB_CATEGORY_LABELS,
   clubCategoryFor,
+  formatClubLabel,
   type ClubCategory,
 } from '@oga/core'
 import DraggableFlatList, {
@@ -423,7 +424,7 @@ export default function BagScreen() {
                       {CANONICAL_CLUBS_BY_CATEGORY[draft.category].map((c) => (
                         <Chip
                           key={c}
-                          label={c}
+                          label={formatClubLabel({ club_type: c })}
                           active={draft.clubType === c}
                           onPress={() =>
                             setDraft((d) => ({ ...d, clubType: c }))
@@ -563,8 +564,10 @@ function ClubRow({
           {club.name}
         </Text>
         <Text style={{ ...KICKER, marginTop: 2 }}>
-          {club.club_type}
-          {club.loft != null ? ` · ${club.loft}°` : ''}
+          {formatClubLabel(club)}
+          {club.loft != null && club.club_type !== 'cw' && club.club_type !== 'custom_wedge'
+            ? ` · ${club.loft}°`
+            : ''}
           {club.typical_distance_yards != null
             ? ` · ${club.typical_distance_yards} yd`
             : ''}

--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -423,7 +423,7 @@ export default function BagScreen() {
                       {CANONICAL_CLUBS_BY_CATEGORY[draft.category].map((c) => (
                         <Chip
                           key={c}
-                          label={c === 'custom_wedge' ? 'Custom (loft)' : c}
+                          label={c}
                           active={draft.clubType === c}
                           onPress={() =>
                             setDraft((d) => ({ ...d, clubType: c }))

--- a/apps/web/src/pages/settings/BagPage.tsx
+++ b/apps/web/src/pages/settings/BagPage.tsx
@@ -776,7 +776,7 @@ function AddClubForm({
             >
               {canonicalOptions.map((c) => (
                 <option key={c} value={c}>
-                  {c === 'custom_wedge' ? 'Custom (loft)' : c}
+                  {c}
                 </option>
               ))}
               <option value={CUSTOM_VALUE}>Other…</option>

--- a/apps/web/src/pages/settings/BagPage.tsx
+++ b/apps/web/src/pages/settings/BagPage.tsx
@@ -4,6 +4,7 @@ import {
   CLUB_CATEGORIES,
   CLUB_CATEGORY_LABELS,
   clubCategoryFor,
+  formatClubLabel,
   type ClubCategory,
 } from '@oga/core'
 import {
@@ -452,8 +453,10 @@ const SortableClubRow = memo(function SortableClubRow({
             className="font-mono uppercase text-caddie-ink-mute"
             style={{ fontSize: 10, letterSpacing: '0.14em', marginTop: 2 }}
           >
-            {club.club_type}
-            {club.loft != null ? ` · ${club.loft}°` : ''}
+            {formatClubLabel(club)}
+            {club.loft != null && club.club_type !== 'cw' && club.club_type !== 'custom_wedge'
+              ? ` · ${club.loft}°`
+              : ''}
             {club.typical_distance_yards != null
               ? ` · ${club.typical_distance_yards} yd`
               : ''}
@@ -776,7 +779,7 @@ function AddClubForm({
             >
               {canonicalOptions.map((c) => (
                 <option key={c} value={c}>
-                  {c}
+                  {formatClubLabel({ club_type: c })}
                 </option>
               ))}
               <option value={CUSTOM_VALUE}>Other…</option>

--- a/packages/core/src/__tests__/clubs.test.ts
+++ b/packages/core/src/__tests__/clubs.test.ts
@@ -139,10 +139,14 @@ describe('CANONICAL_CLUBS_BY_CATEGORY.wedge', () => {
 })
 
 describe('formatClubLabel', () => {
-  it('returns club_type unchanged for non-custom entries', () => {
+  it('returns club_type unchanged for non-custom single-word entries', () => {
     expect(formatClubLabel({ club_type: 'pw' })).toBe('pw')
     expect(formatClubLabel({ club_type: '7i', loft: 34 })).toBe('7i')
     expect(formatClubLabel({ club_type: 'driver', loft: 10.5 })).toBe('driver')
+  })
+
+  it('humanizes underscored club_types so the kicker style does not read MINI_DRIVER', () => {
+    expect(formatClubLabel({ club_type: 'mini_driver' })).toBe('mini driver')
   })
 
   it('returns the loft as the label for cw', () => {

--- a/packages/core/src/__tests__/clubs.test.ts
+++ b/packages/core/src/__tests__/clubs.test.ts
@@ -51,8 +51,13 @@ describe('clubCategoryFor', () => {
     expect(clubCategoryFor('1i')).toBe('iron')
   })
 
-  it('maps approach wedge and the custom_wedge slot', () => {
+  it('maps approach wedge and the cw custom-wedge slot', () => {
     expect(clubCategoryFor('aw')).toBe('wedge')
+    expect(clubCategoryFor('cw')).toBe('wedge')
+  })
+
+  it('still maps the legacy custom_wedge string to wedge', () => {
+    // Pre-rename rows from dev-test of #164. Kept for backwards compat.
     expect(clubCategoryFor('custom_wedge')).toBe('wedge')
   })
 
@@ -115,14 +120,14 @@ describe('DEFAULT_BAG', () => {
 })
 
 describe('CANONICAL_CLUBS_BY_CATEGORY.wedge', () => {
-  it('only contains the five traditional names plus custom_wedge', () => {
+  it('only contains the five traditional names plus cw', () => {
     expect(CANONICAL_CLUBS_BY_CATEGORY.wedge).toEqual([
       'pw',
       'gw',
       'aw',
       'sw',
       'lw',
-      'custom_wedge',
+      'cw',
     ])
   })
 
@@ -140,31 +145,29 @@ describe('formatClubLabel', () => {
     expect(formatClubLabel({ club_type: 'driver', loft: 10.5 })).toBe('driver')
   })
 
-  it('returns the loft as the label for custom_wedge', () => {
+  it('returns the loft as the label for cw', () => {
+    expect(formatClubLabel({ club_type: 'cw', loft: 58 })).toBe('58°')
+    expect(formatClubLabel({ club_type: 'cw', loft: 62 })).toBe('62°')
+  })
+
+  it('also handles the legacy custom_wedge club_type', () => {
     expect(formatClubLabel({ club_type: 'custom_wedge', loft: 58 })).toBe(
       '58°',
     )
-    expect(formatClubLabel({ club_type: 'custom_wedge', loft: 62 })).toBe(
-      '62°',
-    )
   })
 
-  it('falls back to the user-set name when custom_wedge has no loft', () => {
-    expect(
-      formatClubLabel({ club_type: 'custom_wedge', name: 'lob v2' }),
-    ).toBe('lob v2')
+  it('falls back to the user-set name when cw has no loft', () => {
+    expect(formatClubLabel({ club_type: 'cw', name: 'lob v2' })).toBe('lob v2')
   })
 
-  it('falls back to literal "wedge" when custom_wedge has no loft and no name', () => {
-    expect(formatClubLabel({ club_type: 'custom_wedge' })).toBe('wedge')
-    expect(formatClubLabel({ club_type: 'custom_wedge', name: '   ' })).toBe(
-      'wedge',
-    )
+  it('falls back to literal "wedge" when cw has no loft and no name', () => {
+    expect(formatClubLabel({ club_type: 'cw' })).toBe('wedge')
+    expect(formatClubLabel({ club_type: 'cw', name: '   ' })).toBe('wedge')
   })
 
   it('rejects non-finite loft values', () => {
-    expect(
-      formatClubLabel({ club_type: 'custom_wedge', loft: Number.NaN }),
-    ).toBe('wedge')
+    expect(formatClubLabel({ club_type: 'cw', loft: Number.NaN })).toBe(
+      'wedge',
+    )
   })
 })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -73,6 +73,10 @@ export function clubCategoryFor(clubType: string): ClubCategory {
     clubType === 'sw' ||
     clubType === 'lw' ||
     clubType === 'aw' ||
+    clubType === 'cw' ||
+    // Legacy: pre-rename rows from the dev-test phase of issue #164.
+    // Kept so any user_clubs row written before the rename still maps
+    // to the wedge category. New rows use 'cw'.
     clubType === 'custom_wedge'
   )
     return 'wedge'
@@ -83,32 +87,31 @@ export function clubCategoryFor(clubType: string): ClubCategory {
 // web and mobile. Lives here (not in app code) so both apps stay in
 // lockstep — adding a club_type to the picklist is a one-file edit.
 //
-// Wedges are name-based (pw → lw covers ~90% of players) plus a
-// `custom_wedge` slot for grinds outside the standard set. The user
-// captures the loft via the bag editor's loft field; the shot picker
-// reads loft via formatClubLabel below so a custom_wedge chip reads
-// "58°" rather than the raw "custom_wedge" string.
+// Wedges are name-based (pw → lw covers ~90% of players) plus a `cw`
+// slot for grinds outside the standard set. The user captures the
+// loft via the bag editor's loft field; the shot picker reads loft
+// via formatClubLabel below so a cw chip reads "58°" rather than the
+// raw "cw" string.
 export const CANONICAL_CLUBS_BY_CATEGORY: Record<ClubCategory, readonly string[]> = {
   driver: ['driver'],
   wood: ['mini_driver', '2w', '3w', '4w', '5w', '7w', '9w', '11w', '13w'],
   hybrid: ['2h', '3h', '4h', '5h', '6h', '7h'],
   iron: ['1i', '2i', '3i', '4i', '5i', '6i', '7i', '8i', '9i'],
-  wedge: ['pw', 'gw', 'aw', 'sw', 'lw', 'custom_wedge'],
+  wedge: ['pw', 'gw', 'aw', 'sw', 'lw', 'cw'],
   putter: ['putter'],
   utility: [],
 }
 
 // Picker label for a bag entry. Plain club_type for everything except
-// `custom_wedge`, where the loft (e.g. "58°") is the meaningful label.
-// Falls back to the club's free-text name, then the literal club_type
-// when no loft is set, so the chip never reads as raw "custom_wedge"
-// in the shot picker.
+// the custom-wedge slot (`cw`, or legacy `custom_wedge`), where the
+// loft (e.g. "58°") is the meaningful label. Falls back to the club's
+// free-text name, then a literal "wedge" when no loft is set.
 export function formatClubLabel(c: {
   club_type: string
   name?: string | null
   loft?: number | null
 }): string {
-  if (c.club_type === 'custom_wedge') {
+  if (c.club_type === 'cw' || c.club_type === 'custom_wedge') {
     if (c.loft != null && Number.isFinite(c.loft)) return `${c.loft}°`
     const trimmed = c.name?.trim()
     if (trimmed) return trimmed

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -106,6 +106,10 @@ export const CANONICAL_CLUBS_BY_CATEGORY: Record<ClubCategory, readonly string[]
 // the custom-wedge slot (`cw`, or legacy `custom_wedge`), where the
 // loft (e.g. "58°") is the meaningful label. Falls back to the club's
 // free-text name, then a literal "wedge" when no loft is set.
+//
+// Underscores in the club_type are rendered as spaces so multi-word
+// types (mini_driver, etc.) read cleanly under the bag UI's uppercase
+// kicker style — "MINI DRIVER" instead of "MINI_DRIVER".
 export function formatClubLabel(c: {
   club_type: string
   name?: string | null
@@ -117,7 +121,7 @@ export function formatClubLabel(c: {
     if (trimmed) return trimmed
     return 'wedge'
   }
-  return c.club_type
+  return c.club_type.replace(/_/g, ' ')
 }
 
 // Default 14-club starting bag seeded for new users when their bag is


### PR DESCRIPTION
## Summary

Two small polish fixes on top of #194 (just merged).

- **`custom_wedge` → `cw`.** The bag list rendered the slot's club_type as `CUSTOM_WEDGE` (uppercased by the kicker style), visually loud next to two-letter codes pw/gw/aw/sw/lw. Rename to `cw` so the picklist reads as a consistent set of two-letter wedge codes. `clubCategoryFor` and `formatClubLabel` still recognise the legacy `custom_wedge` string so any user_clubs row written during dev-test of #164 keeps working.
- **Humanize underscored club_types in `formatClubLabel`.** `mini_driver` was hitting the same uppercase-kicker readability problem (`MINI_DRIVER`). Replace underscores with spaces in the non-custom path so `mini_driver` → `mini driver` (renders as `MINI DRIVER`). Routes the bag list rows + add-club picker chips on both apps through `formatClubLabel` so future multi-word club_types pick up the same treatment.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` — 253 pass (added a `mini_driver` humanization test + a legacy `custom_wedge` mapping test)

## Test plan

- [ ] Mobile: open `/bag`, add a wedge with picklist `cw` + loft 58, confirm the row reads `cw · 58° · ...` (not `CUSTOM_WEDGE`)
- [ ] Mobile: add a `mini_driver` from the wood category, confirm the row reads `MINI DRIVER`
- [ ] Web: same two checks on `/settings/bag`