### PR TITLE
fix(bag): six custom bag polish items

### DIFF
--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -276,6 +276,9 @@ export default function BagScreen() {
             <ClubRow
               club={item}
               isActive={isActive}
+              hasDuplicateType={
+                bag.filter((c) => c.club_type === item.club_type).length > 1
+              }
               onLongPress={drag}
               onToggle={() => toggleInBag(item)}
               onDelete={() => confirmDelete(item)}
@@ -527,6 +530,7 @@ export default function BagScreen() {
 function ClubRow({
   club,
   isActive,
+  hasDuplicateType,
   onLongPress,
   onToggle,
   onDelete,
@@ -534,6 +538,7 @@ function ClubRow({
 }: {
   club: UserClub
   isActive: boolean
+  hasDuplicateType: boolean
   onLongPress: () => void
   onToggle: () => void
   onDelete: () => void
@@ -564,8 +569,11 @@ function ClubRow({
           {club.name}
         </Text>
         <Text style={{ ...KICKER, marginTop: 2 }}>
-          {formatClubLabel(club)}
-          {club.loft != null && club.club_type !== 'cw' && club.club_type !== 'custom_wedge'
+          {formatClubLabel(club, { hasDuplicateType })}
+          {club.loft != null &&
+          club.club_type !== 'cw' &&
+          club.club_type !== 'custom_wedge' &&
+          !hasDuplicateType
             ? ` · ${club.loft}°`
             : ''}
           {club.typical_distance_yards != null

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -35,12 +35,13 @@ export default function MobileOnboarding() {
   const [goal, setGoal] = useState<Goal | null>(null)
   const [saving, setSaving] = useState(false)
   // Bag step starts with all DEFAULT_BAG selected; user untoggles
-  // clubs they don't carry. seedBag = false means the user explicitly
-  // skipped, so we don't insert any user_clubs rows.
+  // clubs they don't carry. The "Set up later →" button (issue #156)
+  // commits with seed=false so no user_clubs rows are inserted from
+  // onboarding — auto-seed in useUserBag (issue #152) covers them on
+  // first shot log or bag-page visit.
   const [bagSelection, setBagSelection] = useState<Set<string>>(
     () => new Set(DEFAULT_BAG.map((c) => c.club_type)),
   )
-  const [seedBag, setSeedBag] = useState(true)
 
   function toggleBagClub(clubType: string) {
     setBagSelection((prev) => {
@@ -51,7 +52,7 @@ export default function MobileOnboarding() {
     })
   }
 
-  async function save() {
+  async function save(opts: { seedBag: boolean } = { seedBag: true }) {
     if (!user) return
     if (!skill || !goal) {
       Alert.alert('Pick a skill level and a goal first')
@@ -67,7 +68,7 @@ export default function MobileOnboarding() {
       return
     }
     setSaving(true)
-    if (seedBag && bagSelection.size > 0) {
+    if (opts.seedBag && bagSelection.size > 0) {
       try {
         const reseeded = DEFAULT_BAG.filter((c) =>
           bagSelection.has(c.club_type),
@@ -191,68 +192,46 @@ export default function MobileOnboarding() {
           borderColor: '#E4E4E0',
         }}
       >
-        <View
+        <Text
           style={{
-            flexDirection: 'row',
-            justifyContent: 'space-between',
-            alignItems: 'center',
+            color: '#888880',
+            fontSize: 11,
+            fontWeight: '500',
+            letterSpacing: 0.4,
+            textTransform: 'uppercase',
             marginBottom: 6,
           }}
         >
-          <Text
-            style={{
-              color: '#888880',
-              fontSize: 11,
-              fontWeight: '500',
-              letterSpacing: 0.4,
-              textTransform: 'uppercase',
-            }}
-          >
-            Bag (optional)
-          </Text>
-          <Pressable onPress={() => setSeedBag((s) => !s)} hitSlop={6}>
-            <Text style={{ color: '#0F6E56', fontSize: 12 }}>
-              {seedBag ? 'Skip for now' : 'Set up bag'}
-            </Text>
-          </Pressable>
+          Bag (optional)
+        </Text>
+        <Text style={{ color: '#888880', fontSize: 12, marginBottom: 10 }}>
+          Select the clubs you carry. You can customize your bag fully in
+          Settings → My Bag later.
+        </Text>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+          {DEFAULT_BAG.map((c) => (
+            <Chip
+              key={c.club_type}
+              label={c.name}
+              active={bagSelection.has(c.club_type)}
+              onPress={() => toggleBagClub(c.club_type)}
+            />
+          ))}
         </View>
-        {seedBag ? (
-          <>
-            <Text style={{ color: '#888880', fontSize: 12, marginBottom: 10 }}>
-              Standard bags carry up to 14 clubs. Tap to add or remove. Edit
-              any time in Profile → My Bag.
-            </Text>
-            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
-              {DEFAULT_BAG.map((c) => (
-                <Chip
-                  key={c.club_type}
-                  label={c.name}
-                  active={bagSelection.has(c.club_type)}
-                  onPress={() => toggleBagClub(c.club_type)}
-                />
-              ))}
-            </View>
-            <Text
-              style={{
-                color: '#888880',
-                fontSize: 11,
-                marginTop: 8,
-                letterSpacing: 0.3,
-              }}
-            >
-              {bagSelection.size} of {DEFAULT_BAG.length} selected
-            </Text>
-          </>
-        ) : (
-          <Text style={{ color: '#888880', fontSize: 12 }}>
-            Skipped — shot logger will use the default bag until you set yours
-            up.
-          </Text>
-        )}
+        <Text
+          style={{
+            color: '#888880',
+            fontSize: 11,
+            marginTop: 8,
+            letterSpacing: 0.3,
+          }}
+        >
+          {bagSelection.size} of {DEFAULT_BAG.length} selected
+        </Text>
       </View>
 
       <Pressable
-        onPress={save}
+        onPress={() => save({ seedBag: true })}
         disabled={saving}
         style={{
           marginTop: 8,
@@ -265,6 +244,27 @@ export default function MobileOnboarding() {
       >
         <Text style={{ color: '#FFFFFF', fontSize: 13, fontWeight: '500' }}>
           {saving ? 'Saving…' : 'Start tracking'}
+        </Text>
+      </Pressable>
+
+      <Pressable
+        onPress={() => save({ seedBag: false })}
+        disabled={saving}
+        accessibilityRole="button"
+        accessibilityLabel="Set up bag later"
+        style={{
+          marginTop: 10,
+          borderRadius: 10,
+          paddingVertical: 12,
+          alignItems: 'center',
+          borderWidth: 1,
+          borderColor: '#1F3D2C',
+          backgroundColor: 'transparent',
+          opacity: saving ? 0.5 : 1,
+        }}
+      >
+        <Text style={{ color: '#1F3D2C', fontSize: 13, fontWeight: '500' }}>
+          Set up later →
         </Text>
       </Pressable>
     </ScrollView>

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -99,16 +99,23 @@ export function ShotLogger({
 
   // Source the club picker from the user's bag. Fall back to DEFAULT_BAG
   // while the bag is loading or if the user trimmed it to nothing — never
-  // show an empty picker.
-  const { bag } = useUserBag()
-  const clubOptions = useMemo<{ value: string; label: string }[]>(
-    () =>
-      (bag.length > 0 ? bag : DEFAULT_BAG).map((c) => ({
-        value: c.club_type,
-        label: formatClubLabel(c),
-      })),
-    [bag],
-  )
+  // show an empty picker. seedIfEmpty=true ensures a brand-new user
+  // (e.g. one who skipped the optional onboarding bag step, issue #152)
+  // ends up with real user_clubs rows so inferShot's userBag path runs.
+  const { bag } = useUserBag({ seedIfEmpty: true })
+  const clubOptions = useMemo<{ value: string; label: string }[]>(() => {
+    const source = bag.length > 0 ? bag : DEFAULT_BAG
+    const typeCounts = new Map<string, number>()
+    for (const c of source) {
+      typeCounts.set(c.club_type, (typeCounts.get(c.club_type) ?? 0) + 1)
+    }
+    return source.map((c) => ({
+      value: c.club_type,
+      label: formatClubLabel(c, {
+        hasDuplicateType: (typeCounts.get(c.club_type) ?? 0) > 1,
+      }),
+    }))
+  }, [bag])
 
   const isOnGreen = value.lieType === 'green'
 

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -346,25 +346,33 @@ function ShotRow({
     row.club === 'putter' ||
     row.distanceToPin <= NEAR_GREEN_YARDS
   const { toDisplay, toDisplayFt } = useUnits()
-  const bag = useUserBag()
+  const { bag } = useUserBag()
   // Source the club options from the user's bag, falling back to
   // DEFAULT_BAG when empty/loading. Splice in the row's current `club`
   // when it isn't represented (custom utility club types from a bag
   // edit, or a legacy CLUBS-based row from before this PR) so the
   // <select> always shows the value the user actually has. Labels
   // route through `formatClubLabel` so a custom_wedge entry reads as
-  // its loft (e.g. "58°") rather than the raw "custom_wedge" key.
+  // its loft (e.g. "58°") rather than the raw "custom_wedge" key, and
+  // a bag with two of the same `club_type` (e.g. 58° + 60° lobs)
+  // disambiguates by loft.
   const clubOptions = useMemo<{ value: string; label: string }[]>(() => {
-    const source = bag.data && bag.data.length > 0 ? bag.data : DEFAULT_BAG
+    const source = bag.length > 0 ? bag : DEFAULT_BAG
+    const typeCounts = new Map<string, number>()
+    for (const c of source) {
+      typeCounts.set(c.club_type, (typeCounts.get(c.club_type) ?? 0) + 1)
+    }
     const base = source.map((c) => ({
       value: c.club_type,
-      label: formatClubLabel(c),
+      label: formatClubLabel(c, {
+        hasDuplicateType: (typeCounts.get(c.club_type) ?? 0) > 1,
+      }),
     }))
     if (row.club && !base.some((o) => o.value === row.club)) {
       return [{ value: row.club, label: row.club }, ...base]
     }
     return base
-  }, [bag.data, row.club])
+  }, [bag, row.club])
   return (
     <div
       style={{

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -71,7 +71,7 @@ export function ShotEntryModal({
   const createShot = useCreateShot(roundId)
   const updateShot = useUpdateShot(roundId)
   const deleteShot = useDeleteShot(roundId)
-  const bag = useUserBag()
+  const { bag } = useUserBag()
 
   // Source club options from the user's bag (in_bag rows, in sort_order).
   // Fall back to DEFAULT_BAG while loading or if the user has trimmed
@@ -79,14 +79,21 @@ export function ShotEntryModal({
   // club_types pass through as plain strings since `shots.club` is a
   // text column. The label routes through `formatClubLabel` so a
   // custom_wedge entry reads as its loft (e.g. "58°"), not the raw
-  // "custom_wedge" club_type.
+  // "custom_wedge" club_type, and so a bag carrying two clubs of the
+  // same `club_type` (e.g. lw 58° + lw 60°) disambiguates by loft.
   const clubOptions = useMemo<{ value: string; label: string }[]>(() => {
-    const source = bag.data && bag.data.length > 0 ? bag.data : DEFAULT_BAG
+    const source = bag.length > 0 ? bag : DEFAULT_BAG
+    const typeCounts = new Map<string, number>()
+    for (const c of source) {
+      typeCounts.set(c.club_type, (typeCounts.get(c.club_type) ?? 0) + 1)
+    }
     return source.map((c) => ({
       value: c.club_type,
-      label: formatClubLabel(c),
+      label: formatClubLabel(c, {
+        hasDuplicateType: (typeCounts.get(c.club_type) ?? 0) > 1,
+      }),
     }))
-  }, [bag.data])
+  }, [bag])
 
   const holeShots = useMemo(() => {
     return (shotsQuery.data ?? [])
@@ -315,7 +322,7 @@ export function ShotEntryModal({
                       >
                         {s.club
                           ? formatClubLabel(
-                              bag.data?.find((b) => b.club_type === s.club) ?? {
+                              bag.find((b) => b.club_type === s.club) ?? {
                                 club_type: s.club,
                               },
                             )

--- a/apps/web/src/hooks/useUserBag.ts
+++ b/apps/web/src/hooks/useUserBag.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   deleteUserClub,
@@ -23,9 +24,22 @@ function invalidateBag(qc: ReturnType<typeof useQueryClient>, uid: string | unde
   qc.invalidateQueries({ queryKey: ALL_KEY(uid) })
 }
 
-export function useUserBag() {
+interface UseBagResult {
+  bag: UserClub[]
+  isLoading: boolean
+  error: Error | null
+  refetch: () => Promise<void>
+}
+
+// Shape mirrors the mobile useUserBag hook (issue #153) so consumers
+// destructure the same fields on either platform. The auto-seed effect
+// covers the skip-onboarding case (issue #152) — every authenticated
+// user ends up with user_clubs rows on first bag access, even if they
+// skipped the optional bag step in onboarding.
+export function useUserBag(): UseBagResult {
   const { user, loading } = useAuth()
-  return useQuery({
+  const qc = useQueryClient()
+  const query = useQuery({
     queryKey: BAG_KEY(user?.id),
     enabled: !loading && !!user,
     staleTime: 60_000,
@@ -35,6 +49,42 @@ export function useUserBag() {
       return (data ?? []) as UserClub[]
     },
   })
+
+  // Auto-seed when the bag loads empty for an authenticated user.
+  // Attempts at most once per user per hook instance — the ref holds
+  // the user id we've already tried for, not a transient bool. Without
+  // this gate, a user who benches every club (in_bag=false) keeps
+  // returning an empty `getUserBag` result; each `seedDefaultBag` call
+  // is a no-op (pre-filter sees the owned club_types) but the post-seed
+  // invalidation refetches → effect re-fires → tight loop.
+  const attemptedForRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (
+      !loading &&
+      user &&
+      query.data &&
+      query.data.length === 0 &&
+      attemptedForRef.current !== user.id
+    ) {
+      attemptedForRef.current = user.id
+      seedDefaultBag(supabase, user.id, DEFAULT_BAG)
+        .then(() => invalidateBag(qc, user.id))
+        .catch(() => {
+          /* swallow — best-effort seed; user can still log shots via
+             the DEFAULT_BAG fallback in the picker. Server errors
+             surface elsewhere. */
+        })
+    }
+  }, [loading, user, query.data, qc])
+
+  return {
+    bag: query.data ?? [],
+    isLoading: query.isLoading,
+    error: (query.error as Error | null) ?? null,
+    refetch: async () => {
+      await query.refetch()
+    },
+  }
 }
 
 export function useAllUserClubs() {

--- a/apps/web/src/pages/settings/BagPage.tsx
+++ b/apps/web/src/pages/settings/BagPage.tsx
@@ -84,6 +84,15 @@ export function BagPage() {
     }
   }, [allClubs.data, seedIfEmpty])
 
+  // Issue #154: avoid the spinner → empty list → clubs flash on first
+  // visit. Treat the loaded-but-empty state as "still loading" while
+  // the auto-seed mutation is pending or hasn't yet run; once seed
+  // settles the query refetch surfaces the seeded rows.
+  const isSeedingEmpty =
+    !!allClubs.data &&
+    allClubs.data.length === 0 &&
+    (seedIfEmpty.isPending || (!seedIfEmpty.isSuccess && !seedIfEmpty.isError))
+
   useEffect(() => {
     if (allClubs.data && !updateOrder.isPending && !dragDirtyRef.current) {
       setLocalOrder(allClubs.data)
@@ -95,6 +104,15 @@ export function BagPage() {
   // array without forcing the callbacks to re-create on every render.
   const clubsRef = useRef(clubs)
   clubsRef.current = clubs
+
+  // Type-count map drives duplicate-loft labelling on each row. Computed
+  // once per render so two lobs (58° + 60°) read as "lw (58°)" and
+  // "lw (60°)" instead of two identical "lw" rows.
+  const typeCounts = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const c of clubs) m.set(c.club_type, (m.get(c.club_type) ?? 0) + 1)
+    return m
+  }, [clubs])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -257,7 +275,7 @@ export function BagPage() {
         </div>
       )}
 
-      {allClubs.isLoading && (
+      {(allClubs.isLoading || isSeedingEmpty) && (
         <div className="text-caddie-ink-dim" style={{ fontSize: 13 }}>
           Loading bag…
         </div>
@@ -279,7 +297,7 @@ export function BagPage() {
         </div>
       )}
 
-      {!allClubs.isLoading && !allClubs.isError && (
+      {!allClubs.isLoading && !allClubs.isError && !isSeedingEmpty && (
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
           <SortableContext items={clubs.map((c) => c.id)} strategy={verticalListSortingStrategy}>
             <div
@@ -298,6 +316,7 @@ export function BagPage() {
                   saving={upsertClub.isPending}
                   onToggleInBag={onToggleInBag}
                   onDelete={onRequestDelete}
+                  hasDuplicateType={(typeCounts.get(c.club_type) ?? 0) > 1}
                 />
               ))}
             </div>
@@ -391,6 +410,7 @@ interface SortableClubRowProps {
   club: UserClub
   editing: boolean
   saving: boolean
+  hasDuplicateType: boolean
   onStartEdit: () => void
   onCancelEdit: () => void
   onSaveEdit: (
@@ -405,6 +425,7 @@ const SortableClubRow = memo(function SortableClubRow({
   club,
   editing,
   saving,
+  hasDuplicateType,
   onStartEdit,
   onCancelEdit,
   onSaveEdit,
@@ -453,8 +474,11 @@ const SortableClubRow = memo(function SortableClubRow({
             className="font-mono uppercase text-caddie-ink-mute"
             style={{ fontSize: 10, letterSpacing: '0.14em', marginTop: 2 }}
           >
-            {formatClubLabel(club)}
-            {club.loft != null && club.club_type !== 'cw' && club.club_type !== 'custom_wedge'
+            {formatClubLabel(club, { hasDuplicateType })}
+            {club.loft != null &&
+            club.club_type !== 'cw' &&
+            club.club_type !== 'custom_wedge' &&
+            !hasDuplicateType
               ? ` · ${club.loft}°`
               : ''}
             {club.typical_distance_yards != null

--- a/packages/core/src/__tests__/clubs.test.ts
+++ b/packages/core/src/__tests__/clubs.test.ts
@@ -174,4 +174,38 @@ describe('formatClubLabel', () => {
       'wedge',
     )
   })
+
+  it('appends loft in parens when hasDuplicateType and loft is set', () => {
+    expect(
+      formatClubLabel({ club_type: 'lw', loft: 58 }, { hasDuplicateType: true }),
+    ).toBe('lw (58°)')
+    expect(
+      formatClubLabel({ club_type: 'lw', loft: 60 }, { hasDuplicateType: true }),
+    ).toBe('lw (60°)')
+  })
+
+  it('omits the loft suffix when hasDuplicateType is false', () => {
+    expect(
+      formatClubLabel({ club_type: 'lw', loft: 58 }, { hasDuplicateType: false }),
+    ).toBe('lw')
+    expect(formatClubLabel({ club_type: 'lw', loft: 58 })).toBe('lw')
+  })
+
+  it('omits the loft suffix when loft is missing or non-finite', () => {
+    expect(
+      formatClubLabel({ club_type: 'lw' }, { hasDuplicateType: true }),
+    ).toBe('lw')
+    expect(
+      formatClubLabel(
+        { club_type: 'lw', loft: Number.NaN },
+        { hasDuplicateType: true },
+      ),
+    ).toBe('lw')
+  })
+
+  it('still renders cw as the loft alone, ignoring hasDuplicateType', () => {
+    expect(
+      formatClubLabel({ club_type: 'cw', loft: 58 }, { hasDuplicateType: true }),
+    ).toBe('58°')
+  })
 })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -110,18 +110,34 @@ export const CANONICAL_CLUBS_BY_CATEGORY: Record<ClubCategory, readonly string[]
 // Underscores in the club_type are rendered as spaces so multi-word
 // types (mini_driver, etc.) read cleanly under the bag UI's uppercase
 // kicker style — "MINI DRIVER" instead of "MINI_DRIVER".
-export function formatClubLabel(c: {
-  club_type: string
-  name?: string | null
-  loft?: number | null
-}): string {
+//
+// `opts.hasDuplicateType` lets callers disambiguate two clubs of the
+// same `club_type` in the bag (issue #151) — when set and the club has
+// a loft, the loft is appended in parens: "lw (58°)" vs "lw (60°)".
+// `cw` / `custom_wedge` already render as "58°" so they ignore the flag.
+export function formatClubLabel(
+  c: {
+    club_type: string
+    name?: string | null
+    loft?: number | null
+  },
+  opts: { hasDuplicateType?: boolean } = {},
+): string {
   if (c.club_type === 'cw' || c.club_type === 'custom_wedge') {
     if (c.loft != null && Number.isFinite(c.loft)) return `${c.loft}°`
     const trimmed = c.name?.trim()
     if (trimmed) return trimmed
     return 'wedge'
   }
-  return c.club_type.replace(/_/g, ' ')
+  const base = c.club_type.replace(/_/g, ' ')
+  if (
+    opts.hasDuplicateType &&
+    c.loft != null &&
+    Number.isFinite(c.loft)
+  ) {
+    return `${base} (${c.loft}°)`
+  }
+  return base
 }
 
 // Default 14-club starting bag seeded for new users when their bag is

--- a/packages/supabase/src/queries/clubs.ts
+++ b/packages/supabase/src/queries/clubs.ts
@@ -27,42 +27,53 @@ export function getAllUserClubs(client: OgaSupabaseClient, userId: string) {
     .order('sort_order', { ascending: true })
 }
 
-// upsert on (user_id, club_type) — paired with the table's UNIQUE
-// constraint so re-adding a club_type the user already owns updates the
-// existing row instead of throwing.
-export function upsertUserClub(
+// Update by id when an existing row is being edited (id provided);
+// fall back to upsert on (user_id, club_type, loft) for inserts so
+// re-adding the same slot updates instead of throwing. The split is
+// required because migration 0024 changed the unique key to include
+// loft — a user editing an existing row's loft would otherwise miss
+// the conflict target and trip the primary-key on `id` instead.
+export async function upsertUserClub(
   client: OgaSupabaseClient,
   club: UserClubInsert,
 ) {
+  if (club.id) {
+    return client
+      .from('user_clubs')
+      .update(club)
+      .eq('id', club.id)
+      .eq('user_id', club.user_id)
+      .select(USER_CLUB_COLUMNS)
+      .single()
+  }
   return client
     .from('user_clubs')
-    .upsert(club, { onConflict: 'user_id,club_type' })
+    .upsert(club, { onConflict: 'user_id,club_type,loft' })
     .select(USER_CLUB_COLUMNS)
     .single()
 }
 
-// Bulk reorder by id list. The list's index becomes the row's sort_order.
-// supabase-js doesn't expose a raw SQL path so we fan out one UPDATE per
-// row. Errors from any row throw — caller is responsible for refetching
-// to recover the canonical order. A future migration could move this to
-// an Edge Function with a single transaction; for ≤30 clubs the round
-// trips are cheap.
+// Bulk reorder by id list — the list's index becomes the row's
+// sort_order. Wrapped in a single SECURITY DEFINER RPC (migration 0024)
+// so a network drop can't leave sort_order half-applied. The RPC checks
+// auth.uid() inside and only touches rows owned by the caller.
 export async function updateClubOrder(
   client: OgaSupabaseClient,
   userId: string,
   orderedIds: string[],
 ): Promise<void> {
-  const results = await Promise.all(
-    orderedIds.map((id, idx) =>
-      client
-        .from('user_clubs')
-        .update({ sort_order: idx })
-        .eq('id', id)
-        .eq('user_id', userId),
-    ),
-  )
-  const firstError = results.find((r) => r.error)?.error
-  if (firstError) throw firstError
+  if (orderedIds.length === 0) return
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const rpc = (client as any).rpc.bind(client) as (
+    fn: 'update_club_order',
+    args: { p_user_id: string; p_club_ids: string[]; p_orders: number[] },
+  ) => Promise<{ error: { message: string } | null }>
+  const { error } = await rpc('update_club_order', {
+    p_user_id: userId,
+    p_club_ids: orderedIds,
+    p_orders: orderedIds.map((_, i) => i),
+  })
+  if (error) throw error
 }
 
 export function deleteUserClub(client: OgaSupabaseClient, clubId: string, userId: string) {
@@ -73,33 +84,45 @@ export function deleteUserClub(client: OgaSupabaseClient, clubId: string, userId
     .eq('user_id', userId)
 }
 
-// Seeds default clubs into a user's bag. `ignoreDuplicates` makes this
-// safe to call concurrently — a second call (e.g. mobile auto-seed
-// while the bag screen also auto-seeds) won't trip the
-// (user_id, club_type) UNIQUE; existing rows stay untouched. The
-// onboarding path passes a filtered subset (the user pre-trimmed the
-// default bag); subsequent auto-seeds for that user are no-ops.
+// Seeds default clubs into a user's bag. Pre-filters defaults against
+// any club_type the user already owns (regardless of loft) — under the
+// migration-0024 (user_id, club_type, loft) NULLS NOT DISTINCT index a
+// NULL-loft default would not collide with a user-set 58° row of the
+// same type, so unfiltered seeds would silently double-up the slot.
+// Concurrent seed calls (e.g. mobile auto-seed racing the bag screen's
+// auto-seed) settle to the same final state because each filters
+// against the latest read; the unique index catches anything they
+// both still try to insert.
 // Returns the post-seed bag in sort_order.
 export async function seedDefaultBag(
   client: OgaSupabaseClient,
   userId: string,
   defaults: readonly { club_type: string; name: string; sort_order: number }[],
 ): Promise<UserClubRow[]> {
-  const rows: UserClubInsert[] = defaults.map((d) => ({
-    user_id: userId,
-    club_type: d.club_type,
-    name: d.name,
-    sort_order: d.sort_order,
-    in_bag: true,
-  }))
-  if (rows.length > 0) {
-    const upserted = await client
+  if (defaults.length > 0) {
+    const existing = await client
       .from('user_clubs')
-      .upsert(rows, {
-        onConflict: 'user_id,club_type',
-        ignoreDuplicates: true,
-      })
-    if (upserted.error) throw upserted.error
+      .select('club_type')
+      .eq('user_id', userId)
+    if (existing.error) throw existing.error
+    const owned = new Set((existing.data ?? []).map((r) => r.club_type))
+    const filtered = defaults.filter((d) => !owned.has(d.club_type))
+    if (filtered.length > 0) {
+      const rows: UserClubInsert[] = filtered.map((d) => ({
+        user_id: userId,
+        club_type: d.club_type,
+        name: d.name,
+        sort_order: d.sort_order,
+        in_bag: true,
+      }))
+      const upserted = await client
+        .from('user_clubs')
+        .upsert(rows, {
+          onConflict: 'user_id,club_type,loft',
+          ignoreDuplicates: true,
+        })
+      if (upserted.error) throw upserted.error
+    }
   }
   const all = await client
     .from('user_clubs')

--- a/supabase/migrations/0024_bag_wedge_slots_and_reorder_rpc.sql
+++ b/supabase/migrations/0024_bag_wedge_slots_and_reorder_rpc.sql
@@ -1,0 +1,54 @@
+-- Custom bag — duplicate wedge slots + atomic reorder.
+--
+-- Issue #151: a player carrying two lob wedges (58° + 60°) or two
+-- chippers stored as the same `club_type` couldn't both exist under
+-- the original UNIQUE(user_id, club_type). Loosen the constraint so
+-- (user_id, club_type, loft) is the slot key. NULLS NOT DISTINCT
+-- treats two unspecified-loft entries of the same type as a duplicate
+-- so a slot without a loft still can't be added twice silently.
+--
+-- Issue #155: updateClubOrder fanned out N individual UPDATE round
+-- trips via Promise.all — a network drop mid-sequence left
+-- sort_order in a half-applied state. Replace the per-row updates
+-- with a single SECURITY DEFINER RPC that loops in one transaction.
+
+ALTER TABLE public.user_clubs
+  DROP CONSTRAINT IF EXISTS user_clubs_user_club_unique;
+
+CREATE UNIQUE INDEX user_clubs_user_type_loft_unique
+  ON public.user_clubs (user_id, club_type, loft) NULLS NOT DISTINCT;
+
+CREATE OR REPLACE FUNCTION public.update_club_order(
+  p_user_id uuid,
+  p_club_ids uuid[],
+  p_orders integer[]
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  ids_len integer := coalesce(array_length(p_club_ids, 1), 0);
+  orders_len integer := coalesce(array_length(p_orders, 1), 0);
+BEGIN
+  IF auth.uid() IS NULL OR auth.uid() <> p_user_id THEN
+    RAISE EXCEPTION 'not authorized';
+  END IF;
+  IF ids_len <> orders_len THEN
+    RAISE EXCEPTION 'club_ids and orders length mismatch (% vs %)', ids_len, orders_len;
+  END IF;
+  IF ids_len = 0 THEN
+    RETURN;
+  END IF;
+  FOR i IN 1..ids_len LOOP
+    UPDATE public.user_clubs
+       SET sort_order = p_orders[i]
+     WHERE id = p_club_ids[i]
+       AND user_id = p_user_id;
+  END LOOP;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_club_order(uuid, uuid[], integer[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_club_order(uuid, uuid[], integer[]) TO authenticated;


### PR DESCRIPTION
## Summary

Six bag-related polish items in one PR. Each issue noted in commit and below.

- Closes #151 — UNIQUE(user_id, club_type) constraint blocked duplicate wedge slots (e.g. 58° + 60° lobs).
- Closes #152 — ShotLogger fell back to DEFAULT_BAG for users who skipped onboarding bag step; inferShot's userBag path never ran.
- Closes #153 — Web vs mobile useUserBag hook API drift ({ data } vs { bag }).
- Closes #154 — Empty list flash on /settings/bag before auto-seed fired.
- Closes #155 — updateClubOrder fan-out left sort_order half-applied on network drop.
- Closes #156 — Mobile onboarding "Skip for now" toggle had no clear forward affordance.

## Migration

`supabase/migrations/0024_bag_wedge_slots_and_reorder_rpc.sql`

- Drops `user_clubs_user_club_unique` (was `(user_id, club_type)`).
- Adds `user_clubs_user_type_loft_unique` index on `(user_id, club_type, loft) NULLS NOT DISTINCT` (Postgres 15+) so two unspecified-loft entries of the same type still collide while explicit-loft variants coexist.
- Adds SECURITY DEFINER `update_club_order(p_user_id, p_club_ids[], p_orders[])` RPC for atomic bag reordering. Auth check inside (`auth.uid() = p_user_id`); grant scoped to `authenticated`.

Migration applied to linked Supabase via `supabase db push --linked`.

## Commit map (3 commits, 6 issues)

The diff overlaps across files (one hook touches #152 + #153, one component touches #151 + #153, one migration touches #151 + #155), so rather than carve six artificial commits with mid-file states that don't compile, the work landed as three logically-coherent commits:

- `6873462` — fix(bag): duplicate wedge slots + atomic reorder RPC (#151, #155)
- `dd37b6d` — fix(web/bag): hook shape, auto-seed, no empty flash (#152, #153, #154)
- `e8f2f52` — fix(mobile/bag): onboarding skip affordance + auto-seed wiring (#152, #156)

## Notable design notes

- `seedDefaultBag` now pre-filters defaults by existing `club_type`, since under NULLS NOT DISTINCT a NULL-loft default would not collide with a user-set 58° row of the same type.
- `upsertUserClub` splits on `id` presence: edits use UPDATE by id, inserts use UPSERT on `(user_id, club_type, loft)`. Without the split, editing a club's loft would miss the conflict target and trip a PK violation.
- Web `useUserBag` auto-seed pins its attempted-for ref to the user id (not a transient bool) so a user who benches every club doesn't tight-loop the empty `in_bag=true` read against `seedDefaultBag`'s pre-filter no-op. Caught in audit before merge.
- `formatClubLabel` extension is a render-only switch — `cw` / `custom_wedge` continue to render as the loft alone and ignore the new flag.

## Test plan

- [x] `pnpm typecheck` (4 packages) — clean.
- [x] `pnpm --filter @oga/core test --run` — 259/259 (was 255; +4 formatClubLabel cases).
- [x] `pnpm --filter web build` — clean.
- [x] `cd apps/mobile && npm run typecheck` — clean.
- [x] `supabase db push --linked` — migration 0024 applied.
- [ ] Web /settings/bag: add a 58° lob, then add a 60° lob. Both rows render as `lw (58°)` and `lw (60°)`.
- [ ] Web first visit /settings/bag for a brand-new user: no empty-list flash before the seeded clubs appear.
- [ ] Mobile onboarding: "Set up later →" outline button below "Start tracking" commits without seeding; first shot log auto-seeds the default bag.
- [ ] Web bench every club, reload — no infinite seed loop in the network tab.
- [ ] Drag-reorder bag, simulate offline mid-reorder — sort_order doesn't end up half-applied.