### PR TITLE
fix: narrow regenerated Supabase types at DB→core boundary

### DIFF
--- a/apps/web/src/components/rounds/shots/draft.ts
+++ b/apps/web/src/components/rounds/shots/draft.ts
@@ -3,6 +3,7 @@ import {
   type BreakDirection,
   type Club,
   type GreenSpeed,
+  type LieSlope,
   type LieSlopeForward,
   type LieSlopeSide,
   type LieType,
@@ -12,7 +13,22 @@ import {
 } from '@oga/core'
 import type { Database } from '@oga/supabase'
 
+// Mirrors the legacy `putt_result` CHECK vocabulary (migration 0001).
+// Inlined here because @oga/core's `LegacyPuttResult` type isn't exported.
+type LegacyPuttResultStr =
+  | 'made'
+  | 'short'
+  | 'long'
+  | 'missed_left'
+  | 'missed_right'
+
 type ShotRow = Database['public']['Tables']['shots']['Row']
+
+// DB-string → narrow-union casts. Postgres CHECK constraints (migrations
+// 0001 / 0003 / 0005 / 0006 / 0007 / 0009) keep the columns inside their
+// union vocabularies, but the regenerated Supabase types surface them
+// as plain `string | null`. Issue #209 tracks promoting these CHECKs to
+// real Postgres enums so the regen produces narrow types directly.
 
 export interface DraftShot {
   id?: string
@@ -38,34 +54,35 @@ export function shotRowToDraft(s: ShotRow): DraftShot {
   let shotResult: ShotResult | undefined = (s.shot_result as ShotResult | null) ?? undefined
   if (!shotResult && s.ob) shotResult = 'ob'
   else if (!shotResult && s.penalty) shotResult = 'penalty'
-  const legacy = legacySlopeToAxes(s.lie_slope)
+  const legacy = legacySlopeToAxes(s.lie_slope as LieSlope | null)
+  const puttResult = s.putt_result as LegacyPuttResultStr | null
   return {
     id: s.id,
     shotNumber: s.shot_number,
     club: (s.club as Club | null) ?? undefined,
-    lieType: s.lie_type ?? undefined,
-    lieSlopeForward: s.lie_slope_forward ?? legacy.forward,
-    lieSlopeSide: s.lie_slope_side ?? legacy.side,
+    lieType: (s.lie_type as LieType | null) ?? undefined,
+    lieSlopeForward: (s.lie_slope_forward as LieSlopeForward | null) ?? legacy.forward,
+    lieSlopeSide: (s.lie_slope_side as LieSlopeSide | null) ?? legacy.side,
     shotResult,
     distanceToTarget: s.distance_to_target ?? undefined,
     puttDistanceFt: s.putt_distance_ft ?? undefined,
-    puttMade: s.putt_result === 'made' ? true : undefined,
+    puttMade: puttResult === 'made' ? true : undefined,
     puttDistanceResult:
-      s.putt_distance_result ??
-      (s.putt_result === 'short'
+      ((s.putt_distance_result as PuttDistanceResult | null) ?? undefined) ??
+      (puttResult === 'short'
         ? 'short'
-        : s.putt_result === 'long'
+        : puttResult === 'long'
           ? 'long'
           : undefined),
     puttDirectionResult:
-      s.putt_direction_result ??
-      (s.putt_result === 'missed_left'
+      ((s.putt_direction_result as PuttDirectionResult | null) ?? undefined) ??
+      (puttResult === 'missed_left'
         ? 'left'
-        : s.putt_result === 'missed_right'
+        : puttResult === 'missed_right'
           ? 'right'
           : undefined),
     puttSlopePct: s.putt_slope_pct ?? undefined,
-    greenSpeed: s.green_speed ?? undefined,
+    greenSpeed: (s.green_speed as GreenSpeed | null) ?? undefined,
     breakDirection: mapBreakDirection(s.break_direction),
     aimOffsetInches:
       s.aim_offset_yards != null ? Math.round(s.aim_offset_yards * 36) : 0,

--- a/apps/web/src/hooks/useUnits.ts
+++ b/apps/web/src/hooks/useUnits.ts
@@ -12,7 +12,10 @@ export interface UseUnitsResult {
 
 export function useUnits(): UseUnitsResult {
   const { data: profile } = useProfile()
-  const unit: DistanceUnit = profile?.distance_unit ?? 'yards'
+  // DB CHECK constraint (migration 0007) pins distance_unit to the union;
+  // the regenerated Supabase types surface it as plain `string`.
+  const unit: DistanceUnit =
+    (profile?.distance_unit as DistanceUnit | undefined) ?? 'yards'
 
   const toDisplay = useCallback(
     (yards: number, decimals = 0): string => formatDistance(yards, unit, decimals),

--- a/packages/core/src/sg.ts
+++ b/packages/core/src/sg.ts
@@ -19,6 +19,11 @@ export interface RoundSGResult {
   }
 }
 
+// DB-string → narrow-union casts. Postgres CHECK constraints (migrations
+// 0001 / 0003 / 0009) keep these columns inside their union vocabularies,
+// but the regenerated Supabase types surface them as plain `string | null`.
+// Issue #209 tracks promoting these CHECKs to real Postgres enums so the
+// regen produces narrow types directly.
 function shotRowToShot(s: ShotRow): Shot {
   return {
     id: s.id,
@@ -33,16 +38,16 @@ function shotRowToShot(s: ShotRow): Shot {
     startLng: s.start_lng ?? undefined,
     distanceToTarget: s.distance_to_target ?? undefined,
     club: (s.club as Shot['club']) ?? undefined,
-    lieType: s.lie_type ?? undefined,
-    lieSlope: s.lie_slope ?? undefined,
-    lieSlopeForward: s.lie_slope_forward ?? undefined,
-    lieSlopeSide: s.lie_slope_side ?? undefined,
+    lieType: (s.lie_type as Shot['lieType']) ?? undefined,
+    lieSlope: (s.lie_slope as Shot['lieSlope']) ?? undefined,
+    lieSlopeForward: (s.lie_slope_forward as Shot['lieSlopeForward']) ?? undefined,
+    lieSlopeSide: (s.lie_slope_side as Shot['lieSlopeSide']) ?? undefined,
     shotResult: (s.shot_result as Shot['shotResult']) ?? undefined,
     penalty: s.penalty,
     ob: s.ob,
     aimOffsetYards: s.aim_offset_yards ?? undefined,
-    breakDirection: s.break_direction ?? undefined,
-    puttResult: s.putt_result ?? undefined,
+    breakDirection: (s.break_direction as Shot['breakDirection']) ?? undefined,
+    puttResult: (s.putt_result as Shot['puttResult']) ?? undefined,
     puttDistanceFt: s.putt_distance_ft ?? undefined,
     notes: s.notes ?? undefined,
   }

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -4,7 +4,7 @@ import {
   getShotCategory,
 } from './sg-calculator'
 import { NEAR_GREEN_YARDS } from './constants'
-import type { LieSlopeForward, LieSlopeSide, ShotCategory, ShotResult } from './constants'
+import type { LieSlopeForward, LieSlopeSide, LieType, ShotCategory, ShotResult } from './constants'
 import { METERS_TO_YARDS, haversineYards, toRadians } from './units'
 import { RESULT_QUALITY } from './types'
 import type { Database } from '@oga/supabase'
@@ -179,7 +179,7 @@ export function approachByDistance(
       if (s.distance_to_target == null) continue
       const category = getShotCategory(
         {
-          lieType: s.lie_type ?? undefined,
+          lieType: (s.lie_type as LieType | null) ?? undefined,
           distanceToTarget: s.distance_to_target,
         },
         hole.par,
@@ -205,7 +205,7 @@ export function approachByDistance(
       if (next && (next.distance_to_target != null || next.lie_type === 'green')) {
         const nextCat = getShotCategory(
           {
-            lieType: next.lie_type ?? undefined,
+            lieType: (next.lie_type as LieType | null) ?? undefined,
             distanceToTarget: next.distance_to_target ?? undefined,
           },
           hole.par,
@@ -395,7 +395,7 @@ export function ballStrikingStats(rounds: DetailedRound[]): BallStrikingStats {
         // and a pin (per-round preferred).
         const category = getShotCategory(
           {
-            lieType: s.lie_type ?? undefined,
+            lieType: (s.lie_type as LieType | null) ?? undefined,
             distanceToTarget: s.distance_to_target ?? undefined,
           },
           hole.par,

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -1,7 +1,3 @@
-// Hand-authored to mirror supabase/migrations/0001_initial_schema.sql.
-// Replace by running `pnpm --filter @oga/supabase gen-types` once the local
-// Supabase stack is reachable. Keep this file in sync with the migration.
-
 export type Json =
   | string
   | number
@@ -10,632 +6,787 @@ export type Json =
   | { [key: string]: Json | undefined }
   | Json[]
 
-export interface Database {
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.5"
+  }
+  graphql_public: {
+    Tables: {
+      [_ in never]: never
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      graphql: {
+        Args: {
+          extensions?: Json
+          operationName?: string
+          query?: string
+          variables?: Json
+        }
+        Returns: Json
+      }
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
   public: {
     Tables: {
-      profiles: {
+      course_tees: {
         Row: {
-          id: string
-          username: string | null
-          handicap_index: number | null
-          skill_level: 'beginner' | 'casual' | 'developing' | 'competitive' | null
-          goal: 'break_100' | 'break_90' | 'break_80' | 'break_70s' | 'scratch' | null
-          play_frequency: string | null
-          facilities: string[] | null
-          play_style: 'casual' | 'mixed' | 'competitive' | null
-          distance_unit: 'yards' | 'meters'
-          onboarding_completed: boolean
+          course_id: string
+          course_rating: number | null
           created_at: string
+          id: string
+          par: number | null
+          slope_rating: number | null
+          tee_color: string
+          tee_name: string | null
+          total_yards: number | null
         }
         Insert: {
-          id: string
-          username?: string | null
-          handicap_index?: number | null
-          skill_level?: 'beginner' | 'casual' | 'developing' | 'competitive' | null
-          goal?: 'break_100' | 'break_90' | 'break_80' | 'break_70s' | 'scratch' | null
-          play_frequency?: string | null
-          facilities?: string[] | null
-          play_style?: 'casual' | 'mixed' | 'competitive' | null
-          distance_unit?: 'yards' | 'meters'
-          onboarding_completed?: boolean
+          course_id: string
+          course_rating?: number | null
           created_at?: string
+          id?: string
+          par?: number | null
+          slope_rating?: number | null
+          tee_color: string
+          tee_name?: string | null
+          total_yards?: number | null
         }
         Update: {
-          id?: string
-          username?: string | null
-          handicap_index?: number | null
-          skill_level?: 'beginner' | 'casual' | 'developing' | 'competitive' | null
-          goal?: 'break_100' | 'break_90' | 'break_80' | 'break_70s' | 'scratch' | null
-          play_frequency?: string | null
-          facilities?: string[] | null
-          play_style?: 'casual' | 'mixed' | 'competitive' | null
-          distance_unit?: 'yards' | 'meters'
-          onboarding_completed?: boolean
+          course_id?: string
+          course_rating?: number | null
           created_at?: string
-        }
-        Relationships: []
-      }
-      courses: {
-        Row: {
-          id: string
-          name: string
-          external_id: string | null
-          created_by: string | null
-          created_at: string
-          lat: number | null
-          lng: number | null
-          city: string | null
-          state: string | null
-        }
-        Insert: {
           id?: string
-          name: string
-          external_id?: string | null
-          created_by?: string | null
-          created_at?: string
-          lat?: number | null
-          lng?: number | null
-          city?: string | null
-          state?: string | null
-        }
-        Update: {
-          id?: string
-          name?: string
-          external_id?: string | null
-          created_by?: string | null
-          created_at?: string
-          lat?: number | null
-          lng?: number | null
-          city?: string | null
-          state?: string | null
+          par?: number | null
+          slope_rating?: number | null
+          tee_color?: string
+          tee_name?: string | null
+          total_yards?: number | null
         }
         Relationships: [
           {
-            foreignKeyName: 'courses_created_by_fkey'
-            columns: ['created_by']
+            foreignKeyName: "course_tees_course_id_fkey"
+            columns: ["course_id"]
             isOneToOne: false
-            referencedRelation: 'profiles'
-            referencedColumns: ['id']
+            referencedRelation: "courses"
+            referencedColumns: ["id"]
           },
         ]
       }
-      course_tees: {
+      courses: {
         Row: {
-          id: string
-          course_id: string
-          tee_color: string
-          tee_name: string | null
-          course_rating: number | null
-          slope_rating: number | null
-          total_yards: number | null
-          par: number | null
+          city: string | null
           created_at: string
+          created_by: string | null
+          external_id: string | null
+          id: string
+          lat: number | null
+          lng: number | null
+          name: string
+          state: string | null
         }
         Insert: {
-          id?: string
-          course_id: string
-          tee_color: string
-          tee_name?: string | null
-          course_rating?: number | null
-          slope_rating?: number | null
-          total_yards?: number | null
-          par?: number | null
+          city?: string | null
           created_at?: string
+          created_by?: string | null
+          external_id?: string | null
+          id?: string
+          lat?: number | null
+          lng?: number | null
+          name: string
+          state?: string | null
         }
         Update: {
-          id?: string
-          course_id?: string
-          tee_color?: string
-          tee_name?: string | null
-          course_rating?: number | null
-          slope_rating?: number | null
-          total_yards?: number | null
-          par?: number | null
+          city?: string | null
           created_at?: string
+          created_by?: string | null
+          external_id?: string | null
+          id?: string
+          lat?: number | null
+          lng?: number | null
+          name?: string
+          state?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: 'course_tees_course_id_fkey'
-            columns: ['course_id']
+            foreignKeyName: "courses_created_by_fkey"
+            columns: ["created_by"]
             isOneToOne: false
-            referencedRelation: 'courses'
-            referencedColumns: ['id']
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      crawl_state: {
+        Row: {
+          error_message: string | null
+          id: string
+          items_processed: number
+          last_crawled_at: string | null
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          error_message?: string | null
+          id: string
+          items_processed?: number
+          last_crawled_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          error_message?: string | null
+          id?: string
+          items_processed?: number
+          last_crawled_at?: string | null
+          status?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      drills: {
+        Row: {
+          category: string | null
+          created_at: string
+          description: string | null
+          duration_min: number | null
+          facility: string[] | null
+          id: string
+          instructions: string | null
+          name: string
+          skill_levels: string[] | null
+        }
+        Insert: {
+          category?: string | null
+          created_at?: string
+          description?: string | null
+          duration_min?: number | null
+          facility?: string[] | null
+          id?: string
+          instructions?: string | null
+          name: string
+          skill_levels?: string[] | null
+        }
+        Update: {
+          category?: string | null
+          created_at?: string
+          description?: string | null
+          duration_min?: number | null
+          facility?: string[] | null
+          id?: string
+          instructions?: string | null
+          name?: string
+          skill_levels?: string[] | null
+        }
+        Relationships: []
+      }
+      hole_scores: {
+        Row: {
+          fairway_hit: boolean | null
+          gir: boolean | null
+          hole_id: string
+          id: string
+          pin_lat: number | null
+          pin_lng: number | null
+          putts: number | null
+          round_id: string
+          score: number
+          sg_approach: number | null
+          sg_around_green: number | null
+          sg_off_tee: number | null
+          sg_putting: number | null
+        }
+        Insert: {
+          fairway_hit?: boolean | null
+          gir?: boolean | null
+          hole_id: string
+          id?: string
+          pin_lat?: number | null
+          pin_lng?: number | null
+          putts?: number | null
+          round_id: string
+          score: number
+          sg_approach?: number | null
+          sg_around_green?: number | null
+          sg_off_tee?: number | null
+          sg_putting?: number | null
+        }
+        Update: {
+          fairway_hit?: boolean | null
+          gir?: boolean | null
+          hole_id?: string
+          id?: string
+          pin_lat?: number | null
+          pin_lng?: number | null
+          putts?: number | null
+          round_id?: string
+          score?: number
+          sg_approach?: number | null
+          sg_around_green?: number | null
+          sg_off_tee?: number | null
+          sg_putting?: number | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "hole_scores_hole_id_fkey"
+            columns: ["hole_id"]
+            isOneToOne: false
+            referencedRelation: "holes"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "hole_scores_round_id_fkey"
+            columns: ["round_id"]
+            isOneToOne: false
+            referencedRelation: "rounds"
+            referencedColumns: ["id"]
           },
         ]
       }
       holes: {
         Row: {
-          id: string
           course_id: string
+          id: string
           number: number
           par: number
-          yards: number | null
+          pin_lat: number | null
+          pin_lng: number | null
           stroke_index: number | null
           tee_lat: number | null
           tee_lng: number | null
-          pin_lat: number | null
-          pin_lng: number | null
+          yards: number | null
         }
         Insert: {
-          id?: string
           course_id: string
+          id?: string
           number: number
           par: number
-          yards?: number | null
+          pin_lat?: number | null
+          pin_lng?: number | null
           stroke_index?: number | null
           tee_lat?: number | null
           tee_lng?: number | null
-          pin_lat?: number | null
-          pin_lng?: number | null
+          yards?: number | null
         }
         Update: {
-          id?: string
           course_id?: string
+          id?: string
           number?: number
           par?: number
-          yards?: number | null
+          pin_lat?: number | null
+          pin_lng?: number | null
           stroke_index?: number | null
           tee_lat?: number | null
           tee_lng?: number | null
-          pin_lat?: number | null
-          pin_lng?: number | null
+          yards?: number | null
         }
         Relationships: [
           {
-            foreignKeyName: 'holes_course_id_fkey'
-            columns: ['course_id']
+            foreignKeyName: "holes_course_id_fkey"
+            columns: ["course_id"]
             isOneToOne: false
-            referencedRelation: 'courses'
-            referencedColumns: ['id']
+            referencedRelation: "courses"
+            referencedColumns: ["id"]
           },
         ]
+      }
+      practice_plans: {
+        Row: {
+          ai_insight: string | null
+          based_on_rounds: number | null
+          completed_drill_ids: string[]
+          drills: Json | null
+          focus_areas: Json | null
+          generated_at: string
+          id: string
+          user_id: string
+          valid_until: string | null
+        }
+        Insert: {
+          ai_insight?: string | null
+          based_on_rounds?: number | null
+          completed_drill_ids?: string[]
+          drills?: Json | null
+          focus_areas?: Json | null
+          generated_at?: string
+          id?: string
+          user_id: string
+          valid_until?: string | null
+        }
+        Update: {
+          ai_insight?: string | null
+          based_on_rounds?: number | null
+          completed_drill_ids?: string[]
+          drills?: Json | null
+          focus_areas?: Json | null
+          generated_at?: string
+          id?: string
+          user_id?: string
+          valid_until?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "practice_plans_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      profiles: {
+        Row: {
+          created_at: string
+          distance_unit: string
+          facilities: string[] | null
+          goal: string | null
+          handicap_index: number | null
+          id: string
+          onboarding_completed: boolean
+          play_frequency: string | null
+          play_style: string | null
+          skill_level: string | null
+          updated_at: string
+          username: string | null
+        }
+        Insert: {
+          created_at?: string
+          distance_unit?: string
+          facilities?: string[] | null
+          goal?: string | null
+          handicap_index?: number | null
+          id: string
+          onboarding_completed?: boolean
+          play_frequency?: string | null
+          play_style?: string | null
+          skill_level?: string | null
+          updated_at?: string
+          username?: string | null
+        }
+        Update: {
+          created_at?: string
+          distance_unit?: string
+          facilities?: string[] | null
+          goal?: string | null
+          handicap_index?: number | null
+          id?: string
+          onboarding_completed?: boolean
+          play_frequency?: string | null
+          play_style?: string | null
+          skill_level?: string | null
+          updated_at?: string
+          username?: string | null
+        }
+        Relationships: []
       }
       rounds: {
         Row: {
-          id: string
-          user_id: string
           course_id: string
-          played_at: string
-          tee_color: string | null
-          total_score: number | null
-          total_putts: number | null
+          course_tee_id: string | null
+          created_at: string
           fairways_hit: number | null
           fairways_total: number | null
           gir: number | null
-          sg_off_tee: number | null
+          id: string
+          notes: string | null
+          played_at: string
+          score_differential: number | null
           sg_approach: number | null
           sg_around_green: number | null
+          sg_off_tee: number | null
           sg_putting: number | null
           sg_total: number | null
-          course_tee_id: string | null
-          score_differential: number | null
-          notes: string | null
-          created_at: string
-        }
-        Insert: {
-          id?: string
+          tee_color: string | null
+          total_putts: number | null
+          total_score: number | null
           user_id: string
-          course_id: string
-          played_at: string
-          tee_color?: string | null
-          total_score?: number | null
-          total_putts?: number | null
-          fairways_hit?: number | null
-          fairways_total?: number | null
-          gir?: number | null
-          sg_off_tee?: number | null
-          sg_approach?: number | null
-          sg_around_green?: number | null
-          sg_putting?: number | null
-          sg_total?: number | null
-          course_tee_id?: string | null
-          score_differential?: number | null
-          notes?: string | null
-          created_at?: string
-        }
-        Update: {
-          id?: string
-          user_id?: string
-          course_id?: string
-          played_at?: string
-          tee_color?: string | null
-          total_score?: number | null
-          total_putts?: number | null
-          fairways_hit?: number | null
-          fairways_total?: number | null
-          gir?: number | null
-          sg_off_tee?: number | null
-          sg_approach?: number | null
-          sg_around_green?: number | null
-          sg_putting?: number | null
-          sg_total?: number | null
-          course_tee_id?: string | null
-          score_differential?: number | null
-          notes?: string | null
-          created_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: 'rounds_user_id_fkey'
-            columns: ['user_id']
-            isOneToOne: false
-            referencedRelation: 'profiles'
-            referencedColumns: ['id']
-          },
-          {
-            foreignKeyName: 'rounds_course_id_fkey'
-            columns: ['course_id']
-            isOneToOne: false
-            referencedRelation: 'courses'
-            referencedColumns: ['id']
-          },
-        ]
-      }
-      hole_scores: {
-        Row: {
-          id: string
-          round_id: string
-          hole_id: string
-          score: number
-          putts: number | null
-          fairway_hit: boolean | null
-          gir: boolean | null
-          sg_off_tee: number | null
-          sg_approach: number | null
-          sg_around_green: number | null
-          sg_putting: number | null
-          pin_lat: number | null
-          pin_lng: number | null
         }
         Insert: {
+          course_id: string
+          course_tee_id?: string | null
+          created_at?: string
+          fairways_hit?: number | null
+          fairways_total?: number | null
+          gir?: number | null
           id?: string
-          round_id: string
-          hole_id: string
-          score: number
-          putts?: number | null
-          fairway_hit?: boolean | null
-          gir?: boolean | null
-          sg_off_tee?: number | null
+          notes?: string | null
+          played_at: string
+          score_differential?: number | null
           sg_approach?: number | null
           sg_around_green?: number | null
+          sg_off_tee?: number | null
           sg_putting?: number | null
-          pin_lat?: number | null
-          pin_lng?: number | null
+          sg_total?: number | null
+          tee_color?: string | null
+          total_putts?: number | null
+          total_score?: number | null
+          user_id: string
         }
         Update: {
+          course_id?: string
+          course_tee_id?: string | null
+          created_at?: string
+          fairways_hit?: number | null
+          fairways_total?: number | null
+          gir?: number | null
           id?: string
-          round_id?: string
-          hole_id?: string
-          score?: number
-          putts?: number | null
-          fairway_hit?: boolean | null
-          gir?: boolean | null
-          sg_off_tee?: number | null
+          notes?: string | null
+          played_at?: string
+          score_differential?: number | null
           sg_approach?: number | null
           sg_around_green?: number | null
+          sg_off_tee?: number | null
           sg_putting?: number | null
-          pin_lat?: number | null
-          pin_lng?: number | null
+          sg_total?: number | null
+          tee_color?: string | null
+          total_putts?: number | null
+          total_score?: number | null
+          user_id?: string
         }
         Relationships: [
           {
-            foreignKeyName: 'hole_scores_round_id_fkey'
-            columns: ['round_id']
+            foreignKeyName: "rounds_course_id_fkey"
+            columns: ["course_id"]
             isOneToOne: false
-            referencedRelation: 'rounds'
-            referencedColumns: ['id']
+            referencedRelation: "courses"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'hole_scores_hole_id_fkey'
-            columns: ['hole_id']
+            foreignKeyName: "rounds_course_tee_id_fkey"
+            columns: ["course_tee_id"]
             isOneToOne: false
-            referencedRelation: 'holes'
-            referencedColumns: ['id']
+            referencedRelation: "course_tees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "rounds_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
         ]
       }
       shots: {
         Row: {
-          id: string
-          hole_score_id: string
-          user_id: string
-          shot_number: number
-          start_lat: number | null
-          start_lng: number | null
-          end_lat: number | null
-          end_lng: number | null
           aim_lat: number | null
           aim_lng: number | null
-          distance_to_target: number | null
-          club: string | null
-          lie_type:
-            | 'tee'
-            | 'fairway'
-            | 'rough'
-            | 'sand'
-            | 'fringe'
-            | 'recovery'
-            | 'green'
-            | null
-          lie_slope:
-            | 'level'
-            | 'uphill'
-            | 'downhill'
-            | 'ball_above'
-            | 'ball_below'
-            | null
-          lie_slope_forward: 'uphill' | 'level' | 'downhill' | null
-          lie_slope_side: 'ball_above' | 'ball_below' | null
-          shot_result: string | null
-          penalty: boolean
-          ob: boolean
           aim_offset_yards: number | null
-          break_direction:
-            | 'left'
-            | 'right'
-            | 'straight'
-            | 'left_to_right'
-            | 'right_to_left'
-            | 'uphill'
-            | 'downhill'
-            | null
-          putt_result: 'made' | 'short' | 'long' | 'missed_left' | 'missed_right' | null
-          putt_distance_result: 'short' | 'long' | null
-          putt_direction_result: 'left' | 'right' | null
-          putt_distance_ft: number | null
-          putt_slope_pct: number | null
-          green_speed: 'slow' | 'medium' | 'fast' | null
-          notes: string | null
+          break_direction: string | null
+          club: string | null
           created_at: string
-        }
-        Insert: {
-          id?: string
+          distance_to_target: number | null
+          end_lat: number | null
+          end_lng: number | null
+          green_speed: string | null
           hole_score_id: string
-          user_id: string
+          id: string
+          lie_slope: string | null
+          lie_slope_forward: string | null
+          lie_slope_side: string | null
+          lie_type: string | null
+          notes: string | null
+          ob: boolean
+          penalty: boolean
+          putt_direction_result: string | null
+          putt_distance_ft: number | null
+          putt_distance_result: string | null
+          putt_result: string | null
+          putt_slope_pct: number | null
           shot_number: number
-          start_lat?: number | null
-          start_lng?: number | null
-          end_lat?: number | null
-          end_lng?: number | null
+          shot_result: string | null
+          start_lat: number | null
+          start_lng: number | null
+          user_id: string
+        }
+        Insert: {
           aim_lat?: number | null
           aim_lng?: number | null
-          distance_to_target?: number | null
-          club?: string | null
-          lie_type?:
-            | 'tee'
-            | 'fairway'
-            | 'rough'
-            | 'sand'
-            | 'fringe'
-            | 'recovery'
-            | 'green'
-            | null
-          lie_slope?:
-            | 'level'
-            | 'uphill'
-            | 'downhill'
-            | 'ball_above'
-            | 'ball_below'
-            | null
-          lie_slope_forward?: 'uphill' | 'level' | 'downhill' | null
-          lie_slope_side?: 'ball_above' | 'ball_below' | null
-          shot_result?: string | null
-          penalty?: boolean
-          ob?: boolean
           aim_offset_yards?: number | null
-          break_direction?:
-            | 'left'
-            | 'right'
-            | 'straight'
-            | 'left_to_right'
-            | 'right_to_left'
-            | 'uphill'
-            | 'downhill'
-            | null
-          putt_result?: 'made' | 'short' | 'long' | 'missed_left' | 'missed_right' | null
-          putt_distance_result?: 'short' | 'long' | null
-          putt_direction_result?: 'left' | 'right' | null
-          putt_distance_ft?: number | null
-          putt_slope_pct?: number | null
-          green_speed?: 'slow' | 'medium' | 'fast' | null
-          notes?: string | null
+          break_direction?: string | null
+          club?: string | null
           created_at?: string
+          distance_to_target?: number | null
+          end_lat?: number | null
+          end_lng?: number | null
+          green_speed?: string | null
+          hole_score_id: string
+          id?: string
+          lie_slope?: string | null
+          lie_slope_forward?: string | null
+          lie_slope_side?: string | null
+          lie_type?: string | null
+          notes?: string | null
+          ob?: boolean
+          penalty?: boolean
+          putt_direction_result?: string | null
+          putt_distance_ft?: number | null
+          putt_distance_result?: string | null
+          putt_result?: string | null
+          putt_slope_pct?: number | null
+          shot_number: number
+          shot_result?: string | null
+          start_lat?: number | null
+          start_lng?: number | null
+          user_id: string
         }
         Update: {
-          id?: string
+          aim_lat?: number | null
+          aim_lng?: number | null
+          aim_offset_yards?: number | null
+          break_direction?: string | null
+          club?: string | null
+          created_at?: string
+          distance_to_target?: number | null
+          end_lat?: number | null
+          end_lng?: number | null
+          green_speed?: string | null
           hole_score_id?: string
-          user_id?: string
+          id?: string
+          lie_slope?: string | null
+          lie_slope_forward?: string | null
+          lie_slope_side?: string | null
+          lie_type?: string | null
+          notes?: string | null
+          ob?: boolean
+          penalty?: boolean
+          putt_direction_result?: string | null
+          putt_distance_ft?: number | null
+          putt_distance_result?: string | null
+          putt_result?: string | null
+          putt_slope_pct?: number | null
           shot_number?: number
+          shot_result?: string | null
           start_lat?: number | null
           start_lng?: number | null
-          end_lat?: number | null
-          end_lng?: number | null
-          aim_lat?: number | null
-          aim_lng?: number | null
-          distance_to_target?: number | null
-          club?: string | null
-          lie_type?:
-            | 'tee'
-            | 'fairway'
-            | 'rough'
-            | 'sand'
-            | 'fringe'
-            | 'recovery'
-            | 'green'
-            | null
-          lie_slope?:
-            | 'level'
-            | 'uphill'
-            | 'downhill'
-            | 'ball_above'
-            | 'ball_below'
-            | null
-          lie_slope_forward?: 'uphill' | 'level' | 'downhill' | null
-          lie_slope_side?: 'ball_above' | 'ball_below' | null
-          shot_result?: string | null
-          penalty?: boolean
-          ob?: boolean
-          aim_offset_yards?: number | null
-          break_direction?:
-            | 'left'
-            | 'right'
-            | 'straight'
-            | 'left_to_right'
-            | 'right_to_left'
-            | 'uphill'
-            | 'downhill'
-            | null
-          putt_result?: 'made' | 'short' | 'long' | 'missed_left' | 'missed_right' | null
-          putt_distance_result?: 'short' | 'long' | null
-          putt_direction_result?: 'left' | 'right' | null
-          putt_distance_ft?: number | null
-          putt_slope_pct?: number | null
-          green_speed?: 'slow' | 'medium' | 'fast' | null
-          notes?: string | null
-          created_at?: string
-        }
-        Relationships: [
-          {
-            foreignKeyName: 'shots_hole_score_id_fkey'
-            columns: ['hole_score_id']
-            isOneToOne: false
-            referencedRelation: 'hole_scores'
-            referencedColumns: ['id']
-          },
-          {
-            foreignKeyName: 'shots_user_id_fkey'
-            columns: ['user_id']
-            isOneToOne: false
-            referencedRelation: 'profiles'
-            referencedColumns: ['id']
-          },
-        ]
-      }
-      drills: {
-        Row: {
-          id: string
-          name: string
-          description: string | null
-          duration_min: number | null
-          category: 'off_tee' | 'approach' | 'around_green' | 'putting' | null
-          facility: string[] | null
-          skill_levels: string[] | null
-          instructions: string | null
-          created_at: string
-        }
-        Insert: {
-          id?: string
-          name: string
-          description?: string | null
-          duration_min?: number | null
-          category?: 'off_tee' | 'approach' | 'around_green' | 'putting' | null
-          facility?: string[] | null
-          skill_levels?: string[] | null
-          instructions?: string | null
-          created_at?: string
-        }
-        Update: {
-          id?: string
-          name?: string
-          description?: string | null
-          duration_min?: number | null
-          category?: 'off_tee' | 'approach' | 'around_green' | 'putting' | null
-          facility?: string[] | null
-          skill_levels?: string[] | null
-          instructions?: string | null
-          created_at?: string
-        }
-        Relationships: []
-      }
-      practice_plans: {
-        Row: {
-          id: string
-          user_id: string
-          generated_at: string
-          valid_until: string | null
-          based_on_rounds: number | null
-          focus_areas: Json | null
-          drills: Json | null
-          ai_insight: string | null
-          completed_drill_ids: string[]
-        }
-        Insert: {
-          id?: string
-          user_id: string
-          generated_at?: string
-          valid_until?: string | null
-          based_on_rounds?: number | null
-          focus_areas?: Json | null
-          drills?: Json | null
-          ai_insight?: string | null
-          completed_drill_ids?: string[]
-        }
-        Update: {
-          id?: string
           user_id?: string
-          generated_at?: string
-          valid_until?: string | null
-          based_on_rounds?: number | null
-          focus_areas?: Json | null
-          drills?: Json | null
-          ai_insight?: string | null
-          completed_drill_ids?: string[]
         }
         Relationships: [
           {
-            foreignKeyName: 'practice_plans_user_id_fkey'
-            columns: ['user_id']
+            foreignKeyName: "shots_hole_score_id_fkey"
+            columns: ["hole_score_id"]
             isOneToOne: false
-            referencedRelation: 'profiles'
-            referencedColumns: ['id']
+            referencedRelation: "hole_scores"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shots_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
           },
         ]
       }
       user_clubs: {
         Row: {
-          id: string
-          user_id: string
-          name: string
           club_type: string
-          loft: number | null
-          typical_distance_yards: number | null
-          sort_order: number
-          in_bag: boolean
           created_at: string
+          id: string
+          in_bag: boolean
+          loft: number | null
+          name: string
+          sort_order: number
+          typical_distance_yards: number | null
+          user_id: string
         }
         Insert: {
-          id?: string
-          user_id: string
-          name: string
           club_type: string
-          loft?: number | null
-          typical_distance_yards?: number | null
-          sort_order?: number
-          in_bag?: boolean
           created_at?: string
+          id?: string
+          in_bag?: boolean
+          loft?: number | null
+          name: string
+          sort_order?: number
+          typical_distance_yards?: number | null
+          user_id: string
         }
         Update: {
-          id?: string
-          user_id?: string
-          name?: string
           club_type?: string
-          loft?: number | null
-          typical_distance_yards?: number | null
-          sort_order?: number
-          in_bag?: boolean
           created_at?: string
+          id?: string
+          in_bag?: boolean
+          loft?: number | null
+          name?: string
+          sort_order?: number
+          typical_distance_yards?: number | null
+          user_id?: string
         }
         Relationships: []
       }
     }
-    Views: Record<string, never>
+    Views: {
+      [_ in never]: never
+    }
     Functions: {
       search_courses: {
-        Args: { search_query: string; result_limit?: number }
-        Returns: Database['public']['Tables']['courses']['Row'][]
+        Args: { result_limit?: number; search_query: string }
+        Returns: {
+          city: string | null
+          created_at: string
+          created_by: string | null
+          external_id: string | null
+          id: string
+          lat: number | null
+          lng: number | null
+          name: string
+          state: string | null
+        }[]
+        SetofOptions: {
+          from: "*"
+          to: "courses"
+          isOneToOne: false
+          isSetofReturn: true
+        }
+      }
+      show_limit: { Args: never; Returns: number }
+      show_trgm: { Args: { "": string }; Returns: string[] }
+      update_club_order: {
+        Args: { p_club_ids: string[]; p_orders: number[]; p_user_id: string }
+        Returns: undefined
       }
     }
-    Enums: Record<string, never>
-    CompositeTypes: Record<string, never>
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
   }
 }
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  graphql_public: {
+    Enums: {},
+  },
+  public: {
+    Enums: {},
+  },
+} as const


### PR DESCRIPTION
## Summary

Regenerated `packages/supabase/src/types.ts` (Supabase CLI emits PostgrestVersion 14.5 shape) replaces the hand-authored narrow-union types with `string | null` for every column whose vocabulary is enforced via a Postgres `CHECK` constraint rather than a real enum type. 17 typecheck errors shared that single root cause.

This PR commits the regen and casts at the DB→core boundary. Each cast pairs with a Postgres CHECK that rejects out-of-union values, so the runtime contract is preserved — only the static type information is being recovered.

Casts applied:

| File | Columns |
|---|---|
| `apps/web/src/components/rounds/shots/draft.ts` | `lie_type`, `lie_slope`, `lie_slope_forward`, `lie_slope_side`, `putt_distance_result`, `putt_direction_result`, `green_speed`, `putt_result` |
| `apps/web/src/hooks/useUnits.ts` | `distance_unit` |
| `packages/core/src/sg.ts` | `lie_type`, `lie_slope`, `lie_slope_forward`, `lie_slope_side`, `break_direction`, `putt_result` |
| `packages/core/src/stats.ts` | `lie_type` (×3 call sites) |

## Long-term fix

Tracked in #209 — promote each `text + CHECK` column to a real Postgres `enum` type so `supabase gen-types` produces narrow string-literal unions automatically and every cast in this PR can be deleted.

## Test plan

- [x] `pnpm typecheck` — clean (was 17 errors).
- [x] `pnpm --filter @oga/core test --run` — 259/259.
- [x] `pnpm --filter web build` — clean.
- [x] `cd apps/mobile && npm run typecheck` — clean.
- [x] Rebased onto current `origin/dev` (post #208 merge).