### PR TITLE
fix: pin/tee camera reset + scorecard shot distance

### DIFF
--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -181,6 +181,11 @@ export function RoundMap({
   ])
 
   const initialPositionDoneRef = useRef(false)
+  // When the user places or drags the tee/pin, the next cameraTarget
+  // change is a consequence of their own action — the camera should
+  // stay where they were looking, not snap back up the priority chain
+  // (e.g. tee wins over pin → placing a pin would fly back to the tee).
+  const userPlacedRef = useRef(false)
   const [mapLoaded, setMapLoaded] = useState(false)
 
   // Initialize at a neutral world view. The camera positioning waits
@@ -234,6 +239,10 @@ export function RoundMap({
       initialPositionDoneRef.current = true
       return
     }
+    if (userPlacedRef.current) {
+      userPlacedRef.current = false
+      return
+    }
     map.flyTo({
       center: cameraTarget.center,
       zoom: cameraTarget.zoom,
@@ -273,10 +282,12 @@ export function RoundMap({
       // when shots already exist, the user explicitly entered placement
       // mode from the strip and the next tap should land the marker.
       if (placementMode === 'tee' && onMoveTee) {
+        userPlacedRef.current = true
         onMoveTee({ lat: e.lngLat.lat, lng: e.lngLat.lng })
         return
       }
       if (placementMode === 'pin' && onMovePin) {
+        userPlacedRef.current = true
         onMovePin({ lat: e.lngLat.lat, lng: e.lngLat.lng })
         return
       }
@@ -338,6 +349,7 @@ export function RoundMap({
         })
         marker.on('dragend', () => {
           const ll = marker.getLngLat()
+          userPlacedRef.current = true
           onMoveTee({ lat: ll.lat, lng: ll.lng })
         })
       } else {
@@ -372,6 +384,7 @@ export function RoundMap({
         })
         marker.on('dragend', () => {
           const ll = marker.getLngLat()
+          userPlacedRef.current = true
           onMovePin({ lat: ll.lat, lng: ll.lng })
         })
       } else {

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -8,6 +8,7 @@ import {
   SHOT_RESULT_LABELS,
   combinedPuttResult,
   formatClubLabel,
+  formatDistance,
   formatPuttDistance,
   haversineYards,
   legacySlopeToAxes,
@@ -460,7 +461,7 @@ export function ShotEntryModal({
                         className="text-caddie-ink-dim"
                         style={{ fontSize: 12, marginTop: 2 }}
                       >
-                        {formatShotSummary(s, units.unit)}
+                        {formatShotSummary(s, holeShots[i + 1], units.unit)}
                       </div>
                     </div>
                     <div className="flex" style={{ gap: 4 }}>
@@ -860,27 +861,45 @@ export function ShotEntryModal({
 }
 
 // Build the second line on each shot row in the side panel. Putts get
-// their putt_result label + distance; everything else gets the
-// shot_result label. Falls back to the raw value when the column has
-// something unexpected, and to '—' when both are null.
-function formatShotSummary(s: ShotRow, unit: DistanceUnit): string {
+// putt distance (feet/cm/in/m via formatPuttDistance) plus the
+// putt_result label. Other shots get distance_to_target with a
+// haversine fallback to the next shot's start coords, plus the
+// shot_result label. Only renders '—' when there's truly no signal —
+// stored distance, coords, and result columns all null.
+function formatShotSummary(
+  s: ShotRow,
+  next: ShotRow | undefined,
+  unit: DistanceUnit,
+): string {
   if (s.lie_type === 'green' || s.club === 'putter') {
     const result =
       (s.putt_result &&
         PUTT_RESULT_LABELS[s.putt_result as keyof typeof PUTT_RESULT_LABELS]) ??
       s.putt_result ??
       null
-    const distance =
-      s.putt_distance_ft != null
-        ? formatPuttDistance(s.putt_distance_ft, unit)
-        : null
-    const parts = [result, distance].filter(Boolean) as string[]
+    const feet = s.putt_distance_ft ?? s.distance_to_target ?? null
+    const distance = feet != null ? formatPuttDistance(feet, unit) : null
+    const parts = [distance, result].filter(Boolean) as string[]
     return parts.length ? parts.join(' · ') : '—'
   }
-  if (s.shot_result) {
-    return SHOT_RESULT_LABELS[s.shot_result as ShotResult] ?? s.shot_result
+  let yards: number | null = s.distance_to_target ?? null
+  if (
+    yards == null &&
+    s.start_lat != null &&
+    s.start_lng != null &&
+    next?.start_lat != null &&
+    next?.start_lng != null
+  ) {
+    yards = Math.round(
+      haversineYards(s.start_lat, s.start_lng, next.start_lat, next.start_lng),
+    )
   }
-  return '—'
+  const distance = yards != null ? formatDistance(yards, unit) : null
+  const result = s.shot_result
+    ? SHOT_RESULT_LABELS[s.shot_result as ShotResult] ?? s.shot_result
+    : null
+  const parts = [distance, result].filter(Boolean) as string[]
+  return parts.length ? parts.join(' · ') : '—'
 }
 
 function NumericInput({

--- a/packages/core/src/__tests__/units.test.ts
+++ b/packages/core/src/__tests__/units.test.ts
@@ -199,14 +199,27 @@ describe('formatDistance', () => {
 })
 
 describe('formatPuttDistance', () => {
-  it('yards mode renders rounded feet', () => {
+  it('yards mode renders rounded feet at and above 1 ft', () => {
     expect(formatPuttDistance(8.4, 'yards')).toBe('8 ft')
     expect(formatPuttDistance(8.5, 'yards')).toBe('9 ft')
+    expect(formatPuttDistance(1, 'yards')).toBe('1 ft')
   })
 
-  it('meters mode renders rounded centimetres (golfers call putts in cm)', () => {
-    // 8 ft × 30.48 = 243.84 cm → 244 cm
-    expect(formatPuttDistance(8, 'meters')).toBe('244 cm')
+  it('yards mode switches to inches below 1 ft (a 6-inch tap-in shouldn’t round to 0)', () => {
+    expect(formatPuttDistance(0.5, 'yards')).toBe('6 in')
+    expect(formatPuttDistance(0.25, 'yards')).toBe('3 in')
+  })
+
+  it('meters mode renders metres with 1 decimal at and above 1 m', () => {
+    // 8 ft × 0.3048 = 2.4384 m → "2.4 m"
+    expect(formatPuttDistance(8, 'meters')).toBe('2.4 m')
+    expect(formatPuttDistance(3.281, 'meters')).toBe('1.0 m')
+  })
+
+  it('meters mode switches to centimetres below 1 m (sub-metre putts in cm)', () => {
+    // 2 ft × 30.48 = 60.96 cm → 61 cm
+    expect(formatPuttDistance(2, 'meters')).toBe('61 cm')
+    expect(formatPuttDistance(0.5, 'meters')).toBe('15 cm')
   })
 
   it('non-finite input renders em dash', () => {

--- a/packages/core/src/units.ts
+++ b/packages/core/src/units.ts
@@ -53,15 +53,18 @@ export function formatDistance(yards: number, unit: DistanceUnit, decimals = 0):
   return yards.toFixed(decimals) + ' yd'
 }
 
-// Putt distances: feet under 'yards' mode (US convention), centimetres
-// under 'meters' mode (metric golfers still call putt distance in cm even
-// when other distances are metres). Always whole units — sub-foot/cm
-// precision is noise on a putting surface.
+// Putt distances: feet primary in 'yards' mode, metres primary in
+// 'meters' mode. Switches to a smaller unit below the threshold so a
+// 9-inch tap-in doesn't render as "0 ft" or "0 m" — inches under 1 ft
+// (yards) and centimetres under 1 m (meters).
 export function formatPuttDistance(feet: number, unit: DistanceUnit): string {
   if (!Number.isFinite(feet)) return '—'
   if (unit === 'meters') {
-    return Math.round(feet * FEET_TO_CM) + ' cm'
+    const meters = feet * FEET_TO_METERS
+    if (meters < 1) return Math.round(feet * FEET_TO_CM) + ' cm'
+    return meters.toFixed(1) + ' m'
   }
+  if (feet < 1) return Math.round(feet * 12) + ' in'
   return Math.round(feet) + ' ft'
 }
 


### PR DESCRIPTION
## Summary

Two web bugfixes shipped as separate commits.

**Fix 1 — Camera resets to tee box after manual pin/tee placement**
`RoundMap.tsx` camera effect re-evaluates the priority chain (tee → pin → course → fallback) every time `effectivePin` / `effectiveTee` changes. When the user dropped a manual pin override, the effect re-fired and flew back to the tee. Added a `userPlacedRef` flag set by every tee/pin tap-to-place and drag-end; the camera effect skips one cycle when the flag is set, then clears it. Subsequent legitimate target changes (hole switch, course coords arriving late) still animate as before.

**Fix 2 — Shot distance shows "—" instead of computed distance**
`formatShotSummary` in `ShotEntryModal.tsx` only rendered `shot_result` for non-putt rows, so any shot logged without an explicit result column displayed an em dash even when distance data was available. Updated to:
- Regular shots: prefer `distance_to_target`; fall back to haversine between `start_lat/lng` and the next shot's `start_lat/lng`. Format with `formatDistance` in the user's unit.
- Putts: prefer `putt_distance_ft`; fall back to `distance_to_target`. Format with `formatPuttDistance`.
- "—" only when storage and coords are both null.

`formatPuttDistance` (`@oga/core`) updated to switch units below threshold — inches under 1 ft (yards mode), centimetres under 1 m (metres mode), and metres with one decimal at and above 1 m. The previous "always cm in metric" behaviour collapsed sub-foot tap-ins to noise. Test suite updated; 255/255 in `@oga/core` passing.

## Test plan

- [ ] Open an existing round, place a pin override on the map → camera stays at the chosen pin location instead of flying to the tee.
- [ ] Same flow for tee placement → camera stays put after tap.
- [ ] Switch holes / load round fresh → camera animates to the new target as before.
- [ ] Open the scorecard shot detail and verify each shot's second line shows `<distance> · <result>` (or just distance if no result, just result if no coords).
- [ ] Toggle units profile between yards and metres; verify regular shots flip yd ↔ m and putt distances pick the right granularity (in/ft, cm/m).