### PR TITLE
Learn navigation refactor + content batch 2

### DIFF
--- a/apps/mobile/app/(app)/learn/[article].tsx
+++ b/apps/mobile/app/(app)/learn/[article].tsx
@@ -208,43 +208,219 @@ function BenchmarksArticle() {
 function GlossaryArticle() {
   return (
     <View>
-      <Text style={{ ...KICKER, marginBottom: 10 }}>Glossary</Text>
-      <Text style={TITLE}>Stats glossary.</Text>
-      <Text style={BODY}>
-        The terms used across the dashboard, defined in plain English.
-      </Text>
+      <Text style={{ ...KICKER, marginBottom: 10 }}>Understanding the game · Draft</Text>
+      <Text style={TITLE}>Glossary of golf terms.</Text>
+      <Para>
+        The basics — birdie, bogey, par, handicap, GIR — are covered
+        in the app's stat reference section. This glossary focuses
+        on the terms that come up once you start playing regularly
+        and trying to improve.
+      </Para>
 
-      {GLOSSARY.map((g) => (
-        <View
-          key={g.kicker}
-          style={{
-            borderTopWidth: 1,
-            borderColor: '#D9D2BF',
-            paddingTop: 18,
-            marginTop: 18,
-          }}
-        >
-          <Text style={{ ...KICKER, marginBottom: 8 }}>{g.kicker}</Text>
-          <Text
-            style={{
-              color: '#1C211C',
-              fontSize: 20,
-              fontStyle: 'italic',
-              fontWeight: '500',
-              lineHeight: 26,
-              marginBottom: 8,
-            }}
-          >
-            {g.title}
-          </Text>
-          <Text style={{ color: '#1C211C', fontSize: 15, lineHeight: 22 }}>
-            {g.body}
-          </Text>
+      {GLOSSARY_GROUPS.map((group) => (
+        <View key={group.heading}>
+          <Divider />
+          <H3>{group.heading}</H3>
+          {group.intro && <Para>{group.intro}</Para>}
+          {group.terms.map((t) => (
+            <Term key={t.name} name={t.name}>
+              {t.body}
+            </Term>
+          ))}
         </View>
       ))}
+
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderColor: '#D9D2BF',
+          paddingTop: 18,
+          marginTop: 22,
+        }}
+      >
+        <Text style={{ ...KICKER, color: '#8A8B7E', lineHeight: 14 }}>
+          Last reviewed May 2026 · Draft, being expanded · Edit
+          docs/learn/glossary.md to contribute
+        </Text>
+      </View>
     </View>
   )
 }
+
+function Term({ name, children }: { name: string; children: React.ReactNode }) {
+  return (
+    <View
+      style={{
+        borderTopWidth: 1,
+        borderColor: '#D9D2BF',
+        paddingVertical: 12,
+      }}
+    >
+      <Text
+        style={{
+          color: '#1C211C',
+          fontSize: 16,
+          fontStyle: 'italic',
+          fontWeight: '500',
+          marginBottom: 4,
+        }}
+      >
+        {name}
+      </Text>
+      <Text style={{ color: '#1C211C', fontSize: 14, lineHeight: 20 }}>
+        {children}
+      </Text>
+    </View>
+  )
+}
+
+interface GlossaryTerm {
+  name: string
+  body: string
+}
+
+interface GlossaryGroup {
+  heading: string
+  intro?: string
+  terms: GlossaryTerm[]
+}
+
+const GLOSSARY_GROUPS: GlossaryGroup[] = [
+  {
+    heading: 'Shot shapes and ball flight',
+    terms: [
+      { name: 'Draw', body: 'A controlled shot that curves gently from right to left for a right-handed golfer. Typically more roll than a fade. Not to be confused with a hook.' },
+      { name: 'Fade', body: 'A controlled shot that curves gently from left to right for a right-handed golfer. Tour pros often prefer it because the ball lands softer with less roll.' },
+      { name: 'Hook', body: 'An uncontrolled, exaggerated draw. Often the result of a closed clubface at impact.' },
+      { name: 'Slice', body: 'An uncontrolled, exaggerated fade. The most common miss for amateurs — open face plus out-to-in path.' },
+      { name: 'Push', body: 'A shot that flies straight but to the right of the target with no curve. Different from a fade — wrong line, no shape.' },
+      { name: 'Pull', body: 'A shot that flies straight but to the left of the target with no curve. Different from a hook.' },
+      { name: 'Stinger', body: 'A low, penetrating shot hit with minimal loft, played into wind or under trees. Made famous by Tiger Woods.' },
+      { name: 'Punch shot', body: 'A low, controlled shot played with a shortened swing. Stays low, runs out after landing.' },
+      { name: 'Flier', body: 'A shot that travels farther than expected because grass gets between face and ball, reducing backspin. Common from rough.' },
+      { name: 'Spinner', body: 'A wedge struck cleanly into a soft green that spins back toward the player after landing. Useful when the pin is at the back of the green.' },
+      { name: 'Knuckleball', body: 'A shot with almost no spin — the ball flutters unpredictably. Often happens out of thick rough.' },
+      { name: 'Texas Wedge', body: 'Using a putter from off the green — fringe, apron, or even light rough. Highest-percentage shot when the ground between ball and hole is firm and flat.' },
+      { name: 'DOD (Driver Off the Deck)', body: 'Hitting a driver without a tee, from the fairway or rough. One of the hardest shots in golf. Made famous by social media creator "DOD King" Carter Smith.' },
+      { name: 'Thai Spinner', body: 'A low, high-spin shot popularized by Kiradech Aphibarnrat — steep outside-in lob wedge from a tight or grainy lie. Reached wider audiences when Keith Mitchell pulled it off at the 2025 Houston Open.' },
+    ],
+  },
+  {
+    heading: 'Short game shots',
+    terms: [
+      { name: 'Chip', body: 'Low, running shot from just off the green. Less-lofted club, putting-style stroke. Land just on, let it roll.' },
+      { name: 'Pitch', body: 'Higher, softer shot from 20–80 yards. Wedge, fuller swing than a chip. Harder because partial swings demand distance control.' },
+      { name: 'Bump and run', body: 'Mid-iron chip that lands short of the green and runs onto the surface. Favored in firm conditions. Lower risk than a flop.' },
+      { name: 'Flop shot', body: 'High, soft lob-wedge shot that lands softly with minimal roll. High risk — easy to skull or chunk if not practiced.' },
+      { name: 'Chunk / Fat shot', body: 'Hitting the ground behind the ball. Club digs, decelerates, ball comes up well short.' },
+      { name: 'Scalp / Thin / Blade', body: 'Hitting the ball with the leading edge instead of the face. Comes out low and hot, runs through the green.' },
+      { name: 'Flush', body: 'Slang for a perfectly struck shot — clean contact in the center of the face.' },
+    ],
+  },
+  {
+    heading: 'Putting terms',
+    terms: [
+      { name: 'Pin high / Hole high', body: 'Approach finishes level with the pin (correct distance, off line). Generally a good miss — putting across slope, not up or down it.' },
+      { name: 'Spinner (putting)', body: 'A putt that lips out spinning — catches the edge, spins around the rim, comes back out. See also: lip out.' },
+    ],
+  },
+  {
+    heading: 'Course and green terminology',
+    terms: [
+      { name: 'Below the hole', body: 'The lower side of the cup on a sloped green. Leaves an uphill putt — preferred. Tour players always try to stay below.' },
+      { name: 'Above the hole', body: 'The upper side. Leaves a downhill putt — faster, harder to control. Avoid.' },
+      { name: 'Short side', body: 'The side of the green closest to a tucked pin. Missing short side leaves the hardest possible chip. Do not short side yourself.' },
+      { name: 'Grain', body: 'Direction grass grows on a green. Bermuda grain strongly affects speed and break. With the grain is faster; against is slower.' },
+      { name: 'Stimp / Stimpmeter', body: 'Device that measures green speed. 10 = club golf, 12–13 = major championship, 14+ = extremely fast.' },
+      { name: 'False front', body: 'A green that slopes back toward the fairway at the front. Approach shots that land on it roll back off. Take more club.' },
+      { name: 'Apron / Fringe', body: 'Short grass surrounding the green — shorter than fairway, longer than green. Putt-able with care.' },
+      { name: 'Dogleg', body: 'A hole that bends left or right between tee and green.' },
+      { name: 'Bailout', body: 'A safe area to miss to when the primary target is dangerous. Identify before swinging.' },
+      { name: 'Big ball (Earth)', body: 'Slang for chunking — hitting the ground before the ball. The "big ball" is the Earth; you want to hit the small one first.' },
+    ],
+  },
+  {
+    heading: 'Divots and course care',
+    terms: [
+      { name: 'Divot', body: 'The chunk of turf displaced (or the hole left). Replace it, or fill with sand-mix where provided. Hitting from a divot is no relief — play it as it lies.' },
+      { name: 'Pitch mark / Ball mark', body: 'The indentation an approach leaves on the green. Repair yours and any nearby. Push edges down and smooth — do not lift the center.' },
+      { name: 'Burn mark', body: 'Browning on one side of the cup where grain grows away from the cup edge. The healthy side is with the grain; the burned side is into it. Quick read for grain on Bermuda greens.' },
+      { name: 'Divot tool / Pitch fork', body: 'Tool for repairing pitch marks. Insert tines at the edges, push inward. Never pry up from the center.' },
+    ],
+  },
+  {
+    heading: 'Scoring and competition',
+    terms: [
+      { name: 'Snowman', body: 'A score of 8 on a hole — the number 8 looks like a snowman.' },
+      { name: 'Blow up hole', body: 'A hole where everything goes wrong and a large number is recorded. Mental game = minimizing how many.' },
+      { name: 'Honors', body: 'The right to tee off first. In stroke play, goes to the lowest score on the previous hole.' },
+      { name: 'Ready golf', body: 'Hit when you are ready, not strictly by honors order. Speeds pace of play. Standard in casual rounds.' },
+      { name: 'Skins', body: 'Each hole worth a fixed amount. Win the hole outright (no ties) and you win the skin. Ties carry over and stack.' },
+      { name: 'Match play', body: 'Score tracked hole by hole rather than total strokes. Win a hole, go one up.' },
+      { name: 'Stroke play', body: 'Total strokes over the round. Lowest total wins.' },
+      { name: 'Stableford', body: 'Points based on score relative to par. Bogey 1, par 2, birdie 3, eagle 4. Encourages aggressive play.' },
+      { name: 'Nassau', body: 'A bet split into front nine, back nine, and full 18 — three separate match-play competitions.' },
+      { name: 'Press', body: 'A new side bet started mid-round in a Nassau or match play, typically when down by two.' },
+      { name: 'Dormie', body: 'In match play, leading by the same number of holes as remain. Cannot lose — worst outcome is a tie.' },
+    ],
+  },
+  {
+    heading: 'Lie and course conditions',
+    terms: [
+      { name: 'Tight lie', body: 'A ball sitting on bare or closely-mown ground with very little grass underneath. Demands clean contact.' },
+      { name: 'Plugged lie / Fried egg', body: 'Ball embedded in its own pitch mark, often in a bunker — only the top is visible, surrounded by disturbed sand.' },
+      { name: 'Hardpan', body: 'Very firm, dry ground with little or no grass. Produces low running shots; demands precise contact.' },
+    ],
+  },
+  {
+    heading: 'Equipment terms',
+    terms: [
+      { name: 'Muscle back', body: 'Iron with weight in a solid mass behind the center of the face — a blade. Less forgiving than cavity backs but unmatched feedback when struck pure.' },
+      { name: 'Cavity back', body: 'Iron with weight redistributed to the perimeter, creating a cavity. More forgiving on off-center hits. Standard for most amateurs.' },
+      { name: 'Loft', body: 'Angle of the clubface relative to vertical. Higher loft = higher flight, less distance. Lower = lower flight, more distance.' },
+      { name: 'Shaft flex', body: 'How much the shaft bends during the swing. Ladies, Senior, Regular, Stiff, Extra Stiff. Wrong flex affects flight and distance.' },
+      { name: 'Lie angle', body: 'Angle between shaft and ground when soled at address. Wrong lie angle pushes shots consistently left or right even with a good swing.' },
+    ],
+  },
+  {
+    heading: 'Slang and culture',
+    terms: [
+      { name: 'Worm burner', body: 'A shot that never gets airborne, rolling along the ground. Usually a topped or thinned iron.' },
+      { name: 'Shank', body: 'A shot struck off the hosel that fires hard right for a right-handed player. One of the most dreaded misses in golf — some players will not say the word.' },
+      { name: 'Yips', body: 'Involuntary muscle twitches or nerves on short putts (or chips). More mental than physical. Has ended careers.' },
+      { name: 'Cabbage', body: 'Thick, deep rough where the ball sits down and is hard to advance. You are just trying to get out.' },
+      { name: 'Lip out', body: 'A putt that catches the edge of the cup but does not fall in. One of the most frustrating outcomes in golf.' },
+      { name: 'Bite', body: 'What golfers shout asking a ball to stop on the green. Also a verb: "I need this to bite."' },
+      { name: 'Barkie', body: 'Making par after your ball hits a tree. Counted as bonus points in some social games.' },
+      { name: 'Greenie', body: 'In a group game, awarded to the player who hits the green in regulation on a par 3 closest to the pin.' },
+    ],
+  },
+  {
+    heading: 'Rules terms worth knowing',
+    terms: [
+      { name: 'Relief', body: 'When the rules let you move your ball without penalty — cart path, temporary water, GUR, embedded ball.' },
+      { name: 'Penalty area', body: 'Modern rules term (since 2019) for what was a water hazard. Yellow = two relief options, red = three. You may now ground your club.' },
+      { name: 'Ground under repair (GUR)', body: 'Areas marked for maintenance. Free relief.' },
+      { name: 'Provisional ball', body: 'A second ball played when the first may be lost or out of bounds. Must be announced. Saves walking back to replay.' },
+      { name: 'Stroke and distance', body: 'Penalty for a lost ball or OB. One stroke AND back to where you played from. The most severe penalty in golf.' },
+    ],
+  },
+  {
+    heading: 'Historical terms',
+    intro: 'Golf has a longer continuous history than almost any other sport, and its vocabulary reflects that. Some hickory-era terms still surface in writing, course names, or older players using them affectionately.',
+    terms: [
+      { name: 'Brassie', body: 'Old name for a 2-wood — named for the brass plate on the sole.' },
+      { name: 'Spoon', body: 'Old name for a 3-wood — for the shallow, spoon-like face.' },
+      { name: 'Baffy', body: 'Old name for a 4-wood. Rarely heard today.' },
+      { name: 'Cleek', body: 'Low-lofted hickory iron, roughly a modern 1 or 2-iron. Also a narrow-faced iron used for distance from tight lies.' },
+      { name: 'Mashie', body: 'Roughly a modern 5-iron. "Mashie niblick" was between a mashie and niblick — about a 7-iron.' },
+      { name: 'Niblick', body: 'High-lofted hickory club for short approaches and trouble — roughly a 9-iron or wedge.' },
+      { name: 'Jigger', body: 'Utility iron with moderate loft, used for punch shots and running approaches. No clean modern equivalent.' },
+      { name: 'Stymie', body: 'Pre-1952 match-play situation where your opponent\'s ball blocked your line. Still used figuratively — "in a stymie" means stuck.' },
+      { name: 'Fore', body: 'The warning shout when a ball is heading toward other players. Origin disputed — possibly from "forecaddie," possibly military. Still essential.' },
+    ],
+  },
+]
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (
@@ -265,34 +441,6 @@ function Stat({ label, value }: { label: string; value: string }) {
     </View>
   )
 }
-
-const GLOSSARY = [
-  {
-    kicker: 'Handicap',
-    title: 'Your potential best, not your average.',
-    body: 'Average of your eight best score differentials over the last twenty rounds. Differentials normalize for course rating + slope so the same number means the same thing across courses.',
-  },
-  {
-    kicker: 'GIR',
-    title: 'On the green in regulation.',
-    body: 'Reaching the green in (par − 2) strokes. Tour pros sit around 67 percent, scratch amateurs 50, low double digits 30. The cleanest read on ball-striking.',
-  },
-  {
-    kicker: 'Scrambling · Up & down',
-    title: 'When you miss the green.',
-    body: 'Scrambling = par or better after missing the green. Up and down = chip and a putt from within 30 yd, no extra strokes. Tour up-and-down hovers around 60 percent; mid-handicaps closer to 30.',
-  },
-  {
-    kicker: 'Sand save',
-    title: 'Par from the bunker.',
-    body: 'A hole where one of your shots was hit from sand and you still made par or better. 50 percent is excellent recreational play; field average 35.',
-  },
-  {
-    kicker: 'Dispersion',
-    title: 'Reading the pattern.',
-    body: 'The inner ellipse covers 68 percent of your shots — your typical window. The outer one covers 95. A pattern shifted right of centre means a fade bias; the aim correction tip moves the centre back over your target.',
-  },
-]
 
 function HowToPracticeArticle() {
   return (

--- a/apps/mobile/app/(app)/learn/[article].tsx
+++ b/apps/mobile/app/(app)/learn/[article].tsx
@@ -134,6 +134,8 @@ function LiveArticle({ id }: { id: string }) {
       return <CourseManagementArticle />
     case 'mental-game':
       return <MentalGameArticle />
+    case 'skill-games-pressure-games':
+      return <SkillGamesArticle />
     default:
       return <StubBody title="Article" />
   }
@@ -1778,5 +1780,331 @@ const MENTAL_GAME_RESOURCES = [
     title: '"Choke"',
     by: 'Sian Beilock.',
     note: 'The neuroscience of why we perform poorly under pressure and what to do about it.',
+  },
+]
+
+function SkillGamesArticle() {
+  return (
+    <View>
+      <Text style={{ ...KICKER, marginBottom: 10 }}>Improving your game · Draft</Text>
+      <Text style={TITLE}>Skill games and pressure games.</Text>
+
+      <H3>Why games beat mindless repetition</H3>
+      <Para>
+        Hitting the same shot over and over until you run out of
+        balls is the default range session. It feels like practice.
+        It largely isn't.
+      </Para>
+      <Para>
+        Games change the dynamic. A target, a score, stakes. You're
+        tracking something. You either succeed or you don't. That
+        structure forces commitment on each shot — the same
+        commitment you need on the course.
+      </Para>
+      <Para>
+        End sessions with games. Technical work belongs earlier
+        when focus is fresh. Finish with games when you're shifting
+        from mechanics to performance.
+      </Para>
+
+      <Divider />
+
+      <H3>The pressure problem</H3>
+      <Para>
+        The fundamental challenge of practice: you know you have
+        another ball. On the course, you don't. That knowledge
+        removes consequence from every range swing. You never
+        practice the mental state you need when something is
+        riding on the shot.
+      </Para>
+      <Para>
+        Pressure games solve this. Create enough consequence that
+        missing would genuinely bother you. Not so much that you're
+        miserable. Just enough that each shot matters.
+      </Para>
+      <Para>
+        Stakes must be real but not ruinous. A candy bar, ten
+        pushups, coffee with a buddy. Too small and you don't
+        care. Too large and anxiety takes over.
+      </Para>
+      <Para>
+        The last few balls of any range bucket are a natural
+        pressure game. You're out of balls. Make them count.
+      </Para>
+
+      <Divider />
+
+      <H3>Putting games</H3>
+
+      <H4>The clock drill</H4>
+      <Para>
+        Place twelve balls around a hole at three feet — clock
+        positions. Make all twelve in a row. Miss and start over.
+      </Para>
+      <Para>
+        Deceptively brutal. Getting to eleven and then missing is
+        genuinely painful. That pain is the point — it simulates
+        the pressure of needing to make a putt with something on
+        the line.
+      </Para>
+      <Para>
+        Move to four feet, then five. Tour players do this from
+        six feet as a warm-up. Make all twelve from six and your
+        short putting is tour-level.
+      </Para>
+      <KV label="Variation">
+        Use one ball. Walk around the clock, replace after each
+        putt, make all twelve in a row. Harder — no second chances,
+        and the walk resets your mental state between putts.
+      </KV>
+
+      <H4>Three-station pressure drill</H4>
+      <Para>
+        Three feet, six feet, nine feet. Make ten putts at each
+        station before moving on. Miss more than one and start the
+        station over.
+      </Para>
+      <Para>
+        Escalating pressure. Three feet is achievable. Six with
+        the threat of restart matters. Nine, after completing the
+        first two — real pressure. Track total attempts to complete
+        all three across sessions.
+      </Para>
+
+      <H4>The putting circuit</H4>
+      <Para>
+        Pick nine holes on the practice green. Par 2 each — one
+        putt, two-putt is par, three-putt is bogey. Play it as a
+        proper round. Same nine holes every session so you can
+        track improvement.
+      </Para>
+      <KV label="Competitive version">
+        Head to head with a partner. Stroke or match play. Adds
+        pressure solo practice can't replicate.
+      </KV>
+
+      <H4>The gate drill</H4>
+      <Para>
+        Two tees just wider than your putter, a foot in front of
+        the ball on your line. Roll the ball through without
+        touching either tee.
+      </Para>
+      <Para>
+        Trains starting line. Most missed putts are missed before
+        the ball breaks. Start at six feet straight, then ten,
+        then a breaker. Exposes inconsistency in stroke path fast.
+      </Para>
+
+      <H4>Speed control — the ladder drill</H4>
+      <Para>
+        Five balls at ten feet. Hit the first putt — note where it
+        finishes. The second must finish on the opposite side of
+        the hole from the first. The third must finish between the
+        first two.
+      </Para>
+      <Para>
+        Move back five feet and repeat. Trains intentional pace
+        variation — directly transferable to lag putting and fast
+        greens.
+      </Para>
+
+      <Divider />
+
+      <H3>Chipping and short game games</H3>
+
+      <H4>Up and down challenge</H4>
+      <Para>
+        Five spots around the practice green at varying distances.
+        From each spot, chip and putt out. Sum strokes. Set a
+        target — maybe 12 — and try to beat it. Lower as you
+        improve.
+      </Para>
+      <KV label="Pressure version">
+        Five up-and-downs in a row. Miss one and the streak
+        restarts. Getting to four and chunking the next chip is
+        exactly the pressure the course creates.
+      </KV>
+
+      <H4>Three clubs, one ball per station</H4>
+      <Para>
+        Three distances — 20, 40, 60 yards. One ball from each.
+        No mulligan. The single-ball constraint is everything.
+      </Para>
+
+      <H4>Flag left or flag right</H4>
+      <Para>
+        At the range pick a flag. Before each shot, declare: left
+        or right. Within ten feet on the declared side = birdie.
+        Correct side, outside the window = par. Wrong side =
+        double bogey.
+      </Para>
+      <Para>
+        Teaches two things. First, controlling shot shape under
+        pressure — you have to commit before you swing. Second,
+        the cost of the short side. Score over ten shots; -4 or
+        better is good.
+      </Para>
+
+      <Divider />
+
+      <H3>Full swing games</H3>
+
+      <H4>Horse at the range</H4>
+      <Para>
+        Like the basketball game. Pick a target. Hit. Partner has
+        to match it. Miss the match and you get a letter. First
+        to H-O-R-S-E loses. Calling your shot before swinging is
+        the same skill the course demands.
+      </Para>
+
+      <H4>The imaginary fairway</H4>
+      <Para>
+        Two targets define a fairway, 25–30 yards wide. Ten tee
+        shots. Driver in the fairway = 3, fairway wood = 2, iron
+        = 1. -2 if you imagine a hazard side and find it.
+      </Para>
+      <Para>
+        Incentivizes driver — the most distance, the most risk.
+        Forces a real reward-vs-risk decision on every shot.
+      </Para>
+
+      <H4>Same distance, different clubs</H4>
+      <Para>
+        Pick a flag at 100 yards. Hit it with five different clubs.
+        9-iron, 8-iron, PW, GW, SW — each requires a different
+        swing length and speed.
+      </Para>
+      <Para>
+        Builds feel for partial shots. Teaches your actual
+        distances better than full swings — you're forced to
+        feel a 75% swing with each club.
+      </Para>
+
+      <H4>Three club challenge</H4>
+      <Para>
+        Simulated nine-hole round on the range with only three
+        clubs — driver, mid iron, wedge. Tee shot, approach, chip
+        — each to a different target. Forces creativity. You
+        learn to work the ball.
+      </Para>
+
+      <Divider />
+
+      <H3>The last ball rule</H3>
+      <Para>
+        Whatever you're practicing, save your last ball for a
+        specific challenge. Announce it before you hit:
+      </Para>
+      <Bullets
+        items={[
+          '"This drive has to find the fairway."',
+          '"This wedge has to finish within ten feet of the flag."',
+          '"This 7-iron has to carry the 150 marker."',
+        ]}
+      />
+      <Para>
+        One ball, no second chance. The session ends on this shot
+        — and you find out whether the work translates when
+        something is riding on it.
+      </Para>
+
+      <Divider />
+
+      <H3>Building your own pressure games</H3>
+      <Para>
+        Generic drills work. Customized stakes work better.
+      </Para>
+      <KV label="Stakes must be real but not ruinous">
+        Candy bar, coffee, pushups, bragging rights. Twenty dollars
+        or public embarrassment shuts down performance instead of
+        training it.
+      </KV>
+      <KV label="Streaks beat totals">
+        10 of 15 creates less pressure than 5 in a row. Streaks
+        carry the weight of every previous success — closer to
+        how the course feels.
+      </KV>
+      <KV label="One-and-done beats best-of">
+        A single attempt, no mulligans. The closer to the
+        one-chance nature of a real shot, the better.
+      </KV>
+      <KV label="Track scores over time">
+        A game without a scoreboard is a drill. Watching your
+        score improve across months is genuinely motivating.
+      </KV>
+
+      <Divider />
+
+      <H3>Resources</H3>
+      <Note variant="todo">
+        Verify all links before publishing.
+      </Note>
+      {SKILL_GAMES_RESOURCES.map((r) => (
+        <View
+          key={r.title}
+          style={{
+            borderTopWidth: 1,
+            borderColor: '#D9D2BF',
+            paddingVertical: 12,
+          }}
+        >
+          <Text
+            style={{
+              color: '#1C211C',
+              fontSize: 15,
+              fontStyle: 'italic',
+              fontWeight: '500',
+            }}
+          >
+            {r.title}
+            {r.by && (
+              <Text style={{ color: '#5C6356', fontStyle: 'normal', fontWeight: '400' }}>
+                {' '}— {r.by}
+              </Text>
+            )}
+          </Text>
+          <Text style={{ color: '#5C6356', fontSize: 14, lineHeight: 20, marginTop: 4 }}>
+            {r.note}
+          </Text>
+        </View>
+      ))}
+
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderColor: '#D9D2BF',
+          paddingTop: 18,
+          marginTop: 22,
+        }}
+      >
+        <Text style={{ ...KICKER, color: '#8A8B7E', lineHeight: 14 }}>
+          Last reviewed May 2026 · Draft, needs review · Edit
+          docs/learn/skill-games-pressure-games.md to contribute
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+const SKILL_GAMES_RESOURCES = [
+  {
+    title: 'Golf Digest — 15 Best Golf Practice Games',
+    by: '',
+    note: 'golfdigest.com. Good overview of range and putting green games.',
+  },
+  {
+    title: 'Practical Golf — 5 Games That Build Real Skills',
+    by: '',
+    note: 'practical-golf.com. Solid pressure games with scoring systems.',
+  },
+  {
+    title: '"Dave Pelz\'s Short Game Bible"',
+    by: '',
+    note: 'Research-based approach to short game practice. Specific drills backed by data.',
+  },
+  {
+    title: 'The Upbeat Golfer (Manu)',
+    by: '',
+    note: 'YouTube. Process under pressure, routine under stakes.',
   },
 ]

--- a/apps/mobile/app/(app)/learn/[article].tsx
+++ b/apps/mobile/app/(app)/learn/[article].tsx
@@ -132,6 +132,8 @@ function LiveArticle({ id }: { id: string }) {
       return <HowToPracticeArticle />
     case 'course-management':
       return <CourseManagementArticle />
+    case 'mental-game':
+      return <MentalGameArticle />
     default:
       return <StubBody title="Article" />
   }
@@ -1409,5 +1411,372 @@ const RESOURCES = [
     title: '"Golf Is Not a Game of Perfect"',
     by: 'Bob Rotella.',
     note: 'The standard text on playing with what you have that day.',
+  },
+]
+
+function MentalGameArticle() {
+  return (
+    <View>
+      <Text style={{ ...KICKER, marginBottom: 10 }}>On the course · Draft</Text>
+      <Text style={TITLE}>The mental game.</Text>
+
+      <H3>Golf is you versus you</H3>
+      <Para>
+        Every other sport has an opponent actively trying to stop
+        you. In golf, the course is static. The ball sits still and
+        waits. Nobody is trying to beat you except you.
+      </Para>
+      <Para>
+        Once you have a functional swing, the game becomes almost
+        entirely mental. Most amateurs spend 95% of their practice
+        on the physical game and almost none on the mental game.
+        The swing is largely solved. The mental game is the frontier.
+      </Para>
+      <Para>
+        Golf is also one of the most humbling experiences available.
+        It will find every weakness in your ego and expose it
+        repeatedly. Either reduce the ego or suffer. There is no
+        third option.
+      </Para>
+
+      <Divider />
+
+      <H3>One shot at a time</H3>
+      <Para>
+        Every touring professional eventually says the same thing:
+        one shot at a time. It is repeated so often because it is
+        literally true. You cannot replay the last shot. You cannot
+        hit the next one until this one is done. The only shot that
+        exists is the one in front of you.
+      </Para>
+      <Para>
+        The brain doesn't work this way naturally. It replays the
+        shot you just botched. It fast-forwards to the putt on 18.
+        It calculates score. All of this thinking happens at exactly
+        the moment you need to be doing one thing.
+      </Para>
+      <Para>
+        Bob Rotella describes this as refusing to be seduced by
+        results. At the 2008 Masters, Trevor Immelman did not look
+        at a single leaderboard until walking up 18. The routine
+        protected him all day. The moment he stepped outside it,
+        the pressure arrived.
+      </Para>
+      <Para>
+        The short memory is a skill, not a trait. Give yourself a
+        window to feel the emotion — Rotella calls it walking it
+        off — then drop it. The bad shot already happened. Carrying
+        it into the next shot is a choice.
+      </Para>
+
+      <Divider />
+
+      <H3>Sulking won't get you anything</H3>
+      <Para>
+        When Padraig Harrington won the 2007 British Open, he
+        knocked two balls into the water on the last hole and made
+        double bogey. He still won. He told Rotella afterward that
+        it never entered his mind he might blow it. His only
+        thought was getting the ball in the hole so he could make
+        the playoff.
+      </Para>
+      <Para>
+        Rotella is direct: sulking won't get you anything. Feeling
+        sorry, replaying the mistake — none of it changes what
+        happened, all of it damages what comes next.
+      </Para>
+
+      <Divider />
+
+      <H3>The productive delusion</H3>
+      <Para>
+        Rotella's first rule: believe you can win. Not hope. Not
+        think you have a chance. Believe.
+      </Para>
+      <Para>
+        The player on a putting heater approaches the next putt
+        believing it's going in. The player who has been missing
+        all afternoon thinks: I'm due. Both are irrational. But the
+        golfer who believes stands over the ball with a different
+        quality of attention — and that affects the outcome.
+      </Para>
+      <Para>
+        It is the deliberate construction of a mental state that
+        serves performance. Call it confidence, call it a productive
+        delusion. You are allowed to be delusional in your own
+        favor. In golf, it is the correct strategy.
+      </Para>
+
+      <Divider />
+
+      <H3>Visualization</H3>
+      <Para>
+        Before a shot, the mental game starts. Not on the backswing
+        — before you take the club out of the bag.
+      </Para>
+      <Para>
+        See the shot you want to hit. The flight, the trajectory,
+        the bounce and roll. Like a video, in real time, as if it
+        already happened. For putting: see the line, see the ball
+        rolling along it, see it drop.
+      </Para>
+      <Para>
+        This is not mysticism. The brain rehearses motor patterns
+        through visualization in ways that translate into physical
+        execution. Pick a target, visualize the shot, let it rip.
+        In that order, every time.
+      </Para>
+      <Note variant="research">
+        Research basis: mental imagery and motor performance. See
+        Guillot &amp; Collet (2008) on mental simulation of motor
+        actions.
+      </Note>
+
+      <Divider />
+
+      <H3>The routine as an anchor</H3>
+      <Para>
+        A consistent pre-shot routine prepares you physically and
+        gives you a repeatable process. But it has a third purpose
+        most golfers miss: the routine is an anchor to the present
+        moment.
+      </Para>
+      <Para>
+        Curtis Strange won the 1988 U.S. Open looking calm on TV
+        but with his heart pounding. He told Rotella he was working
+        his tail off just to stay in the present. The routine made
+        him look calm and kept him functional.
+      </Para>
+      <Para>
+        When the mind is scattered, going through the routine
+        brings you back. Not magic — executing familiar physical
+        actions requires present-moment attention.
+      </Para>
+      <Para>
+        Routine must be consistent. Same grip check, same practice
+        swing, same target look — every time. The bigger the
+        moment, the more important it is the routine does not change.
+      </Para>
+      <Note variant="research">
+        Manu, The Upbeat Golfer — YouTube. Target commitment and
+        pre-shot routine for process-driven play.
+      </Note>
+
+      <Divider />
+
+      <H3>Patience over aggression</H3>
+      <Para>
+        Rotella's fourth rule: every time you have the urge to make
+        an aggressive play, go with the more conservative one. You
+        will always be okay.
+      </Para>
+      <Para>
+        At the 1992 U.S. Open, Tom Kite shot even par in 35-mph
+        wind and won by two. Most players didn't break 80. He did
+        it by staying patient and letting others beat themselves.
+        Patience compounds across 18 holes.
+      </Para>
+
+      <Divider />
+
+      <H3>Ignore unsolicited swing advice</H3>
+      <Para>
+        Rotella tells of a player who made eight birdies in round
+        one, stopped by the putting green, got two unsolicited
+        comments on his setup, and was a mess by the next day.
+      </Para>
+      <Para>
+        Stop them before they speak. Their comments will creep in
+        at the moment you need to be thinking about your target.
+        File anything observed for the range later — or let it go.
+      </Para>
+
+      <Divider />
+
+      <H3>Calm is a superpower</H3>
+      <Para>
+        You cannot make good decisions when angry. You cannot swing
+        well when amped up or seething. The state of anger is the
+        opposite of the state required to hit a golf ball.
+      </Para>
+      <Para>
+        This is not about being emotionless. Feel it briefly,
+        privately, then drop it. The next shot needs your full
+        attention.
+      </Para>
+      <Para>
+        Hand on chest, feel your breath, look at something specific
+        in your environment — grounding techniques exist to pull
+        you out of your own mind and back to the course where the
+        actual game is being played.
+      </Para>
+
+      <Divider />
+
+      <H3>Grounding and the present moment</H3>
+      <Para>
+        When the mind spirals, the way back is through the body,
+        not through more thinking. Feel your feet on the ground.
+        Feel the grip in your hands. Look at the grass, the trees,
+        the sky.
+      </Para>
+      <Para>
+        The mind in a spiral is pulling you into the past or the
+        future. The body only exists in the present. Returning
+        attention to physical sensation is the fastest route back
+        to where the golf shot actually lives.
+      </Para>
+      <Para>
+        Golf becomes deeply Buddhist here — not attached to
+        outcomes, not grasping at results, returning again and
+        again to what is actually happening right now. Everything
+        else is noise.
+      </Para>
+
+      <Divider />
+
+      <H3>Find someone who believes in you</H3>
+      <Para>
+        Ben Hogan considered quitting early in his career. Valerie
+        Hogan wouldn't let him. Confidence in yourself is essential.
+        Having someone who sees what you can't yet see in yourself
+        — a spouse, a friend, a coach — compounds it.
+      </Para>
+      <Para>
+        For amateurs this might be a playing partner who knows your
+        game, or a coach who genuinely believes in your potential.
+        Anyone who reflects your capability back to you on the days
+        you can't see it. The mental game is not fought entirely
+        alone.
+      </Para>
+
+      <Divider />
+
+      <H3>Be process-driven, not results-driven</H3>
+      <Para>
+        Most golfers think too little — react emotionally to where
+        the ball goes. The opposite problem: thinking too much.
+        Grinding swing thoughts, replaying the last bad shot.
+        Analysis paralysis is just as damaging as mindlessness.
+      </Para>
+      <Para>The sweet spot is a clear, repeatable pre-shot process:</Para>
+      <Bullets
+        items={[
+          'Pick a specific target',
+          'Visualize the shot',
+          'Commit fully',
+          'Go through your routine',
+          'Pull the trigger',
+        ]}
+      />
+      <Para>
+        Try tracking — alongside your score — whether you committed
+        to each shot. Not whether the result was what you wanted.
+        Whether you actually went through your process without
+        doubt. Process-oriented thinking gives you the best chance
+        of executing.
+      </Para>
+
+      <Divider />
+
+      <H3>It never gets fully solved</H3>
+      <Para>
+        Tour pros — with decades of experience and sports
+        psychologists — still get in their own way. The goal is
+        not to eliminate the mental challenge. It is to recover
+        more quickly. The pro who has a double on 6 and is back to
+        full focus on 7 has the same challenge as the amateur who
+        takes four holes to recover. They just recover faster.
+      </Para>
+      <Para>That recovery time is what you are training.</Para>
+
+      <Divider />
+
+      <H3>Resources</H3>
+      <Note variant="todo">
+        Verify all links before publishing.
+      </Note>
+      {MENTAL_GAME_RESOURCES.map((r) => (
+        <View
+          key={r.title}
+          style={{
+            borderTopWidth: 1,
+            borderColor: '#D9D2BF',
+            paddingVertical: 12,
+          }}
+        >
+          <Text
+            style={{
+              color: '#1C211C',
+              fontSize: 15,
+              fontStyle: 'italic',
+              fontWeight: '500',
+            }}
+          >
+            {r.title}
+            {r.by && (
+              <Text style={{ color: '#5C6356', fontStyle: 'normal', fontWeight: '400' }}>
+                {' '}— {r.by}
+              </Text>
+            )}
+          </Text>
+          <Text style={{ color: '#5C6356', fontSize: 14, lineHeight: 20, marginTop: 4 }}>
+            {r.note}
+          </Text>
+        </View>
+      ))}
+
+      <View
+        style={{
+          borderTopWidth: 1,
+          borderColor: '#D9D2BF',
+          paddingTop: 18,
+          marginTop: 22,
+        }}
+      >
+        <Text style={{ ...KICKER, color: '#8A8B7E', lineHeight: 14 }}>
+          Last reviewed May 2026 · Draft, needs review · Edit
+          docs/learn/mental-game.md to contribute
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+const MENTAL_GAME_RESOURCES = [
+  {
+    title: '"Golf Is Not a Game of Perfect"',
+    by: 'Bob Rotella.',
+    note: 'The gold standard in golf psychology. Essential reading.',
+  },
+  {
+    title: '"Golf Is a Game of Confidence"',
+    by: 'Bob Rotella.',
+    note: 'The follow-up, equally valuable.',
+  },
+  {
+    title: 'Bob Rotella — "My 10 Rules on Mental Fitness"',
+    by: '',
+    note: 'GolfWRX. The ten rules referenced throughout this article.',
+  },
+  {
+    title: '"Zen Golf"',
+    by: 'Joseph Parent.',
+    note: 'Buddhist-influenced approach to present-moment play.',
+  },
+  {
+    title: 'The Upbeat Golfer (Manu)',
+    by: '',
+    note: 'YouTube. Process-driven mental approach, target commitment, playing without fear.',
+  },
+  {
+    title: '"The Inner Game of Tennis"',
+    by: 'Tim Gallwey.',
+    note: 'Not golf-specific but the foundational text on getting out of your own way in sport.',
+  },
+  {
+    title: '"Choke"',
+    by: 'Sian Beilock.',
+    note: 'The neuroscience of why we perform poorly under pressure and what to do about it.',
   },
 ]

--- a/apps/web/src/pages/learn/articles/GlossaryArticle.tsx
+++ b/apps/web/src/pages/learn/articles/GlossaryArticle.tsx
@@ -1,5 +1,4 @@
-import { Body, Lede } from '../components/ArticlePrimitives'
-import type { ReactNode } from 'react'
+const DEV = import.meta.env.DEV
 
 export function GlossaryArticle() {
   return (
@@ -12,7 +11,7 @@ export function GlossaryArticle() {
       }}
     >
       <div className="kicker" style={{ marginBottom: 14 }}>
-        Understanding the game · Glossary
+        Understanding the game · Draft
       </div>
       <h2
         className="font-serif text-caddie-ink"
@@ -25,134 +24,701 @@ export function GlossaryArticle() {
           marginBottom: 18,
         }}
       >
-        Stat glossary.
+        Glossary of golf terms.
       </h2>
 
-      <Term kicker="Handicap index" title="The handicap, briefly.">
-        <Lede>
-          A handicap index is your <em>potential best</em> — the average
-          of your eight best score differentials over the last twenty
-          rounds, give or take. It is not your average score; it's a
-          portrait of what you can do when things go right.
-        </Lede>
-        <Body>
-          Each round's "score differential" adjusts the raw score for
-          course difficulty (rating + slope), so 84 at a brutal track is
-          treated more kindly than 84 at a pitch-and-putt. After you
-          post a round, the system recomputes your index, which is why
-          your number can move a touch even after you played well.
-        </Body>
+      <P>
+        The basics — birdie, bogey, par, handicap, GIR — are covered
+        in the app's stat reference section. This glossary focuses
+        on the terms that come up once you start playing regularly
+        and trying to improve.
+      </P>
+
+      <Hr />
+
+      <H3>Shot shapes and ball flight</H3>
+      <Term name="Draw">
+        A controlled shot that curves gently from right to left in
+        the air (for a right-handed golfer). The opposite of a fade.
+        A draw typically produces more roll than a fade and is
+        generally considered easier to generate distance with. Not
+        to be confused with a hook.
+      </Term>
+      <Term name="Fade">
+        A controlled shot that curves gently from left to right
+        (for a right-handed golfer). Tour professionals often prefer
+        a fade because the ball lands softer with less roll. Not to
+        be confused with a slice.
+      </Term>
+      <Term name="Hook">
+        An uncontrolled, exaggerated draw. The ball curves hard
+        left for a right-handed player. Often the result of a closed
+        clubface at impact. Differs from a draw in that a hook is
+        unintended and more severe.
+      </Term>
+      <Term name="Slice">
+        An uncontrolled, exaggerated fade. The ball curves hard
+        right for a right-handed player. The most common miss for
+        amateur golfers. Caused by an open clubface at impact
+        combined with an out-to-in swing path.
+      </Term>
+      <Term name="Push">
+        A shot that flies straight but to the right of the target
+        (for a right-handed golfer), with no curve. Different from
+        a fade — a pushed shot travels on the wrong line without
+        curving.
+      </Term>
+      <Term name="Pull">
+        A shot that flies straight but to the left of the target
+        (for a right-handed golfer), with no curve. Different from
+        a hook — a pulled shot travels on the wrong line without
+        curving.
+      </Term>
+      <Term name="Stinger">
+        A low, penetrating shot hit with minimal loft, often used
+        into the wind or to punch out from under trees. Made famous
+        by Tiger Woods. Achieved by playing the ball back in the
+        stance and limiting the follow-through.
+      </Term>
+      <Term name="Punch shot">
+        A low, controlled shot played with a shortened swing,
+        typically from trouble — under tree branches, into wind, or
+        from a tight lie. The ball stays low and runs out after
+        landing.
+      </Term>
+      <Term name="Flier">
+        A shot that travels farther than expected because grass
+        gets trapped between the clubface and ball at impact,
+        reducing backspin. Common from rough. A flier lie is any
+        lie where you expect this to happen. Always account for
+        extra distance from light rough.
+      </Term>
+      <Term name="Spinner">
+        A shot hit with enough backspin that the ball spins back
+        toward the player after landing on the green. Typically
+        happens on clean contact with a wedge into a soft green. A
+        desirable shot when the pin is at the back of the green and
+        you need the ball to check up and release toward the hole.
+      </Term>
+      <Term name="Knuckleball">
+        A shot with almost no spin — the ball flutters and moves
+        unpredictably in the air, like a knuckleball pitch in
+        baseball. Usually caused by hitting the ball with a grooved
+        club that has a grass or moisture patch between face and
+        ball. Notoriously hard to control distance and direction.
+        Often happens from thick rough.
+      </Term>
+      <Term name="Texas Wedge">
+        Using a putter from off the green — from the fringe, apron,
+        or even light rough — instead of chipping. Often the
+        highest percentage shot when the ground between ball and
+        hole is firm and flat.
+      </Term>
+      <Term name="DOD (Driver Off the Deck)">
+        Hitting a driver without a tee, from the fairway or rough.
+        One of the hardest shots in golf due to the low loft and
+        long shaft. Useful on long par 5s when you need maximum
+        distance and can't reach the green with a fairway wood.
+        Requires a shallow, sweeping angle of attack. Made famous
+        by social media creator "DOD King" Carter Smith, who built
+        an entire golf persona around the shot.
+      </Term>
+      <Term name="Thai Spinner">
+        A low, high-spin shot around the greens popularized by Thai
+        PGA Tour player Kiradech Aphibarnrat. The ball is struck
+        first (not the ground) with a steep, outside-in swing using
+        a lob wedge, producing a low ball flight that jumps and
+        stops quickly due to extreme spin. Useful from tight or
+        grainy lies where a standard chip would skid through. Made
+        famous to wider audiences when Keith Mitchell executed it
+        from a nearly impossible bunker lie at the 2025 Texas
+        Children's Houston Open.
       </Term>
 
-      <Term kicker="GIR" title="Greens in regulation.">
-        <Lede>
-          Reaching the green in <em>par minus two</em> strokes — one on
-          a par-3, two on a par-4, three on a par-5. Once on, you have
-          two putts to match par.
-        </Lede>
-        <Body>
-          GIR percentage is the cleanest read on ball-striking. PGA Tour
-          pros sit around 67%, scratch amateurs 50%, low double digits
-          land closer to 30%. Ten extra GIRs across a season tend to
-          translate to a couple of strokes in scoring average.
-        </Body>
+      <Hr />
+
+      <H3>Short game shots</H3>
+      <Term name="Chip">
+        A low, running shot played from just off the green where
+        the ball spends more time on the ground than in the air.
+        Uses a less-lofted club (7-iron through pitching wedge
+        typically) and a putting-style stroke. The classic chip:
+        land the ball just on the green and let it roll to the hole.
+      </Term>
+      <Term name="Pitch">
+        A higher, softer shot played from farther away than a chip
+        — typically 20–80 yards from the green. Uses a wedge and a
+        fuller swing than a chip. The ball spends more time in the
+        air and stops more quickly than a chip. Pitches are harder
+        than chips because they require distance control with a
+        partial swing.
+      </Term>
+      <Term name="Bump and run">
+        A chip-like shot played with a mid-iron (5–7 iron) that
+        lands short of the green and runs onto the putting surface.
+        Favored in links golf and firm conditions where the ground
+        is predictable. Lower risk than a flop shot — fewer moving
+        parts, less chance of a mishit. Harvey Penick was a famous
+        advocate of this shot for amateurs.
+      </Term>
+      <Term name="Flop shot">
+        A high, soft shot played with an open lob wedge that lands
+        softly with minimal roll. Used when you need to carry a
+        hazard and stop the ball quickly. High risk — a mishit flop
+        can be skulled over the green or chunked short. Not
+        recommended unless you practice it regularly.
+      </Term>
+      <Term name="Chunk / Fat shot">
+        Hitting the ground behind the ball before making contact,
+        resulting in a shot that comes up well short of the target.
+        The club digs into the turf and decelerates. One of the
+        most common short game misses for amateurs. Also called a
+        heavy shot.
+      </Term>
+      <Term name="Scalp / Thin / Blade">
+        Hitting the ball with the leading edge of the club instead
+        of the face — typically the bottom groove of the iron. The
+        ball comes out low and hot, usually running through the
+        green. The opposite problem from a chunk. Common on tight
+        lies and downhill shots. Also called skulling the ball.
+      </Term>
+      <Term name="Flush">
+        Slang for a perfectly struck shot — clean contact with the
+        center of the clubface. "I flushed a 7-iron to two feet."
+        Also used as an adjective: "That was a flush strike."
       </Term>
 
-      <Term kicker="Scrambling" title="When you miss the green.">
-        <Lede>
-          The percent of holes where you missed the green and{' '}
-          <em>still made par or better</em>. It rewards saving strokes
-          you should have lost.
-        </Lede>
-        <Body>
-          A useful pair with GIR — high GIR with low scrambling means
-          you bleed strokes whenever the ball-striking blinks. High
-          scrambling with low GIR means your short game props you up,
-          but a leak above the green still costs you long-term.
-        </Body>
+      <Hr />
+
+      <H3>Putting terms</H3>
+      <Term name="Pin high / Hole high">
+        When your approach shot finishes level with the pin (the
+        same distance from the front of the green as the hole) but
+        to the left or right of it. Pin high means your distance
+        control was correct even if your direction was off. Generally
+        considered a good miss — you're putting across the slope
+        rather than up or down it.
+      </Term>
+      <Term name="Spinner (putting)">
+        In putting context, a spinner refers to a putt that lips
+        out spinning — the ball catches the edge of the cup, spins
+        around the rim and comes back out. One of the most
+        frustrating outcomes in golf. See also: lip out.
       </Term>
 
-      <Term kicker="Up and down" title="Two strokes from off the green.">
-        <Lede>
-          A subset of scrambling: a <em>chip and a putt</em> from within
-          ~30 yards of the green, completed without going to a third
-          shot. Doesn't apply when you're already on the green or when
-          you've reached green-side bunker territory.
-        </Lede>
-        <Body>
-          Tour up-and-down rate hovers around 60%. For mid-handicaps
-          it's closer to 30%. Improving here is largely about distance
-          control on chips and reading the first putt.
-        </Body>
+      <Hr />
+
+      <H3>Course and green terminology</H3>
+      <Term name="Below the hole">
+        The lower side of the hole on a sloped green. A ball
+        finishing below the hole leaves an uphill putt — the
+        preferred position. Tour players always try to leave
+        themselves below the hole.
+      </Term>
+      <Term name="Above the hole">
+        The upper side of the hole on a sloped green. Leaves a
+        downhill putt, which is faster and harder to control. Avoid
+        finishing above the hole when possible.
+      </Term>
+      <Term name="Short side">
+        The side of the green closest to the pin when the pin is
+        tucked near an edge. Missing a green on the short side
+        leaves an extremely difficult chip with little green to
+        work with. One of the most costly mistakes in course
+        management. Do not short side yourself.
+      </Term>
+      <Term name="Grain">
+        The direction in which grass grows on a putting green.
+        Bermuda grass greens (common in warm climates) have strong
+        grain that significantly affects putt speed and break.
+        Putting with the grain is faster; against the grain is
+        slower. Identifying grain is an important green-reading
+        skill.
+      </Term>
+      <Term name="Stimp / Stimpmeter">
+        A device that measures green speed by rolling a ball down
+        a ramp and measuring how far it travels. A stimp reading of
+        10 is moderately fast (typical club golf), 12–13 is fast
+        (major championship conditions), 14+ is extremely fast.
+      </Term>
+      <Term name="False front">
+        A green that slopes sharply back toward the fairway at the
+        front. Approach shots that land on the false front roll
+        back off the green. Requires more club than it appears to
+        hold the green.
+      </Term>
+      <Term name="Apron / Fringe">
+        The short grass surrounding the putting green, shorter than
+        the fairway but longer than the green itself. Putting from
+        the apron is usually possible with a putter, though the
+        slightly longer grass affects roll.
+      </Term>
+      <Term name="Dogleg">
+        A hole that bends left or right between the tee and green.
+        A dogleg left bends left; dogleg right bends right.
+      </Term>
+      <Term name="Bailout">
+        A safe area to miss to when the primary target is dangerous.
+        Good course management always identifies the bailout before
+        swinging.
+      </Term>
+      <Term name="Big ball (Earth)">
+        Slang for hitting the ground before the ball — chunking or
+        fatting a shot. "He hit the big ball first." A humorous way
+        of saying someone hit it fat. The "big ball" is the Earth
+        itself; the small ball is the golf ball. You want to hit
+        the small one first.
       </Term>
 
-      <Term kicker="Sand save" title="From the bunker, par or better.">
-        <Lede>
-          A specific case: any hole where one of your shots was hit from
-          a sand bunker and you still made par or better. Hard for
-          amateurs because the shot itself is hard.
-        </Lede>
-        <Body>
-          A 50% sand save is excellent recreational play; the field
-          average is closer to 35%. The right baseline depends on how
-          far from the hole you typically end up — a buried 30-yard
-          bunker shot is a different animal than a tap from a green-side
-          trap.
-        </Body>
+      <Hr />
+
+      <H3>Divots and course care</H3>
+      <Term name="Divot">
+        The chunk of turf displaced by the club during an iron shot.
+        Two meanings: (1) the chunk of turf itself, and (2) the
+        hole left in the ground. Replacing your divot after a shot
+        is standard golf etiquette. Many courses provide sand-mix
+        bottles to fill divots instead. Hitting from a divot left
+        by a previous player is a common bad lie — no relief, play
+        it as it lies.
+      </Term>
+      <Term name="Pitch mark / Ball mark">
+        The indentation left in the green when an approach shot
+        lands. Repairing your pitch mark — and any others nearby —
+        is one of the most important etiquette habits in golf.
+        Unrepaired pitch marks take weeks to heal and create bumpy
+        putting surfaces for everyone. Repair by pushing the edges
+        down and smoothing, not by lifting the center up.
+      </Term>
+      <Term name="Burn mark">
+        The browning or dying of grass on one side of the hole cup,
+        caused by the grain growing away from that side and
+        exposing the roots. The burned side indicates where the
+        grain is running from — grain runs toward the healthy
+        green side of the cup. Reading burn marks is a quick way
+        to identify grain direction on Bermuda greens before
+        putting. The side with the burn is into the grain; the
+        healthy side is with the grain.
+      </Term>
+      <Term name="Divot tool / Pitch fork">
+        The small forked tool used to repair pitch marks on the
+        green. Every golfer should carry one. Insert the tines at
+        the edges of the mark and push inward to level it out. Do
+        not pry up from the center — this damages the roots. A ball
+        marker (usually a coin) is used alongside the divot tool to
+        mark your ball position on the green.
       </Term>
 
-      <Term kicker="Dispersion" title="Reading your shot pattern.">
-        <Lede>
-          The pattern of where your shots actually land relative to
-          where you aimed. Centred on your aim point, not the pin.
-        </Lede>
-        <Body>
-          The inner ellipse covers 68% of your shots — your typical
-          window. The outer one covers 95% — including the bad ones. Two
-          ellipses tilted right of centre means a fade pattern; shifted
-          long means you over-club. Aim correction tips you to move the
-          centre back over the target by adjusting aim the opposite way
-          of the bias.
-        </Body>
+      <Hr />
+
+      <H3>Scoring and competition terms</H3>
+      <Term name="Snowman">
+        Slang for a score of 8 on a hole — because the number 8
+        looks like a snowman. Not a term you want to hear often.
       </Term>
+      <Term name="Blow up hole">
+        A hole where everything goes wrong and a large number is
+        recorded. Every golfer has them. The mental game skill is
+        minimizing how many and how severe.
+      </Term>
+      <Term name="Honors">
+        The player who tees off first on a hole has the honors. In
+        stroke play, honors goes to the player with the lowest
+        score on the previous hole.
+      </Term>
+      <Term name="Ready golf">
+        Hitting when you're ready rather than strictly following
+        honors order. Speeds up pace of play significantly. Standard
+        in casual rounds.
+      </Term>
+      <Term name="Skins">
+        A golf betting format where each hole is worth a set amount
+        of money (a "skin"). The player who wins the hole outright
+        — no ties — wins the skin. If two or more players tie, the
+        skin carries over to the next hole, making it worth more.
+        Skins can stack up over several holes and create exciting
+        swings.
+      </Term>
+      <Term name="Match play">
+        A format where the score is tracked hole by hole rather
+        than total strokes. Win a hole by taking fewer strokes and
+        you go one up. The player who wins the most holes wins the
+        match.
+      </Term>
+      <Term name="Stroke play">
+        The standard format where total strokes over the entire
+        round are counted. The player with the fewest total strokes
+        wins.
+      </Term>
+      <Term name="Stableford">
+        A scoring format where points are awarded based on score
+        relative to par. Typically: bogey = 1 point, par = 2 points,
+        birdie = 3 points, eagle = 4 points. Encourages aggressive
+        play. Popular in social golf.
+      </Term>
+      <Term name="Nassau">
+        A common golf bet consisting of three separate wagers: the
+        front nine, the back nine, and the full 18 holes. Each is
+        a separate match play competition.
+      </Term>
+      <Term name="Press">
+        In a Nassau or match play bet, a press is a new side bet
+        started mid-round, typically when a player or team is down
+        by two holes.
+      </Term>
+      <Term name="Dormie">
+        In match play, when a player leads by the same number of
+        holes as remain to be played. Cannot lose — worst outcome
+        is a tie.
+      </Term>
+
+      <Hr />
+
+      <H3>Lie and course conditions</H3>
+      <Term name="Tight lie">
+        A ball sitting on bare or closely-mown ground with very
+        little grass underneath. Requires clean contact.
+      </Term>
+      <Term name="Plugged lie / Fried egg">
+        A ball that has embedded in its own pitch mark, typically
+        in soft ground or a bunker. Also called a fried egg in a
+        bunker — only the top of the ball is visible, surrounded by
+        a ring of disturbed sand.
+      </Term>
+      <Term name="Hardpan">
+        Very firm, dry ground with little or no grass. Produces low,
+        running shots and requires precise contact.
+      </Term>
+
+      <Hr />
+
+      <H3>Equipment terms</H3>
+      <Term name="Muscle back">
+        An iron design where the weight is concentrated in a solid
+        mass directly behind the center of the clubface — sometimes
+        called a blade. No cavity in the back. Preferred by better
+        players for the feel, feedback, and shot-shaping ability
+        they provide. Less forgiving than cavity backs — off-center
+        hits are more penalized. If you hit it pure, a muscle back
+        feels unlike anything else in golf — the feedback through
+        the hands is immediate and unmistakable. Miss it, and you'll
+        know that too.
+      </Term>
+      <Term name="Cavity back">
+        An iron design where weight is redistributed to the
+        perimeter of the clubhead, creating a cavity in the back.
+        More forgiving than muscle backs — off-center hits still
+        travel reasonably well. Standard for most amateur golfers.
+      </Term>
+      <Term name="Loft">
+        The angle of the clubface relative to vertical. Higher loft
+        = higher ball flight and less distance. Lower loft = lower
+        ball flight and more distance.
+      </Term>
+      <Term name="Shaft flex">
+        How much the shaft bends during the swing. Options from
+        most to least flexible: Ladies, Senior, Regular, Stiff,
+        Extra Stiff. Wrong shaft flex affects ball flight and
+        distance.
+      </Term>
+      <Term name="Lie angle">
+        The angle between the shaft and the ground when the club is
+        soled correctly at address. If lie angle is wrong, shots
+        will miss consistently left or right even with a good
+        swing. Can be adjusted by a fitter.
+      </Term>
+
+      <Hr />
+
+      <H3>Slang and culture</H3>
+      <Term name="Worm burner">
+        A shot that never gets airborne, rolling along the ground.
+        Usually a topped or thinned iron.
+      </Term>
+      <Term name="Shank">
+        A shot struck with the hosel (the socket connecting shaft
+        to clubhead) rather than the face, resulting in a shot that
+        fires dramatically to the right for a right-handed player.
+        One of the most dreaded misses in golf. Some golfers avoid
+        saying the word on the course, as if merely uttering it
+        invites one.
+      </Term>
+      <Term name="Yips">
+        A condition where involuntary muscle twitches or nerves
+        cause jerky, uncontrolled strokes — most commonly on short
+        putts. Can affect chipping as well. More mental than
+        physical, though the exact cause is debated. Has ended
+        careers.
+      </Term>
+      <Term name="Cabbage">
+        Thick, deep rough where the ball sits down and is difficult
+        to advance. You are just trying to get out of cabbage, not
+        reach the green.
+      </Term>
+      <Term name="Lip out">
+        A putt that rolls around or over the edge of the cup
+        without falling in. One of the most frustrating outcomes
+        in golf.
+      </Term>
+      <Term name="Bite">
+        What golfers say to a ball approaching the green that they
+        want to stop quickly — asking the backspin to grab and hold
+        the green. "Bite!" Also used as a verb: "I need this to
+        bite."
+      </Term>
+      <Term name="Barkie">
+        Making par after your ball hits a tree. Counted as bonus
+        points in some social games.
+      </Term>
+      <Term name="Greenie">
+        In a group game, awarded to the player who hits the green
+        in regulation on a par 3 and is closest to the pin. Common
+        side bet in casual golf.
+      </Term>
+
+      <Hr />
+
+      <H3>Rules terms worth knowing</H3>
+      <Term name="Relief">
+        When the rules allow you to move your ball without penalty
+        — from a cart path, temporary water, ground under repair,
+        or an embedded ball.
+      </Term>
+      <Term name="Penalty area">
+        The modern Rules term (since 2019) for what was previously
+        called a water hazard. Yellow penalty areas offer two
+        relief options; red penalty areas offer three. You may now
+        ground your club in a penalty area.
+      </Term>
+      <Term name="Ground under repair (GUR)">
+        Areas of the course marked for maintenance. Free relief is
+        available from GUR.
+      </Term>
+      <Term name="Provisional ball">
+        A second ball played when you believe your first ball may
+        be lost or out of bounds. Must be announced as provisional
+        before playing. Saves time — avoids walking back to replay.
+      </Term>
+      <Term name="Stroke and distance">
+        The penalty for a lost ball or out-of-bounds shot. Add one
+        penalty stroke AND return to where you played from. The
+        most severe penalty in golf.
+      </Term>
+
+      <Hr />
+
+      <H3>Historical terms (and why you still hear them)</H3>
+      <P>
+        Golf has a longer continuous history than almost any other
+        sport, and its vocabulary reflects that. Some terms from
+        the hickory-shaft era (roughly pre-1930) have stuck around
+        — either in formal golf writing, in the names of classic
+        holes and courses, or because older golfers still use them
+        affectionately. Younger players sometimes use them cheekily.
+      </P>
+      <Term name="Brassie">
+        The old name for what we now call a 2-wood. Named for the
+        brass plate on the sole of the club. You might hear someone
+        pull out their fairway wood and say "give me the brassie"
+        as a throwback reference.
+      </Term>
+      <Term name="Spoon">
+        Old name for a 3-wood. The shallow, spoon-like face of the
+        club gave it the name. Still occasionally used by writers
+        describing vintage golf or classic architecture.
+      </Term>
+      <Term name="Baffy">
+        Old name for a 4-wood. Rarely heard today but shows up in
+        historical writing about early golf.
+      </Term>
+      <Term name="Cleek">
+        A low-lofted iron from the hickory era, roughly equivalent
+        to a modern 1 or 2-iron. Also used to describe a
+        narrow-faced iron used for distance from tight lies. "The
+        cleek" appears frequently in descriptions of early 20th
+        century golf.
+      </Term>
+      <Term name="Mashie">
+        Old name roughly equivalent to a modern 5-iron. One of the
+        most commonly referenced hickory-era clubs. "Mashie niblick"
+        was a club between the mashie and niblick — roughly a
+        7-iron equivalent.
+      </Term>
+      <Term name="Niblick">
+        A high-lofted hickory club used for short approach shots
+        and trouble shots — roughly equivalent to a modern 9-iron
+        or wedge. The niblick was the go-to club for escaping
+        difficult lies.
+      </Term>
+      <Term name="Jigger">
+        A utility iron from the hickory era with moderate loft,
+        used for punch shots and running approaches. No clean
+        modern equivalent. The term occasionally resurfaces in
+        discussions of bump-and-run shot technique.
+      </Term>
+      <Term name="Stymie">
+        A now-abolished situation in match play where your
+        opponent's ball blocked your putting line and you had to
+        play around or over it. Eliminated from the rules in 1952
+        when ball marking became standard. Still used figuratively
+        in everyday English — "I'm in a bit of a stymie" — meaning
+        blocked or stuck.
+      </Term>
+      <Term name="Fore">
+        Still very much in use — the warning shout when a ball is
+        heading toward other players. The origin is disputed:
+        possibly from "forecaddie" (a spotter walking ahead),
+        possibly a military "beware before" command. One of golf's
+        oldest surviving terms and one of its most important.
+      </Term>
+      <EditorialNote variant="todo">
+        Verify historical club equivalencies — sources vary on
+        exact loft comparisons between hickory era clubs and modern
+        equivalents.
+      </EditorialNote>
+
+      <Footer />
     </article>
   )
 }
 
-function Term({
-  kicker,
-  title,
-  children,
-}: {
-  kicker: string
-  title: string
-  children: ReactNode
-}) {
+// ===========================================================================
+// Components
+// ===========================================================================
+
+function H3({ children }: { children: React.ReactNode }) {
   return (
-    <section
+    <h3
+      className="font-serif text-caddie-ink"
       style={{
-        borderTop: '1px solid #D9D2BF',
-        paddingTop: 22,
-        marginBottom: 32,
+        fontSize: 22,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        letterSpacing: '-0.01em',
+        lineHeight: 1.2,
+        marginTop: 26,
+        marginBottom: 14,
       }}
     >
-      <div className="kicker" style={{ marginBottom: 12 }}>
-        {kicker}
-      </div>
-      <h3
+      {children}
+    </h3>
+  )
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="text-caddie-ink"
+      style={{
+        fontSize: 15,
+        lineHeight: 1.6,
+        maxWidth: 680,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </p>
+  )
+}
+
+function Term({ name, children }: { name: string; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        padding: '12px 0',
+        maxWidth: 680,
+      }}
+    >
+      <div
         className="font-serif text-caddie-ink"
         style={{
-          fontSize: 22,
+          fontSize: 16,
           fontWeight: 500,
           fontStyle: 'italic',
-          letterSpacing: '-0.015em',
-          lineHeight: 1.2,
-          marginBottom: 12,
+          marginBottom: 4,
         }}
       >
-        {title}
-      </h3>
-      {children}
-    </section>
+        {name}
+      </div>
+      <div
+        className="text-caddie-ink"
+        style={{ fontSize: 14, lineHeight: 1.55 }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Hr() {
+  return (
+    <div
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        margin: '22px 0',
+      }}
+    />
+  )
+}
+
+function EditorialNote({
+  variant,
+  children,
+}: {
+  variant: 'research' | 'todo'
+  children: React.ReactNode
+}) {
+  if (!DEV) return null
+  const tone = variant === 'research' ? '#1F3D2C' : '#A66A1F'
+  const label = variant === 'research' ? 'Source' : 'Todo'
+  return (
+    <div
+      style={{
+        background: '#EBE5D6',
+        borderLeft: `3px solid ${tone}`,
+        padding: '10px 14px',
+        marginBottom: 14,
+        marginTop: 14,
+        maxWidth: 680,
+      }}
+    >
+      <div
+        className="font-mono uppercase"
+        style={{
+          fontSize: 10,
+          letterSpacing: '0.14em',
+          color: tone,
+          marginBottom: 4,
+        }}
+      >
+        {label} · dev only
+      </div>
+      <div
+        className="text-caddie-ink-dim"
+        style={{ fontSize: 13, lineHeight: 1.5, fontStyle: 'italic' }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Footer() {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 1.6,
+      }}
+    >
+      Last reviewed May 2026 · Draft, being expanded · Edit
+      docs/learn/glossary.md to contribute
+    </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/MentalGameArticle.tsx
+++ b/apps/web/src/pages/learn/articles/MentalGameArticle.tsx
@@ -1,0 +1,675 @@
+const DEV = import.meta.env.DEV
+
+export function MentalGameArticle() {
+  return (
+    <article
+      id="mental-game"
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 22,
+        marginBottom: 32,
+      }}
+    >
+      <div className="kicker" style={{ marginBottom: 14 }}>
+        On the course · Draft
+      </div>
+      <h2
+        className="font-serif text-caddie-ink"
+        style={{
+          fontSize: 28,
+          fontWeight: 500,
+          fontStyle: 'italic',
+          letterSpacing: '-0.015em',
+          lineHeight: 1.15,
+          marginBottom: 18,
+        }}
+      >
+        The mental game.
+      </h2>
+
+      <H3>Golf is you versus you</H3>
+      <P>
+        Every other sport has an opponent actively trying to stop
+        you. A defender. A pitcher. A goalie. In golf, the course is
+        static. The ball sits still and waits. Nobody is trying to
+        beat you except you.
+      </P>
+      <P>
+        Once you have a functional golf swing — once you understand
+        the basic mechanics of how the club interacts with the ball,
+        the turf, the wind — the game becomes almost entirely mental.
+        The physical skill gets you onto the course. What happens
+        there is a different problem entirely.
+      </P>
+      <P>
+        Most amateurs spend 95% of their practice time on the physical
+        game and almost none on the mental game. This is backwards
+        for anyone who has been playing more than a couple of years.
+        The swing is largely solved. The mental game is the frontier.
+      </P>
+      <P>
+        Golf is also one of the most humbling experiences available
+        to a human being. It will find every weakness in your ego
+        and expose it repeatedly. If you play with a large ego, the
+        game will spend a long time teaching you to either reduce it
+        or suffer. There is no third option.
+      </P>
+
+      <Hr />
+
+      <H3>One shot at a time</H3>
+      <P>
+        Every touring professional, when asked about performance,
+        eventually says the same thing: one shot at a time. It sounds
+        like a cliché because it gets repeated so often. It gets
+        repeated so often because it is genuinely, literally true.
+      </P>
+      <P>
+        You cannot hit the shot you just hit over again. You cannot
+        hit the next shot until you finish this one. The only shot
+        that exists is the one in front of you right now.
+      </P>
+      <P>
+        The mental game problem is that the human brain doesn't
+        naturally work this way. It replays the shot you just botched.
+        It fast-forwards to the putt you need to make on 18. It
+        calculates what score you need on the remaining holes. All
+        of this thinking happens at exactly the moment you need to
+        be doing one thing: hitting the shot in front of you.
+      </P>
+      <P>
+        Bob Rotella describes this as refusing to be seduced by
+        results. At the 2008 Masters, Trevor Immelman held a two-shot
+        lead going into the final round and made a decision: he
+        would not look at a single leaderboard all day. His plan was
+        simple — pick a target, visualize the shot, hit it. Walking
+        up the 18th fairway, it was the first time all day he allowed
+        himself to think about the outcome. He asked his caddie how
+        they stood. Three shots over Tiger. His immediate thought:
+        how can I not five-putt this? The routine had protected him
+        all day. The moment he stepped outside it, the pressure
+        arrived.
+      </P>
+      <P>
+        The short memory is not something you are born with. It is
+        a skill you develop deliberately. You give yourself a window
+        to feel the emotion — Rotella describes walking it off,
+        physically moving away from the shot, letting the feeling
+        pass — and then you are done with it. The bad shot already
+        happened. It cannot be changed. Carrying it into the next
+        shot is a choice, and it is a bad one.
+      </P>
+      <P>
+        The same discipline applies to good shots. A stretch of made
+        putts, a run of flushed irons — the player who stays even
+        through the highs as well as the lows is harder to shake
+        than the player who rides the wave. The wave always comes
+        back down. Stay level.
+      </P>
+
+      <Hr />
+
+      <H3>Sulking won't get you anything</H3>
+      <P>
+        When Padraig Harrington won the 2007 British Open, he knocked
+        two balls into the water on the last hole and made double
+        bogey. He still won. He told Rotella afterward that he had a
+        level of acceptance that earlier in his career he didn't
+        have — it never entered his mind that he might blow the
+        tournament. His only thought was getting the ball in the
+        hole so he could make the playoff.
+      </P>
+      <P>
+        That is the mental game in one story. Bad things happened.
+        Catastrophically bad things. And his response was not panic,
+        not despair, not self-recrimination. It was: what is the
+        next shot?
+      </P>
+      <P>
+        Rotella is direct about this: sulking won't get you anything.
+        Feeling sorry for yourself, thinking the golf gods are
+        conspiring against you, replaying the mistake — none of it
+        changes what happened and all of it damages what comes next.
+        The worst thing you can do for your prospects after a bad
+        shot is to get down.
+      </P>
+      <P>
+        Give yourself a moment. Feel it briefly. Then drop it. You
+        have more golf to play and you need to be present for it.
+      </P>
+
+      <Hr />
+
+      <H3>The productive delusion</H3>
+      <P>
+        Rotella's first rule is the one that separates good mental
+        players from great ones: believe you can win. Not hope you
+        might. Not think you have a chance. Believe.
+      </P>
+      <P>
+        This extends to every shot. The player on a putting heater —
+        making everything they look at — approaches the next putt
+        believing it's going in too, because they've been making
+        everything. The player who has been missing putts all
+        afternoon approaches the next one thinking: I'm due, this
+        one is definitely going in.
+      </P>
+      <P>
+        Both of these are, strictly speaking, irrational. Previous
+        putts have no causal relationship to the next one. But the
+        golfer who believes they're going to make the putt stands
+        over the ball with a fundamentally different quality of
+        attention than the golfer who doubts. And that quality of
+        attention affects the outcome.
+      </P>
+      <P>
+        This is not blind positivity. It is the deliberate
+        construction of a mental state that serves your performance.
+        Rotella calls it confidence. It might also be called a
+        productive delusion. The tour player who says "I just knew
+        I was going to make it" is not describing a premonition.
+        They are describing a trained mental habit of belief.
+      </P>
+      <P>
+        You are allowed to be delusional in your own favor. In golf,
+        it is the correct strategy.
+      </P>
+
+      <Hr />
+
+      <H3>Visualization</H3>
+      <P>
+        Before a shot, the mental game starts. Not on the backswing —
+        before you even take the club out of the bag.
+      </P>
+      <P>
+        Visualization is the process of seeing the shot you want to
+        hit before you hit it. Not hoping for it. Not wishing for
+        it. Actually seeing it — the ball flight, the trajectory,
+        the landing spot, the bounce and roll. Seeing it like a
+        video, in real time, as if it has already happened.
+      </P>
+      <P>
+        For putting: see the line. See the ball rolling along that
+        line. See it drop into the cup. Make the visualization as
+        vivid and specific as possible.
+      </P>
+      <P>
+        This is not mysticism. It is how motor learning works. The
+        brain rehearses movement patterns through visualization in
+        ways that translate directly into physical execution.
+        Athletes across every sport use it. Pick a target, visualize
+        the shot, let it rip. In that order, every time.
+      </P>
+      <P>
+        The practical version: before every shot, take a moment to
+        see exactly what you want the ball to do. Then step into the
+        shot with that image in your mind — not with swing thoughts,
+        not with mechanical checkpoints. The image.
+      </P>
+      <EditorialNote variant="research">
+        Research basis: mental imagery and motor performance. See
+        Guillot &amp; Collet (2008) on mental simulation of motor
+        actions.
+      </EditorialNote>
+      <EditorialNote variant="todo">
+        TODO: Add more specific research citations
+      </EditorialNote>
+
+      <Hr />
+
+      <H3>The routine as an anchor</H3>
+      <P>
+        A consistent pre-shot routine serves two purposes that most
+        golfers understand: it prepares you physically for the shot
+        and gives you a repeatable process. But it serves a third
+        purpose that is underappreciated.
+      </P>
+      <P>The routine is an anchor to the present moment.</P>
+      <P>
+        Curtis Strange won the 1988 U.S. Open and went home to watch
+        the tape with his wife and kids. They kept commenting on how
+        cool and calm he looked. Strange told Rotella: "I'm thinking,
+        who in the world are they talking about? They can't be
+        talking about me. I couldn't get any moisture in my mouth.
+        My heart was jumping out of my chest."
+      </P>
+      <P>
+        He had so much emotion in his body it was unbelievable. He
+        was working his tail off just to stay in the present, hit
+        one shot at a time, and not think about what it would mean
+        to win the U.S. Open. The routine made him look calm. More
+        importantly, the routine kept him functional.
+      </P>
+      <P>
+        When the mind is scattered — worried about score, replaying
+        a bad hole, distracted by pressure — going through the
+        routine brings you back. Not because it is magic, but because
+        executing a sequence of familiar physical actions requires
+        present-moment attention.
+      </P>
+      <P>
+        This is why the routine must be consistent. An inconsistent
+        routine cannot serve as an anchor because there is nothing
+        consistent to return to. The same grip check, the same
+        practice swing, the same target look — every time, regardless
+        of the situation. The bigger the moment, the more important
+        it is that the routine does not change.
+      </P>
+      <EditorialNote variant="research">
+        Manu, The Upbeat Golfer — YouTube. Target commitment and
+        pre-shot routine for process-driven play.
+      </EditorialNote>
+
+      <Hr />
+
+      <H3>Patience over aggression</H3>
+      <P>
+        Rotella's fourth rule: every time you have the urge to make
+        an aggressive play, go with the more conservative one. You
+        will always be okay.
+      </P>
+      <P>
+        At the 1992 U.S. Open at Pebble Beach, Tom Kite had been
+        0 for 20 in U.S. Opens. Wind gusts reached 35 miles per
+        hour on Sunday. Most players didn't break 80. Kite shot
+        even par and won by two. He did it by not getting flustered.
+        By staying patient. By letting others beat themselves.
+      </P>
+      <P>
+        In tough conditions — and golf is almost always tough
+        conditions of some kind — patience is a competitive
+        advantage. The impatient player forces shots. The patient
+        player waits for the right opportunity and executes the
+        percentages. Over 18 holes this compounds significantly.
+      </P>
+
+      <Hr />
+
+      <H3>Ignore unsolicited swing advice</H3>
+      <P>This one is practical and underappreciated.</P>
+      <P>
+        Rotella tells a story about a player who had been struggling,
+        found some form, made eight birdies in the first round of a
+        tournament, and was feeling great. He stopped by the putting
+        green and within minutes two different players had commented
+        on his setup and his eye position. By the next day he was a
+        mess.
+      </P>
+      <P>
+        You will have well-meaning friends, playing partners, and
+        observers who want to give you advice on the course or
+        between rounds. Don't accept it. In fact, stop them before
+        they can say a word. Their comments will creep into your
+        mind when you are on the course, at exactly the moment you
+        need to be thinking about one thing: your target.
+      </P>
+      <P>
+        If you've worked on your game and made a plan with your
+        coach, commit to it. Stay confident. Someone else's
+        observation about your backswing on hole 12 is not something
+        you can do anything useful with right now. File it for the
+        range later, or let it go entirely.
+      </P>
+
+      <Hr />
+
+      <H3>Calm is a superpower</H3>
+      <P>
+        You cannot make good decisions when you're angry. You cannot
+        execute a golf swing well when you're amped up or brooding
+        or seething. The physiological state of anger — elevated
+        heart rate, tunnel vision, impaired judgment — is the exact
+        opposite of the state required to hit a golf ball well.
+      </P>
+      <P>
+        This is not about being emotionless. Emotion is human and
+        golf produces a lot of it. A good shot feels great. A bad
+        one is genuinely frustrating. You are allowed to feel that.
+      </P>
+      <P>
+        What you are not allowed to do — if you want to play well —
+        is let it linger. Give yourself the walk. Feel it. Let it
+        out briefly and privately. Then drop it. The next shot
+        requires your full attention and you cannot give it that if
+        you are still living in the last one.
+      </P>
+      <P>
+        Placing your hand on your chest, feeling your breath, looking
+        at something specific in your physical environment — these
+        grounding techniques exist to pull you out of the prison of
+        your own mind and back onto the golf course where the actual
+        game is being played. They sound simple and almost silly
+        until you try them under real pressure. They work.
+      </P>
+
+      <Hr />
+
+      <H3>Grounding and the present moment</H3>
+      <P>
+        When the mind spirals — after a run of bad holes, after a
+        penalty, after a blow-up — the way back is through the body,
+        not through more thinking.
+      </P>
+      <P>
+        Grounding techniques bring you back to the present moment
+        physically. Feel your feet on the ground. Feel the grip in
+        your hands. Look at the grass, the trees, the sky. Notice
+        something specific about your physical environment.
+      </P>
+      <P>
+        The mind in a spiral is pulling you into the past (the shots
+        you have already hit) or the future (what your score might
+        end up being). The body only exists in the present. Returning
+        attention to physical sensation is the fastest route back to
+        the present moment where the golf shot actually lives.
+      </P>
+      <P>
+        This is where golf becomes deeply Buddhist in its demands —
+        not attached to outcomes, not grasping at results, returning
+        again and again to what is actually happening right now. The
+        shot in front of you. The target you have chosen. The swing
+        you trust.
+      </P>
+      <P>That is all there is. Everything else is noise.</P>
+
+      <Hr />
+
+      <H3>Find someone who believes in you</H3>
+      <P>
+        Rotella's tenth rule is the one that gets overlooked in
+        conversations about the mental game: find someone who
+        believes in you.
+      </P>
+      <P>
+        Ben Hogan told Rotella he had considered quitting the game
+        several times early in his career because he didn't think
+        he was providing for his wife the way he should. Valerie
+        Hogan wouldn't let him quit. She knew he would never be
+        satisfied until he won majors. Having confidence in yourself
+        is essential. But having someone who sees what you can't yet
+        see in yourself — a spouse, a friend, a coach — compounds it.
+      </P>
+      <P>
+        For amateur golfers this might be a playing partner who
+        knows your game and backs you. A coach who genuinely
+        believes in your potential. Anyone who reflects your
+        capability back to you on the days you can't see it
+        yourself.
+      </P>
+      <P>The mental game is not fought entirely alone.</P>
+
+      <Hr />
+
+      <H3>Be process-driven, not results-driven</H3>
+      <P>
+        Most golfers think too little on the golf course. They step
+        up to the ball, swing, and react emotionally to wherever it
+        goes. There is no plan and no process.
+      </P>
+      <P>
+        But there is an opposite problem: once golfers start trying
+        to improve, they often start thinking too much. They
+        outthink themselves — grinding over swing thoughts, worrying
+        about mechanics, replaying the last bad shot — because they
+        are not yet good enough to execute what they are thinking
+        about. Analysis paralysis is just as damaging as mindlessness.
+      </P>
+      <P>The sweet spot is a clear, repeatable pre-shot process:</P>
+      <ul style={UL_STYLE}>
+        <li>Pick a specific target</li>
+        <li>Visualize the shot</li>
+        <li>Commit fully</li>
+        <li>Go through your routine</li>
+        <li>Pull the trigger</li>
+      </ul>
+      <P>
+        That is it. You do not need to solve the hole. You need to
+        play one shot at a time with full commitment.
+      </P>
+      <P>
+        Try tracking — alongside your score — whether you committed
+        to each shot. Not whether it went where you wanted. Whether
+        you actually went through your process and pulled the trigger
+        without doubt.
+      </P>
+      <P>
+        Results-oriented thinking leads to tension, steering, and
+        the exact outcome you were afraid of. Process-oriented
+        thinking gives you the best chance of executing the shot.
+        The score takes care of itself when the process is right.
+      </P>
+
+      <Hr />
+
+      <H3>It never gets fully solved</H3>
+      <P>
+        One of the more humbling truths about the mental game is
+        that it never gets fully mastered. Tour professionals — with
+        decades of experience, sports psychologists, meditation
+        practices, and more mental reps than most amateurs will ever
+        have — still get in their own way. Still lose shots to the
+        mental game.
+      </P>
+      <P>
+        The goal is not to eliminate the mental challenge. The goal
+        is to get better at returning to the right state more
+        quickly. The tour player who has a double bogey on hole 6
+        and is back to full focus on hole 7 has the same mental
+        challenge as the amateur who takes four holes to recover —
+        they just recover faster.
+      </P>
+      <P>
+        That recovery time is what you are training. Not the absence
+        of difficulty. The speed of return.
+      </P>
+
+      <Hr />
+
+      <H3>Resources</H3>
+      <EditorialNote variant="todo">
+        Verify all links before publishing.
+      </EditorialNote>
+      <ResourceList
+        items={[
+          {
+            title: '"Golf Is Not a Game of Perfect"',
+            by: 'Bob Rotella.',
+            note: 'The gold standard in golf psychology. Essential reading.',
+          },
+          {
+            title: '"Golf Is a Game of Confidence"',
+            by: 'Bob Rotella.',
+            note: 'The follow-up, equally valuable.',
+          },
+          {
+            title: 'Bob Rotella — "My 10 Rules on Mental Fitness"',
+            note: 'GolfWRX. The ten rules referenced throughout this article.',
+          },
+          {
+            title: '"Zen Golf"',
+            by: 'Joseph Parent.',
+            note: 'Buddhist-influenced approach to present-moment play.',
+          },
+          {
+            title: 'The Upbeat Golfer (Manu)',
+            note: 'YouTube. Process-driven mental approach, target commitment, playing without fear.',
+          },
+          {
+            title: '"The Inner Game of Tennis"',
+            by: 'Tim Gallwey.',
+            note: 'Not golf-specific but the foundational text on getting out of your own way in sport. Directly applicable.',
+          },
+          {
+            title: '"Choke"',
+            by: 'Sian Beilock.',
+            note: 'The neuroscience of why we perform poorly under pressure and what to do about it.',
+          },
+        ]}
+      />
+      <EditorialNote variant="todo">
+        TODO: Add sports psychology research citations on visualization
+        and motor performance
+      </EditorialNote>
+
+      <Footer />
+    </article>
+  )
+}
+
+// ===========================================================================
+// Components
+// ===========================================================================
+
+function H3({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 22,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        letterSpacing: '-0.01em',
+        lineHeight: 1.2,
+        marginTop: 22,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </h3>
+  )
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="text-caddie-ink"
+      style={{
+        fontSize: 15,
+        lineHeight: 1.6,
+        maxWidth: 680,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </p>
+  )
+}
+
+function Hr() {
+  return (
+    <div
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        margin: '22px 0',
+      }}
+    />
+  )
+}
+
+const UL_STYLE: React.CSSProperties = {
+  listStyle: 'disc',
+  paddingLeft: 20,
+  margin: '8px 0 14px',
+  fontSize: 15,
+  lineHeight: 1.7,
+  color: '#1C211C',
+  maxWidth: 680,
+}
+
+interface ResourceItem {
+  title: string
+  by?: string
+  note: string
+}
+
+function ResourceList({ items }: { items: ResourceItem[] }) {
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 14px', maxWidth: 680 }}>
+      {items.map((r) => (
+        <li
+          key={r.title}
+          style={{
+            padding: '12px 0',
+            borderTop: '1px solid #D9D2BF',
+          }}
+        >
+          <div
+            className="font-serif text-caddie-ink"
+            style={{ fontSize: 15, fontWeight: 500, fontStyle: 'italic' }}
+          >
+            {r.title}
+            {r.by && (
+              <span className="text-caddie-ink-dim" style={{ fontStyle: 'normal', fontWeight: 400 }}>
+                {' '}— {r.by}
+              </span>
+            )}
+          </div>
+          <div className="text-caddie-ink-dim" style={{ fontSize: 14, lineHeight: 1.55, marginTop: 4 }}>
+            {r.note}
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function EditorialNote({
+  variant,
+  children,
+}: {
+  variant: 'research' | 'todo'
+  children: React.ReactNode
+}) {
+  if (!DEV) return null
+  const tone = variant === 'research' ? '#1F3D2C' : '#A66A1F'
+  const label = variant === 'research' ? 'Source' : 'Todo'
+  return (
+    <div
+      style={{
+        background: '#EBE5D6',
+        borderLeft: `3px solid ${tone}`,
+        padding: '10px 14px',
+        marginBottom: 14,
+        maxWidth: 680,
+      }}
+    >
+      <div
+        className="font-mono uppercase"
+        style={{
+          fontSize: 10,
+          letterSpacing: '0.14em',
+          color: tone,
+          marginBottom: 4,
+        }}
+      >
+        {label} · dev only
+      </div>
+      <div
+        className="text-caddie-ink-dim"
+        style={{ fontSize: 13, lineHeight: 1.5, fontStyle: 'italic' }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Footer() {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 1.6,
+      }}
+    >
+      Last reviewed May 2026 · Draft, needs review · Edit
+      docs/learn/mental-game.md to contribute
+    </div>
+  )
+}

--- a/apps/web/src/pages/learn/articles/SkillGamesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/SkillGamesArticle.tsx
@@ -1,0 +1,615 @@
+const DEV = import.meta.env.DEV
+
+export function SkillGamesArticle() {
+  return (
+    <article
+      id="skill-games-pressure-games"
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 22,
+        marginBottom: 32,
+      }}
+    >
+      <div className="kicker" style={{ marginBottom: 14 }}>
+        Improving your game · Draft
+      </div>
+      <h2
+        className="font-serif text-caddie-ink"
+        style={{
+          fontSize: 28,
+          fontWeight: 500,
+          fontStyle: 'italic',
+          letterSpacing: '-0.015em',
+          lineHeight: 1.15,
+          marginBottom: 18,
+        }}
+      >
+        Skill games and pressure games.
+      </h2>
+
+      <H3>Why games beat mindless repetition</H3>
+      <P>
+        Hitting the same shot over and over until you run out of
+        balls is the default range session for most golfers. It
+        feels like practice. It largely isn't.
+      </P>
+      <P>
+        Games change the dynamic. A game has a target, a score, and
+        stakes. You're tracking something. You either succeed or you
+        don't. That structure forces commitment on each shot — the
+        same commitment you need on the course — in a way that
+        hitting bucket after bucket never will.
+      </P>
+      <P>
+        The best practice sessions end with games. Not start with
+        them — your technical work belongs earlier in the session
+        when your focus is fresh — but finish with them, when you're
+        shifting from mechanics to performance.
+      </P>
+
+      <Hr />
+
+      <H3>The pressure problem</H3>
+      <P>
+        Here is the fundamental challenge of practice: you know you
+        have another ball. On the course, you don't.
+      </P>
+      <P>
+        That knowledge — that there's always another shot coming —
+        removes the consequence from every swing on the range. You
+        can be a little loose. You can bail out. Nothing is riding
+        on it. And so you never practice the mental state you
+        actually need when something is riding on it.
+      </P>
+      <P>
+        Pressure games exist to solve this. The goal is to create
+        enough consequence that you actually care about the shot —
+        that your heart rate ticks up slightly, that missing would
+        genuinely bother you. Not so much that you're miserable if
+        you miss. Just enough that each shot matters.
+      </P>
+      <P>
+        The stakes need to be real to you. They don't need to be
+        large. A candy bar if you make five putts in a row. Ten
+        pushups if you miss this last drive. Playing for coffee
+        with a buddy. Whatever makes you care — that's the right
+        level. Too small and you still don't care. Too large and
+        anxiety takes over and defeats the purpose.
+      </P>
+      <P>
+        The last few balls of a range bucket are a natural pressure
+        game. You're out of balls. These are the last ones. Make
+        them count. That scarcity, even artificially constructed,
+        changes how you approach the shot.
+      </P>
+
+      <Hr />
+
+      <H3>Putting games</H3>
+
+      <H4>The clock drill</H4>
+      <P>
+        Place twelve balls around a hole at a consistent distance —
+        three feet is a good starting point. The balls form a clock
+        face, one ball at each hour position.
+      </P>
+      <P>
+        The goal: make all twelve in a row. If you miss, start over
+        from zero.
+      </P>
+      <P>
+        This drill is deceptively brutal. Making the first few is
+        easy. Getting to eleven and then missing is genuinely
+        painful. That pain is the point — it simulates the pressure
+        of needing to make a putt with something on the line.
+      </P>
+      <P>
+        As you improve, move to four feet, then five. PGA Tour
+        players do this drill from six feet as a standard warm-up.
+        If you can make all twelve from six feet without missing,
+        your short putting is tour-level.
+      </P>
+      <Kv label="Variation">
+        Do it with only one ball. Walk around the clock, replace
+        the ball after each putt, make all twelve in a row. The
+        single-ball version is harder because you get no second
+        chances and the walk resets your mental state between putts
+        — exactly like on the course.
+      </Kv>
+
+      <H4>The three-station pressure drill</H4>
+      <P>
+        Set up three stations: three feet, six feet, and nine feet.
+      </P>
+      <P>
+        The goal: make ten putts at each station before moving to
+        the next. Miss more than one at any station and you go back
+        to the start of that station.
+      </P>
+      <P>
+        This creates escalating pressure. Making ten from three
+        feet is achievable. Moving to six and knowing you have to
+        start the station over if you miss two — now it matters.
+        Getting to the nine-foot station after successfully
+        completing the first two — the pressure is real.
+      </P>
+      <P>
+        Track your score across sessions. How many total attempts
+        before you complete all three stations? That number should
+        drop over time as your putting under pressure improves.
+      </P>
+
+      <H4>The putting circuit</H4>
+      <P>
+        Pick nine holes on the practice green and play them as a
+        course. Par 2 for each hole — you're trying to one-putt
+        every hole, with a two-putt as par. Three putts is a bogey.
+      </P>
+      <P>
+        Play it as a proper nine-hole round. Keep score. Play the
+        same nine holes every session so you can track improvement
+        over time. This also forces you to practice from all
+        different distances and read different breaks rather than
+        repeatedly putting the same flat putt.
+      </P>
+      <Kv label="Competitive version">
+        Play it head to head with a partner. Stroke play or match
+        play — both work. Competition adds pressure that solo
+        practice can't replicate.
+      </Kv>
+
+      <H4>The gate drill</H4>
+      <P>
+        Place two tees just wider than your putter head a foot in
+        front of the ball on your intended line, forming a gate.
+        The ball must roll through the gate without touching either
+        tee.
+      </P>
+      <P>
+        This trains starting line. Most missed putts are missed
+        before the ball breaks — the line is wrong at impact. The
+        gate makes you accountable for that immediately.
+      </P>
+      <P>
+        Start at six feet on a relatively straight putt. When you
+        can consistently roll it through the gate, move back to
+        ten feet. Move to a breaking putt. The gate exposes any
+        inconsistency in your stroke path fast.
+      </P>
+
+      <H4>Speed control — the ladder drill</H4>
+      <P>
+        Drop five balls at ten feet from the hole. Hit the first
+        putt and watch where it finishes — past the hole, short,
+        wherever. Your second putt must finish on the opposite side
+        of the hole from the first. Your third putt must finish
+        between the first two.
+      </P>
+      <P>
+        If you pull it off, move back five feet and repeat. If you
+        miss the requirement, start over from ten feet.
+      </P>
+      <P>
+        This trains speed control and the ability to intentionally
+        vary your pace — skills that transfer directly to lag
+        putting and managing fast greens.
+      </P>
+
+      <Hr />
+
+      <H3>Chipping and short game games</H3>
+
+      <H4>Up and down challenge</H4>
+      <P>
+        Pick five spots around the practice green at varying
+        distances and difficulties. From each spot, chip and then
+        finish the hole out with the putter. Count the total strokes
+        for all five holes.
+      </P>
+      <P>
+        Set a target score — maybe 12 to start — and try to beat it
+        each session. Lower your target as you improve.
+      </P>
+      <Kv label="Pressure version">
+        You must get up and down five in a row. Miss any one and
+        start the streak over. Getting to four in a row and then
+        chunking a chip is exactly the kind of pressure the course
+        creates.
+      </Kv>
+
+      <H4>Three clubs, one ball per station</H4>
+      <P>
+        Pick three distances — say 20 yards, 40 yards, and 60 yards.
+        Hit one ball from each distance to a specific target. One
+        ball. You don't get another one.
+      </P>
+      <P>
+        The single-ball constraint is everything. When you know
+        there's no mulligan, the shot suddenly matters in a way it
+        doesn't when you have a pile of balls at your feet.
+      </P>
+
+      <H4>Flag left or flag right</H4>
+      <P>
+        At the range, pick a flag as your target. Before each shot,
+        declare: left or right. If your ball finishes within a
+        defined window on the declared side — say ten feet — that's
+        a birdie. If it finishes on the correct side but outside
+        the window, that's par. If it finishes on the wrong side of
+        the flag, that's double bogey.
+      </P>
+      <P>
+        This game teaches two things. First, you learn to control
+        shot shape under pressure — you have to commit to a side
+        before you swing. Second, and more importantly, you learn
+        the cost of the short side. Finishing on the wrong side of
+        the flag on an approach shot leaves you the hardest possible
+        chip. The game makes you feel that cost in practice so you
+        respect it on the course.
+      </P>
+      <P>
+        Keep score over ten shots. A good round is -4 or better.
+      </P>
+
+      <Hr />
+
+      <H3>Full swing games</H3>
+
+      <H4>Horse at the range</H4>
+      <P>
+        Exactly like the basketball game. Pick a target — a specific
+        flag, a yardage sign, a tree in the distance. Hit your shot.
+        Your partner has to match it with the same or similar club.
+        Miss and you get a letter. First to H-O-R-S-E loses.
+      </P>
+      <P>
+        This game is deceptively effective because calling your
+        shot — committing to a specific target before you swing —
+        is exactly the skill you need on the course. You can't hide
+        in vagueness when your partner is watching to see if you
+        matched the shot.
+      </P>
+
+      <H4>The imaginary fairway</H4>
+      <P>
+        Pick two targets on the range to define a fairway — two
+        flags, two trees, whatever. Make the fairway about 25–30
+        yards wide for a standard driver shot. Narrower if you want
+        more challenge.
+      </P>
+      <P>
+        Hit ten tee shots. Score: driver in the fairway = 3 points,
+        fairway wood = 2 points, iron = 1 point. Add a penalty: -2
+        points for a shot that would find water if you imagine a
+        hazard on one side.
+      </P>
+      <P>
+        The scoring system incentivizes you to use driver — the
+        club that gives you the most distance but the most risk.
+        It also forces a decision on every shot about whether the
+        reward is worth the risk. That's the tee shot decision on
+        every hole of real golf.
+      </P>
+
+      <H4>Same distance, different clubs</H4>
+      <P>
+        Pick a target on the range — a flag at, say, 100 yards. Now
+        try to hit that target with five different clubs. Your
+        9-iron, your 8-iron, your pitching wedge, your gap wedge,
+        your sand wedge. Each club requires a different swing length
+        and speed to cover the same distance.
+      </P>
+      <P>
+        This game builds the feel for partial shots — one of the
+        hardest skills in golf and one that most amateurs never
+        specifically practice. It also teaches you your actual
+        distances more precisely than full swings ever will, because
+        you're forced to feel what a 75% swing with each club
+        produces.
+      </P>
+
+      <H4>Three club challenge</H4>
+      <P>
+        Play a simulated nine-hole round on the range using only
+        three clubs. Pick a driver, a mid iron, and a wedge. Play
+        nine imaginary holes, hitting each shot as if you're on a
+        real course — tee shot to a target, approach to a different
+        target, chip to a third.
+      </P>
+      <P>
+        Three clubs forces creativity. You can't default to the
+        perfect club for every situation because perfect clubs
+        aren't available. You learn to work the ball, manufacture
+        shots, and think your way around a hole rather than just
+        grinding through it mechanically.
+      </P>
+
+      <Hr />
+
+      <H3>The last ball rule</H3>
+      <P>
+        Here is a simple pressure practice habit that requires no
+        setup and no partner.
+      </P>
+      <P>
+        Whatever you're practicing on the range — irons, driver,
+        wedges — save your last ball for a specific challenge.
+        Announce it to yourself before you hit it.
+      </P>
+      <ul style={UL_STYLE}>
+        <li>"This drive has to find the fairway."</li>
+        <li>"This wedge has to finish within ten feet of the flag."</li>
+        <li>"This 7-iron has to carry the 150 marker."</li>
+      </ul>
+      <P>
+        One ball. No second chance. The session ends on this shot
+        and you find out whether the work you just did translates
+        when something is riding on it.
+      </P>
+      <P>
+        You will be surprised how differently you approach a shot
+        when you know it's the last one.
+      </P>
+
+      <Hr />
+
+      <H3>Building your own pressure games</H3>
+      <P>
+        The best pressure games are the ones where the stakes feel
+        real to you personally. Generic drills work, but customized
+        stakes work better.
+      </P>
+      <P>A few principles for building your own:</P>
+      <Kv label="The stakes must be real but not ruinous">
+        A candy bar, a coffee, ten pushups, bragging rights — these
+        work. Losing twenty dollars, embarrassing yourself in front
+        of a crowd — these create the wrong kind of pressure that
+        shuts down performance rather than training it.
+      </Kv>
+      <Kv label="Streaks create more pressure than totals">
+        Making ten putts out of fifteen creates less pressure than
+        making five in a row. The streak format means every putt
+        after a successful one carries the weight of the whole
+        streak. That's closer to how the course actually feels.
+      </Kv>
+      <Kv label="One-and-done beats best-of">
+        A single ball, a single attempt, no mulligans. The more the
+        practice shot resembles the one-chance nature of a real
+        shot, the more it trains the right mental state.
+      </Kv>
+      <Kv label="Track your scores over time">
+        A game without a scoreboard is just a drill. The scoreboard
+        is what makes it a game — and watching your score improve
+        over months is genuinely motivating.
+      </Kv>
+
+      <Hr />
+
+      <H3>Resources</H3>
+      <EditorialNote variant="todo">
+        Verify all links before publishing.
+      </EditorialNote>
+      <ResourceList
+        items={[
+          {
+            title: 'Golf Digest — 15 Best Golf Practice Games',
+            note: 'golfdigest.com. Good overview of range and putting green games.',
+          },
+          {
+            title: 'Practical Golf — 5 Games That Build Real Skills',
+            note: 'practical-golf.com. Solid collection of pressure games with scoring systems.',
+          },
+          {
+            title: '"Dave Pelz\'s Short Game Bible"',
+            note: 'The research-based approach to short game practice. Specific drills backed by data.',
+          },
+          {
+            title: 'The Upbeat Golfer (Manu)',
+            note: 'YouTube. Process under pressure, routine under stakes.',
+          },
+        ]}
+      />
+      <EditorialNote variant="todo">
+        TODO: Add research citations on pressure practice and
+        performance transfer (see Sian Beilock's work on choking
+        and practice under pressure)
+      </EditorialNote>
+
+      <Footer />
+    </article>
+  )
+}
+
+// ===========================================================================
+// Components
+// ===========================================================================
+
+function H3({ children }: { children: React.ReactNode }) {
+  return (
+    <h3
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 22,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        letterSpacing: '-0.01em',
+        lineHeight: 1.2,
+        marginTop: 22,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </h3>
+  )
+}
+
+function H4({ children }: { children: React.ReactNode }) {
+  return (
+    <h4
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 17,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        marginTop: 18,
+        marginBottom: 8,
+      }}
+    >
+      {children}
+    </h4>
+  )
+}
+
+function P({ children }: { children: React.ReactNode }) {
+  return (
+    <p
+      className="text-caddie-ink"
+      style={{
+        fontSize: 15,
+        lineHeight: 1.6,
+        maxWidth: 680,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </p>
+  )
+}
+
+function Kv({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 12, maxWidth: 680 }}>
+      <span
+        className="font-serif text-caddie-ink"
+        style={{
+          fontSize: 15,
+          fontWeight: 500,
+          fontStyle: 'italic',
+        }}
+      >
+        {label}.
+      </span>{' '}
+      <span className="text-caddie-ink" style={{ fontSize: 15, lineHeight: 1.6 }}>
+        {children}
+      </span>
+    </div>
+  )
+}
+
+function Hr() {
+  return (
+    <div
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        margin: '22px 0',
+      }}
+    />
+  )
+}
+
+const UL_STYLE: React.CSSProperties = {
+  listStyle: 'disc',
+  paddingLeft: 20,
+  margin: '8px 0 14px',
+  fontSize: 15,
+  lineHeight: 1.7,
+  color: '#1C211C',
+  maxWidth: 680,
+}
+
+interface ResourceItem {
+  title: string
+  by?: string
+  note: string
+}
+
+function ResourceList({ items }: { items: ResourceItem[] }) {
+  return (
+    <ul style={{ listStyle: 'none', padding: 0, margin: '8px 0 14px', maxWidth: 680 }}>
+      {items.map((r) => (
+        <li
+          key={r.title}
+          style={{
+            padding: '12px 0',
+            borderTop: '1px solid #D9D2BF',
+          }}
+        >
+          <div
+            className="font-serif text-caddie-ink"
+            style={{ fontSize: 15, fontWeight: 500, fontStyle: 'italic' }}
+          >
+            {r.title}
+            {r.by && (
+              <span className="text-caddie-ink-dim" style={{ fontStyle: 'normal', fontWeight: 400 }}>
+                {' '}— {r.by}
+              </span>
+            )}
+          </div>
+          <div className="text-caddie-ink-dim" style={{ fontSize: 14, lineHeight: 1.55, marginTop: 4 }}>
+            {r.note}
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function EditorialNote({
+  variant,
+  children,
+}: {
+  variant: 'research' | 'todo'
+  children: React.ReactNode
+}) {
+  if (!DEV) return null
+  const tone = variant === 'research' ? '#1F3D2C' : '#A66A1F'
+  const label = variant === 'research' ? 'Source' : 'Todo'
+  return (
+    <div
+      style={{
+        background: '#EBE5D6',
+        borderLeft: `3px solid ${tone}`,
+        padding: '10px 14px',
+        marginBottom: 14,
+        maxWidth: 680,
+      }}
+    >
+      <div
+        className="font-mono uppercase"
+        style={{
+          fontSize: 10,
+          letterSpacing: '0.14em',
+          color: tone,
+          marginBottom: 4,
+        }}
+      >
+        {label} · dev only
+      </div>
+      <div
+        className="text-caddie-ink-dim"
+        style={{ fontSize: 13, lineHeight: 1.5, fontStyle: 'italic' }}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Footer() {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 1.6,
+      }}
+    >
+      Last reviewed May 2026 · Draft, needs review · Edit
+      docs/learn/skill-games-pressure-games.md to contribute
+    </div>
+  )
+}

--- a/apps/web/src/pages/learn/data/articleRegistry.ts
+++ b/apps/web/src/pages/learn/data/articleRegistry.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from 'react'
 import { CourseManagementArticle } from '../articles/CourseManagementArticle'
 import { GlossaryArticle } from '../articles/GlossaryArticle'
 import { HowToPracticeArticle } from '../articles/HowToPracticeArticle'
+import { MentalGameArticle } from '../articles/MentalGameArticle'
 import { ReadingStatsArticle } from '../articles/ReadingStatsArticle'
 import { StrokesGainedArticle } from '../articles/StrokesGainedArticle'
 
@@ -11,6 +12,7 @@ const ARTICLE_COMPONENTS: Record<string, ComponentType> = {
   glossary: GlossaryArticle,
   'how-to-practice': HowToPracticeArticle,
   'course-management': CourseManagementArticle,
+  'mental-game': MentalGameArticle,
 }
 
 export function getArticleComponent(slug: string): ComponentType | null {

--- a/apps/web/src/pages/learn/data/articleRegistry.ts
+++ b/apps/web/src/pages/learn/data/articleRegistry.ts
@@ -4,6 +4,7 @@ import { GlossaryArticle } from '../articles/GlossaryArticle'
 import { HowToPracticeArticle } from '../articles/HowToPracticeArticle'
 import { MentalGameArticle } from '../articles/MentalGameArticle'
 import { ReadingStatsArticle } from '../articles/ReadingStatsArticle'
+import { SkillGamesArticle } from '../articles/SkillGamesArticle'
 import { StrokesGainedArticle } from '../articles/StrokesGainedArticle'
 
 const ARTICLE_COMPONENTS: Record<string, ComponentType> = {
@@ -13,6 +14,7 @@ const ARTICLE_COMPONENTS: Record<string, ComponentType> = {
   'how-to-practice': HowToPracticeArticle,
   'course-management': CourseManagementArticle,
   'mental-game': MentalGameArticle,
+  'skill-games-pressure-games': SkillGamesArticle,
 }
 
 export function getArticleComponent(slug: string): ComponentType | null {

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -1,0 +1,617 @@
+---
+title: Glossary of Golf Terms
+section: Understanding the Game
+status: draft
+last_reviewed: 2026-05
+contributors: []
+content_warning: |
+  This article expands on the in-app glossary with
+  intermediate and advanced terms. Core definitions
+  are well-established. Some slang entries are
+  colloquial and may vary by region.
+---
+
+# Glossary of Golf Terms
+
+> **Work in progress.** Being expanded over time.
+> Suggest missing terms by opening a PR editing
+> docs/learn/glossary.md
+
+The basics — birdie, bogey, par, handicap, GIR —
+are covered in the app's stat reference section.
+This glossary focuses on the terms that come up
+once you start playing regularly and trying to
+improve.
+
+---
+
+## Shot shapes and ball flight
+
+**Draw**
+A controlled shot that curves gently from right to
+left in the air (for a right-handed golfer). The
+opposite of a fade. A draw typically produces more
+roll than a fade and is generally considered easier
+to generate distance with. Not to be confused with
+a hook.
+
+**Fade**
+A controlled shot that curves gently from left to
+right (for a right-handed golfer). Tour professionals
+often prefer a fade because the ball lands softer
+with less roll. Not to be confused with a slice.
+
+**Hook**
+An uncontrolled, exaggerated draw. The ball curves
+hard left for a right-handed player. Often the result
+of a closed clubface at impact. Differs from a draw
+in that a hook is unintended and more severe.
+
+**Slice**
+An uncontrolled, exaggerated fade. The ball curves
+hard right for a right-handed player. The most common
+miss for amateur golfers. Caused by an open clubface
+at impact combined with an out-to-in swing path.
+
+**Push**
+A shot that flies straight but to the right of the
+target (for a right-handed golfer), with no curve.
+Different from a fade — a pushed shot travels on
+the wrong line without curving.
+
+**Pull**
+A shot that flies straight but to the left of the
+target (for a right-handed golfer), with no curve.
+Different from a hook — a pulled shot travels on
+the wrong line without curving.
+
+**Stinger**
+A low, penetrating shot hit with minimal loft,
+often used into the wind or to punch out from under
+trees. Made famous by Tiger Woods. Achieved by
+playing the ball back in the stance and limiting
+the follow-through.
+
+**Punch shot**
+A low, controlled shot played with a shortened swing,
+typically from trouble — under tree branches, into
+wind, or from a tight lie. The ball stays low and
+runs out after landing.
+
+**Flier**
+A shot that travels farther than expected because
+grass gets trapped between the clubface and ball at
+impact, reducing backspin. Common from rough.
+A flier lie is any lie where you expect this to
+happen. Always account for extra distance from
+light rough.
+
+**Spinner**
+A shot hit with enough backspin that the ball spins
+back toward the player after landing on the green.
+Typically happens on clean contact with a wedge into
+a soft green. A desirable shot when the pin is at
+the back of the green and you need the ball to check
+up and release toward the hole.
+
+**Knuckleball**
+A shot with almost no spin — the ball flutters and
+moves unpredictably in the air, like a knuckleball
+pitch in baseball. Usually caused by hitting the
+ball with a grooved club that has a grass or moisture
+patch between face and ball. Notoriously hard to
+control distance and direction. Often happens from
+thick rough.
+
+**Texas Wedge**
+Using a putter from off the green — from the fringe,
+apron, or even light rough — instead of chipping.
+Often the highest percentage shot when the ground
+between ball and hole is firm and flat.
+
+**DOD (Driver Off the Deck)**
+Hitting a driver without a tee, from the fairway or
+rough. One of the hardest shots in golf due to the
+low loft and long shaft. Useful on long par 5s when
+you need maximum distance and can't reach the green
+with a fairway wood. Requires a shallow, sweeping
+angle of attack. Made famous by social media creator
+"DOD King" Carter Smith, who built an entire golf
+persona around the shot.
+
+**Thai Spinner**
+A low, high-spin shot around the greens popularized
+by Thai PGA Tour player Kiradech Aphibarnrat. The
+ball is struck first (not the ground) with a steep,
+outside-in swing using a lob wedge, producing a low
+ball flight that jumps and stops quickly due to
+extreme spin. Useful from tight or grainy lies where
+a standard chip would skid through. Made famous to
+wider audiences when Keith Mitchell executed it from
+a nearly impossible bunker lie at the 2025 Texas
+Children's Houston Open.
+
+---
+
+## Short game shots
+
+**Chip**
+A low, running shot played from just off the green
+where the ball spends more time on the ground than
+in the air. Uses a less-lofted club (7-iron through
+pitching wedge typically) and a putting-style stroke.
+The classic chip: land the ball just on the green
+and let it roll to the hole.
+
+**Pitch**
+A higher, softer shot played from farther away than
+a chip — typically 20-80 yards from the green. Uses
+a wedge and a fuller swing than a chip. The ball
+spends more time in the air and stops more quickly
+than a chip. Pitches are harder than chips because
+they require distance control with a partial swing.
+
+**Bump and run**
+A chip-like shot played with a mid-iron (5-7 iron)
+that lands short of the green and runs onto the
+putting surface. Favored in links golf and firm
+conditions where the ground is predictable. Lower
+risk than a flop shot — fewer moving parts, less
+chance of a mishit. Harvey Penick was a famous
+advocate of this shot for amateurs.
+
+**Flop shot**
+A high, soft shot played with an open lob wedge
+that lands softly with minimal roll. Used when you
+need to carry a hazard and stop the ball quickly.
+High risk — a mishit flop can be skulled over the
+green or chunked short. Not recommended unless you
+practice it regularly.
+
+**Chunk / Fat shot**
+Hitting the ground behind the ball before making
+contact, resulting in a shot that comes up well
+short of the target. The club digs into the turf
+and decelerates. One of the most common short game
+misses for amateurs. Also called a heavy shot.
+
+**Scalp / Thin / Blade**
+Hitting the ball with the leading edge of the club
+instead of the face — typically the bottom groove
+of the iron. The ball comes out low and hot, usually
+running through the green. The opposite problem from
+a chunk. Common on tight lies and downhill shots.
+Also called skulling the ball.
+
+**Flush**
+Slang for a perfectly struck shot — clean contact
+with the center of the clubface. "I flushed a 7-iron
+to two feet." Also used as an adjective: "That was
+a flush strike."
+
+---
+
+## Putting terms
+
+**Pin high / Hole high**
+When your approach shot finishes level with the pin
+(the same distance from the front of the green as
+the hole) but to the left or right of it. Pin high
+means your distance control was correct even if your
+direction was off. Generally considered a good miss
+— you're putting across the slope rather than up
+or down it.
+
+**Spinner (putting)**
+In putting context, a spinner refers to a putt that
+lips out spinning — the ball catches the edge of
+the cup, spins around the rim and comes back out.
+One of the most frustrating outcomes in golf. See
+also: lip out.
+
+---
+
+## Course and green terminology
+
+**Below the hole**
+The lower side of the hole on a sloped green. A ball
+finishing below the hole leaves an uphill putt —
+the preferred position. Tour players always try to
+leave themselves below the hole.
+
+**Above the hole**
+The upper side of the hole on a sloped green. Leaves
+a downhill putt, which is faster and harder to
+control. Avoid finishing above the hole when possible.
+
+**Short side**
+The side of the green closest to the pin when the
+pin is tucked near an edge. Missing a green on the
+short side leaves an extremely difficult chip with
+little green to work with. One of the most costly
+mistakes in course management. Do not short side
+yourself.
+
+**Grain**
+The direction in which grass grows on a putting
+green. Bermuda grass greens (common in warm climates)
+have strong grain that significantly affects putt
+speed and break. Putting with the grain is faster;
+against the grain is slower. Identifying grain is
+an important green-reading skill.
+
+**Stimp / Stimpmeter**
+A device that measures green speed by rolling a
+ball down a ramp and measuring how far it travels.
+A stimp reading of 10 is moderately fast (typical
+club golf), 12-13 is fast (major championship
+conditions), 14+ is extremely fast.
+
+**False front**
+A green that slopes sharply back toward the fairway
+at the front. Approach shots that land on the false
+front roll back off the green. Requires more club
+than it appears to hold the green.
+
+**Apron / Fringe**
+The short grass surrounding the putting green,
+shorter than the fairway but longer than the green
+itself. Putting from the apron is usually possible
+with a putter, though the slightly longer grass
+affects roll.
+
+**Dogleg**
+A hole that bends left or right between the tee and
+green. A dogleg left bends left; dogleg right bends
+right.
+
+**Bailout**
+A safe area to miss to when the primary target is
+dangerous. Good course management always identifies
+the bailout before swinging.
+
+**Big ball (Earth)**
+Slang for hitting the ground before the ball —
+chunking or fatting a shot. "He hit the big ball
+first." A humorous way of saying someone hit it
+fat. The "big ball" is the Earth itself; the small
+ball is the golf ball. You want to hit the small
+one first.
+
+---
+
+## Divots and course care
+
+**Divot**
+The chunk of turf displaced by the club during an
+iron shot. Two meanings: (1) the chunk of turf
+itself, and (2) the hole left in the ground. Replacing
+your divot after a shot is standard golf etiquette.
+Many courses provide sand-mix bottles to fill divots
+instead. Hitting from a divot left by a previous
+player is a common bad lie — no relief, play it
+as it lies.
+
+**Pitch mark / Ball mark**
+The indentation left in the green when an approach
+shot lands. Repairing your pitch mark — and any
+others nearby — is one of the most important
+etiquette habits in golf. Unrepaired pitch marks
+take weeks to heal and create bumpy putting surfaces
+for everyone. Repair by pushing the edges down and
+smoothing, not by lifting the center up.
+
+**Burn mark**
+The browning or dying of grass on one side of the hole cup, caused by the grain growing away from that side and exposing the roots. The burned side indicates where the grain is running from — grain runs toward the healthy green side of the cup. Reading burn marks is a quick way to identify grain direction on Bermuda greens before putting. The side with the burn is into the grain; the healthy side is with the grain.
+
+**Divot tool / Pitch fork**
+The small forked tool used to repair pitch marks on
+the green. Every golfer should carry one. Insert
+the tines at the edges of the mark and push inward
+to level it out. Do not pry up from the center —
+this damages the roots. A ball marker (usually a
+coin) is used alongside the divot tool to mark your
+ball position on the green.
+
+**Scalp**
+To hit the top of the ball (same as thin or blade).
+Also used as a noun: "He left a big scalp on the
+fairway" — meaning a divot cut so shallow it's
+more of a skin than a proper divot.
+
+---
+
+## Scoring and competition terms
+
+**Snowman**
+Slang for a score of 8 on a hole — because the
+number 8 looks like a snowman. Not a term you want
+to hear often.
+
+**Blow up hole**
+A hole where everything goes wrong and a large
+number is recorded. Every golfer has them. The
+mental game skill is minimizing how many and
+how severe.
+
+**Honors**
+The player who tees off first on a hole has the
+honors. In stroke play, honors goes to the player
+with the lowest score on the previous hole.
+
+**Ready golf**
+Hitting when you're ready rather than strictly
+following honors order. Speeds up pace of play
+significantly. Standard in casual rounds.
+
+**Skins**
+A golf betting format where each hole is worth a
+set amount of money (a "skin"). The player who wins
+the hole outright — no ties — wins the skin. If
+two or more players tie, the skin carries over to
+the next hole, making it worth more. Skins can
+stack up over several holes and create exciting
+swings. A popular format for casual gambling rounds
+and some professional made-for-TV events.
+
+**Match play**
+A format where the score is tracked hole by hole
+rather than total strokes. Win a hole by taking
+fewer strokes and you go one up. The player who wins
+the most holes wins the match.
+
+**Stroke play**
+The standard format where total strokes over the
+entire round are counted. The player with the fewest
+total strokes wins.
+
+**Stableford**
+A scoring format where points are awarded based on
+score relative to par. Typically: bogey = 1 point,
+par = 2 points, birdie = 3 points, eagle = 4 points.
+Encourages aggressive play. Popular in social golf.
+
+**Nassau**
+A common golf bet consisting of three separate
+wagers: the front nine, the back nine, and the
+full 18 holes. Each is a separate match play
+competition.
+
+**Press**
+In a Nassau or match play bet, a press is a new
+side bet started mid-round, typically when a
+player or team is down by two holes.
+
+**Dormie**
+In match play, when a player leads by the same
+number of holes as remain to be played. Cannot
+lose — worst outcome is a tie.
+
+---
+
+## Lie and course conditions
+
+**Tight lie**
+A ball sitting on bare or closely-mown ground with
+very little grass underneath. Requires clean contact.
+
+**Plugged lie / Fried egg**
+A ball that has embedded in its own pitch mark,
+typically in soft ground or a bunker. Also called
+a fried egg in a bunker — only the top of the ball
+is visible, surrounded by a ring of disturbed sand.
+
+**Hardpan**
+Very firm, dry ground with little or no grass.
+Produces low, running shots and requires precise
+contact.
+
+---
+
+## Equipment terms
+
+**Muscle back**
+An iron design where the weight is concentrated in
+a solid mass directly behind the center of the
+clubface — sometimes called a blade. No cavity in
+the back. Preferred by better players for the feel,
+feedback, and shot-shaping ability they provide.
+Less forgiving than cavity backs — off-center hits
+are more penalized. If you hit it pure, a muscle back
+feels unlike anything else in golf — the feedback
+through the hands is immediate and unmistakable.
+Miss it, and you'll know that too.
+
+**Cavity back**
+An iron design where weight is redistributed to the
+perimeter of the clubhead, creating a cavity in the
+back. More forgiving than muscle backs — off-center
+hits still travel reasonably well. Standard for most
+amateur golfers.
+
+**Loft**
+The angle of the clubface relative to vertical.
+Higher loft = higher ball flight and less distance.
+Lower loft = lower ball flight and more distance.
+
+**Shaft flex**
+How much the shaft bends during the swing. Options
+from most to least flexible: Ladies, Senior, Regular,
+Stiff, Extra Stiff. Wrong shaft flex affects ball
+flight and distance.
+
+**Lie angle**
+The angle between the shaft and the ground when
+the club is soled correctly at address. If lie angle
+is wrong, shots will miss consistently left or right
+even with a good swing. Can be adjusted by a fitter.
+
+---
+
+## Slang and culture
+
+**Flush**
+See short game section above.
+
+**Worm burner**
+A shot that never gets airborne, rolling along the
+ground. Usually a topped or thinned iron.
+
+**Shank**
+A shot struck with the hosel (the socket connecting
+shaft to clubhead) rather than the face, resulting
+in a shot that fires dramatically to the right for
+a right-handed player. One of the most dreaded
+misses in golf. Some golfers avoid saying the word
+on the course, as if merely uttering it invites one.
+
+**Yips**
+A condition where involuntary muscle twitches or
+nerves cause jerky, uncontrolled strokes — most
+commonly on short putts. Can affect chipping as
+well. More mental than physical, though the exact
+cause is debated. Has ended careers.
+
+**Cabbage**
+Thick, deep rough where the ball sits down and
+is difficult to advance. You are just trying to
+get out of cabbage, not reach the green.
+
+**Lip out**
+A putt that rolls around or over the edge of the
+cup without falling in. One of the most frustrating
+outcomes in golf.
+
+**Bite**
+What golfers say to a ball approaching the green
+that they want to stop quickly — asking the backspin
+to grab and hold the green. "Bite!" Also used as a
+verb: "I need this to bite."
+
+**Barkie**
+Making par after your ball hits a tree. Counted as
+bonus points in some social games.
+
+**Greenie**
+In a group game, awarded to the player who hits the
+green in regulation on a par 3 and is closest to
+the pin. Common side bet in casual golf.
+
+---
+
+## Rules terms worth knowing
+
+**Relief**
+When the rules allow you to move your ball without
+penalty — from a cart path, temporary water, ground
+under repair, or an embedded ball.
+
+**Penalty area**
+The modern Rules term (since 2019) for what was
+previously called a water hazard. Yellow penalty
+areas offer two relief options; red penalty areas
+offer three. You may now ground your club in a
+penalty area.
+
+**Ground under repair (GUR)**
+Areas of the course marked for maintenance.
+Free relief is available from GUR.
+
+**Provisional ball**
+A second ball played when you believe your first
+ball may be lost or out of bounds. Must be announced
+as provisional before playing. Saves time — avoids
+walking back to replay.
+
+**Stroke and distance**
+The penalty for a lost ball or out-of-bounds shot.
+Add one penalty stroke AND return to where you
+played from. The most severe penalty in golf.
+
+---
+
+## Historical terms (and why you still hear them)
+
+Golf has a longer continuous history than almost any
+other sport, and its vocabulary reflects that. Some
+terms from the hickory-shaft era (roughly pre-1930)
+have stuck around — either in formal golf writing,
+in the names of classic holes and courses, or because
+older golfers still use them affectionately. Younger
+players sometimes use them cheekily.
+
+**Brassie**
+The old name for what we now call a 2-wood. Named
+for the brass plate on the sole of the club. You
+might hear someone pull out their fairway wood and
+say "give me the brassie" as a throwback reference.
+
+**Spoon**
+Old name for a 3-wood. The shallow, spoon-like face
+of the club gave it the name. Still occasionally
+used by writers describing vintage golf or classic
+architecture.
+
+**Baffy**
+Old name for a 4-wood. Rarely heard today but shows
+up in historical writing about early golf.
+
+**Cleek**
+A low-lofted iron from the hickory era, roughly
+equivalent to a modern 1 or 2-iron. Also used to
+describe a narrow-faced iron used for distance from
+tight lies. "The cleek" appears frequently in
+descriptions of early 20th century golf.
+
+**Mashie**
+Old name roughly equivalent to a modern 5-iron.
+One of the most commonly referenced hickory-era
+clubs. "Mashie niblick" was a club between the
+mashie and niblick — roughly a 7-iron equivalent.
+
+**Niblick**
+A high-lofted hickory club used for short approach
+shots and trouble shots — roughly equivalent to a
+modern 9-iron or wedge. The niblick was the go-to
+club for escaping difficult lies.
+
+**Jigger**
+A utility iron from the hickory era with moderate
+loft, used for punch shots and running approaches.
+No clean modern equivalent. The term occasionally
+resurfaces in discussions of bump-and-run
+shot technique.
+
+**Stymie**
+A now-abolished situation in match play where your
+opponent's ball blocked your putting line and you
+had to play around or over it. Eliminated from the
+rules in 1952 when ball marking became standard.
+Still used figuratively in everyday English — "I'm
+in a bit of a stymie" — meaning blocked or stuck.
+
+**Dormie**
+While still used today in match play (see scoring
+section), dormie has its roots in early golf
+language. Some historians believe it derives from
+the French "dormir" (to sleep) — the leading player
+could sleep easy knowing the worst outcome was a
+tie. Others dispute this etymology.
+
+**Fore**
+Still very much in use — the warning shout when a
+ball is heading toward other players. The origin is
+disputed: possibly from "forecaddie" (a spotter
+walking ahead), possibly a military "beware before"
+command. One of golf's oldest surviving terms and
+one of its most important.
+
+> ⚠️ *TODO: Verify historical club equivalencies —
+> sources vary on exact loft comparisons between
+> hickory era clubs and modern equivalents.*
+
+---
+
+*Last reviewed: May 2026*
+*Status: Draft — being expanded over time*
+*To contribute: open a PR editing docs/learn/glossary.md*

--- a/docs/learn/mental-game.md
+++ b/docs/learn/mental-game.md
@@ -1,0 +1,448 @@
+---
+title: The Mental Game
+section: On the Course
+status: draft
+last_reviewed: 2026-05
+contributors: []
+content_warning: |
+  This article is a work in progress. The structure and core
+  ideas are established but individual sections need deeper
+  research, better resource links, and review before
+  being considered complete. Do not treat any specific
+  advice as authoritative until this notice is removed.
+---
+
+# The Mental Game
+
+> **Work in progress.** This article is being developed.
+> Core structure is in place but content needs review
+> and additional research.
+> Resource links are placeholders — verify before using.
+
+## Golf is you versus you
+
+Every other sport has an opponent actively trying to stop
+you. A defender. A pitcher. A goalie. In golf, the course
+is static. The ball sits still and waits. Nobody is trying
+to beat you except you.
+
+Once you have a functional golf swing — once you understand
+the basic mechanics of how the club interacts with the ball,
+the turf, the wind — the game becomes almost entirely
+mental. The physical skill gets you onto the course. What
+happens there is a different problem entirely.
+
+Most amateurs spend 95% of their practice time on the
+physical game and almost none on the mental game. This is
+backwards for anyone who has been playing more than a
+couple of years. The swing is largely solved. The mental
+game is the frontier.
+
+Golf is also one of the most humbling experiences available
+to a human being. It will find every weakness in your ego
+and expose it repeatedly. If you play with a large ego,
+the game will spend a long time teaching you to either
+reduce it or suffer. There is no third option.
+
+---
+
+## One shot at a time
+
+Every touring professional, when asked about performance,
+eventually says the same thing: one shot at a time. It
+sounds like a cliché because it gets repeated so often.
+It gets repeated so often because it is genuinely,
+literally true.
+
+You cannot hit the shot you just hit over again. You
+cannot hit the next shot until you finish this one. The
+only shot that exists is the one in front of you right now.
+
+The mental game problem is that the human brain doesn't
+naturally work this way. It replays the shot you just
+botched. It fast-forwards to the putt you need to make
+on 18. It calculates what score you need on the remaining
+holes. All of this thinking happens at exactly the moment
+you need to be doing one thing: hitting the shot in front
+of you.
+
+Bob Rotella describes this as refusing to be seduced by
+results. At the 2008 Masters, Trevor Immelman held a
+two-shot lead going into the final round and made a
+decision: he would not look at a single leaderboard all
+day. His plan was simple — pick a target, visualize the
+shot, hit it. Walking up the 18th fairway, it was the
+first time all day he allowed himself to think about the
+outcome. He asked his caddie how they stood. Three shots
+over Tiger. His immediate thought: how can I not five-putt
+this? The routine had protected him all day. The moment
+he stepped outside it, the pressure arrived.
+
+The short memory is not something you are born with. It
+is a skill you develop deliberately. You give yourself a
+window to feel the emotion — Rotella describes walking it
+off, physically moving away from the shot, letting the
+feeling pass — and then you are done with it. The bad
+shot already happened. It cannot be changed. Carrying it
+into the next shot is a choice, and it is a bad one.
+
+The same discipline applies to good shots. A stretch of
+made putts, a run of flushed irons — the player who stays
+even through the highs as well as the lows is harder to
+shake than the player who rides the wave. The wave always
+comes back down. Stay level.
+
+---
+
+## Sulking won't get you anything
+
+When Padraig Harrington won the 2007 British Open, he
+knocked two balls into the water on the last hole and
+made double bogey. He still won. He told Rotella afterward
+that he had a level of acceptance that earlier in his
+career he didn't have — it never entered his mind that
+he might blow the tournament. His only thought was getting
+the ball in the hole so he could make the playoff.
+
+That is the mental game in one story. Bad things happened.
+Catastrophically bad things. And his response was not
+panic, not despair, not self-recrimination. It was: what
+is the next shot?
+
+Rotella is direct about this: sulking won't get you
+anything. Feeling sorry for yourself, thinking the golf
+gods are conspiring against you, replaying the mistake —
+none of it changes what happened and all of it damages
+what comes next. The worst thing you can do for your
+prospects after a bad shot is to get down.
+
+Give yourself a moment. Feel it briefly. Then drop it.
+You have more golf to play and you need to be present
+for it.
+
+---
+
+## The productive delusion
+
+Rotella's first rule is the one that separates good mental
+players from great ones: believe you can win. Not hope
+you might. Not think you have a chance. Believe.
+
+This extends to every shot. The player on a putting
+heater — making everything they look at — approaches the
+next putt believing it's going in too, because they've
+been making everything. The player who has been missing
+putts all afternoon approaches the next one thinking:
+I'm due, this one is definitely going in.
+
+Both of these are, strictly speaking, irrational. Previous
+putts have no causal relationship to the next one. But the
+golfer who believes they're going to make the putt stands
+over the ball with a fundamentally different quality of
+attention than the golfer who doubts. And that quality of
+attention affects the outcome.
+
+This is not blind positivity. It is the deliberate
+construction of a mental state that serves your
+performance. Rotella calls it confidence. It might also
+be called a productive delusion. The tour player who says
+"I just knew I was going to make it" is not describing a
+premonition. They are describing a trained mental habit
+of belief.
+
+You are allowed to be delusional in your own favor.
+In golf, it is the correct strategy.
+
+---
+
+## Visualization
+
+Before a shot, the mental game starts. Not on the
+backswing — before you even take the club out of the bag.
+
+Visualization is the process of seeing the shot you want
+to hit before you hit it. Not hoping for it. Not wishing
+for it. Actually seeing it — the ball flight, the
+trajectory, the landing spot, the bounce and roll. Seeing
+it like a video, in real time, as if it has already
+happened.
+
+For putting: see the line. See the ball rolling along
+that line. See it drop into the cup. Make the
+visualization as vivid and specific as possible.
+
+This is not mysticism. It is how motor learning works.
+The brain rehearses movement patterns through visualization
+in ways that translate directly into physical execution.
+Athletes across every sport use it. Pick a target,
+visualize the shot, let it rip. In that order, every time.
+
+The practical version: before every shot, take a moment
+to see exactly what you want the ball to do. Then step
+into the shot with that image in your mind — not with
+swing thoughts, not with mechanical checkpoints. The image.
+
+> 📚 *Research basis: mental imagery and motor performance.
+> See Guillot & Collet (2008) on mental simulation of
+> motor actions.*
+> ⚠️ *TODO: Add more specific research citations*
+
+---
+
+## The routine as an anchor
+
+A consistent pre-shot routine serves two purposes that
+most golfers understand: it prepares you physically for
+the shot and gives you a repeatable process. But it serves
+a third purpose that is underappreciated.
+
+The routine is an anchor to the present moment.
+
+Curtis Strange won the 1988 U.S. Open and went home to
+watch the tape with his wife and kids. They kept commenting
+on how cool and calm he looked. Strange told Rotella: "I'm
+thinking, who in the world are they talking about? They
+can't be talking about me. I couldn't get any moisture in
+my mouth. My heart was jumping out of my chest."
+
+He had so much emotion in his body it was unbelievable.
+He was working his tail off just to stay in the present,
+hit one shot at a time, and not think about what it would
+mean to win the U.S. Open. The routine made him look
+calm. More importantly, the routine kept him functional.
+
+When the mind is scattered — worried about score,
+replaying a bad hole, distracted by pressure — going
+through the routine brings you back. Not because it is
+magic, but because executing a sequence of familiar
+physical actions requires present-moment attention.
+
+This is why the routine must be consistent. An inconsistent
+routine cannot serve as an anchor because there is nothing
+consistent to return to. The same grip check, the same
+practice swing, the same target look — every time,
+regardless of the situation. The bigger the moment, the
+more important it is that the routine does not change.
+
+> 📚 *Manu, The Upbeat Golfer — YouTube. Target commitment
+> and pre-shot routine for process-driven play.*
+
+---
+
+## Patience over aggression
+
+Rotella's fourth rule: every time you have the urge to
+make an aggressive play, go with the more conservative
+one. You will always be okay.
+
+At the 1992 U.S. Open at Pebble Beach, Tom Kite had been
+0 for 20 in U.S. Opens. Wind gusts reached 35 miles per
+hour on Sunday. Most players didn't break 80. Kite shot
+even par and won by two. He did it by not getting flustered.
+By staying patient. By letting others beat themselves.
+
+In tough conditions — and golf is almost always tough
+conditions of some kind — patience is a competitive
+advantage. The impatient player forces shots. The patient
+player waits for the right opportunity and executes the
+percentages. Over 18 holes this compounds significantly.
+
+---
+
+## Ignore unsolicited swing advice
+
+This one is practical and underappreciated.
+
+Rotella tells a story about a player who had been
+struggling, found some form, made eight birdies in the
+first round of a tournament, and was feeling great. He
+stopped by the putting green and within minutes two
+different players had commented on his setup and his
+eye position. By the next day he was a mess.
+
+You will have well-meaning friends, playing partners,
+and observers who want to give you advice on the course
+or between rounds. Don't accept it. In fact, stop them
+before they can say a word. Their comments will creep
+into your mind when you are on the course, at exactly
+the moment you need to be thinking about one thing:
+your target.
+
+If you've worked on your game and made a plan with your
+coach, commit to it. Stay confident. Someone else's
+observation about your backswing on hole 12 is not
+something you can do anything useful with right now.
+File it for the range later, or let it go entirely.
+
+---
+
+## Calm is a superpower
+
+You cannot make good decisions when you're angry. You
+cannot execute a golf swing well when you're amped up
+or brooding or seething. The physiological state of anger
+— elevated heart rate, tunnel vision, impaired judgment
+— is the exact opposite of the state required to hit a
+golf ball well.
+
+This is not about being emotionless. Emotion is human
+and golf produces a lot of it. A good shot feels great.
+A bad one is genuinely frustrating. You are allowed to
+feel that.
+
+What you are not allowed to do — if you want to play
+well — is let it linger. Give yourself the walk. Feel
+it. Let it out briefly and privately. Then drop it.
+The next shot requires your full attention and you cannot
+give it that if you are still living in the last one.
+
+Placing your hand on your chest, feeling your breath,
+looking at something specific in your physical
+environment — these grounding techniques exist to pull
+you out of the prison of your own mind and back onto the
+golf course where the actual game is being played. They
+sound simple and almost silly until you try them under
+real pressure. They work.
+
+---
+
+## Grounding and the present moment
+
+When the mind spirals — after a run of bad holes, after
+a penalty, after a blow-up — the way back is through
+the body, not through more thinking.
+
+Grounding techniques bring you back to the present moment
+physically. Feel your feet on the ground. Feel the grip
+in your hands. Look at the grass, the trees, the sky.
+Notice something specific about your physical environment.
+
+The mind in a spiral is pulling you into the past (the
+shots you have already hit) or the future (what your score
+might end up being). The body only exists in the present.
+Returning attention to physical sensation is the fastest
+route back to the present moment where the golf shot
+actually lives.
+
+This is where golf becomes deeply Buddhist in its demands
+— not attached to outcomes, not grasping at results,
+returning again and again to what is actually happening
+right now. The shot in front of you. The target you have
+chosen. The swing you trust.
+
+That is all there is. Everything else is noise.
+
+---
+
+## Find someone who believes in you
+
+Rotella's tenth rule is the one that gets overlooked in
+conversations about the mental game: find someone who
+believes in you.
+
+Ben Hogan told Rotella he had considered quitting the
+game several times early in his career because he didn't
+think he was providing for his wife the way he should.
+Valerie Hogan wouldn't let him quit. She knew he would
+never be satisfied until he won majors. Having confidence
+in yourself is essential. But having someone who sees
+what you can't yet see in yourself — a spouse, a friend,
+a coach — compounds it.
+
+For amateur golfers this might be a playing partner who
+knows your game and backs you. A coach who genuinely
+believes in your potential. Anyone who reflects your
+capability back to you on the days you can't see it
+yourself.
+
+The mental game is not fought entirely alone.
+
+---
+
+## Be process-driven, not results-driven
+
+Most golfers think too little on the golf course. They
+step up to the ball, swing, and react emotionally to
+wherever it goes. There is no plan and no process.
+
+But there is an opposite problem: once golfers start
+trying to improve, they often start thinking too much.
+They outthink themselves — grinding over swing thoughts,
+worrying about mechanics, replaying the last bad shot —
+because they are not yet good enough to execute what
+they are thinking about. Analysis paralysis is just as
+damaging as mindlessness.
+
+The sweet spot is a clear, repeatable pre-shot process:
+- Pick a specific target
+- Visualize the shot
+- Commit fully
+- Go through your routine
+- Pull the trigger
+
+That is it. You do not need to solve the hole. You need
+to play one shot at a time with full commitment.
+
+Try tracking — alongside your score — whether you
+committed to each shot. Not whether it went where you
+wanted. Whether you actually went through your process
+and pulled the trigger without doubt.
+
+Results-oriented thinking leads to tension, steering,
+and the exact outcome you were afraid of. Process-oriented
+thinking gives you the best chance of executing the shot.
+The score takes care of itself when the process is right.
+
+---
+
+## It never gets fully solved
+
+One of the more humbling truths about the mental game
+is that it never gets fully mastered. Tour professionals
+— with decades of experience, sports psychologists,
+meditation practices, and more mental reps than most
+amateurs will ever have — still get in their own way.
+Still lose shots to the mental game.
+
+The goal is not to eliminate the mental challenge. The
+goal is to get better at returning to the right state
+more quickly. The tour player who has a double bogey on
+hole 6 and is back to full focus on hole 7 has the same
+mental challenge as the amateur who takes four holes to
+recover — they just recover faster.
+
+That recovery time is what you are training. Not the
+absence of difficulty. The speed of return.
+
+---
+
+## Resources
+
+> ⚠️ *Verify all links before publishing*
+
+- **"Golf Is Not a Game of Perfect"** — Bob Rotella.
+  The gold standard in golf psychology. Essential reading.
+- **"Golf Is a Game of Confidence"** — Bob Rotella.
+  The follow-up, equally valuable.
+- **Bob Rotella — "My 10 Rules on Mental Fitness"**
+  GolfWRX. The ten rules referenced throughout this
+  article.
+  https://www.golfwrx.com/5689/dr-bob-rotella-my-10-rules-on-mental-fitness/
+- **"Zen Golf"** — Joseph Parent. Buddhist-influenced
+  approach to present-moment play.
+- **The Upbeat Golfer (Manu)** — YouTube. Process-driven
+  mental approach, target commitment, playing without fear.
+- **"The Inner Game of Tennis"** — Tim Gallwey. Not
+  golf-specific but the foundational text on getting out
+  of your own way in sport. Directly applicable.
+- **"Choke"** — Sian Beilock. The neuroscience of why
+  we perform poorly under pressure and what to do about it.
+
+> ⚠️ *TODO: Add sports psychology research citations
+> on visualization and motor performance*
+
+---
+
+*Last reviewed: May 2026*
+*Status: Draft — needs review before publishing*
+*To contribute: open a PR editing docs/learn/mental-game.md*

--- a/docs/learn/skill-games-pressure-games.md
+++ b/docs/learn/skill-games-pressure-games.md
@@ -1,0 +1,361 @@
+---
+title: Skill Games and Pressure Games
+section: Improving Your Game
+status: draft
+last_reviewed: 2026-05
+contributors: []
+content_warning: |
+  This article is a work in progress. Content is drawn from
+  established practice methodology and personal experience.
+  Games and drills are well-documented but individual results
+  vary. Do not treat any specific advice as authoritative
+  until this notice is removed.
+---
+
+# Skill Games and Pressure Games
+
+> **Work in progress.** This article is being developed.
+> Core structure is in place but content needs review.
+
+## Why games beat mindless repetition
+
+Hitting the same shot over and over until you run out of
+balls is the default range session for most golfers. It
+feels like practice. It largely isn't.
+
+Games change the dynamic. A game has a target, a score,
+and stakes. You're tracking something. You either succeed
+or you don't. That structure forces commitment on each
+shot — the same commitment you need on the course — in
+a way that hitting bucket after bucket never will.
+
+The best practice sessions end with games. Not start with
+them — your technical work belongs earlier in the session
+when your focus is fresh — but finish with them, when
+you're shifting from mechanics to performance.
+
+---
+
+## The pressure problem
+
+Here is the fundamental challenge of practice: you know
+you have another ball. On the course, you don't.
+
+That knowledge — that there's always another shot coming
+— removes the consequence from every swing on the range.
+You can be a little loose. You can bail out. Nothing is
+riding on it. And so you never practice the mental state
+you actually need when something is riding on it.
+
+Pressure games exist to solve this. The goal is to create
+enough consequence that you actually care about the shot
+— that your heart rate ticks up slightly, that missing
+would genuinely bother you. Not so much that you're
+miserable if you miss. Just enough that each shot matters.
+
+The stakes need to be real to you. They don't need to be
+large. A candy bar if you make five putts in a row. Ten
+pushups if you miss this last drive. Playing for coffee
+with a buddy. Whatever makes you care — that's the right
+level. Too small and you still don't care. Too large and
+anxiety takes over and defeats the purpose.
+
+The last few balls of a range bucket are a natural
+pressure game. You're out of balls. These are the last
+ones. Make them count. That scarcity, even artificially
+constructed, changes how you approach the shot.
+
+---
+
+## Putting games
+
+### The clock drill
+
+Place twelve balls around a hole at a consistent distance
+— three feet is a good starting point. The balls form
+a clock face, one ball at each hour position.
+
+The goal: make all twelve in a row. If you miss, start
+over from zero.
+
+This drill is deceptively brutal. Making the first few
+is easy. Getting to eleven and then missing is genuinely
+painful. That pain is the point — it simulates the
+pressure of needing to make a putt with something on the
+line.
+
+As you improve, move to four feet, then five. PGA Tour
+players do this drill from six feet as a standard warm-up.
+If you can make all twelve from six feet without missing,
+your short putting is tour-level.
+
+**Variation:** Do it with only one ball. Walk around the
+clock, replace the ball after each putt, make all twelve
+in a row. The single-ball version is harder because you
+get no second chances and the walk resets your mental
+state between putts — exactly like on the course.
+
+### The three-station pressure drill
+
+Set up three stations: three feet, six feet, and nine feet.
+
+The goal: make ten putts at each station before moving
+to the next. Miss more than one at any station and you
+go back to the start of that station.
+
+This creates escalating pressure. Making ten from three
+feet is achievable. Moving to six and knowing you have
+to start the station over if you miss two — now it matters.
+Getting to the nine-foot station after successfully
+completing the first two — the pressure is real.
+
+Track your score across sessions. How many total attempts
+before you complete all three stations? That number should
+drop over time as your putting under pressure improves.
+
+### The putting circuit
+
+Pick nine holes on the practice green and play them as
+a course. Par 2 for each hole — you're trying to one-putt
+every hole, with a two-putt as par. Three putts is a bogey.
+
+Play it as a proper nine-hole round. Keep score. Play
+the same nine holes every session so you can track
+improvement over time. This also forces you to practice
+from all different distances and read different breaks
+rather than repeatedly putting the same flat putt.
+
+**Competitive version:** play it head to head with a
+partner. Stroke play or match play — both work. Competition
+adds pressure that solo practice can't replicate.
+
+### The gate drill
+
+Place two tees just wider than your putter head a foot
+in front of the ball on your intended line, forming a
+gate. The ball must roll through the gate without
+touching either tee.
+
+This trains starting line. Most missed putts are missed
+before the ball breaks — the line is wrong at impact.
+The gate makes you accountable for that immediately.
+
+Start at six feet on a relatively straight putt. When
+you can consistently roll it through the gate, move back
+to ten feet. Move to a breaking putt. The gate exposes
+any inconsistency in your stroke path fast.
+
+### Speed control — the ladder drill
+
+Drop five balls at ten feet from the hole. Hit the first
+putt and watch where it finishes — past the hole, short,
+wherever. Your second putt must finish on the opposite
+side of the hole from the first. Your third putt must
+finish between the first two.
+
+If you pull it off, move back five feet and repeat. If
+you miss the requirement, start over from ten feet.
+
+This trains speed control and the ability to intentionally
+vary your pace — skills that transfer directly to
+lag putting and managing fast greens.
+
+---
+
+## Chipping and short game games
+
+### Up and down challenge
+
+Pick five spots around the practice green at varying
+distances and difficulties. From each spot, chip and
+then finish the hole out with the putter. Count the
+total strokes for all five holes.
+
+Set a target score — maybe 12 to start — and try to
+beat it each session. Lower your target as you improve.
+
+**Pressure version:** you must get up and down five in
+a row. Miss any one and start the streak over. Getting
+to four in a row and then chunking a chip is exactly
+the kind of pressure the course creates.
+
+### Three clubs, one ball per station
+
+Pick three distances — say 20 yards, 40 yards, and 60
+yards. Hit one ball from each distance to a specific
+target. One ball. You don't get another one.
+
+The single-ball constraint is everything. When you know
+there's no mulligan, the shot suddenly matters in a way
+it doesn't when you have a pile of balls at your feet.
+
+### Flag left or flag right
+
+At the range, pick a flag as your target. Before each
+shot, declare: left or right. If your ball finishes
+within a defined window on the declared side — say
+ten feet — that's a birdie. If it finishes on the
+correct side but outside the window, that's par.
+If it finishes on the wrong side of the flag, that's
+double bogey.
+
+This game teaches two things. First, you learn to
+control shot shape under pressure — you have to commit
+to a side before you swing. Second, and more importantly,
+you learn the cost of the short side. Finishing on the
+wrong side of the flag on an approach shot leaves you
+the hardest possible chip. The game makes you feel that
+cost in practice so you respect it on the course.
+
+Keep score over ten shots. A good round is -4 or better.
+
+---
+
+## Full swing games
+
+### Horse at the range
+
+Exactly like the basketball game. Pick a target —
+a specific flag, a yardage sign, a tree in the distance.
+Hit your shot. Your partner has to match it with the
+same or similar club. Miss and you get a letter.
+First to H-O-R-S-E loses.
+
+This game is deceptively effective because calling your
+shot — committing to a specific target before you swing
+— is exactly the skill you need on the course. You
+can't hide in vagueness when your partner is watching
+to see if you matched the shot.
+
+### The imaginary fairway
+
+Pick two targets on the range to define a fairway —
+two flags, two trees, whatever. Make the fairway about
+25-30 yards wide for a standard driver shot. Narrower
+if you want more challenge.
+
+Hit ten tee shots. Score: driver in the fairway = 3
+points, fairway wood = 2 points, iron = 1 point.
+Add a penalty: -2 points for a shot that would find
+water if you imagine a hazard on one side.
+
+The scoring system incentivizes you to use driver — the
+club that gives you the most distance but the most risk.
+It also forces a decision on every shot about whether
+the reward is worth the risk. That's the tee shot
+decision on every hole of real golf.
+
+### Same distance, different clubs
+
+Pick a target on the range — a flag at, say, 100 yards.
+Now try to hit that target with five different clubs.
+Your 9-iron, your 8-iron, your pitching wedge, your
+gap wedge, your sand wedge. Each club requires a
+different swing length and speed to cover the same
+distance.
+
+This game builds the feel for partial shots — one of
+the hardest skills in golf and one that most amateurs
+never specifically practice. It also teaches you your
+actual distances more precisely than full swings ever
+will, because you're forced to feel what a 75% swing
+with each club produces.
+
+### Three club challenge
+
+Play a simulated nine-hole round on the range using
+only three clubs. Pick a driver, a mid iron, and a
+wedge. Play nine imaginary holes, hitting each shot
+as if you're on a real course — tee shot to a target,
+approach to a different target, chip to a third.
+
+Three clubs forces creativity. You can't default to
+the perfect club for every situation because perfect
+clubs aren't available. You learn to work the ball,
+manufacture shots, and think your way around a hole
+rather than just grinding through it mechanically.
+
+---
+
+## The last ball rule
+
+Here is a simple pressure practice habit that requires
+no setup and no partner.
+
+Whatever you're practicing on the range — irons,
+driver, wedges — save your last ball for a specific
+challenge. Announce it to yourself before you hit it.
+
+"This drive has to find the fairway."
+"This wedge has to finish within ten feet of the flag."
+"This 7-iron has to carry the 150 marker."
+
+One ball. No second chance. The session ends on this
+shot and you find out whether the work you just did
+translates when something is riding on it.
+
+You will be surprised how differently you approach a
+shot when you know it's the last one.
+
+---
+
+## Building your own pressure games
+
+The best pressure games are the ones where the stakes
+feel real to you personally. Generic drills work, but
+customized stakes work better.
+
+A few principles for building your own:
+
+**The stakes must be real but not ruinous.** A candy
+bar, a coffee, ten pushups, bragging rights — these
+work. Losing twenty dollars, embarrassing yourself in
+front of a crowd — these create the wrong kind of
+pressure that shuts down performance rather than
+training it.
+
+**Streaks create more pressure than totals.** Making
+ten putts out of fifteen creates less pressure than
+making five in a row. The streak format means every
+putt after a successful one carries the weight of
+the whole streak. That's closer to how the course
+actually feels.
+
+**One-and-done beats best-of.** A single ball, a
+single attempt, no mulligans. The more the practice
+shot resembles the one-chance nature of a real shot,
+the more it trains the right mental state.
+
+**Track your scores over time.** A game without
+a scoreboard is just a drill. The scoreboard is what
+makes it a game — and watching your score improve
+over months is genuinely motivating.
+
+---
+
+## Resources
+
+> ⚠️ *Verify all links before publishing*
+
+- **Golf Digest — 15 Best Golf Practice Games**
+  golfdigest.com. Good overview of range and
+  putting green games.
+- **Practical Golf — 5 Games That Build Real Skills**
+  practical-golf.com. Solid collection of pressure
+  games with scoring systems.
+- **"Dave Pelz's Short Game Bible"** — The research-based
+  approach to short game practice. Specific drills
+  backed by data.
+- **The Upbeat Golfer (Manu)** — YouTube. Process under
+  pressure, routine under stakes.
+
+> ⚠️ *TODO: Add research citations on pressure practice
+> and performance transfer (see Sian Beilock's work
+> on choking and practice under pressure)*
+
+---
+
+*Last reviewed: May 2026*
+*Status: Draft — needs review before publishing*
+*To contribute: open a PR editing
+docs/learn/skill-games-pressure-games.md*

--- a/packages/core/src/learn.ts
+++ b/packages/core/src/learn.ts
@@ -45,9 +45,9 @@ export const LEARN_SECTIONS: LearnSection[] = [
         id: 'glossary',
         title: 'Glossary of golf terms',
         description:
-          'Handicap, GIR, scrambling, up-and-down, sand save, dispersion — the working vocabulary of the app.',
-        status: 'published',
-        words: 700,
+          'Intermediate and advanced terms beyond the basics — shot shapes, green reading, slang, rules, and historical terms.',
+        status: 'draft',
+        words: 3500,
       },
     ],
   },

--- a/packages/core/src/learn.ts
+++ b/packages/core/src/learn.ts
@@ -142,9 +142,11 @@ export const LEARN_SECTIONS: LearnSection[] = [
       },
       {
         id: 'mental-game',
-        title: 'Mental game and on-course psychology',
-        description: 'Routines, target focus, recovering from a bad shot mid-round.',
-        status: 'soon',
+        title: 'The mental game',
+        description:
+          'One shot at a time, the productive delusion, visualization, and staying calm when it matters.',
+        status: 'draft',
+        words: 2900,
       },
       {
         id: 'practice-vs-scoring-round',

--- a/packages/core/src/learn.ts
+++ b/packages/core/src/learn.ts
@@ -102,10 +102,12 @@ export const LEARN_SECTIONS: LearnSection[] = [
         status: 'soon',
       },
       {
-        id: 'skill-and-pressure-games',
+        id: 'skill-games-pressure-games',
         title: 'Skill games and pressure games',
-        description: 'Range games that build skills that survive the first tee.',
-        status: 'soon',
+        description:
+          'Clock drill, putting circuits, flag left or right, HORSE, and why the last ball in the bucket matters.',
+        status: 'draft',
+        words: 1900,
       },
       {
         id: 'understanding-your-swing',


### PR DESCRIPTION
## Summary
- Refactors Learn from a single long page into proper section/article routing (`/learn` index + `/learn/:slug` article pages on web, `/(app)/learn` and `/(app)/learn/[article]` on mobile). The shared catalog, helpers, and components live in `@oga/core` and per-app primitives.
- Adds three drafted articles: **The mental game**, **Skill games and pressure games**, and an expanded **Glossary of golf terms** (intermediate/advanced terms, slang, rules, historical hickory-era vocabulary).
- Web `LearnArticlePage` reads slug, looks up the registered component, and renders the article with breadcrumb, dismissable WIP banner for drafts, and prev/next navigation. Mobile `[article].tsx` mirrors the same flow with a switch over slugs.
- All draft article copy lives both in `docs/learn/*.md` (canonical source) and in dedicated React components — the markdown drives the editorial content; the components ship the typography that matches DESIGN.md.

## Test plan
- [ ] `/learn` index renders all five sections with article cards; search filters by title and description; "Soon" rows are muted and not tappable
- [ ] `/learn/strokes-gained`, `/learn/benchmarks`, `/learn/glossary`, `/learn/how-to-practice`, `/learn/course-management`, `/learn/mental-game`, `/learn/skill-games-pressure-games` all render
- [ ] Draft articles show the dismissable WIP banner; dismissal persists for the session
- [ ] Prev/next links walk forward and backward within the section, skipping `soon` entries
- [ ] Mobile `/(app)/learn` lists sections; tapping a draft article renders the matching component with the WIP banner; "Soon" rows do not navigate
- [ ] Unknown slug on web redirects to `/learn`; unknown slug on mobile shows the not-found state
- [ ] `pnpm typecheck`, `pnpm test`, `pnpm --filter web build`, and mobile `npm run typecheck` all pass