### PR TITLE
feat: course management article in Learn section

### DIFF
--- a/apps/mobile/app/(app)/learn/[article].tsx
+++ b/apps/mobile/app/(app)/learn/[article].tsx
@@ -99,6 +99,8 @@ function LiveArticle({ id }: { id: string }) {
       return <GlossaryArticle />
     case 'how-to-practice':
       return <HowToPracticeArticle />
+    case 'course-management':
+      return <CourseManagementArticle />
     default:
       return <StubBody title="Article" />
   }
@@ -883,5 +885,548 @@ const BENCHMARKS = [
     scratch: '250 yd',
     mid: '220 yd',
     high: '190 yd',
+  },
+]
+
+function CourseManagementArticle() {
+  return (
+    <View>
+      <Text style={{ ...KICKER, marginBottom: 10 }}>On the course · Draft</Text>
+      <Text style={TITLE}>Course management.</Text>
+
+      <WipBanner />
+
+      <H3>You are not on the range anymore</H3>
+      <Para>
+        The driving range is where you work on your golf swing. The
+        golf course is where you work on your score. These are two
+        different activities requiring two different mindsets.
+      </Para>
+      <Para>
+        On the range, perfect is the goal. On the course, useful is
+        the goal. The player who shoots 78 with ugly but functional
+        golf beats the player who shoots 84 hitting it beautifully.
+        Score is the only thing the card cares about.
+      </Para>
+      <Para>
+        The moment you step onto the first tee, stop being a golfer
+        working on your swing and become a player trying to shoot
+        the lowest number possible with the tools you have today.
+        Your clubs are tools to get the ball in the hole. Not every
+        shot needs to be pretty. It just needs to work.
+      </Para>
+
+      <Divider />
+
+      <H3>Know your game, not your best game</H3>
+      <Para>
+        Course management starts with brutal honesty about what you
+        actually do — not what you're capable of on a perfect day.
+      </Para>
+      <Para>
+        Every player has tendencies. You probably miss in a
+        predictable direction. You probably have a club you don't
+        fully trust. You probably have a shot shape that shows up
+        under pressure whether you want it or not.
+      </Para>
+      <Para>
+        The player who knows they hit a soft fade under pressure and
+        plays for it will outscore the player who aims straight and
+        gets "surprised" by the same fade every time.
+      </Para>
+      <Para>Before you play, know:</Para>
+      <Bullets
+        items={[
+          'Your predominant miss direction',
+          "Which clubs you genuinely trust vs which ones you're hoping work out",
+          'How far you actually carry the ball — not your best carry, your reliable carry',
+          'Where your game breaks down under pressure',
+        ]}
+      />
+      <Para>
+        Your OGA strokes gained data tells you this more clearly
+        than your gut does. If SG approach is -1.4 per round, your
+        irons are leaking. If SG putting is +0.8, your putter is an
+        asset. Play accordingly.
+      </Para>
+
+      <Divider />
+
+      <H3>The confidence club rule</H3>
+      <Para>
+        For any shot on the course, choose the club you can hit the
+        shot you need 8 times out of 10. Not the club that gets you
+        there if you pure it. Not the club that's technically correct
+        on paper. The club you trust.
+      </Para>
+      <Para>
+        Standing over a shot with doubt is one of the most expensive
+        things you can do in golf. A committed swing with the "wrong"
+        club almost always beats a tentative swing with the "right"
+        one. If you're between clubs and one of them makes you
+        nervous — hit the other one. Every time.
+      </Para>
+      <Para>
+        Off the tee: hit the longest club you can confidently keep
+        in play. That is it. You don't need a perfect drive. You
+        need a ball in play. A 220-yard drive in the fairway beats a
+        280-yard drive in the trees every single time. Driver is not
+        always the answer and there is no shame in hitting 3-wood or
+        hybrid off the tee on a tight hole. The Playa doesn't care
+        what club anyone else is hitting. The Playa cares about the
+        score.
+      </Para>
+
+      <Divider />
+
+      <H3>The Way of the Playa</H3>
+      <Para>
+        Golf content creator Golf Sidekick has articulated a
+        philosophy called the Way of the Playa that every amateur
+        should understand. The core idea is simple: your ego is the
+        most expensive thing in your bag.
+      </Para>
+      <Para>
+        The Playa doesn't care about looking good. The Playa doesn't
+        care what club other people are hitting or whether the shot
+        looks impressive. The Playa cares about one thing — getting
+        the ball in the hole in as few strokes as possible — and
+        makes every decision in service of that goal.
+      </Para>
+      <Para>In practice this looks like:</Para>
+      <Bullets
+        items={[
+          'Hitting 3-wood off the tee when driver puts you in trouble',
+          'Laying up short of a hazard even when you think you can probably carry it',
+          'Chipping out sideways without shame when trees are in the way',
+          'Playing to the fat part of the green instead of attacking a tucked pin',
+          'Accepting the penalty and moving on instead of compounding the mistake',
+        ]}
+      />
+      <Para>
+        None of these decisions feel exciting. All of them save
+        strokes.
+      </Para>
+      <Para>
+        The Playa understands that golf is not a contest of who hits
+        the most impressive shots. It's a contest of who takes the
+        fewest. These are different games and most amateurs are
+        playing the wrong one.
+      </Para>
+      <Note variant="research">
+        Golf Sidekick — YouTube. Search "Way of the Playa." Practical,
+        ego-free approach to scoring.
+      </Note>
+
+      <Divider />
+
+      <H3>Aim at the center of the green</H3>
+      <Para>
+        This is a simple rule that will immediately save you strokes.
+      </Para>
+      <Para>
+        Most amateur golfers aim at the pin. The pin is rarely in
+        the center of the green. This means most amateur golfers are
+        constantly playing the hardest target available — the one
+        with the least margin for error.
+      </Para>
+      <Para>
+        Aim at the center of the green unless you have a very
+        specific, very good reason not to. The center of the green
+        is always a good shot. It never leaves you with a chip from
+        the wrong side. It gives you the most margin for your miss.
+      </Para>
+      <Para>
+        A birdie putt from 25 feet is still a birdie putt. What you
+        won't have is a chip from the rough, or a three-putt from 60
+        feet, or a false front situation because you were attacking
+        a back left pin from 170 yards.
+      </Para>
+
+      <Divider />
+
+      <H3>Plan the hole backwards</H3>
+      <Para>
+        Most amateurs walk up to the tee and hit their driver as far
+        as they can, then figure out what to do next. This is
+        reactive golf. It works well enough on straightforward holes
+        and falls apart on anything with a hazard, a difficult
+        green, or a premium on position.
+      </Para>
+      <Para>
+        The better approach is to plan the hole in reverse —
+        starting at the pin and working back to the tee.
+      </Para>
+      <Para>
+        Start on the green. Where is the pin today? Is it tucked
+        behind a bunker, on a shelf, near a false front? Now ask:
+        where on the green do I want to be putting from? That tells
+        you the ideal approach angle and the ideal landing zone for
+        your approach shot.
+      </Para>
+      <Para>
+        Now work back one more shot. To hit the approach from that
+        ideal spot, where does your previous shot need to land?
+        What's the right side of the fairway? What distance leaves
+        you a comfortable full shot rather than an awkward partial?
+      </Para>
+      <Para>
+        Now you know where your tee shot needs to go. Not just "in
+        the fairway" — a specific zone that sets up everything that
+        follows.
+      </Para>
+      <Para>
+        On a par 5: the same logic applies across three shots
+        instead of two. Where do you want to be for your pitch or
+        third shot? What does the layup need to accomplish to get
+        you there? Where does the tee shot need to go to make the
+        layup straightforward?
+      </Para>
+      <Para>
+        This is how caddies think. This is how tour professionals
+        think. And it's available to any amateur willing to spend 60
+        seconds on the tee thinking before swinging.
+      </Para>
+      <Para>
+        The practice round is where you build this map. Walk the
+        hole from green to tee. Stand where the approach shot will
+        be played from and look back at the fairway — you'll see
+        angles and landing zones you never noticed from the tee.
+        That knowledge compounds over time. Players who know a
+        course well aren't lucky. They've done this work.
+      </Para>
+
+      <Divider />
+
+      <H3>Your free throw range</H3>
+      <Para>
+        Every player has a distance where they feel genuinely
+        comfortable — a yardage where they know, without much doubt,
+        that they can get the ball close. This is your free throw
+        range.
+      </Para>
+      <Para>
+        For most amateurs it's somewhere between 50 and 100 yards.
+        For better players it might be 100-120. Whatever yours is,
+        identify it honestly.
+      </Para>
+      <Para>
+        Now start playing shots to leave yourself that number rather
+        than just maximizing distance on every shot. Course
+        management is partly about engineering the right approach
+        shot.
+      </Para>
+      <Para>
+        A 60-yard full wedge from a clean lie is easier than an
+        85-yard partial wedge from an awkward distance. Partial
+        wedge shots are hard. Full swing wedges are repeatable.
+        Don't manufacture difficult shots when strategy can avoid
+        them.
+      </Para>
+      <Para>
+        Off the tee on a long par 4: consider what club leaves you a
+        full shot in your free throw range rather than just
+        grip-and-ripping driver. On a par 5: a layup to your number
+        beats going for it from 230 yards with a marginal lie.
+      </Para>
+
+      <Divider />
+
+      <H3>The Scoring Method and the Scoring Zone</H3>
+      <Para>
+        Will Robins, PGA member and Golf Digest Best Young Teachers
+        honoree, developed a course management system called The
+        Scoring Method that reframes how amateurs think about every
+        hole.
+      </Para>
+      <Para>
+        The core concept is the Scoring Zone — a distance close
+        enough to the green that you're confident you can finish the
+        hole in 3 more shots or fewer. For most beginners and high
+        handicappers, start at 75 yards. As your game improves,
+        tighten it.
+      </Para>
+      <Para>
+        The Scoring Method tracks just two things per hole on a
+        modified scorecard:
+      </Para>
+      <H4>1. Did you reach the Scoring Zone in two shots?</H4>
+      <Para>
+        After your first two shots, are you inside your distance?
+        Yes or no.
+      </Para>
+      <H4>
+        2. Did you get up and down in 3 shots or fewer from the
+        Scoring Zone?
+      </H4>
+      <Para>
+        Once inside your zone, did you convert? Or did you take 4
+        from there?
+      </Para>
+      <Para>
+        Track these two numbers for a few rounds and patterns emerge
+        fast. Most amateurs discover they're actually reaching the
+        Scoring Zone regularly — the problem is converting once they
+        get there. That tells you exactly where to practice.
+      </Para>
+      <Para>
+        The deeper power of this system is that it shifts your
+        measure of success away from score and toward process. A
+        player who reaches the Scoring Zone in two shots and
+        converts every time will shoot in the 80s almost regardless
+        of how their ball-striking looks. The system shows you what
+        actually matters hole by hole.
+      </Para>
+      <Note variant="research">
+        Will Robins — The Scoring Method. thescoringmethod.com and
+        YouTube @thescoringmethod
+      </Note>
+
+      <Divider />
+
+      <H3>Think target, not trouble</H3>
+      <Para>
+        When you stand over a shot thinking "don't hit it in the
+        water" — you are thinking about the water. Your brain
+        doesn't process the "don't" particularly well. You are
+        programming yourself to think about exactly what you want to
+        avoid.
+      </Para>
+      <Para>
+        Instead: pick a specific, positive target. Not "away from
+        the bunker" but "at that tree on the left edge of the
+        fairway." A specific target gives your brain and body
+        something to work toward rather than something to flee from.
+      </Para>
+      <Para>
+        Manu from The Upbeat Golfer talks extensively about this —
+        committing fully to a target and a process before stepping
+        into the ball, then letting go of the result. The shot is
+        decided before you address it. Doubt after you've committed
+        is the enemy. Indecision kills golf shots more reliably than
+        poor mechanics.
+      </Para>
+      <Note variant="research">
+        The Upbeat Golfer (Manu) — YouTube. Process-driven approach,
+        target commitment, playing without fear.
+      </Note>
+
+      <Divider />
+
+      <H3>Never make two mistakes in a row</H3>
+      <Para>
+        You will hit bad shots. Every player at every level hits bad
+        shots. A bad shot is not a crisis — it's golf.
+      </Para>
+      <Para>
+        What turns a bad shot into a big number is the decision that
+        follows it.
+      </Para>
+      <Para>
+        After a bad shot, your only job is to get back into
+        position. Not to make up for it. Not to be a hero. Not to
+        erase it. Just to get somewhere you can play a normal golf
+        shot from.
+      </Para>
+      <Para>Punch out. Accept the bogey. Move on.</Para>
+      <Para>
+        The double bogey that becomes a triple happens because the
+        player tried to thread the needle through the trees instead
+        of punching out sideways. The bogey that becomes a triple
+        happens because the player went for the green from an
+        impossible lie when laying up was obviously the right call.
+      </Para>
+      <Para>
+        A bogey is one over par. A triple is three over. The shots
+        themselves might be identical — the decisions are what
+        separate them. The Playa takes his medicine every time. The
+        Playa never follows a bad shot with a stupid shot.
+      </Para>
+
+      <Divider />
+
+      <H3>Be process-driven, not results-driven</H3>
+      <Para>
+        Most golfers think too little on the golf course. They step
+        up to the ball, swing, and react emotionally to wherever it
+        goes. There's no plan and no process.
+      </Para>
+      <Para>
+        But there's an opposite problem: once golfers start trying
+        to improve, they often start thinking too much. They
+        outthink themselves — grinding over swing thoughts, worrying
+        about mechanics, replaying the last bad shot — because they
+        aren't yet good enough to execute what they're thinking
+        about. Analysis paralysis is just as damaging as
+        mindlessness.
+      </Para>
+      <Para>
+        The sweet spot is a clear, repeatable pre-shot process:
+      </Para>
+      <Bullets
+        items={[
+          'Pick a specific target',
+          'Commit fully to the shot',
+          'Go through your routine',
+          'Pull the trigger',
+        ]}
+      />
+      <Para>
+        That's it. You don't need to solve the hole. You need to
+        play one shot at a time with full commitment.
+      </Para>
+      <Para>
+        Try tracking — alongside your score — whether you committed
+        to each shot. Not whether it went where you wanted. Whether
+        you actually went through your process and pulled the
+        trigger without doubt.
+      </Para>
+      <Para>
+        Players who track this consistently find their scores drop
+        naturally. Not because they're grinding harder on results,
+        but because they've replaced reactive, emotional golf with a
+        repeatable approach. Results-oriented thinking leads to
+        tension, steering, and the exact outcome you were afraid of.
+        Process-oriented thinking gives you the best chance of
+        executing the shot.
+      </Para>
+
+      <Divider />
+
+      <H3>The practice round</H3>
+      <Para>
+        Course management is not something you can learn sitting in
+        a cart or watching videos. It's learned by doing — and the
+        practice round is where you do it.
+      </Para>
+      <Para>
+        Play two balls off the tee on every hole. Hit the aggressive
+        line you want to hit and the conservative line you think you
+        should hit. See which one actually leaves you the better
+        approach. You will be surprised how often the conservative
+        play gives you just as good an angle — sometimes better.
+      </Para>
+      <Para>
+        From trouble, play a second ball both ways. Hit the hero
+        shot you were tempted to play AND the safe punch-out. See
+        what actually happens. Most of the time the hero shot costs
+        you more than the punch-out. Your gut will stop suggesting
+        it so often once your eyes have seen the real results.
+      </Para>
+      <Para>
+        Use the practice round to find your Scoring Zone entry
+        points on each hole. Where do you need to be after two shots
+        to have a comfortable third? Work backwards from there to
+        plan your tee shot.
+      </Para>
+      <Para>
+        A practice round played thoughtfully and with intention is
+        worth more for course management than ten range sessions.
+        The course is the classroom.
+      </Para>
+
+      <Divider />
+
+      <H3>Keep it simple</H3>
+      <Para>
+        The fundamentals that will lower your score, in order of
+        importance:
+      </Para>
+      <Bullets
+        items={[
+          'Ball in play off the tee with the longest club you trust',
+          'Plan the hole backwards from the pin before you swing',
+          "Think about your target, not about where you can't go",
+          'Aim at the center of the green',
+          'Play to your free throw range',
+          'Commit to every shot through your full routine',
+          'Never follow a bad shot with a dumb shot',
+          'Take your medicine, make your bogey, move on',
+        ]}
+      />
+      <Para>
+        That's course management for most amateurs. It's not
+        complicated. It's just hard to actually do when there's
+        water on the left and your playing partners are watching.
+      </Para>
+      <Para>
+        The Way of the Playa is not a swing philosophy. It's a
+        mindset. And it's available to every player at every level
+        starting on the very next round they play.
+      </Para>
+
+      <Divider />
+
+      <H3>Resources</H3>
+      <Note variant="todo">
+        Verify all links before publishing.
+      </Note>
+      {RESOURCES.map((r) => (
+        <View
+          key={r.title}
+          style={{
+            borderTopWidth: 1,
+            borderColor: '#D9D2BF',
+            paddingVertical: 12,
+          }}
+        >
+          <Text
+            style={{
+              color: '#1C211C',
+              fontSize: 15,
+              fontStyle: 'italic',
+              fontWeight: '500',
+            }}
+          >
+            {r.title}
+            {r.by && (
+              <Text style={{ color: '#5C6356', fontStyle: 'normal', fontWeight: '400' }}>
+                {' '}— {r.by}
+              </Text>
+            )}
+          </Text>
+          <Text style={{ color: '#5C6356', fontSize: 14, lineHeight: 20, marginTop: 4 }}>
+            {r.note}
+          </Text>
+        </View>
+      ))}
+
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderColor: '#D9D2BF',
+          paddingTop: 18,
+          marginTop: 22,
+        }}
+      >
+        <Text style={{ ...KICKER, color: '#8A8B7E', lineHeight: 14 }}>
+          Last reviewed May 2026 · Draft, needs instructor review ·
+          Edit docs/learn/course-management.md to contribute
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+const RESOURCES = [
+  {
+    title: 'Golf Sidekick',
+    by: '',
+    note: 'YouTube. Search "Way of the Playa." Ego-free, score-focused course management for amateurs.',
+  },
+  {
+    title: 'The Upbeat Golfer (Manu)',
+    by: '',
+    note: 'YouTube. Process-driven mental approach and target commitment.',
+  },
+  {
+    title: 'Will Robins — The Scoring Method',
+    by: '',
+    note: 'thescoringmethod.com and YouTube @thescoringmethod. The Scoring Zone framework and modified scorecard system.',
+  },
+  {
+    title: '"Golf Is Not a Game of Perfect"',
+    by: 'Bob Rotella.',
+    note: 'The standard text on playing with what you have that day.',
   },
 ]

--- a/apps/mobile/components/learn/sections.ts
+++ b/apps/mobile/components/learn/sections.ts
@@ -53,7 +53,7 @@ export const LEARN_SECTIONS: LearnSection[] = [
     number: 'Section four',
     title: 'On the course',
     articles: [
-      { id: 'course-management', title: 'Course management guide', status: 'stub' },
+      { id: 'course-management', title: 'Course management guide', status: 'live' },
       { id: 'mental-game', title: 'Mental game and on-course psychology', status: 'stub' },
       { id: 'practice-vs-scoring-round', title: 'Practice round vs scoring round', status: 'stub' },
       { id: 'self-diagnosis', title: 'Self-diagnosis: finding your weaknesses', status: 'stub' },

--- a/apps/web/src/pages/learn/articles/CourseManagementArticle.tsx
+++ b/apps/web/src/pages/learn/articles/CourseManagementArticle.tsx
@@ -1,0 +1,787 @@
+import { useEffect, useState } from 'react'
+
+const DEV = import.meta.env.DEV
+const WIP_KEY = 'oga.learn.course-management.wip-dismissed'
+
+export function CourseManagementArticle() {
+  return (
+    <article
+      id="course-management"
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 22,
+        marginBottom: 32,
+      }}
+    >
+      <div className="kicker" style={{ marginBottom: 14 }}>
+        On the course · Draft
+      </div>
+      <h2
+        className="font-serif text-caddie-ink"
+        style={{
+          fontSize: 28,
+          fontWeight: 500,
+          fontStyle: 'italic',
+          letterSpacing: '-0.015em',
+          lineHeight: 1.15,
+          marginBottom: 18,
+        }}
+      >
+        Course management.
+      </h2>
+
+      <WipBanner />
+
+      <H3>You are not on the range anymore</H3>
+      <P>
+        The driving range is where you work on your golf swing. The
+        golf course is where you work on your score. These are two
+        different activities requiring two different mindsets.
+      </P>
+      <P>
+        On the range, perfect is the goal. On the course, useful is
+        the goal. The player who shoots 78 with ugly but functional
+        golf beats the player who shoots 84 hitting it beautifully.
+        Score is the only thing the card cares about.
+      </P>
+      <P>
+        The moment you step onto the first tee, stop being a golfer
+        working on your swing and become a player trying to shoot the
+        lowest number possible with the tools you have today. Your
+        clubs are tools to get the ball in the hole. Not every shot
+        needs to be pretty. It just needs to work.
+      </P>
+
+      <Hr />
+
+      <H3>Know your game, not your best game</H3>
+      <P>
+        Course management starts with brutal honesty about what you
+        actually do — not what you're capable of on a perfect day.
+      </P>
+      <P>
+        Every player has tendencies. You probably miss in a
+        predictable direction. You probably have a club you don't
+        fully trust. You probably have a shot shape that shows up
+        under pressure whether you want it or not.
+      </P>
+      <P>
+        The player who knows they hit a soft fade under pressure and
+        plays for it will outscore the player who aims straight and
+        gets "surprised" by the same fade every time.
+      </P>
+      <P>Before you play, know:</P>
+      <ul style={UL_STYLE}>
+        <li>Your predominant miss direction</li>
+        <li>
+          Which clubs you genuinely trust vs which ones you're hoping
+          work out
+        </li>
+        <li>
+          How far you actually carry the ball — not your best carry,
+          your reliable carry
+        </li>
+        <li>Where your game breaks down under pressure</li>
+      </ul>
+      <P>
+        Your OGA strokes gained data tells you this more clearly than
+        your gut does. If SG approach is -1.4 per round, your irons
+        are leaking. If SG putting is +0.8, your putter is an asset.
+        Play accordingly.
+      </P>
+
+      <Hr />
+
+      <H3>The confidence club rule</H3>
+      <P>
+        For any shot on the course, choose the club you can hit the
+        shot you need 8 times out of 10. Not the club that gets you
+        there if you pure it. Not the club that's technically correct
+        on paper. The club you trust.
+      </P>
+      <P>
+        Standing over a shot with doubt is one of the most expensive
+        things you can do in golf. A committed swing with the "wrong"
+        club almost always beats a tentative swing with the "right"
+        one. If you're between clubs and one of them makes you
+        nervous — hit the other one. Every time.
+      </P>
+      <P>
+        <strong>Off the tee:</strong> hit the longest club you can
+        confidently keep in play. That is it. You don't need a
+        perfect drive. You need a ball in play. A 220-yard drive in
+        the fairway beats a 280-yard drive in the trees every single
+        time. Driver is not always the answer and there is no shame
+        in hitting 3-wood or hybrid off the tee on a tight hole. The
+        Playa doesn't care what club anyone else is hitting. The
+        Playa cares about the score.
+      </P>
+
+      <Hr />
+
+      <H3>The Way of the Playa</H3>
+      <P>
+        Golf content creator Golf Sidekick has articulated a
+        philosophy called the Way of the Playa that every amateur
+        should understand. The core idea is simple: your ego is the
+        most expensive thing in your bag.
+      </P>
+      <P>
+        The Playa doesn't care about looking good. The Playa doesn't
+        care what club other people are hitting or whether the shot
+        looks impressive. The Playa cares about one thing — getting
+        the ball in the hole in as few strokes as possible — and
+        makes every decision in service of that goal.
+      </P>
+      <P>In practice this looks like:</P>
+      <ul style={UL_STYLE}>
+        <li>
+          Hitting 3-wood off the tee when driver puts you in trouble
+        </li>
+        <li>
+          Laying up short of a hazard even when you think you can
+          probably carry it
+        </li>
+        <li>
+          Chipping out sideways without shame when trees are in the
+          way
+        </li>
+        <li>
+          Playing to the fat part of the green instead of attacking a
+          tucked pin
+        </li>
+        <li>
+          Accepting the penalty and moving on instead of compounding
+          the mistake
+        </li>
+      </ul>
+      <P>
+        None of these decisions feel exciting. All of them save
+        strokes.
+      </P>
+      <P>
+        The Playa understands that golf is not a contest of who hits
+        the most impressive shots. It's a contest of who takes the
+        fewest. These are different games and most amateurs are
+        playing the wrong one.
+      </P>
+      <EditorialNote variant="research">
+        Golf Sidekick — YouTube. Search "Way of the Playa." Practical,
+        ego-free approach to scoring.
+      </EditorialNote>
+
+      <Hr />
+
+      <H3>Aim at the center of the green</H3>
+      <P>
+        This is a simple rule that will immediately save you strokes.
+      </P>
+      <P>
+        Most amateur golfers aim at the pin. The pin is rarely in the
+        center of the green. This means most amateur golfers are
+        constantly playing the hardest target available — the one
+        with the least margin for error.
+      </P>
+      <P>
+        Aim at the center of the green unless you have a very
+        specific, very good reason not to. The center of the green is
+        always a good shot. It never leaves you with a chip from the
+        wrong side. It gives you the most margin for your miss.
+      </P>
+      <P>
+        A birdie putt from 25 feet is still a birdie putt. What you
+        won't have is a chip from the rough, or a three-putt from 60
+        feet, or a false front situation because you were attacking a
+        back left pin from 170 yards.
+      </P>
+
+      <Hr />
+
+      <H3>Plan the hole backwards</H3>
+      <P>
+        Most amateurs walk up to the tee and hit their driver as far
+        as they can, then figure out what to do next. This is
+        reactive golf. It works well enough on straightforward holes
+        and falls apart on anything with a hazard, a difficult green,
+        or a premium on position.
+      </P>
+      <P>
+        The better approach is to plan the hole in reverse — starting
+        at the pin and working back to the tee.
+      </P>
+      <P>
+        Start on the green. Where is the pin today? Is it tucked
+        behind a bunker, on a shelf, near a false front? Now ask:
+        where on the green do I want to be putting from? That tells
+        you the ideal approach angle and the ideal landing zone for
+        your approach shot.
+      </P>
+      <P>
+        Now work back one more shot. To hit the approach from that
+        ideal spot, where does your previous shot need to land?
+        What's the right side of the fairway? What distance leaves
+        you a comfortable full shot rather than an awkward partial?
+      </P>
+      <P>
+        Now you know where your tee shot needs to go. Not just "in
+        the fairway" — a specific zone that sets up everything that
+        follows.
+      </P>
+      <P>
+        On a par 5: the same logic applies across three shots instead
+        of two. Where do you want to be for your pitch or third shot?
+        What does the layup need to accomplish to get you there?
+        Where does the tee shot need to go to make the layup
+        straightforward?
+      </P>
+      <P>
+        This is how caddies think. This is how tour professionals
+        think. And it's available to any amateur willing to spend 60
+        seconds on the tee thinking before swinging.
+      </P>
+      <P>
+        The practice round is where you build this map. Walk the hole
+        from green to tee. Stand where the approach shot will be
+        played from and look back at the fairway — you'll see angles
+        and landing zones you never noticed from the tee. That
+        knowledge compounds over time. Players who know a course well
+        aren't lucky. They've done this work.
+      </P>
+
+      <Hr />
+
+      <H3>Your free throw range</H3>
+      <P>
+        Every player has a distance where they feel genuinely
+        comfortable — a yardage where they know, without much doubt,
+        that they can get the ball close. This is your free throw
+        range.
+      </P>
+      <P>
+        For most amateurs it's somewhere between 50 and 100 yards.
+        For better players it might be 100-120. Whatever yours is,
+        identify it honestly.
+      </P>
+      <P>
+        Now start playing shots to leave yourself that number rather
+        than just maximizing distance on every shot. Course
+        management is partly about engineering the right approach
+        shot.
+      </P>
+      <P>
+        A 60-yard full wedge from a clean lie is easier than an
+        85-yard partial wedge from an awkward distance. Partial wedge
+        shots are hard. Full swing wedges are repeatable. Don't
+        manufacture difficult shots when strategy can avoid them.
+      </P>
+      <P>
+        Off the tee on a long par 4: consider what club leaves you a
+        full shot in your free throw range rather than just
+        grip-and-ripping driver. On a par 5: a layup to your number
+        beats going for it from 230 yards with a marginal lie.
+      </P>
+
+      <Hr />
+
+      <H3>The Scoring Method and the Scoring Zone</H3>
+      <P>
+        Will Robins, PGA member and Golf Digest Best Young Teachers
+        honoree, developed a course management system called The
+        Scoring Method that reframes how amateurs think about every
+        hole.
+      </P>
+      <P>
+        The core concept is the <strong>Scoring Zone</strong> — a
+        distance close enough to the green that you're confident you
+        can finish the hole in 3 more shots or fewer. For most
+        beginners and high handicappers, start at 75 yards. As your
+        game improves, tighten it.
+      </P>
+      <P>
+        The Scoring Method tracks just two things per hole on a
+        modified scorecard:
+      </P>
+      <H4>1. Did you reach the Scoring Zone in two shots?</H4>
+      <P>
+        After your first two shots, are you inside your distance? Yes
+        or no.
+      </P>
+      <H4>
+        2. Did you get up and down in 3 shots or fewer from the
+        Scoring Zone?
+      </H4>
+      <P>
+        Once inside your zone, did you convert? Or did you take 4
+        from there?
+      </P>
+      <P>
+        Track these two numbers for a few rounds and patterns emerge
+        fast. Most amateurs discover they're actually reaching the
+        Scoring Zone regularly — the problem is converting once they
+        get there. That tells you exactly where to practice.
+      </P>
+      <P>
+        The deeper power of this system is that it shifts your
+        measure of success away from score and toward process. A
+        player who reaches the Scoring Zone in two shots and converts
+        every time will shoot in the 80s almost regardless of how
+        their ball-striking looks. The system shows you what actually
+        matters hole by hole.
+      </P>
+      <EditorialNote variant="research">
+        Will Robins — The Scoring Method. thescoringmethod.com and
+        YouTube @thescoringmethod
+      </EditorialNote>
+
+      <Hr />
+
+      <H3>Think target, not trouble</H3>
+      <P>
+        When you stand over a shot thinking "don't hit it in the
+        water" — you are thinking about the water. Your brain doesn't
+        process the "don't" particularly well. You are programming
+        yourself to think about exactly what you want to avoid.
+      </P>
+      <P>
+        Instead: pick a specific, positive target. Not "away from the
+        bunker" but "at that tree on the left edge of the fairway." A
+        specific target gives your brain and body something to work
+        toward rather than something to flee from.
+      </P>
+      <P>
+        Manu from The Upbeat Golfer talks extensively about this —
+        committing fully to a target and a process before stepping
+        into the ball, then letting go of the result. The shot is
+        decided before you address it. Doubt after you've committed
+        is the enemy. Indecision kills golf shots more reliably than
+        poor mechanics.
+      </P>
+      <EditorialNote variant="research">
+        The Upbeat Golfer (Manu) — YouTube. Process-driven approach,
+        target commitment, playing without fear.
+      </EditorialNote>
+
+      <Hr />
+
+      <H3>Never make two mistakes in a row</H3>
+      <P>
+        You will hit bad shots. Every player at every level hits bad
+        shots. A bad shot is not a crisis — it's golf.
+      </P>
+      <P>
+        What turns a bad shot into a big number is the decision that
+        follows it.
+      </P>
+      <P>
+        After a bad shot, your only job is to get back into position.
+        Not to make up for it. Not to be a hero. Not to erase it.
+        Just to get somewhere you can play a normal golf shot from.
+      </P>
+      <P>
+        <strong>Punch out. Accept the bogey. Move on.</strong>
+      </P>
+      <P>
+        The double bogey that becomes a triple happens because the
+        player tried to thread the needle through the trees instead
+        of punching out sideways. The bogey that becomes a triple
+        happens because the player went for the green from an
+        impossible lie when laying up was obviously the right call.
+      </P>
+      <P>
+        A bogey is one over par. A triple is three over. The shots
+        themselves might be identical — the decisions are what
+        separate them. The Playa takes his medicine every time. The
+        Playa never follows a bad shot with a stupid shot.
+      </P>
+
+      <Hr />
+
+      <H3>Be process-driven, not results-driven</H3>
+      <P>
+        Most golfers think too little on the golf course. They step
+        up to the ball, swing, and react emotionally to wherever it
+        goes. There's no plan and no process.
+      </P>
+      <P>
+        But there's an opposite problem: once golfers start trying to
+        improve, they often start thinking too much. They outthink
+        themselves — grinding over swing thoughts, worrying about
+        mechanics, replaying the last bad shot — because they aren't
+        yet good enough to execute what they're thinking about.
+        Analysis paralysis is just as damaging as mindlessness.
+      </P>
+      <P>
+        The sweet spot is a clear, repeatable pre-shot process:
+      </P>
+      <ul style={UL_STYLE}>
+        <li>Pick a specific target</li>
+        <li>Commit fully to the shot</li>
+        <li>Go through your routine</li>
+        <li>Pull the trigger</li>
+      </ul>
+      <P>
+        That's it. You don't need to solve the hole. You need to play
+        one shot at a time with full commitment.
+      </P>
+      <P>
+        Try tracking — alongside your score — whether you committed
+        to each shot. Not whether it went where you wanted. Whether
+        you actually went through your process and pulled the trigger
+        without doubt.
+      </P>
+      <P>
+        Players who track this consistently find their scores drop
+        naturally. Not because they're grinding harder on results,
+        but because they've replaced reactive, emotional golf with a
+        repeatable approach. Results-oriented thinking leads to
+        tension, steering, and the exact outcome you were afraid of.
+        Process-oriented thinking gives you the best chance of
+        executing the shot.
+      </P>
+
+      <Hr />
+
+      <H3>The practice round</H3>
+      <P>
+        Course management is not something you can learn sitting in a
+        cart or watching videos. It's learned by doing — and the
+        practice round is where you do it.
+      </P>
+      <P>
+        Play two balls off the tee on every hole. Hit the aggressive
+        line you want to hit and the conservative line you think you
+        should hit. See which one actually leaves you the better
+        approach. You will be surprised how often the conservative
+        play gives you just as good an angle — sometimes better.
+      </P>
+      <P>
+        From trouble, play a second ball both ways. Hit the hero shot
+        you were tempted to play AND the safe punch-out. See what
+        actually happens. Most of the time the hero shot costs you
+        more than the punch-out. Your gut will stop suggesting it so
+        often once your eyes have seen the real results.
+      </P>
+      <P>
+        Use the practice round to find your Scoring Zone entry points
+        on each hole. Where do you need to be after two shots to have
+        a comfortable third? Work backwards from there to plan your
+        tee shot.
+      </P>
+      <P>
+        A practice round played thoughtfully and with intention is
+        worth more for course management than ten range sessions. The
+        course is the classroom.
+      </P>
+
+      <Hr />
+
+      <H3>Keep it simple</H3>
+      <P>
+        The fundamentals that will lower your score, in order of
+        importance:
+      </P>
+      <ul style={UL_STYLE}>
+        <li>Ball in play off the tee with the longest club you trust</li>
+        <li>Plan the hole backwards from the pin before you swing</li>
+        <li>Think about your target, not about where you can't go</li>
+        <li>Aim at the center of the green</li>
+        <li>Play to your free throw range</li>
+        <li>Commit to every shot through your full routine</li>
+        <li>Never follow a bad shot with a dumb shot</li>
+        <li>Take your medicine, make your bogey, move on</li>
+      </ul>
+      <P>
+        That's course management for most amateurs. It's not
+        complicated. It's just hard to actually do when there's water
+        on the left and your playing partners are watching.
+      </P>
+      <P>
+        The Way of the Playa is not a swing philosophy. It's a
+        mindset. And it's available to every player at every level
+        starting on the very next round they play.
+      </P>
+
+      <Hr />
+
+      <H3>Resources</H3>
+      <EditorialNote variant="todo">
+        Verify all links before publishing.
+      </EditorialNote>
+      <ResourceList
+        items={[
+          {
+            title: 'Golf Sidekick',
+            note: 'YouTube. Search "Way of the Playa." Ego-free, score-focused course management for amateurs.',
+          },
+          {
+            title: 'The Upbeat Golfer (Manu)',
+            note: 'YouTube. Process-driven mental approach and target commitment.',
+          },
+          {
+            title: 'Will Robins — The Scoring Method',
+            note: 'thescoringmethod.com and YouTube @thescoringmethod. The Scoring Zone framework and modified scorecard system.',
+          },
+          {
+            title: '"Golf Is Not a Game of Perfect"',
+            by: 'Bob Rotella.',
+            note: 'The standard text on playing with what you have that day.',
+          },
+        ]}
+      />
+
+      <Footer />
+    </article>
+  )
+}
+
+// ===========================================================================
+// Components
+// ===========================================================================
+
+function WipBanner() {
+  const [dismissed, setDismissed] = useState(false)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (window.sessionStorage.getItem(WIP_KEY) === '1') setDismissed(true)
+  }, [])
+  if (dismissed) return null
+  return (
+    <div
+      role="note"
+      style={{
+        background: '#FBF8F1',
+        borderLeft: '3px solid #A66A1F',
+        borderTop: '1px solid #D9D2BF',
+        borderRight: '1px solid #D9D2BF',
+        borderBottom: '1px solid #D9D2BF',
+        borderRadius: 2,
+        padding: '14px 18px',
+        marginBottom: 22,
+        display: 'flex',
+        gap: 14,
+        alignItems: 'flex-start',
+      }}
+    >
+      <div style={{ flex: 1 }}>
+        <div className="kicker" style={{ marginBottom: 6, color: '#A66A1F' }}>
+          Work in progress
+        </div>
+        <p
+          className="text-caddie-ink"
+          style={{ fontSize: 14, lineHeight: 1.55 }}
+        >
+          This guide is a work in progress and is being reviewed for
+          accuracy. Treat specific technique advice as provisional
+          until the notice is removed.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={() => {
+          window.sessionStorage.setItem(WIP_KEY, '1')
+          setDismissed(true)
+        }}
+        className="font-mono uppercase"
+        style={{
+          background: 'transparent',
+          border: '1px solid #D9D2BF',
+          padding: '6px 10px',
+          fontSize: 10,
+          letterSpacing: '0.14em',
+          color: '#5C6356',
+          cursor: 'pointer',
+          borderRadius: 2,
+        }}
+      >
+        Dismiss
+      </button>
+    </div>
+  )
+}
+
+function H3({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 22,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        letterSpacing: '-0.01em',
+        lineHeight: 1.2,
+        marginTop: 22,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </h3>
+  )
+}
+
+function H4({ children }: { children: React.ReactNode }) {
+  return (
+    <h4
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 17,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        marginTop: 18,
+        marginBottom: 8,
+      }}
+    >
+      {children}
+    </h4>
+  )
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="text-caddie-ink"
+      style={{
+        fontSize: 15,
+        lineHeight: 1.6,
+        maxWidth: 680,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </p>
+  )
+}
+
+function Hr() {
+  return (
+    <div
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        margin: '22px 0',
+      }}
+    />
+  )
+}
+
+const UL_STYLE: React.CSSProperties = {
+  listStyle: 'disc',
+  paddingLeft: 20,
+  margin: '8px 0 14px',
+  fontSize: 15,
+  lineHeight: 1.7,
+  color: '#1C211C',
+  maxWidth: 680,
+}
+
+interface ResourceItem {
+  title: string
+  by?: string
+  note: string
+}
+
+function ResourceList({ items }: { items: ResourceItem[] }) {
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 14px', maxWidth: 680 }}>
+      {items.map((r) => (
+        <li
+          key={r.title}
+          style={{
+            padding: '12px 0',
+            borderTop: '1px solid #D9D2BF',
+          }}
+        >
+          <div
+            className="font-serif text-caddie-ink"
+            style={{ fontSize: 15, fontWeight: 500, fontStyle: 'italic' }}
+          >
+            {r.title}
+            {r.by && (
+              <span className="text-caddie-ink-dim" style={{ fontStyle: 'normal', fontWeight: 400 }}>
+                {' '}— {r.by}
+              </span>
+            )}
+          </div>
+          <div className="text-caddie-ink-dim" style={{ fontSize: 14, lineHeight: 1.55, marginTop: 4 }}>
+            {r.note}
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function EditorialNote({
+  variant,
+  inline,
+  children,
+}: {
+  variant: 'research' | 'todo'
+  inline?: boolean
+  children: React.ReactNode
+}) {
+  if (!DEV) return null
+  const tone = variant === 'research' ? '#1F3D2C' : '#A66A1F'
+  const label = variant === 'research' ? 'Source' : 'Todo'
+  if (inline) {
+    return (
+      <span
+        className="font-mono uppercase"
+        style={{
+          fontSize: 10,
+          letterSpacing: '0.14em',
+          color: tone,
+          marginLeft: 8,
+        }}
+      >
+        [{label}: {children}]
+      </span>
+    )
+  }
+  return (
+    <div
+      style={{
+        background: '#EBE5D6',
+        borderLeft: `3px solid ${tone}`,
+        padding: '10px 14px',
+        marginBottom: 14,
+        maxWidth: 680,
+      }}
+    >
+      <div
+        className="font-mono uppercase"
+        style={{
+          fontSize: 10,
+          letterSpacing: '0.14em',
+          color: tone,
+          marginBottom: 4,
+        }}
+      >
+        {label} · dev only
+      </div>
+      <div
+        className="text-caddie-ink-dim"
+        style={{ fontSize: 13, lineHeight: 1.5, fontStyle: 'italic' }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Footer() {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 1.6,
+      }}
+    >
+      Last reviewed May 2026 · Draft, needs instructor review · Edit
+      docs/learn/course-management.md to contribute
+    </div>
+  )
+}

--- a/apps/web/src/pages/learn/components/LiveArticle.tsx
+++ b/apps/web/src/pages/learn/components/LiveArticle.tsx
@@ -1,3 +1,4 @@
+import { CourseManagementArticle } from '../articles/CourseManagementArticle'
 import { HowToPracticeArticle } from '../articles/HowToPracticeArticle'
 import { StubEntry } from './ArticleStub'
 
@@ -5,6 +6,8 @@ export function LiveArticle({ id, title }: { id: string; title: string }) {
   switch (id) {
     case 'how-to-practice':
       return <HowToPracticeArticle />
+    case 'course-management':
+      return <CourseManagementArticle />
     default:
       return <StubEntry id={id} title={title} />
   }

--- a/apps/web/src/pages/learn/data/learnSections.ts
+++ b/apps/web/src/pages/learn/data/learnSections.ts
@@ -51,7 +51,7 @@ export const LEARN_SECTIONS: LearnSection[] = [
     number: 'Section four',
     title: 'On the course',
     articles: [
-      { id: 'course-management', title: 'Course management guide', status: 'stub' },
+      { id: 'course-management', title: 'Course management guide', status: 'live' },
       { id: 'mental-game', title: 'Mental game and on-course psychology', status: 'stub' },
       { id: 'practice-vs-scoring-round', title: 'Practice round vs scoring round', status: 'stub' },
       { id: 'self-diagnosis', title: 'Self-diagnosis: finding your weaknesses', status: 'stub' },

--- a/docs/learn/course-management.md
+++ b/docs/learn/course-management.md
@@ -1,0 +1,244 @@
+---
+title: Course Management
+section: On the Course
+status: draft
+last_reviewed: 2026-05
+contributors: []
+content_warning: |
+  This article is a work in progress. The structure and core
+  ideas are established but individual sections need deeper
+  research, better resource links, and review by a qualified
+  golf instructor before being considered complete.
+  Do not treat any specific technique advice as authoritative
+  until this notice is removed.
+---
+
+# Course Management
+
+> **Work in progress.** This article is being developed.
+> Core structure is in place but content needs review,
+> additional research, and input from qualified instructors.
+> Resource links are placeholders — verify before using.
+
+## You are not on the range anymore
+
+The driving range is where you work on your golf swing. The golf course is where you work on your score. These are two different activities requiring two different mindsets.
+
+On the range, perfect is the goal. On the course, useful is the goal. The player who shoots 78 with ugly but functional golf beats the player who shoots 84 hitting it beautifully. Score is the only thing the card cares about.
+
+The moment you step onto the first tee, stop being a golfer working on your swing and become a player trying to shoot the lowest number possible with the tools you have today. Your clubs are tools to get the ball in the hole. Not every shot needs to be pretty. It just needs to work.
+
+---
+
+## Know your game, not your best game
+
+Course management starts with brutal honesty about what you actually do — not what you're capable of on a perfect day.
+
+Every player has tendencies. You probably miss in a predictable direction. You probably have a club you don't fully trust. You probably have a shot shape that shows up under pressure whether you want it or not.
+
+The player who knows they hit a soft fade under pressure and plays for it will outscore the player who aims straight and gets "surprised" by the same fade every time.
+
+Before you play, know:
+- Your predominant miss direction
+- Which clubs you genuinely trust vs which ones you're hoping work out
+- How far you actually carry the ball — not your best carry, your reliable carry
+- Where your game breaks down under pressure
+
+Your OGA strokes gained data tells you this more clearly than your gut does. If SG approach is -1.4 per round, your irons are leaking. If SG putting is +0.8, your putter is an asset. Play accordingly.
+
+---
+
+## The confidence club rule
+
+For any shot on the course, choose the club you can hit the shot you need 8 times out of 10. Not the club that gets you there if you pure it. Not the club that's technically correct on paper. The club you trust.
+
+Standing over a shot with doubt is one of the most expensive things you can do in golf. A committed swing with the "wrong" club almost always beats a tentative swing with the "right" one. If you're between clubs and one of them makes you nervous — hit the other one. Every time.
+
+**Off the tee:** hit the longest club you can confidently keep in play. That is it. You don't need a perfect drive. You need a ball in play. A 220-yard drive in the fairway beats a 280-yard drive in the trees every single time. Driver is not always the answer and there is no shame in hitting 3-wood or hybrid off the tee on a tight hole. The Playa doesn't care what club anyone else is hitting. The Playa cares about the score.
+
+---
+
+## The Way of the Playa
+
+Golf content creator Golf Sidekick has articulated a philosophy called the Way of the Playa that every amateur should understand. The core idea is simple: your ego is the most expensive thing in your bag.
+
+The Playa doesn't care about looking good. The Playa doesn't care what club other people are hitting or whether the shot looks impressive. The Playa cares about one thing — getting the ball in the hole in as few strokes as possible — and makes every decision in service of that goal.
+
+In practice this looks like:
+- Hitting 3-wood off the tee when driver puts you in trouble
+- Laying up short of a hazard even when you think you can probably carry it
+- Chipping out sideways without shame when trees are in the way
+- Playing to the fat part of the green instead of attacking a tucked pin
+- Accepting the penalty and moving on instead of compounding the mistake
+
+None of these decisions feel exciting. All of them save strokes.
+
+The Playa understands that golf is not a contest of who hits the most impressive shots. It's a contest of who takes the fewest. These are different games and most amateurs are playing the wrong one.
+
+> 📚 *Golf Sidekick — YouTube. Search "Way of the Playa." Practical, ego-free approach to scoring.*
+
+---
+
+## Aim at the center of the green
+
+This is a simple rule that will immediately save you strokes.
+
+Most amateur golfers aim at the pin. The pin is rarely in the center of the green. This means most amateur golfers are constantly playing the hardest target available — the one with the least margin for error.
+
+Aim at the center of the green unless you have a very specific, very good reason not to. The center of the green is always a good shot. It never leaves you with a chip from the wrong side. It gives you the most margin for your miss.
+
+A birdie putt from 25 feet is still a birdie putt. What you won't have is a chip from the rough, or a three-putt from 60 feet, or a false front situation because you were attacking a back left pin from 170 yards.
+
+---
+
+## Plan the hole backwards
+
+Most amateurs walk up to the tee and hit their driver as far as they can, then figure out what to do next. This is reactive golf. It works well enough on straightforward holes and falls apart on anything with a hazard, a difficult green, or a premium on position.
+
+The better approach is to plan the hole in reverse — starting at the pin and working back to the tee.
+
+Start on the green. Where is the pin today? Is it tucked behind a bunker, on a shelf, near a false front? Now ask: where on the green do I want to be putting from? That tells you the ideal approach angle and the ideal landing zone for your approach shot.
+
+Now work back one more shot. To hit the approach from that ideal spot, where does your previous shot need to land? What's the right side of the fairway? What distance leaves you a comfortable full shot rather than an awkward partial?
+
+Now you know where your tee shot needs to go. Not just "in the fairway" — a specific zone that sets up everything that follows.
+
+On a par 5: the same logic applies across three shots instead of two. Where do you want to be for your pitch or third shot? What does the layup need to accomplish to get you there? Where does the tee shot need to go to make the layup straightforward?
+
+This is how caddies think. This is how tour professionals think. And it's available to any amateur willing to spend 60 seconds on the tee thinking before swinging.
+
+The practice round is where you build this map. Walk the hole from green to tee. Stand where the approach shot will be played from and look back at the fairway — you'll see angles and landing zones you never noticed from the tee. That knowledge compounds over time. Players who know a course well aren't lucky. They've done this work.
+
+---
+
+## Your free throw range
+
+Every player has a distance where they feel genuinely comfortable — a yardage where they know, without much doubt, that they can get the ball close. This is your free throw range.
+
+For most amateurs it's somewhere between 50 and 100 yards. For better players it might be 100-120. Whatever yours is, identify it honestly.
+
+Now start playing shots to leave yourself that number rather than just maximizing distance on every shot. Course management is partly about engineering the right approach shot.
+
+A 60-yard full wedge from a clean lie is easier than an 85-yard partial wedge from an awkward distance. Partial wedge shots are hard. Full swing wedges are repeatable. Don't manufacture difficult shots when strategy can avoid them.
+
+Off the tee on a long par 4: consider what club leaves you a full shot in your free throw range rather than just grip-and-ripping driver. On a par 5: a layup to your number beats going for it from 230 yards with a marginal lie.
+
+---
+
+## The Scoring Method and the Scoring Zone
+
+Will Robins, PGA member and Golf Digest Best Young Teachers honoree, developed a course management system called The Scoring Method that reframes how amateurs think about every hole.
+
+The core concept is the **Scoring Zone** — a distance close enough to the green that you're confident you can finish the hole in 3 more shots or fewer. For most beginners and high handicappers, start at 75 yards. As your game improves, tighten it.
+
+The Scoring Method tracks just two things per hole on a modified scorecard:
+
+**1. Did you reach the Scoring Zone in two shots?**
+After your first two shots, are you inside your distance? Yes or no.
+
+**2. Did you get up and down in 3 shots or fewer from the Scoring Zone?**
+Once inside your zone, did you convert? Or did you take 4 from there?
+
+Track these two numbers for a few rounds and patterns emerge fast. Most amateurs discover they're actually reaching the Scoring Zone regularly — the problem is converting once they get there. That tells you exactly where to practice.
+
+The deeper power of this system is that it shifts your measure of success away from score and toward process. A player who reaches the Scoring Zone in two shots and converts every time will shoot in the 80s almost regardless of how their ball-striking looks. The system shows you what actually matters hole by hole.
+
+> 📚 *Will Robins — The Scoring Method. thescoringmethod.com and YouTube @thescoringmethod*
+
+---
+
+## Think target, not trouble
+
+When you stand over a shot thinking "don't hit it in the water" — you are thinking about the water. Your brain doesn't process the "don't" particularly well. You are programming yourself to think about exactly what you want to avoid.
+
+Instead: pick a specific, positive target. Not "away from the bunker" but "at that tree on the left edge of the fairway." A specific target gives your brain and body something to work toward rather than something to flee from.
+
+Manu from The Upbeat Golfer talks extensively about this — committing fully to a target and a process before stepping into the ball, then letting go of the result. The shot is decided before you address it. Doubt after you've committed is the enemy. Indecision kills golf shots more reliably than poor mechanics.
+
+> 📚 *The Upbeat Golfer (Manu) — YouTube. Process-driven approach, target commitment, playing without fear.*
+
+---
+
+## Never make two mistakes in a row
+
+You will hit bad shots. Every player at every level hits bad shots. A bad shot is not a crisis — it's golf.
+
+What turns a bad shot into a big number is the decision that follows it.
+
+After a bad shot, your only job is to get back into position. Not to make up for it. Not to be a hero. Not to erase it. Just to get somewhere you can play a normal golf shot from.
+
+**Punch out. Accept the bogey. Move on.**
+
+The double bogey that becomes a triple happens because the player tried to thread the needle through the trees instead of punching out sideways. The bogey that becomes a triple happens because the player went for the green from an impossible lie when laying up was obviously the right call.
+
+A bogey is one over par. A triple is three over. The shots themselves might be identical — the decisions are what separate them. The Playa takes his medicine every time. The Playa never follows a bad shot with a stupid shot.
+
+---
+
+## Be process-driven, not results-driven
+
+Most golfers think too little on the golf course. They step up to the ball, swing, and react emotionally to wherever it goes. There's no plan and no process.
+
+But there's an opposite problem: once golfers start trying to improve, they often start thinking too much. They outthink themselves — grinding over swing thoughts, worrying about mechanics, replaying the last bad shot — because they aren't yet good enough to execute what they're thinking about. Analysis paralysis is just as damaging as mindlessness.
+
+The sweet spot is a clear, repeatable pre-shot process:
+- Pick a specific target
+- Commit fully to the shot
+- Go through your routine
+- Pull the trigger
+
+That's it. You don't need to solve the hole. You need to play one shot at a time with full commitment.
+
+Try tracking — alongside your score — whether you committed to each shot. Not whether it went where you wanted. Whether you actually went through your process and pulled the trigger without doubt.
+
+Players who track this consistently find their scores drop naturally. Not because they're grinding harder on results, but because they've replaced reactive, emotional golf with a repeatable approach. Results-oriented thinking leads to tension, steering, and the exact outcome you were afraid of. Process-oriented thinking gives you the best chance of executing the shot.
+
+---
+
+## The practice round
+
+Course management is not something you can learn sitting in a cart or watching videos. It's learned by doing — and the practice round is where you do it.
+
+Play two balls off the tee on every hole. Hit the aggressive line you want to hit and the conservative line you think you should hit. See which one actually leaves you the better approach. You will be surprised how often the conservative play gives you just as good an angle — sometimes better.
+
+From trouble, play a second ball both ways. Hit the hero shot you were tempted to play AND the safe punch-out. See what actually happens. Most of the time the hero shot costs you more than the punch-out. Your gut will stop suggesting it so often once your eyes have seen the real results.
+
+Use the practice round to find your Scoring Zone entry points on each hole. Where do you need to be after two shots to have a comfortable third? Work backwards from there to plan your tee shot.
+
+A practice round played thoughtfully and with intention is worth more for course management than ten range sessions. The course is the classroom.
+
+---
+
+## Keep it simple
+
+The fundamentals that will lower your score, in order of importance:
+
+- Ball in play off the tee with the longest club you trust
+- Plan the hole backwards from the pin before you swing
+- Think about your target, not about where you can't go
+- Aim at the center of the green
+- Play to your free throw range
+- Commit to every shot through your full routine
+- Never follow a bad shot with a dumb shot
+- Take your medicine, make your bogey, move on
+
+That's course management for most amateurs. It's not complicated. It's just hard to actually do when there's water on the left and your playing partners are watching.
+
+The Way of the Playa is not a swing philosophy. It's a mindset. And it's available to every player at every level starting on the very next round they play.
+
+---
+
+## Resources
+
+> ⚠️ *Verify all links before publishing*
+
+- **Golf Sidekick** — YouTube. Search "Way of the Playa." Ego-free, score-focused course management for amateurs.
+- **The Upbeat Golfer (Manu)** — YouTube. Process-driven mental approach and target commitment.
+- **Will Robins — The Scoring Method** — thescoringmethod.com and YouTube @thescoringmethod. The Scoring Zone framework and modified scorecard system.
+- **"Golf Is Not a Game of Perfect"** — Bob Rotella. The standard text on playing with what you have that day.
+
+---
+
+*Last reviewed: May 2026*
+*Status: Draft — needs instructor review before publishing*
+*To contribute: open a PR editing docs/learn/course-management.md*


### PR DESCRIPTION
## Summary

- Wires the course-management Learn article (web + mobile), same pattern as how-to-practice (PR #181).
- Adds `CourseManagementArticle.tsx` on web, mobile article fn in `[article].tsx`, flips status to `live` in both `learnSections.ts` files (TOC drops the `Soon` badge automatically).
- WIP banner at top of both, dismissable per session (web uses `sessionStorage`; mobile local state, mirroring how-to-practice).
- Editorial `Source`/`Todo` notes are dev-only — invisible in production builds.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm --filter web build`
- [x] mobile `npm run typecheck`
- [ ] Manual: open `/learn` on web, expand "On the course", confirm full article renders + WIP banner dismisses
- [ ] Manual: open Learn → Course management guide on mobile, confirm article renders + WIP banner dismisses