### PR TITLE
fix: mini-map gating + interactivity, explicit aim point dialog

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -154,6 +154,12 @@ export default function HoleScreen() {
   // often enough (chipping from rough at 25 yd, fringe lie at 8 yd)
   // that the prompt is the safer default.
   const [onGreenPromptOpen, setOnGreenPromptOpen] = useState(false)
+  // "Set an aim point?" confirmation. Opens after the player marks the
+  // ball (and after the on-green-no path) so the aim choice is explicit
+  // every shot rather than buried in a "Skip aim" link inside the SET_AIM
+  // phase. Confirm enters SET_AIM; cancel runs the existing skipAim flow
+  // straight into SHOT_DETAIL.
+  const [aimPromptOpen, setAimPromptOpen] = useState(false)
   // Seed lie type that gets passed to ShotLogger when it opens. Used
   // to pre-fill 'green' for the YES path on the prompt and 'rough' for
   // NO so the player isn't picking a lie chip from scratch every time.
@@ -659,7 +665,7 @@ export default function HoleScreen() {
       setOnGreenPromptOpen(true)
       return
     }
-    setRoundState('SET_AIM')
+    setAimPromptOpen(true)
   }
 
   function handleOnGreenYes() {
@@ -690,6 +696,16 @@ export default function HoleScreen() {
     setAim(null)
     setRoundState('SHOT_DETAIL')
     setLoggerOpen(true)
+  }
+
+  function handleAimPromptConfirm() {
+    setAimPromptOpen(false)
+    setRoundState('SET_AIM')
+  }
+
+  function handleAimPromptSkip() {
+    setAimPromptOpen(false)
+    skipAim()
   }
 
   function closeLogger() {
@@ -1403,6 +1419,16 @@ export default function HoleScreen() {
         cancelLabel="No"
         onConfirm={handleOnGreenYes}
         onCancel={handleOnGreenNo}
+      />
+
+      <ConfirmDialog
+        visible={aimPromptOpen}
+        title="Set an aim point?"
+        message="Your aim point is your start line — where you intend to start the ball, not where you want it to finish."
+        confirmLabel="Set aim point →"
+        cancelLabel="Skip"
+        onConfirm={handleAimPromptConfirm}
+        onCancel={handleAimPromptSkip}
       />
 
       <Modal

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -11,6 +11,7 @@ import {
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import * as Location from 'expo-location'
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import type { Database } from '@oga/supabase'
 import {
   HoleMap,
@@ -160,6 +161,10 @@ export default function HoleScreen() {
   // phase. Confirm enters SET_AIM; cancel runs the existing skipAim flow
   // straight into SHOT_DETAIL.
   const [aimPromptOpen, setAimPromptOpen] = useState(false)
+  // First-use hint that "aim point = start line, drag to adjust." Gated
+  // by AsyncStorage so it only appears the first time the player ever
+  // sets an aim point on this device, then auto-dismisses after 3s.
+  const [aimHintVisible, setAimHintVisible] = useState(false)
   // Seed lie type that gets passed to ShotLogger when it opens. Used
   // to pre-fill 'green' for the YES path on the prompt and 'rough' for
   // NO so the player isn't picking a lie chip from scratch every time.
@@ -276,6 +281,28 @@ export default function HoleScreen() {
   useEffect(() => {
     loadAll()
   }, [loadAll])
+
+  // First-aim hint: when `aim` first transitions to non-null, check
+  // AsyncStorage. If the hint hasn't been shown on this device, mark
+  // it shown and surface the toast for 3s. Tap-to-dismiss is wired in
+  // the render block below.
+  useEffect(() => {
+    if (!aim) return
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    AsyncStorage.getItem('oga.aim-hint-shown')
+      .then((v) => {
+        if (cancelled || v) return
+        AsyncStorage.setItem('oga.aim-hint-shown', '1').catch(() => {})
+        setAimHintVisible(true)
+        timer = setTimeout(() => setAimHintVisible(false), 3000)
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [aim?.lat, aim?.lng])
 
   // Reload remote + local shot/putt counts whenever the active hole_score
   // changes. Putts are counted as shots where club='putter' OR lie_type='green'.
@@ -1065,6 +1092,29 @@ export default function HoleScreen() {
           }}
           onPlacePin={persistRoundPin}
         />
+        {aimHintVisible && (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Dismiss aim point hint"
+            onPress={() => setAimHintVisible(false)}
+            style={{
+              position: 'absolute',
+              top: 48,
+              left: 12,
+              right: 12,
+              backgroundColor: 'rgba(28,33,28,0.92)',
+              borderColor: 'rgba(159,149,128,0.6)',
+              borderWidth: 1,
+              borderRadius: 4,
+              paddingHorizontal: 14,
+              paddingVertical: 10,
+            }}
+          >
+            <Text style={{ color: '#F2EEE5', fontSize: 13, lineHeight: 18 }}>
+              Aim point = start line. Drag to adjust.
+            </Text>
+          </Pressable>
+        )}
       </View>
 
       <View

--- a/apps/mobile/components/round/HoleMapOverlays.tsx
+++ b/apps/mobile/components/round/HoleMapOverlays.tsx
@@ -33,7 +33,7 @@ export function TopHint({ isPinMode, isAimPhase }: TopHintProps) {
         {isPinMode
           ? 'Pin mode — tap to place flag'
           : isAimPhase
-            ? 'Long-press to set aim point'
+            ? 'Long-press to set aim line — where you started the ball, not where it finishes'
             : 'Drag the ball to refine, then tap Mark ball here'}
       </Text>
     </View>

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -13,7 +13,6 @@ import {
   type ReviewedShotRow,
 } from '@oga/core'
 import type { PlacedPoint } from './RoundMap'
-import { ShotMiniMap } from './ShotMiniMap'
 import type { WebPuttData } from './WebPuttingSheet'
 import { useUnits } from '../../hooks/useUnits'
 import { useUserBag } from '../../hooks/useUserBag'
@@ -237,9 +236,6 @@ export function HoleReviewSheet({
             <ShotRow
               key={row.shotNumber}
               row={row}
-              nextRow={rows[idx + 1] ?? null}
-              pinLat={pinLat}
-              pinLng={pinLng}
               onChange={(next) =>
                 setRows((prev) => {
                   const copy = prev.slice()
@@ -335,15 +331,9 @@ export function HoleReviewSheet({
 
 function ShotRow({
   row,
-  nextRow,
-  pinLat,
-  pinLng,
   onChange,
 }: {
   row: ReviewedShotRow
-  nextRow: ReviewedShotRow | null
-  pinLat: number | null
-  pinLng: number | null
   onChange: (next: ReviewedShotRow) => void
 }) {
   // Mirror mobile's PUTTING_RADIUS_YARDS — any shot starting within 30 yd
@@ -375,29 +365,6 @@ function ShotRow({
     }
     return base
   }, [bag.data, row.club])
-  const handleStartDrag = (point: { lat: number; lng: number }) => {
-    const nextLat =
-      nextRow && nextRow.startLat != null ? nextRow.startLat : point.lat
-    const nextLng =
-      nextRow && nextRow.startLng != null ? nextRow.startLng : point.lng
-    const newDistanceYards = haversineYards(
-      point.lat,
-      point.lng,
-      nextLat,
-      nextLng,
-    )
-    const newDistanceToPin =
-      pinLat != null && pinLng != null
-        ? haversineYards(point.lat, point.lng, pinLat, pinLng)
-        : row.distanceToPin
-    onChange({
-      ...row,
-      startLat: point.lat,
-      startLng: point.lng,
-      distanceYards: row.isLastShot ? row.distanceYards : newDistanceYards,
-      distanceToPin: newDistanceToPin,
-    })
-  }
   return (
     <div
       style={{
@@ -408,15 +375,6 @@ function ShotRow({
         borderBottom: '1px solid #D9D2BF',
       }}
     >
-      <ShotMiniMap
-        shotNumber={row.shotNumber}
-        startLat={row.startLat}
-        startLng={row.startLng}
-        endLat={nextRow ? nextRow.startLat : pinLat}
-        endLng={nextRow ? nextRow.startLng : pinLng}
-        onChangeStart={handleStartDrag}
-        height={140}
-      />
       <div
         style={{
           display: 'flex',

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -823,10 +823,11 @@ export function RoundMapInstructionStrip({
         ) : aimMode ? (
           <>
             <div className="kicker" style={{ marginBottom: 2 }}>
-              Aim point — shot {shotsPlaced}
+              Aim line — shot {shotsPlaced}
             </div>
             <div className="text-caddie-ink" style={{ fontSize: 13 }}>
-              Tap where you were aiming when you hit shot {shotsPlaced}.
+              Tap your aim line — where you started shot {shotsPlaced}, not
+              where it finished.
             </div>
           </>
         ) : (

--- a/apps/web/src/components/round/ShotMiniMap.tsx
+++ b/apps/web/src/components/round/ShotMiniMap.tsx
@@ -35,7 +35,7 @@ export function ShotMiniMap({
   aimLat,
   aimLng,
   onChangeStart,
-  height = 160,
+  height = 200,
 }: ShotMiniMapProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const mapRef = useRef<mapboxgl.Map | null>(null)
@@ -55,15 +55,11 @@ export function ShotMiniMap({
       center: [startLng!, startLat!],
       zoom: 17,
       attributionControl: false,
-      dragPan: false,
-      scrollZoom: false,
-      doubleClickZoom: false,
-      boxZoom: false,
-      dragRotate: false,
-      keyboard: false,
-      touchZoomRotate: false,
-      interactive: false,
     })
+    map.addControl(
+      new mapboxgl.NavigationControl({ showCompass: false }),
+      'bottom-right',
+    )
     map.on('load', () => setMapLoaded(true))
     mapRef.current = map
     return () => {

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -516,7 +516,9 @@ export function ShotEntryModal({
             </div>
 
             <div className="flex flex-col" style={{ gap: 18 }}>
-              {editingRow && editingRow.start_lat != null && (
+              {editingRow &&
+                editingRow.start_lat != null &&
+                editingRow.start_lng != null && (
                 <ShotMiniMap
                   shotNumber={editingRow.shot_number}
                   startLat={editingRow.start_lat}

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -301,6 +301,11 @@ export function RoundDetailPage() {
   // primary aim-collection moment. Putt placements skip it (putts
   // capture aim through the putting sheet's break/aim-offset fields).
   const [aimPromptOpen, setAimPromptOpen] = useState(false)
+  // First-use hint shown the first time the player ever places an aim
+  // point — explains that aim = start line, not finish target. Gated by
+  // localStorage so it appears once per device and auto-dismisses after
+  // 3s or on tap.
+  const [aimHintVisible, setAimHintVisible] = useState(false)
   const [shareTone, setShareTone] = useState<'light' | 'dark'>('light')
   const [sharing, setSharing] = useState(false)
   const shareCardRef = useRef<HTMLDivElement | null>(null)
@@ -367,6 +372,17 @@ export function RoundDetailPage() {
       }
     }
   }, [shotDragUndo])
+
+  const placedAimsHaveAny = placedAims.some((a) => a != null)
+  useEffect(() => {
+    if (!placedAimsHaveAny) return
+    if (typeof window === 'undefined') return
+    if (window.localStorage.getItem('oga.aim-hint-shown')) return
+    window.localStorage.setItem('oga.aim-hint-shown', '1')
+    setAimHintVisible(true)
+    const t = window.setTimeout(() => setAimHintVisible(false), 3000)
+    return () => window.clearTimeout(t)
+  }, [placedAimsHaveAny])
 
   // Synthetic fallback when the course has no rows in the `holes` table
   // (typical for OSM-imported courses that never went through enrichment).
@@ -1197,6 +1213,30 @@ export function RoundDetailPage() {
         }}
         onCancel={() => setAimPromptOpen(false)}
       />
+
+      {aimHintVisible && (
+        <button
+          type="button"
+          onClick={() => setAimHintVisible(false)}
+          aria-label="Dismiss aim point hint"
+          style={{
+            position: 'fixed',
+            bottom: 24,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            background: '#1C211C',
+            color: '#F2EEE5',
+            borderRadius: 4,
+            padding: '12px 18px',
+            fontSize: 13,
+            zIndex: 100,
+            border: '1px solid #9F9580',
+            cursor: 'pointer',
+          }}
+        >
+          Aim point = start line. Drag to adjust.
+        </button>
+      )}
 
       {completeError && (
         <div

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -295,6 +295,12 @@ export function RoundDetailPage() {
   const [onGreenPrompt, setOnGreenPrompt] = useState<PlacedPoint | null>(
     null,
   )
+  // "Set an aim point?" prompt — opens after every non-putt PUSH_POINT
+  // so the player decides explicitly whether this shot has aim data.
+  // Replaces the easy-to-miss "Set aim" button on the strip as the
+  // primary aim-collection moment. Putt placements skip it (putts
+  // capture aim through the putting sheet's break/aim-offset fields).
+  const [aimPromptOpen, setAimPromptOpen] = useState(false)
   const [shareTone, setShareTone] = useState<'light' | 'dark'>('light')
   const [sharing, setSharing] = useState(false)
   const shareCardRef = useRef<HTMLDivElement | null>(null)
@@ -645,6 +651,7 @@ export function RoundDetailPage() {
           point: p,
           openPuttSheet: false,
         })
+        setAimPromptOpen(true)
       },
       onMovePoint: (idx: number, p: PlacedPoint) =>
         dispatchHoleView({ type: 'MOVE_POINT', index: idx, point: p }),
@@ -1172,9 +1179,23 @@ export function RoundDetailPage() {
               point: onGreenPrompt,
               openPuttSheet: false,
             })
+            setAimPromptOpen(true)
           }
           setOnGreenPrompt(null)
         }}
+      />
+
+      <ConfirmDialog
+        open={aimPromptOpen}
+        title="Set an aim point?"
+        message="Your aim point is your start line — where you intend to start the ball, not where you want it to finish."
+        confirmLabel="Set aim point →"
+        cancelLabel="Skip"
+        onConfirm={() => {
+          dispatchHoleView({ type: 'AIM_MODE', on: true })
+          setAimPromptOpen(false)
+        }}
+        onCancel={() => setAimPromptOpen(false)}
       />
 
       {completeError && (


### PR DESCRIPTION
## Summary

Four targeted UX fixes split across the post-round map editor and the live-round flow.

- **FIX 1** — `ShotMiniMap` no longer renders inside `HoleReviewSheet` (the slide-up sheet shown when saving a hole). That sheet is for confirming the hole, not editing position. The mini-map stays in `ShotEntryModal` and only when the saved row has both `start_lat` and `start_lng`.
- **FIX 2** — `ShotMiniMap` is now interactive: pan, scroll-zoom, and double-click zoom are all enabled, and a `NavigationControl` is added in the bottom-right. Default height bumps from 160→200px to give room for the controls. Marker drag still works.
- **FIX 3** — After marking the ball (web `PUSH_POINT`, mobile `markBallHere`), a new "Set an aim point?" `ConfirmDialog` makes the aim choice explicit every shot. Confirm enters aim placement mode (web `AIM_MODE`, mobile `SET_AIM`); Skip bypasses aim entirely. Putt placements still skip the prompt — the putting sheet's break/aim-offset already captures putt aim.
- **FIX 4** — Aim-mode copy on both platforms now leads with "aim line" and spells out the start-vs-finish distinction. A one-time toast ("Aim point = start line. Drag to adjust.") surfaces the first time the player ever sets an aim, gated by `localStorage` (web) / `AsyncStorage` (mobile) and auto-dismissed after 3s.

## Test plan

- [ ] In a logged round, open the round detail page → click "Edit shots" on a hole → mini-map appears at the top of the edit panel only when the shot already has start coordinates; mini-map is pannable + zoomable + has zoom buttons.
- [ ] Open the "Done with hole" review sheet during a live entry round → no mini-maps inside the per-shot rows.
- [ ] On web map view, tap to place a shot off the green → "Set an aim point?" dialog appears with the start-line subtext. Skip → next tap = next shot. Set aim point → next tap = aim for the just-placed shot.
- [ ] On web, tap near the green → "On the green?" dialog. Pick "No" → aim prompt fires after the push. Pick "Yes" → putting sheet opens, no aim prompt.
- [ ] On mobile, mark ball off the green → aim prompt appears. Skip → ShotLogger opens with no aim. Set aim → SET_AIM phase as before.
- [ ] First time a player ever places an aim point on a fresh device, a toast says "Aim point = start line. Drag to adjust." Auto-dismisses after 3s. Subsequent rounds: no toast.
- [ ] Aim-mode strip copy reads "aim line — where you started shot N, not where it finished" on web and the mobile TopHint reads "set aim line — where you started the ball, not where it finishes."