### PR TITLE
feat: edit saved shot positions on web map (closes #163)

### DIFF
--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -13,6 +13,7 @@ import {
   type ReviewedShotRow,
 } from '@oga/core'
 import type { PlacedPoint } from './RoundMap'
+import { ShotMiniMap } from './ShotMiniMap'
 import type { WebPuttData } from './WebPuttingSheet'
 import { useUnits } from '../../hooks/useUnits'
 import { useUserBag } from '../../hooks/useUserBag'
@@ -236,10 +237,42 @@ export function HoleReviewSheet({
             <ShotRow
               key={row.shotNumber}
               row={row}
+              nextRow={rows[idx + 1] ?? null}
+              pinLat={pinLat}
+              pinLng={pinLng}
               onChange={(next) =>
                 setRows((prev) => {
                   const copy = prev.slice()
                   copy[idx] = next
+                  // When start moves, the prior shot's end no longer
+                  // matches — keep them paired so the trajectory line
+                  // and SG distances stay consistent on save. Skip when
+                  // either coord side is null (synthetic-fallback rows
+                  // built without coords); those flows save without
+                  // start/end pairing in the first place.
+                  const prior = idx > 0 ? prev[idx - 1] : null
+                  if (
+                    prior &&
+                    next.startLat != null &&
+                    next.startLng != null &&
+                    prior.startLat != null &&
+                    prior.startLng != null &&
+                    (prior.endLat !== next.startLat ||
+                      prior.endLng !== next.startLng)
+                  ) {
+                    const priorDist = haversineYards(
+                      prior.startLat,
+                      prior.startLng,
+                      next.startLat,
+                      next.startLng,
+                    )
+                    copy[idx - 1] = {
+                      ...prior,
+                      endLat: next.startLat,
+                      endLng: next.startLng,
+                      distanceYards: priorDist,
+                    }
+                  }
                   return copy
                 })
               }
@@ -302,9 +335,15 @@ export function HoleReviewSheet({
 
 function ShotRow({
   row,
+  nextRow,
+  pinLat,
+  pinLng,
   onChange,
 }: {
   row: ReviewedShotRow
+  nextRow: ReviewedShotRow | null
+  pinLat: number | null
+  pinLng: number | null
   onChange: (next: ReviewedShotRow) => void
 }) {
   // Mirror mobile's PUTTING_RADIUS_YARDS — any shot starting within 30 yd
@@ -336,17 +375,56 @@ function ShotRow({
     }
     return base
   }, [bag.data, row.club])
+  const handleStartDrag = (point: { lat: number; lng: number }) => {
+    const nextLat =
+      nextRow && nextRow.startLat != null ? nextRow.startLat : point.lat
+    const nextLng =
+      nextRow && nextRow.startLng != null ? nextRow.startLng : point.lng
+    const newDistanceYards = haversineYards(
+      point.lat,
+      point.lng,
+      nextLat,
+      nextLng,
+    )
+    const newDistanceToPin =
+      pinLat != null && pinLng != null
+        ? haversineYards(point.lat, point.lng, pinLat, pinLng)
+        : row.distanceToPin
+    onChange({
+      ...row,
+      startLat: point.lat,
+      startLng: point.lng,
+      distanceYards: row.isLastShot ? row.distanceYards : newDistanceYards,
+      distanceToPin: newDistanceToPin,
+    })
+  }
   return (
     <div
       style={{
         display: 'flex',
-        alignItems: 'center',
-        gap: 14,
+        flexDirection: 'column',
+        gap: 10,
         padding: '14px 0',
         borderBottom: '1px solid #D9D2BF',
-        flexWrap: 'wrap',
       }}
     >
+      <ShotMiniMap
+        shotNumber={row.shotNumber}
+        startLat={row.startLat}
+        startLng={row.startLng}
+        endLat={nextRow ? nextRow.startLat : pinLat}
+        endLng={nextRow ? nextRow.startLng : pinLng}
+        onChangeStart={handleStartDrag}
+        height={140}
+      />
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 14,
+          flexWrap: 'wrap',
+        }}
+      >
       <div
         className="kicker"
         style={{ minWidth: 56 }}
@@ -445,6 +523,7 @@ function ShotRow({
       {isPutt && !row.puttMade && (
         <PuttMissAxes row={row} onChange={onChange} />
       )}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -635,6 +635,11 @@ interface RoundMapInstructionStripProps {
   editing?: boolean
   shotsPlaced: number
   remainingToPin: number | null
+  /** Label for the most recent saved-shot drag — when non-null, render
+   *  an Undo button on the logged-hole strip. The parent owns the 5s
+   *  fade timer and clears the label by passing null. */
+  shotDragUndoLabel?: string | null
+  onApplyShotDragUndo?: () => void
   /** False when this hole has no pin coordinates — drives the "— to
    *  pin" placeholder instead of just hiding the distance silently. */
   pinAvailable?: boolean
@@ -680,6 +685,8 @@ export function RoundMapInstructionStrip({
   needsTee = false,
   needsPin = false,
   placementMode = null,
+  shotDragUndoLabel = null,
+  onApplyShotDragUndo,
   onStartPlaceTee,
   onStartPlacePin,
   onCancelPlacement,
@@ -808,7 +815,9 @@ export function RoundMapInstructionStrip({
               Logged hole
             </div>
             <div className="text-caddie-ink" style={{ fontSize: 13 }}>
-              Drag any marker to adjust its position.
+              {shotDragUndoLabel
+                ? `${shotDragUndoLabel} updated.`
+                : 'Drag any marker to adjust its position.'}
             </div>
           </>
         ) : aimMode ? (
@@ -946,9 +955,25 @@ export function RoundMapInstructionStrip({
             Done with hole →
           </button>
         </div>
-      ) : placeButtons ? (
+      ) : (placeButtons || (shotDragUndoLabel && onApplyShotDragUndo)) ? (
         <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
           {placeButtons}
+          {shotDragUndoLabel && onApplyShotDragUndo && (
+            <button
+              type="button"
+              onClick={onApplyShotDragUndo}
+              className="text-caddie-ink-dim"
+              style={{
+                border: '1px solid #D9D2BF',
+                borderRadius: 2,
+                padding: '6px 10px',
+                fontSize: 12,
+                background: 'transparent',
+              }}
+            >
+              Undo
+            </button>
+          )}
         </div>
       ) : null}
     </div>

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -28,6 +28,8 @@ export interface ExistingShot {
   endLng: number | null
   startLat: number | null
   startLng: number | null
+  aimLat?: number | null
+  aimLng?: number | null
   category?: 'tee' | 'approach' | 'around-green' | 'putt' | null
 }
 
@@ -77,6 +79,13 @@ interface RoundMapProps {
   onMovePin?: (point: PlacedPoint) => void
   onMoveTee?: (point: PlacedPoint) => void
   onSetAim?: (index: number, point: PlacedPoint | null) => void
+  /** Drag end on a saved shot's start marker. When wired, saved shot
+   *  markers become draggable so the player can correct positions
+   *  after a hole is logged. */
+  onMoveExistingShot?: (shotId: string, point: PlacedPoint) => void
+  /** Drag end on a saved shot's aim ghost. When wired (and the shot has
+   *  aim coords), the aim marker becomes draggable. */
+  onMoveExistingShotAim?: (shotId: string, point: PlacedPoint) => void
 }
 
 const MARKER_COLORS = {
@@ -106,6 +115,8 @@ export function RoundMap({
   onMovePin,
   onMoveTee,
   onSetAim,
+  onMoveExistingShot,
+  onMoveExistingShotAim,
 }: RoundMapProps) {
   const { toDisplay } = useUnits()
   // Memoized so downstream effects can dep on the object directly without
@@ -373,6 +384,7 @@ export function RoundMap({
     // Marker N renders at the START of shot N — that's "where the player
     // stood for shot N", matching the post-round tap flow. Falling back
     // to end coords for legacy rows that pre-date start_lat/lng.
+    const existingAimLines: [number, number][][] = []
     const existingValid = existingShots.filter(
       (s) =>
         (s.startLat != null && s.startLng != null) ||
@@ -388,13 +400,86 @@ export function RoundMap({
               ? MARKER_COLORS.approach
               : MARKER_COLORS.green
       const parts = makeNumberedMarker(s.shotNumber, color, '#FBF8F1')
-      parts.outer.title = `Shot ${s.shotNumber}`
       const lng = s.startLng ?? s.endLng!
       const lat = s.startLat ?? s.endLat!
-      const marker = new mapboxgl.Marker({ element: parts.outer })
+      // Drag is gated on the parent wiring a handler AND the row having a
+      // real start coord — moving an end-only legacy fallback would
+      // silently coerce it into a start coord on save.
+      const draggable =
+        !!onMoveExistingShot && s.startLat != null && s.startLng != null
+      const marker = new mapboxgl.Marker({
+        element: parts.outer,
+        draggable,
+      })
         .setLngLat([lng, lat])
         .addTo(map)
+      if (draggable) {
+        attachDragFx({
+          outer: parts.outer,
+          content: parts.content,
+          marker,
+          tooltip: `Shot ${s.shotNumber} — drag to adjust`,
+        })
+        marker.on('dragend', () => {
+          const ll = marker.getLngLat()
+          onMoveExistingShot!(s.id, { lat: ll.lat, lng: ll.lng })
+        })
+      } else {
+        parts.outer.title = `Shot ${s.shotNumber}`
+      }
       markerRefs.current.push(marker)
+
+      // Aim ghost for saved shots. Same warn palette as the placed-aim
+      // marker so the visual vocabulary stays consistent across modes.
+      if (s.aimLat != null && s.aimLng != null) {
+        const aimEl = makeAimMarker()
+        const aimDraggable = !!onMoveExistingShotAim
+        const aimMarker = new mapboxgl.Marker({
+          element: aimEl,
+          draggable: aimDraggable,
+        })
+          .setLngLat([s.aimLng, s.aimLat])
+          .addTo(map)
+        if (aimDraggable) {
+          aimEl.title = `Shot ${s.shotNumber} aim — drag to adjust`
+          aimEl.style.cursor = 'grab'
+          aimMarker.on('dragstart', () => {
+            aimEl.style.cursor = 'grabbing'
+          })
+          aimMarker.on('dragend', () => {
+            aimEl.style.cursor = 'grab'
+            const ll = aimMarker.getLngLat()
+            onMoveExistingShotAim!(s.id, { lat: ll.lat, lng: ll.lng })
+          })
+        }
+        markerRefs.current.push(aimMarker)
+
+        // Dashed aim line + AIM distance pill, mirroring the placed-shot
+        // version below. Uses the shot's start coord (with end fallback)
+        // so the line origin matches the numbered marker on the map.
+        const startLng = s.startLng ?? s.endLng
+        const startLat = s.startLat ?? s.endLat
+        if (startLat != null && startLng != null) {
+          const aimYards = Math.round(
+            haversineYards(startLat, startLng, s.aimLat, s.aimLng),
+          )
+          if (aimYards > 0) {
+            const mid: [number, number] = [
+              (startLng + s.aimLng) / 2,
+              (startLat + s.aimLat) / 2,
+            ]
+            const pill = makeDistancePill(`AIM ${toDisplay(aimYards)}`)
+            const pillMarker = new mapboxgl.Marker({ element: pill })
+              .setLngLat(mid)
+              .addTo(map)
+            markerRefs.current.push(pillMarker)
+          }
+          existingAimLines.push([
+            [startLng, startLat],
+            [s.aimLng, s.aimLat],
+          ])
+        }
+      }
     }
 
     // Placed points (tap-to-place mode).
@@ -492,6 +577,7 @@ export function RoundMap({
       }
     })
     upsertDashedLines(map, 'aim-lines', aimLineCoords, '#A66A1F')
+    upsertDashedLines(map, 'existing-aim-lines', existingAimLines, '#A66A1F')
   }, [
     existingShots,
     hole,
@@ -500,6 +586,8 @@ export function RoundMap({
     onMovePoint,
     onMovePin,
     onMoveTee,
+    onMoveExistingShot,
+    onMoveExistingShotAim,
     effectivePin,
     effectiveTee,
     toDisplay,
@@ -720,7 +808,7 @@ export function RoundMapInstructionStrip({
               Logged hole
             </div>
             <div className="text-caddie-ink" style={{ fontSize: 13 }}>
-              Drag any marker to refine its position.
+              Drag any marker to adjust its position.
             </div>
           </>
         ) : aimMode ? (

--- a/apps/web/src/components/round/ShotMiniMap.tsx
+++ b/apps/web/src/components/round/ShotMiniMap.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useRef, useState } from 'react'
+import { mapboxgl, MAPBOX_TOKEN_PRESENT } from '../../lib/mapbox'
+
+export interface ShotMiniMapProps {
+  shotNumber: number
+  startLat: number | null
+  startLng: number | null
+  /** Either the next shot's start or the pin — used purely to fit the
+   *  camera so the player sees the shot's path. Null hides nothing; the
+   *  marker still drops at the start coord and the camera frames it. */
+  endLat?: number | null
+  endLng?: number | null
+  /** Aim coord for this shot, when set. Drawn as a dashed line + ghost
+   *  marker so the player sees where they were aiming. Not draggable
+   *  here — the round map is the place to retarget aim. */
+  aimLat?: number | null
+  aimLng?: number | null
+  /** Drag-end on the start marker. Returns the new lat/lng. */
+  onChangeStart: (point: { lat: number; lng: number }) => void
+  height?: number
+}
+
+// Auto-fit padding + zoom cap. Without the cap a shot whose start and
+// end are within a couple feet would zoom in past the satellite tile
+// resolution; 18 keeps the imagery sharp.
+const FIT_PADDING = 24
+const MAX_ZOOM = 18
+
+export function ShotMiniMap({
+  shotNumber,
+  startLat,
+  startLng,
+  endLat,
+  endLng,
+  aimLat,
+  aimLng,
+  onChangeStart,
+  height = 160,
+}: ShotMiniMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<mapboxgl.Map | null>(null)
+  const startMarkerRef = useRef<mapboxgl.Marker | null>(null)
+  const aimMarkerRef = useRef<mapboxgl.Marker | null>(null)
+  const [mapLoaded, setMapLoaded] = useState(false)
+
+  const hasStart = startLat != null && startLng != null
+
+  useEffect(() => {
+    if (!containerRef.current || !MAPBOX_TOKEN_PRESENT) return
+    if (mapRef.current) return
+    if (!hasStart) return
+    const map = new mapboxgl.Map({
+      container: containerRef.current,
+      style: 'mapbox://styles/mapbox/satellite-streets-v12',
+      center: [startLng!, startLat!],
+      zoom: 17,
+      attributionControl: false,
+      dragPan: false,
+      scrollZoom: false,
+      doubleClickZoom: false,
+      boxZoom: false,
+      dragRotate: false,
+      keyboard: false,
+      touchZoomRotate: false,
+      interactive: false,
+    })
+    map.on('load', () => setMapLoaded(true))
+    mapRef.current = map
+    return () => {
+      map.remove()
+      mapRef.current = null
+      startMarkerRef.current = null
+      aimMarkerRef.current = null
+      setMapLoaded(false)
+    }
+    // hasStart gate; coords change reactively in the next effects.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasStart])
+
+  // Fit camera to start + end (or aim) so the shot's path frames cleanly.
+  // Falls back to a tight zoom on the start coord when no companion
+  // point is available.
+  useEffect(() => {
+    if (!mapLoaded || !mapRef.current || !hasStart) return
+    const map = mapRef.current
+    const points: [number, number][] = [[startLng!, startLat!]]
+    if (endLat != null && endLng != null) points.push([endLng, endLat])
+    if (aimLat != null && aimLng != null) points.push([aimLng, aimLat])
+    if (points.length === 1) {
+      map.jumpTo({ center: points[0]!, zoom: 17 })
+      return
+    }
+    const bounds = points.reduce(
+      (b, p) => b.extend(p),
+      new mapboxgl.LngLatBounds(points[0]!, points[0]!),
+    )
+    map.fitBounds(bounds, {
+      padding: FIT_PADDING,
+      maxZoom: MAX_ZOOM,
+      duration: 0,
+    })
+  }, [mapLoaded, hasStart, startLat, startLng, endLat, endLng, aimLat, aimLng])
+
+  // Draggable start marker. Recreated when coords change so the
+  // mapbox-internal position matches React-side state without a manual
+  // setLngLat dance.
+  useEffect(() => {
+    if (!mapLoaded || !mapRef.current || !hasStart) return
+    if (startMarkerRef.current) {
+      startMarkerRef.current.setLngLat([startLng!, startLat!])
+      return
+    }
+    const el = makeMiniNumberedMarker(shotNumber)
+    const marker = new mapboxgl.Marker({ element: el, draggable: true })
+      .setLngLat([startLng!, startLat!])
+      .addTo(mapRef.current)
+    el.style.cursor = 'grab'
+    marker.on('dragstart', () => {
+      el.style.cursor = 'grabbing'
+    })
+    marker.on('dragend', () => {
+      el.style.cursor = 'grab'
+      const ll = marker.getLngLat()
+      onChangeStart({ lat: ll.lat, lng: ll.lng })
+    })
+    startMarkerRef.current = marker
+  }, [mapLoaded, hasStart, startLat, startLng, shotNumber, onChangeStart])
+
+  // Aim ghost (read-only).
+  useEffect(() => {
+    if (!mapLoaded || !mapRef.current) return
+    const map = mapRef.current
+    if (aimLat == null || aimLng == null) {
+      if (aimMarkerRef.current) {
+        aimMarkerRef.current.remove()
+        aimMarkerRef.current = null
+      }
+      return
+    }
+    if (aimMarkerRef.current) {
+      aimMarkerRef.current.setLngLat([aimLng, aimLat])
+      return
+    }
+    const el = document.createElement('div')
+    el.style.cssText = [
+      'width:10px',
+      'height:10px',
+      'border-radius:999px',
+      'background:#A66A1F',
+      'border:2px solid #FBF8F1',
+      'pointer-events:none',
+    ].join(';')
+    aimMarkerRef.current = new mapboxgl.Marker({ element: el })
+      .setLngLat([aimLng, aimLat])
+      .addTo(map)
+  }, [mapLoaded, aimLat, aimLng])
+
+  if (!hasStart) {
+    return (
+      <div
+        className="text-caddie-ink-mute"
+        style={{
+          height,
+          background: '#EBE5D6',
+          border: '1px solid #D9D2BF',
+          borderRadius: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 12,
+        }}
+      >
+        No position data
+      </div>
+    )
+  }
+
+  if (!MAPBOX_TOKEN_PRESENT) {
+    return (
+      <div
+        className="text-caddie-ink-mute"
+        style={{
+          height,
+          background: '#EBE5D6',
+          border: '1px solid #D9D2BF',
+          borderRadius: 2,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 12,
+          padding: 14,
+          textAlign: 'center',
+        }}
+      >
+        Map unavailable
+      </div>
+    )
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        height,
+        width: '100%',
+        background: '#1C211C',
+        borderRadius: 2,
+        border: '1px solid #D9D2BF',
+        overflow: 'hidden',
+      }}
+    />
+  )
+}
+
+function makeMiniNumberedMarker(n: number): HTMLElement {
+  const el = document.createElement('div')
+  el.style.cssText = [
+    'width:22px',
+    'height:22px',
+    'border-radius:999px',
+    'background:#1F3D2C',
+    'color:#FBF8F1',
+    'font-family:Inter, sans-serif',
+    'font-weight:600',
+    'font-size:11px',
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'border:2px solid #FBF8F1',
+  ].join(';')
+  el.textContent = String(n)
+  return el
+}

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -9,6 +9,7 @@ import {
   combinedPuttResult,
   formatClubLabel,
   formatPuttDistance,
+  haversineYards,
   legacySlopeToAxes,
   type BreakDirection,
   type Club,
@@ -32,6 +33,7 @@ import {
 import { useAuth } from '../../hooks/useAuth'
 import { LieSlopeGrid } from '../forms/LieSlopeGrid'
 import { GreenDiagram } from '../round/GreenDiagram'
+import { ShotMiniMap } from '../round/ShotMiniMap'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { useUnits } from '../../hooks/useUnits'
 
@@ -69,6 +71,10 @@ interface ShotEntryModalProps {
   holeScoreId: string
   holeNumber: number
   holePar: number
+  /** Pin coords for this hole (round-pin override → static hole pin →
+   *  null). Drives the mini-map's distance_to_target recalc on drag. */
+  pinLat: number | null
+  pinLng: number | null
   onClose: () => void
 }
 
@@ -162,6 +168,8 @@ export function ShotEntryModal({
   holeScoreId,
   holeNumber,
   holePar,
+  pinLat,
+  pinLng,
   onClose,
 }: ShotEntryModalProps) {
   const { user } = useAuth()
@@ -317,6 +325,35 @@ export function ShotEntryModal({
   }
 
   const isPutt = draft.lieType === 'green'
+
+  // Source shot row + its successor for the mini-map. Mini-map shows
+  // only when editing a saved shot with start coords; new-shot drafts
+  // hide it because there's nothing on the map yet.
+  const editingRow = editing ? holeShots.find((s) => s.id === editing) : null
+  const editingNext = editingRow
+    ? holeShots.find((s) => s.shot_number === editingRow.shot_number + 1)
+    : null
+  async function handleMiniMapDrag(point: { lat: number; lng: number }) {
+    if (!editingRow) return
+    // Mirror RoundMap's drag handler — recalc distance_to_target against
+    // the pin so SG for this shot stays accurate. Skipped for putts
+    // (distance_to_target stays null; putt_distance_ft tracks that flow
+    // and isn't auto-recalculated on drag).
+    const isPutt =
+      editingRow.lie_type === 'green' || editingRow.club === 'putter'
+    const newDistance =
+      !isPutt && pinLat != null && pinLng != null
+        ? Math.round(haversineYards(point.lat, point.lng, pinLat, pinLng))
+        : null
+    await updateShot.mutateAsync({
+      id: editingRow.id,
+      updates: {
+        start_lat: point.lat,
+        start_lng: point.lng,
+        ...(isPutt ? {} : { distance_to_target: newDistance }),
+      },
+    })
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-caddie-ink/60 sm:p-4">
@@ -479,6 +516,19 @@ export function ShotEntryModal({
             </div>
 
             <div className="flex flex-col" style={{ gap: 18 }}>
+              {editingRow && editingRow.start_lat != null && (
+                <ShotMiniMap
+                  shotNumber={editingRow.shot_number}
+                  startLat={editingRow.start_lat}
+                  startLng={editingRow.start_lng}
+                  endLat={editingNext?.start_lat ?? editingRow.end_lat}
+                  endLng={editingNext?.start_lng ?? editingRow.end_lng}
+                  aimLat={editingRow.aim_lat}
+                  aimLng={editingRow.aim_lng}
+                  onChangeStart={handleMiniMapDrag}
+                />
+              )}
+
               {isPutt && (
                 <GreenDiagram
                   distanceFt={draft.puttDistanceFt ?? 0}

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -55,7 +55,11 @@ import {
   useHolesForCourse,
 } from '../../hooks/useCourses'
 import { useHoleScores, useUpsertHoleScore } from '../../hooks/useHoleScores'
-import { useCreateShot, useShotsForRound } from '../../hooks/useShots'
+import {
+  useCreateShot,
+  useShotsForRound,
+  useUpdateShot,
+} from '../../hooks/useShots'
 import { useCompleteRound } from '../../hooks/useCompleteRound'
 import { useProfile } from '../../hooks/useProfile'
 import { useAuth } from '../../hooks/useAuth'
@@ -279,6 +283,7 @@ export function RoundDetailPage() {
   const shotsQuery = useShotsForRound(roundId)
   const upsertHoleScore = useUpsertHoleScore(roundId)
   const createShot = useCreateShot(roundId)
+  const updateShot = useUpdateShot(roundId)
   const completeMutation = useCompleteRound()
   const deleteMutation = useDeleteRound()
   const allRounds = useRounds(50)
@@ -499,6 +504,8 @@ export function RoundDetailPage() {
         endLng: s.end_lng,
         startLat: s.start_lat,
         startLng: s.start_lng,
+        aimLat: s.aim_lat,
+        aimLng: s.aim_lng,
         category: categorizeShot(s, activeHole?.par ?? 4),
       }))
       .sort((a, b) => a.shotNumber - b.shotNumber)
@@ -637,6 +644,65 @@ export function RoundDetailPage() {
   const switchHole = useCallback((n: number) => {
     dispatchHoleView({ type: 'SWITCH_HOLE', holeNumber: n })
   }, [])
+
+  // Drag end on a saved shot's start marker. Persists the new coord and
+  // recalculates distance_to_target against the current pin (skipped for
+  // putts — putt distance lives on putt_distance_ft and tracking start-
+  // to-pin yardage there would corrupt it). Stashes prev coords for the
+  // 5s undo button.
+  const handleMoveExistingShot = useCallback(
+    async (shotId: string, point: PlacedPoint) => {
+      const shot = activeHoleShots.find((s) => s.id === shotId)
+      if (!shot) return
+      const isPutt = shot.category === 'putt'
+      const newDistance =
+        !isPutt && effectivePin
+          ? Math.round(
+              haversineYards(
+                point.lat,
+                point.lng,
+                effectivePin.lat,
+                effectivePin.lng,
+              ),
+            )
+          : null
+      try {
+        await updateShot.mutateAsync({
+          id: shotId,
+          updates: {
+            start_lat: point.lat,
+            start_lng: point.lng,
+            ...(isPutt ? {} : { distance_to_target: newDistance }),
+          },
+        })
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
+          console.error('[RoundDetailPage/moveExistingShot]', err)
+        }
+      }
+    },
+    [activeHoleShots, effectivePin, updateShot],
+  )
+
+  const handleMoveExistingShotAim = useCallback(
+    async (shotId: string, point: PlacedPoint) => {
+      const shot = activeHoleShots.find((s) => s.id === shotId)
+      if (!shot) return
+      try {
+        await updateShot.mutateAsync({
+          id: shotId,
+          updates: { aim_lat: point.lat, aim_lng: point.lng },
+        })
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          // eslint-disable-next-line no-console
+          console.error('[RoundDetailPage/moveExistingShotAim]', err)
+        }
+      }
+    },
+    [activeHoleShots, updateShot],
+  )
 
   if (round.isLoading || holesQuery.isLoading) {
     return (
@@ -1075,6 +1141,8 @@ export function RoundDetailPage() {
           teeOverride={teeOverride}
           placementMode={placementMode}
           handlers={placeHandlers}
+          onMoveExistingShot={handleMoveExistingShot}
+          onMoveExistingShotAim={handleMoveExistingShotAim}
           saveError={saveError}
           editingOnMap={editingOnMap}
           reviewSheet={
@@ -1129,15 +1197,33 @@ export function RoundDetailPage() {
         />
       )}
 
-      {shotsModalFor && round.data && (
-        <ShotEntryModal
-          roundId={round.data.id}
-          holeScoreId={shotsModalFor.holeScoreId}
-          holeNumber={shotsModalFor.holeNumber}
-          holePar={shotsModalFor.holePar}
-          onClose={() => setShotsModalFor(null)}
-        />
-      )}
+      {shotsModalFor && round.data && (() => {
+        // Resolve pin for the modal's mini-map distance recalc. Per-round
+        // override on hole_scores wins over the static holes-table pin,
+        // matching the priority used by RoundMap and the live entry flow.
+        const hsRow = (round.data.hole_scores as
+          | Array<{
+              id: string
+              hole_id: string
+              pin_lat: number | null
+              pin_lng: number | null
+            }>
+          | undefined)?.find((h) => h.id === shotsModalFor.holeScoreId)
+        const holeRow = holes.find((h) => h.id === hsRow?.hole_id)
+        const pinLat = hsRow?.pin_lat ?? holeRow?.pin_lat ?? null
+        const pinLng = hsRow?.pin_lng ?? holeRow?.pin_lng ?? null
+        return (
+          <ShotEntryModal
+            roundId={round.data.id}
+            holeScoreId={shotsModalFor.holeScoreId}
+            holeNumber={shotsModalFor.holeNumber}
+            holePar={shotsModalFor.holePar}
+            pinLat={pinLat}
+            pinLng={pinLng}
+            onClose={() => setShotsModalFor(null)}
+          />
+        )
+      })()}
     </div>
   )
 }
@@ -1353,6 +1439,10 @@ interface MapViewProps {
   }
   saveError: string | null
   editingOnMap: boolean
+  /** Drag-end on a saved shot's start marker. Forwarded to RoundMap. */
+  onMoveExistingShot: (shotId: string, point: PlacedPoint) => void
+  /** Drag-end on a saved shot's aim ghost. */
+  onMoveExistingShotAim: (shotId: string, point: PlacedPoint) => void
   reviewSheet?: ReactNode
 }
 
@@ -1374,6 +1464,8 @@ function MapView({
   teeOverride,
   placementMode,
   handlers,
+  onMoveExistingShot,
+  onMoveExistingShotAim,
   saveError,
   editingOnMap,
   reviewSheet,
@@ -1521,6 +1613,8 @@ function MapView({
             onMovePin={handlers.onMovePin}
             onMoveTee={handlers.onMoveTee}
             onSetAim={handlers.onSetAim}
+            onMoveExistingShot={onMoveExistingShot}
+            onMoveExistingShotAim={onMoveExistingShotAim}
           />
         </Suspense>
         {reviewSheet}

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -329,6 +329,39 @@ export function RoundDetailPage() {
   } = holeView
   const [savingHole, setSavingHole] = useState(false)
 
+  // Last drag-edit on a saved shot. Surfaces the Undo button on the
+  // logged-hole strip for 5s after every drag, then clears itself.
+  // Holds the previous coords so the undo can restore them via the same
+  // mutation path the drag took. `field` is the column the drag
+  // touched ('start' = start_lat/lng + distance_to_target, 'aim' =
+  // aim_lat/lng).
+  type ShotDragUndo = {
+    shotId: string
+    field: 'start' | 'aim'
+    prev: {
+      lat: number | null
+      lng: number | null
+      distanceToTarget?: number | null
+    }
+    label: string
+  }
+  const [shotDragUndo, setShotDragUndo] = useState<ShotDragUndo | null>(null)
+  const undoTimerRef = useRef<number | null>(null)
+  useEffect(() => {
+    if (undoTimerRef.current != null) {
+      window.clearTimeout(undoTimerRef.current)
+    }
+    if (!shotDragUndo) return
+    undoTimerRef.current = window.setTimeout(() => {
+      setShotDragUndo(null)
+    }, 5000)
+    return () => {
+      if (undoTimerRef.current != null) {
+        window.clearTimeout(undoTimerRef.current)
+      }
+    }
+  }, [shotDragUndo])
+
   // Synthetic fallback when the course has no rows in the `holes` table
   // (typical for OSM-imported courses that never went through enrichment).
   // Without this, every downstream feature gates on `activeHole` being
@@ -654,6 +687,9 @@ export function RoundDetailPage() {
     async (shotId: string, point: PlacedPoint) => {
       const shot = activeHoleShots.find((s) => s.id === shotId)
       if (!shot) return
+      // distance_to_target lives on the raw row — pull it for the undo
+      // snapshot. ExistingShot only exposes coords + numbering.
+      const rawShot = (shotsQuery.data ?? []).find((s) => s.id === shotId)
       const isPutt = shot.category === 'putt'
       const newDistance =
         !isPutt && effectivePin
@@ -666,6 +702,21 @@ export function RoundDetailPage() {
               ),
             )
           : null
+      // Stash prev for undo BEFORE the mutation — if the user immediately
+      // drags again the second drag's prev should reflect the first
+      // drag's end position, not what was on screen before either edit.
+      setShotDragUndo({
+        shotId,
+        field: 'start',
+        prev: {
+          lat: shot.startLat,
+          lng: shot.startLng,
+          distanceToTarget: isPutt
+            ? undefined
+            : rawShot?.distance_to_target ?? null,
+        },
+        label: `Shot ${shot.shotNumber} position`,
+      })
       try {
         await updateShot.mutateAsync({
           id: shotId,
@@ -680,15 +731,25 @@ export function RoundDetailPage() {
           // eslint-disable-next-line no-console
           console.error('[RoundDetailPage/moveExistingShot]', err)
         }
+        setShotDragUndo(null)
       }
     },
-    [activeHoleShots, effectivePin, updateShot],
+    [activeHoleShots, shotsQuery.data, effectivePin, updateShot],
   )
 
   const handleMoveExistingShotAim = useCallback(
     async (shotId: string, point: PlacedPoint) => {
       const shot = activeHoleShots.find((s) => s.id === shotId)
       if (!shot) return
+      setShotDragUndo({
+        shotId,
+        field: 'aim',
+        prev: {
+          lat: shot.aimLat ?? null,
+          lng: shot.aimLng ?? null,
+        },
+        label: `Shot ${shot.shotNumber} aim`,
+      })
       try {
         await updateShot.mutateAsync({
           id: shotId,
@@ -699,10 +760,41 @@ export function RoundDetailPage() {
           // eslint-disable-next-line no-console
           console.error('[RoundDetailPage/moveExistingShotAim]', err)
         }
+        setShotDragUndo(null)
       }
     },
     [activeHoleShots, updateShot],
   )
+
+  const applyShotDragUndo = useCallback(async () => {
+    const u = shotDragUndo
+    if (!u) return
+    setShotDragUndo(null)
+    try {
+      if (u.field === 'start') {
+        await updateShot.mutateAsync({
+          id: u.shotId,
+          updates: {
+            start_lat: u.prev.lat,
+            start_lng: u.prev.lng,
+            ...(u.prev.distanceToTarget !== undefined
+              ? { distance_to_target: u.prev.distanceToTarget }
+              : {}),
+          },
+        })
+      } else {
+        await updateShot.mutateAsync({
+          id: u.shotId,
+          updates: { aim_lat: u.prev.lat, aim_lng: u.prev.lng },
+        })
+      }
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        // eslint-disable-next-line no-console
+        console.error('[RoundDetailPage/applyShotDragUndo]', err)
+      }
+    }
+  }, [shotDragUndo, updateShot])
 
   if (round.isLoading || holesQuery.isLoading) {
     return (
@@ -1143,6 +1235,8 @@ export function RoundDetailPage() {
           handlers={placeHandlers}
           onMoveExistingShot={handleMoveExistingShot}
           onMoveExistingShotAim={handleMoveExistingShotAim}
+          shotDragUndoLabel={shotDragUndo?.label ?? null}
+          onApplyShotDragUndo={applyShotDragUndo}
           saveError={saveError}
           editingOnMap={editingOnMap}
           reviewSheet={
@@ -1443,6 +1537,10 @@ interface MapViewProps {
   onMoveExistingShot: (shotId: string, point: PlacedPoint) => void
   /** Drag-end on a saved shot's aim ghost. */
   onMoveExistingShotAim: (shotId: string, point: PlacedPoint) => void
+  /** Label for the most recent saved-shot drag, or null when no recent
+   *  edit exists. Drives the Undo affordance on the logged-hole strip. */
+  shotDragUndoLabel: string | null
+  onApplyShotDragUndo: () => void
   reviewSheet?: ReactNode
 }
 
@@ -1466,6 +1564,8 @@ function MapView({
   handlers,
   onMoveExistingShot,
   onMoveExistingShotAim,
+  shotDragUndoLabel,
+  onApplyShotDragUndo,
   saveError,
   editingOnMap,
   reviewSheet,
@@ -1570,6 +1670,8 @@ function MapView({
           needsTee={needsTee}
           needsPin={needsPin}
           placementMode={placementMode}
+          shotDragUndoLabel={shotDragUndoLabel}
+          onApplyShotDragUndo={onApplyShotDragUndo}
           onStartPlaceTee={handlers.onStartPlaceTee}
           onStartPlacePin={handlers.onStartPlacePin}
           onCancelPlacement={handlers.onCancelPlacement}


### PR DESCRIPTION
## Summary
- Saved shot markers and aim ghosts on the round map are now draggable in LOGGED HOLE state. Drag end persists `start_lat/lng` (or `aim_lat/lng`) via `useUpdateShot` and recalculates `distance_to_target` against the active pin (skipped for putts) so SG stays accurate.
- Inline `ShotMiniMap` (small read-only Mapbox tile, single draggable marker, dragPan/scrollZoom disabled) embedded in `ShotEntryModal`'s edit panel and `HoleReviewSheet`'s per-shot rows so positions can be corrected from any shot detail surface. Hidden when no coords exist.
- 5s Undo button on the logged-hole strip after every drag, restoring previous coords + distance via the same mutation path. State carries field + label so the strip copy reads, e.g., "Shot 3 position updated" rather than a generic message.

## Test plan
- [ ] Log a hole on a course with full layout. Open Map view. Drag a numbered shot marker — DB row updates, distance pill on the line refreshes, distance_to_target on the row updates.
- [ ] Drag aim ghost on a shot that has aim coords — only `aim_lat/lng` change.
- [ ] Drag a putt — `start_lat/lng` update, `distance_to_target` stays null.
- [ ] After drag, click Undo within 5s → marker returns to prior position and distance_to_target restores.
- [ ] After drag, wait 5s → Undo button disappears.
- [ ] Edit a shot from the scorecard via Shots → modal opens with mini-map showing satellite tile + numbered marker. Drag → DB updates.
- [ ] In post-hole HoleReviewSheet, each row shows a mini-map. Drag updates row coords; prior row's end_lat/lng follow so the trajectory stays paired.