### PR TITLE
fix: audit findings — WHS handicap, NaN guard, save gate, holes policy, getCourses, lazy recharts

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -405,6 +405,7 @@ export default function HoleScreen() {
         totalShotsThisHole={totalShotsThisHole}
         ending={actions.ending}
         deleting={actions.deleting}
+        saving={actions.saving}
         onPersistShot={actions.persistShot}
         onPersistPutt={actions.persistPutt}
         onCloseLogger={actions.closeLogger}

--- a/apps/mobile/app/(app)/round/[id]/hole/components/HoleModals.tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/components/HoleModals.tsx
@@ -43,6 +43,7 @@ interface HoleModalsProps {
   totalShotsThisHole: number
   ending: boolean
   deleting: boolean
+  saving: boolean
   onPersistShot: (v: ShotLoggerValue | null) => void
   onPersistPutt: (v: PuttingValue) => Promise<void>
   onCloseLogger: () => void
@@ -84,6 +85,7 @@ export function HoleModals(props: HoleModalsProps) {
     totalShotsThisHole,
     ending,
     deleting,
+    saving,
     onPersistShot,
     onPersistPutt,
     onCloseLogger,
@@ -112,6 +114,7 @@ export function HoleModals(props: HoleModalsProps) {
             : undefined
         }
         initial={loggerInitial}
+        saving={saving}
         onSave={(v) => onPersistShot(v)}
         onSkip={() => onPersistShot(null)}
         onClose={onCloseLogger}

--- a/apps/mobile/app/(app)/round/[id]/hole/hooks/useShotActions.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/hooks/useShotActions.ts
@@ -1,4 +1,4 @@
-import { useState, type Dispatch, type SetStateAction } from 'react'
+import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { Alert } from 'react-native'
 import { useRouter } from 'expo-router'
 import type { User } from '@supabase/supabase-js'
@@ -79,6 +79,11 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   } = input
   const router = useRouter()
   const [saving, setSaving] = useState(false)
+  // Ref-based in-flight gate. The `saving` state setter is async, so
+  // a fast double-tap on the Save button can fire `persistShot` twice
+  // before React commits the next render — both calls see `saving`
+  // === false. The ref flips synchronously and blocks the second call.
+  const persistShotInFlightRef = useRef(false)
   const [ending, setEnding] = useState(false)
   const [deleting, setDeleting] = useState(false)
 
@@ -147,8 +152,10 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   }
 
   async function persistShot(meta: ShotLoggerValue | null) {
+    if (persistShotInFlightRef.current) return
     const payload = buildPayload(meta)
     if (!payload) return
+    persistShotInFlightRef.current = true
     setSaving(true)
     try {
       const localId = await insertPendingShot(payload)
@@ -193,6 +200,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       console.error('shot save failed', err, payload)
       Alert.alert('Save failed', (err as Error).message)
     } finally {
+      persistShotInFlightRef.current = false
       setSaving(false)
     }
   }

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -218,11 +218,16 @@ export default function NewRound() {
       const detail = await getOpenGolfApiCourse(r.id)
       const city = detail.city ?? r.city ?? null
       const state = detail.state ?? r.state ?? null
+      // `created_by` required by holes INSERT policy (migration 0026):
+      // the followup createHoles call below RLS-fails on courses with
+      // created_by IS NULL.
+      if (!user) throw new Error('not authenticated')
       const { data: course, error: courseErr } = await createCourse(supabase, {
         name: detail.name || r.name,
         city,
         state,
         external_id: r.id,
+        created_by: user.id,
       })
       if (courseErr || !course) throw courseErr ?? new Error('Course insert failed')
 
@@ -287,9 +292,10 @@ export default function NewRound() {
                 : trimmed || null
             const state =
               commaIdx >= 0 ? trimmed.slice(commaIdx + 1).trim() || null : null
+            if (!user) throw new Error('not authenticated')
             const { data: course, error: courseErr } = await createCourse(
               supabase,
-              { name: name.trim(), city, state },
+              { name: name.trim(), city, state, created_by: user.id },
             )
             if (courseErr || !course) {
               throw courseErr ?? new Error('Course insert failed')

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -41,6 +41,11 @@ interface ShotLoggerProps {
   /** Seed putt distance from GPS (ball→pin) when starting in putting mode. */
   puttDistanceFt?: number
   initial?: ShotLoggerValue
+  /** True while a save is in flight. Disables the Save button so a fast
+   *  double-tap can't enqueue two pending_shots rows for the same shot
+   *  number. The ref-based gate in useShotActions is the durable
+   *  backstop; this just gives the button a visible disabled state. */
+  saving?: boolean
   onSave: (value: ShotLoggerValue) => void
   onSkip: () => void
   onClose: () => void
@@ -84,6 +89,7 @@ export function ShotLogger({
   isPutt,
   puttDistanceFt,
   initial,
+  saving = false,
   onSave,
   onSkip,
   onClose,
@@ -404,6 +410,8 @@ export function ShotLogger({
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Save shot and continue"
+              accessibilityState={{ disabled: saving }}
+              disabled={saving}
               onPress={() => onSave(value)}
               style={{
                 flex: 1,
@@ -411,6 +419,7 @@ export function ShotLogger({
                 paddingVertical: 14,
                 borderRadius: 2,
                 backgroundColor: '#1F3D2C',
+                opacity: saving ? 0.6 : 1,
               }}
             >
               <Text
@@ -421,7 +430,7 @@ export function ShotLogger({
                   letterSpacing: 0.3,
                 }}
               >
-                Save + next →
+                {saving ? 'Saving…' : 'Save + next →'}
               </Text>
             </Pressable>
           </View>

--- a/apps/web/src/hooks/useCourses.ts
+++ b/apps/web/src/hooks/useCourses.ts
@@ -19,6 +19,7 @@ import {
 import type { Database } from '@oga/supabase'
 import { supabase } from '../lib/supabase'
 import { useDebounce } from './useDebounce'
+import { useAuth } from './useAuth'
 
 type CourseRow = Database['public']['Tables']['courses']['Row']
 type HoleInsert = Database['public']['Tables']['holes']['Insert']
@@ -97,8 +98,10 @@ interface ImportFromApiArgs {
 // scorecard from OpenGolfAPI and inserts course + holes.
 export function useImportApiCourse() {
   const qc = useQueryClient()
+  const { user } = useAuth()
   return useMutation({
     mutationFn: async (args: ImportFromApiArgs) => {
+      if (!user) throw new Error('not authenticated')
       const { data: existing, error: existingError } = await getCourseByExternalId(
         supabase,
         args.apiId,
@@ -142,11 +145,16 @@ export function useImportApiCourse() {
           commaIdx >= 0 ? trimmed.slice(commaIdx + 1).trim() || null : null
       }
 
+      // `created_by` is required by the holes INSERT policy (migration
+      // 0026): the immediate `createHoles` call below RLS-fails on
+      // courses with `created_by IS NULL`. Stamp the caller's user id
+      // so the policy's `c.created_by = auth.uid()` check passes.
       const { data: course, error } = await createCourse(supabase, {
         name: detail?.name ?? args.fallbackName,
         city,
         state,
         external_id: args.apiId,
+        created_by: user.id,
       })
       if (error || !course) throw error ?? new Error('Course insert failed')
 
@@ -233,18 +241,23 @@ interface ManualCourseArgs {
 // Used by "Course not found? Add it →" form. pars.length determines 9-vs-18.
 export function useCreateManualCourse() {
   const qc = useQueryClient()
+  const { user } = useAuth()
   return useMutation({
     mutationFn: async (args: ManualCourseArgs) => {
+      if (!user) throw new Error('not authenticated')
       const trimmed = args.location?.trim() ?? ''
       const commaIdx = trimmed.indexOf(',')
       const city =
         commaIdx >= 0 ? trimmed.slice(0, commaIdx).trim() || null : trimmed || null
       const state =
         commaIdx >= 0 ? trimmed.slice(commaIdx + 1).trim() || null : null
+      // See useImportApiCourse — `created_by` required by holes INSERT
+      // policy (migration 0026) so the followup createHoles passes RLS.
       const { data: course, error: courseError } = await createCourse(supabase, {
         name: args.name.trim(),
         city,
         state,
+        created_by: user.id,
       })
       if (courseError || !course) {
         throw courseError ?? new Error('Course insert failed')

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -1,17 +1,16 @@
-import { useMemo } from 'react'
+import { lazy, Suspense, useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts'
 import { formatSG } from '@oga/core'
 import { useRecentSG } from '../../hooks/useRounds'
 import { useProfile } from '../../hooks/useProfile'
+
+// Lazy-load recharts off the dashboard's first-paint chunk. Without this
+// the recharts vendor bundle (~150KB gzip) ships alongside the index
+// chunk on every authenticated cold start. Suspense fallback matches
+// the chart's container height so layout doesn't shift on hydration.
+const SGTrendChart = lazy(() =>
+  import('./components/SGTrendChart').then((m) => ({ default: m.SGTrendChart })),
+)
 
 const SG_KEYS = [
   { key: 'sg_off_tee', label: 'Off tee' },
@@ -19,17 +18,6 @@ const SG_KEYS = [
   { key: 'sg_around_green', label: 'Around green' },
   { key: 'sg_putting', label: 'Putting' },
 ] as const
-
-const TICK_STYLE = { fontSize: 11, fill: '#8A8B7E' } as const
-
-const TOOLTIP_STYLE = {
-  backgroundColor: '#FBF8F1',
-  border: '1px solid #D9D2BF',
-  borderRadius: 4,
-  fontSize: 11,
-  padding: '8px 10px',
-  fontFamily: 'Inter, sans-serif',
-} as const
 
 export function DashboardPage() {
   const profile = useProfile()
@@ -131,34 +119,16 @@ export function DashboardPage() {
 
       <Section kicker="SG total trend">
         <div style={{ height: 220 }}>
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={trendData} margin={{ top: 4, right: 8, bottom: 4, left: -16 }}>
-              <CartesianGrid stroke="#EBE5D6" vertical={false} />
-              <XAxis
-                dataKey="date"
-                tick={TICK_STYLE}
-                tickLine={false}
-                axisLine={{ stroke: '#D9D2BF' }}
+          <Suspense
+            fallback={
+              <div
+                className="bg-caddie-surface animate-pulse"
+                style={{ height: '100%', borderRadius: 4 }}
               />
-              <YAxis
-                tick={TICK_STYLE}
-                tickLine={false}
-                axisLine={{ stroke: '#D9D2BF' }}
-              />
-              <Tooltip
-                contentStyle={TOOLTIP_STYLE}
-                labelStyle={{ color: '#8A8B7E' }}
-              />
-              <Line
-                type="monotone"
-                dataKey="sg"
-                stroke="#1F3D2C"
-                strokeWidth={1.5}
-                dot={{ r: 2.5, fill: '#1F3D2C', strokeWidth: 0 }}
-                activeDot={{ r: 4 }}
-              />
-            </LineChart>
-          </ResponsiveContainer>
+            }
+          >
+            <SGTrendChart data={trendData} />
+          </Suspense>
         </div>
       </Section>
 

--- a/apps/web/src/pages/dashboard/components/SGTrendChart.tsx
+++ b/apps/web/src/pages/dashboard/components/SGTrendChart.tsx
@@ -1,0 +1,65 @@
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+interface SGTrendPoint {
+  date: string
+  sg: number
+}
+
+interface SGTrendChartProps {
+  data: SGTrendPoint[]
+}
+
+const TICK_STYLE = { fontSize: 11, fill: '#8A8B7E' } as const
+
+const TOOLTIP_STYLE = {
+  backgroundColor: '#FBF8F1',
+  border: '1px solid #D9D2BF',
+  borderRadius: 4,
+  fontSize: 11,
+  padding: '8px 10px',
+  fontFamily: 'Inter, sans-serif',
+} as const
+
+// Extracted from DashboardPage so recharts (~150KB gzip) loads
+// asynchronously on the dashboard route — without this split, recharts
+// rides eagerly on the first authenticated paint.
+export function SGTrendChart({ data }: SGTrendChartProps) {
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={data} margin={{ top: 4, right: 8, bottom: 4, left: -16 }}>
+        <CartesianGrid stroke="#EBE5D6" vertical={false} />
+        <XAxis
+          dataKey="date"
+          tick={TICK_STYLE}
+          tickLine={false}
+          axisLine={{ stroke: '#D9D2BF' }}
+        />
+        <YAxis
+          tick={TICK_STYLE}
+          tickLine={false}
+          axisLine={{ stroke: '#D9D2BF' }}
+        />
+        <Tooltip
+          contentStyle={TOOLTIP_STYLE}
+          labelStyle={{ color: '#8A8B7E' }}
+        />
+        <Line
+          type="monotone"
+          dataKey="sg"
+          stroke="#1F3D2C"
+          strokeWidth={1.5}
+          dot={{ r: 2.5, fill: '#1F3D2C', strokeWidth: 0 }}
+          activeDot={{ r: 4 }}
+        />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -42,13 +42,6 @@ export type ShotDragUndo = {
   label: string
 }
 
-interface EnsureRealHoleOpts {
-  teeLat?: number | null
-  teeLng?: number | null
-  pinLat?: number | null
-  pinLng?: number | null
-}
-
 interface UseRoundActionsInput {
   roundId: string | undefined
   user: User | null
@@ -72,7 +65,7 @@ interface UseRoundActionsInput {
 }
 
 export interface UseRoundActionsResult {
-  ensureRealHole: (hole: HoleRow, opts?: EnsureRealHoleOpts) => Promise<string>
+  ensureRealHole: (hole: HoleRow) => Promise<string>
   persistRoundPin: (point: PlacedPoint) => Promise<void>
   placeHandlers: {
     onPlace: (p: PlacedPoint) => void
@@ -148,47 +141,44 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
   // Materialize a synthetic hole into a real `holes` row before any
   // operation that writes to hole_scores. Synthetic ids (prefixed
   // 'synthetic-') come from the no-OSM-data fallback in the `holes`
-  // memo above; hole_scores.hole_id has a FK to holes.id, so without
-  // this an upsert would fail. On insert, invalidate the holes query
-  // so the synthetic placeholder gets replaced with the real row on
-  // the next read. On unique-violation (course_id,number race), look
-  // up the existing row instead of clobbering it.
+  // memo; hole_scores.hole_id has a FK to holes.id, so without this an
+  // upsert would fail.
+  //
+  // Routed through the `insert_synthetic_hole` RPC (migration 0026) —
+  // the new holes INSERT policy disallows client-side inserts for
+  // crawler-imported courses (`created_by IS NULL`), so this path goes
+  // through a SECURITY DEFINER function that checks `auth.uid()` owns
+  // the round before bypassing RLS. ON CONFLICT inside the RPC is
+  // idempotent so concurrent calls converge on the same row.
   const ensureRealHole = useCallback(
-    async (hole: HoleRow, opts?: EnsureRealHoleOpts): Promise<string> => {
+    async (hole: HoleRow): Promise<string> => {
       if (!hole.id.startsWith('synthetic-')) return hole.id
-      const { data: inserted, error: insertErr } = await supabase
-        .from('holes')
-        .insert({
-          course_id: hole.course_id,
-          number: hole.number,
-          par: hole.par,
-          yards: null,
-          stroke_index: hole.number,
-          tee_lat: opts?.teeLat ?? null,
-          tee_lng: opts?.teeLng ?? null,
-          pin_lat: opts?.pinLat ?? null,
-          pin_lng: opts?.pinLng ?? null,
-        })
-        .select('id')
-        .single()
-      if (!insertErr && inserted) {
-        queryClient.invalidateQueries({ queryKey: ['holes', hole.course_id] })
-        return inserted.id
+      if (!roundId) throw new Error('roundId required to materialize hole')
+      // supabase-js's generated types don't yet know about this RPC
+      // (regen lands separately). Cast to the narrow shape we use here.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const rpc = (supabase as any).rpc.bind(supabase) as (
+        fn: 'insert_synthetic_hole',
+        args: {
+          p_course_id: string
+          p_number: number
+          p_par: number
+          p_round_id: string
+        },
+      ) => Promise<{ data: string | null; error: { message: string } | null }>
+      const { data: holeId, error } = await rpc('insert_synthetic_hole', {
+        p_course_id: hole.course_id,
+        p_number: hole.number,
+        p_par: hole.par ?? 4,
+        p_round_id: roundId,
+      })
+      if (error || !holeId) {
+        throw new Error(error?.message ?? 'insert_synthetic_hole returned no id')
       }
-      if (insertErr?.code === '23505') {
-        const { data: existing, error: selectErr } = await supabase
-          .from('holes')
-          .select('id')
-          .eq('course_id', hole.course_id)
-          .eq('number', hole.number)
-          .single()
-        if (selectErr || !existing) throw selectErr ?? insertErr
-        queryClient.invalidateQueries({ queryKey: ['holes', hole.course_id] })
-        return existing.id
-      }
-      throw insertErr ?? new Error('hole insert failed')
+      queryClient.invalidateQueries({ queryKey: ['holes', hole.course_id] })
+      return holeId
     },
-    [queryClient],
+    [queryClient, roundId],
   )
 
   // The round-pin write is best-effort — we update local state synchronously
@@ -496,15 +486,13 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
             r.distanceToPin <= NEAR_GREEN_YARDS,
         ).length
         // Materialize the synthetic hole if needed before upserting the
-        // hole_score (FK to holes.id). Seeds the new holes row with any
-        // session tee/pin overrides so manual placements persist as the
-        // course's first real layout data — every save curates the course.
-        const realHoleId = await ensureRealHole(activeHole, {
-          teeLat: teeOverride?.lat ?? null,
-          teeLng: teeOverride?.lng ?? null,
-          pinLat: pinOverride?.lat ?? null,
-          pinLng: pinOverride?.lng ?? null,
-        })
+        // hole_score (FK to holes.id). The RPC inserts only (course_id,
+        // number, par, stroke_index) — per-round tee/pin overrides
+        // continue to live on hole_scores.pin_lat/lng (the round-pin
+        // path). Course-level tee/pin seeding from the review save was
+        // dropped in #220; track re-adding via a separate "course
+        // curation from completed rounds" issue.
+        const realHoleId = await ensureRealHole(activeHole)
         // Infer fairway_hit + gir from the placed shot lies. Existing
         // manual entries from HoleScoreCard win via the ?? — re-saving
         // the map review never silently overwrites a value the player

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -10,16 +10,27 @@ export default defineConfig({
     rollupOptions: {
       output: {
         // Split the heaviest deps into their own chunks so the initial
-        // bundle isn't dragged down by Recharts (~400 KB) and Mapbox
-        // (only loaded by the round map, which is itself lazy). Routes
-        // that don't use Recharts (dashboard, rounds list, settings)
-        // skip its chunk entirely.
+        // bundle isn't dragged down by Recharts (~150 KB gzip) and
+        // Mapbox (~490 KB gzip). Routes that don't use Recharts
+        // (dashboard's static path, rounds list, settings) skip its
+        // chunk entirely.
         manualChunks: {
           recharts: ['recharts'],
           mapbox: ['mapbox-gl'],
           core: ['@oga/core'],
         },
       },
+    },
+    // Strip recharts from the entry chunk's modulepreload list —
+    // SGTrendChart on the dashboard and the StrokesGainedSection on
+    // the lazy /stats route both go through dynamic imports, so the
+    // chunk should download lazily. Vite's default preloads it
+    // alongside index.js, putting the bytes back on the first-paint
+    // path. Same treatment for mapbox so its ~490 KB gzip chunk only
+    // hits the wire when the round-map route mounts.
+    modulePreload: {
+      resolveDependencies: (_filename, deps) =>
+        deps.filter((d) => !d.includes('recharts') && !d.includes('mapbox')),
     },
   },
 })

--- a/packages/core/src/__tests__/sg-baselines.test.ts
+++ b/packages/core/src/__tests__/sg-baselines.test.ts
@@ -99,6 +99,15 @@ describe('interpolateBaseline', () => {
   it('throws on an empty table', () => {
     expect(() => interpolateBaseline({}, 100)).toThrow()
   })
+
+  it('returns null for NaN distance (prevents propagation into stored SG)', () => {
+    expect(interpolateBaseline(table, Number.NaN)).toBe(null)
+  })
+
+  it('returns null for Infinity / -Infinity distance', () => {
+    expect(interpolateBaseline(table, Number.POSITIVE_INFINITY)).toBe(null)
+    expect(interpolateBaseline(table, Number.NEGATIVE_INFINITY)).toBe(null)
+  })
 })
 
 describe('interpolateBaseline — putting baselines (feet)', () => {
@@ -126,6 +135,7 @@ describe('interpolateBaseline — putting baselines (feet)', () => {
     let prev = 0
     for (const h of HANDICAP_BRACKETS) {
       const expected = interpolateBaseline(PUTTING_BASELINES[h], 5)
+      if (expected === null) throw new Error('expected finite baseline')
       expect(expected).toBeGreaterThan(prev)
       prev = expected
     }
@@ -137,6 +147,7 @@ describe('interpolateBaseline — putting baselines (feet)', () => {
     let prev = 0
     for (const dist of [3, 5, 8, 10, 15, 20, 30, 40, 60]) {
       const e = interpolateBaseline(scratch, dist)
+      if (e === null) throw new Error('expected finite baseline')
       expect(e).toBeGreaterThan(prev)
       prev = e
     }
@@ -172,6 +183,7 @@ describe('interpolateBaseline — approach baselines (yards)', () => {
     let prev = 0
     for (const h of HANDICAP_BRACKETS) {
       const e = interpolateBaseline(APPROACH_BASELINES[h], 150)
+      if (e === null) throw new Error('expected finite baseline')
       expect(e).toBeGreaterThan(prev)
       prev = e
     }

--- a/packages/core/src/handicap.test.ts
+++ b/packages/core/src/handicap.test.ts
@@ -6,56 +6,103 @@ import {
 } from './handicap'
 
 describe('calculateDifferential', () => {
-  it('matches the USGA formula (84, 71.2, 124) → ~11.66', () => {
-    const d = calculateDifferential(84, 71.2, 124)
-    // (84 - 71.2) * 113 / 124 = 11.6645
-    expect(d).toBeCloseTo(11.66, 1)
+  it('matches the WHS formula (84, 71.2, 124) → 11.7', () => {
+    // (84 - 71.2) * 113 / 124 = 11.6645... → rounded to 11.7
+    expect(calculateDifferential(84, 71.2, 124)).toBe(11.7)
   })
 
   it('returns negative differentials for sub-rating rounds', () => {
-    const d = calculateDifferential(68, 70.5, 130)
-    expect(d).toBeLessThan(0)
+    expect(calculateDifferential(68, 70.5, 130)).toBeLessThan(0)
   })
 
-  it('throws when slope is zero or negative', () => {
+  it('throws when slope is zero, negative, or non-finite', () => {
     expect(() => calculateDifferential(80, 72, 0)).toThrow()
     expect(() => calculateDifferential(80, 72, -120)).toThrow()
+    expect(() => calculateDifferential(80, 72, Number.NaN)).toThrow()
+  })
+
+  it('rounds to one decimal place', () => {
+    // (90 - 72) * 113 / 113 = 18.000 → 18
+    expect(calculateDifferential(90, 72, 113)).toBe(18)
   })
 })
 
-describe('calculateHandicapIndex', () => {
+describe('calculateHandicapIndex (WHS)', () => {
   it('returns null with fewer than three differentials', () => {
     expect(calculateHandicapIndex([])).toBe(null)
     expect(calculateHandicapIndex([10])).toBe(null)
     expect(calculateHandicapIndex([10, 12])).toBe(null)
   })
 
-  it('uses 1 of 3 best at 3 submissions', () => {
-    // Best 1 of 3 = 10 → 10 * 0.96 = 9.6
-    const idx = calculateHandicapIndex([15, 12, 10])
-    expect(idx).toBe(9.6)
+  it('uses lowest 1 minus 2.0 at 3 differentials', () => {
+    // best 1 of [15, 12, 10] = 10; 10 - 2.0 = 8.0
+    expect(calculateHandicapIndex([15, 12, 10])).toBe(8.0)
   })
 
-  it('uses best 2 of 5', () => {
-    const idx = calculateHandicapIndex([10, 11, 12, 13, 14])
-    // best 2 = (10 + 11) / 2 = 10.5; * 0.96 = 10.08 → 10.1
-    expect(idx).toBe(10.1)
+  it('uses lowest 1 minus 1.0 at 4 differentials', () => {
+    // best 1 of [15, 12, 11, 10] = 10; 10 - 1.0 = 9.0
+    expect(calculateHandicapIndex([15, 12, 11, 10])).toBe(9.0)
   })
 
-  it('uses best 8 of 20+', () => {
+  it('uses lowest 1 with no adjustment at 5 differentials', () => {
+    // best 1 of [10, 11, 12, 13, 14] = 10
+    expect(calculateHandicapIndex([10, 11, 12, 13, 14])).toBe(10.0)
+  })
+
+  it('uses average of lowest 2 minus 1.0 at 6 differentials', () => {
+    // best 2 of [10, 11, 12, 13, 14, 15] = (10 + 11) / 2 = 10.5; - 1.0 = 9.5
+    expect(calculateHandicapIndex([10, 11, 12, 13, 14, 15])).toBe(9.5)
+  })
+
+  it('uses average of lowest 2 with no adjustment at 7 differentials', () => {
+    // best 2 = (10 + 11) / 2 = 10.5
+    expect(calculateHandicapIndex([10, 11, 12, 13, 14, 15, 16])).toBe(10.5)
+  })
+
+  it('uses average of lowest 3 at 9 differentials', () => {
+    // best 3 of 9.0..17.0 = (9.0 + 10.0 + 11.0) / 3 = 10.0
+    const diffs = [9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0]
+    expect(calculateHandicapIndex(diffs)).toBe(10.0)
+  })
+
+  it('uses average of lowest 4 at 12 differentials', () => {
+    // best 4 = (8 + 9 + 10 + 11) / 4 = 9.5
+    const diffs = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+    expect(calculateHandicapIndex(diffs)).toBe(9.5)
+  })
+
+  it('uses average of lowest 8 of all 20 at 20 differentials', () => {
     const diffs = [
       8.0, 8.5, 9.1, 9.5, 10.0, 10.4, 10.8, 11.2, 11.5, 11.9,
       12.3, 12.7, 13.0, 13.4, 13.7, 14.0, 14.4, 14.8, 15.2, 15.5,
     ]
-    const idx = calculateHandicapIndex(diffs)
-    // best 8 = (8.0 + 8.5 + 9.1 + 9.5 + 10.0 + 10.4 + 10.8 + 11.2) / 8 = 9.6875
-    // * 0.96 = 9.30 → 9.3
-    expect(idx).toBe(9.3)
+    // best 8 = (8.0 + 8.5 + 9.1 + 9.5 + 10.0 + 10.4 + 10.8 + 11.2) / 8
+    //       = 77.5 / 8 = 9.6875 → 9.7
+    expect(calculateHandicapIndex(diffs)).toBe(9.7)
+  })
+
+  it('uses only the most recent 20 at 25 differentials', () => {
+    // First (most recent) 20 are 5..24; next 5 are 25..29 (all higher).
+    // The recent-20 window's best 8 = (5+6+7+8+9+10+11+12)/8 = 8.5.
+    // Without the window cap the best 8 would still be 5..12 = 8.5,
+    // so to actually exercise the cap we put low values in the OLDEST
+    // slots and high values in the newest 20. Reorder so the newest 20
+    // are 30..49 and the oldest 5 are 1..5 — those should be ignored.
+    const newest20 = Array.from({ length: 20 }, (_, i) => 30 + i) // 30..49 (most recent)
+    const oldest5 = [1, 2, 3, 4, 5] // older — should be excluded
+    const diffs = [...newest20, ...oldest5]
+    // best 8 of recent 20 = (30+31+32+33+34+35+36+37)/8 = 33.5
+    expect(calculateHandicapIndex(diffs)).toBe(33.5)
   })
 
   it('rounds to one decimal place', () => {
-    const idx = calculateHandicapIndex([10.0, 10.0, 10.0])
-    expect(idx).toBe(9.6)
+    // [10, 10, 10] → best 1 = 10; - 2.0 = 8.0
+    expect(calculateHandicapIndex([10.0, 10.0, 10.0])).toBe(8.0)
+  })
+
+  it('caps the index at 54.0', () => {
+    // best 1 of [60, 70, 80] = 60; - 2.0 = 58 → capped to 54.0
+    expect(calculateHandicapIndex([60, 70, 80])).toBe(54.0)
   })
 
   it('ignores non-finite differentials', () => {
@@ -66,7 +113,13 @@ describe('calculateHandicapIndex', () => {
       Number.NaN,
       Number.POSITIVE_INFINITY,
     ])
-    expect(idx).not.toBeNull()
+    // After filter: [8, 9, 10] — 3 valid diffs → best 1 = 8; - 2.0 = 6.0
+    expect(idx).toBe(6.0)
+  })
+
+  it('does not apply the legacy 0.96 multiplier anywhere', () => {
+    // Spot check: 5 diffs, lowest = 12. WHS yields 12.0, not 11.5.
+    expect(calculateHandicapIndex([12, 13, 14, 15, 16])).toBe(12.0)
   })
 })
 

--- a/packages/core/src/handicap.ts
+++ b/packages/core/src/handicap.ts
@@ -1,14 +1,19 @@
-// USGA-style handicap mechanics.
-// - calculateDifferential — per-round score differential from
-//   adjusted score, course rating, slope rating.
-// - calculateHandicapIndex — averages the best of the last N
-//   differentials (lookup table per submission count) and applies
-//   the 0.96 confidence factor.
-// - adjustedScore — Equitable Stroke Control: caps each hole's
-//   score for handicap purposes based on the player's index.
+// World Handicap System (WHS) mechanics — in effect since January 2020.
 //
-// Pure module — no DB, no React. Used by web + mobile finalize
-// flows and any future server-side handicap recompute.
+// - calculateDifferential: per-round score differential from adjusted
+//   score, course rating, slope rating. Rounded to one decimal per
+//   USGA Rule 5.1.
+// - calculateHandicapIndex: averages the lowest N differentials per
+//   the WHS table (Rule 5.2a) and applies the low-round adjustment.
+//   Replaces the legacy 0.96 multiplier — WHS does not use one.
+// - adjustedScore: Equitable Stroke Control caps each hole's score
+//   for handicap purposes based on the player's index.
+//
+// Pure module — no DB, no React. Used by web + mobile finalize flows
+// and any future server-side handicap recompute.
+
+const MAX_HANDICAP_INDEX = 54.0
+const RECENT_WINDOW = 20
 
 export function calculateDifferential(
   adjustedScore: number,
@@ -18,31 +23,50 @@ export function calculateDifferential(
   if (!Number.isFinite(slopeRating) || slopeRating <= 0) {
     throw new Error('slopeRating must be a positive number')
   }
-  return ((adjustedScore - courseRating) * 113) / slopeRating
+  const raw = ((adjustedScore - courseRating) * 113) / slopeRating
+  return Math.round(raw * 10) / 10
 }
 
+interface BracketRule {
+  bestCount: number
+  adjustment: number
+}
+
+// WHS Rule 5.2a table. `count` is the number of acceptable
+// differentials (capped at 20 — see `considered` below).
+function bracketFor(count: number): BracketRule {
+  if (count >= 20) return { bestCount: 8, adjustment: 0 }
+  if (count === 19) return { bestCount: 7, adjustment: 0 }
+  if (count >= 17) return { bestCount: 6, adjustment: 0 }
+  if (count >= 15) return { bestCount: 5, adjustment: 0 }
+  if (count >= 12) return { bestCount: 4, adjustment: 0 }
+  if (count >= 9) return { bestCount: 3, adjustment: 0 }
+  if (count >= 7) return { bestCount: 2, adjustment: 0 }
+  if (count === 6) return { bestCount: 2, adjustment: -1.0 }
+  if (count === 5) return { bestCount: 1, adjustment: 0 }
+  if (count === 4) return { bestCount: 1, adjustment: -1.0 }
+  return { bestCount: 1, adjustment: -2.0 } // count === 3
+}
+
+// `differentials` is most-recent-first. For 20+ we drop everything
+// past the most-recent-20 window before picking the best 8 — this
+// matches WHS "of the most recent 20 scores" wording.
 export function calculateHandicapIndex(
   differentials: number[],
 ): number | null {
   const valid = differentials.filter((d) => Number.isFinite(d))
   if (valid.length < 3) return null
 
-  const sorted = [...valid].sort((a, b) => a - b)
-  const count = valid.length
+  const considered =
+    valid.length >= RECENT_WINDOW ? valid.slice(0, RECENT_WINDOW) : valid
 
-  let bestCount: number
-  if (count >= 20) bestCount = 8
-  else if (count >= 17) bestCount = 7
-  else if (count >= 14) bestCount = 6
-  else if (count >= 11) bestCount = 5
-  else if (count >= 9) bestCount = 4
-  else if (count >= 7) bestCount = 3
-  else if (count >= 5) bestCount = 2
-  else bestCount = 1
-
+  const { bestCount, adjustment } = bracketFor(considered.length)
+  const sorted = [...considered].sort((a, b) => a - b)
   const best = sorted.slice(0, bestCount)
   const avg = best.reduce((a, b) => a + b, 0) / best.length
-  return Math.round(avg * 0.96 * 10) / 10
+  const result = avg + adjustment
+  const rounded = Math.round(result * 10) / 10
+  return Math.min(rounded, MAX_HANDICAP_INDEX)
 }
 
 // ESC: cap each hole's gross score before computing the adjusted

--- a/packages/core/src/sg-baselines.ts
+++ b/packages/core/src/sg-baselines.ts
@@ -49,10 +49,15 @@ export function getHandicapBracket(handicap: number): HandicapBracket {
   return 30
 }
 
+// Returns `null` when distance is NaN/Infinity. The previous behavior
+// silently returned NaN (via `[undefined] + ratio * (...)`), which then
+// got stored on hole_scores.sg_* as a literal Postgres NaN — corrupting
+// stats forever. Callers already propagate null via getExpectedStrokes.
 export function interpolateBaseline(
   table: Record<number, number>,
   distance: number,
-): number {
+): number | null {
+  if (!Number.isFinite(distance)) return null
   const keys = Object.keys(table)
     .map(Number)
     .sort((a, b) => a - b)

--- a/packages/supabase/src/queries/courses.ts
+++ b/packages/supabase/src/queries/courses.ts
@@ -8,10 +8,6 @@ type HoleInsert = Database['public']['Tables']['holes']['Insert']
 // the hole-map fallback; external_id keeps the OpenGolfAPI link reachable.
 const COURSE_COLUMNS = 'id, name, city, state, lat, lng, external_id'
 
-export function getCourses(client: OgaSupabaseClient) {
-  return client.from('courses').select(COURSE_COLUMNS).order('name')
-}
-
 export function searchCourses(client: OgaSupabaseClient, query: string, limit = 10) {
   const trimmed = query.trim()
   if (!trimmed) {

--- a/supabase/migrations/0026_tighten_holes_policy.sql
+++ b/supabase/migrations/0026_tighten_holes_policy.sql
@@ -1,0 +1,86 @@
+-- Tighten holes INSERT — security audit (closes #220).
+--
+-- Migration 0001 created the policy "Course creators can insert holes"
+-- with `OR c.created_by IS NULL` in the WITH CHECK. With 15K+ crawler-
+-- imported rows where `created_by IS NULL`, any authenticated user could
+-- insert hole rows for those courses and poison tee/pin coords for
+-- everyone. New policy strips the NULL fallback.
+--
+-- Synthetic-holes / `ensureRealHole` callers used to rely on the open
+-- policy for materializing crawler courses. They now go through
+-- `insert_synthetic_hole(...)` (SECURITY DEFINER) below, which bypasses
+-- RLS but checks that the caller owns the round before inserting.
+
+drop policy if exists "Course creators can insert holes" on public.holes;
+drop policy if exists "Users can insert holes for own courses" on public.holes;
+
+create policy "Users can insert holes for own courses"
+  on public.holes for insert
+  with check (
+    exists (
+      select 1 from public.courses c
+      where c.id = holes.course_id
+        and c.created_by = auth.uid()
+    )
+  );
+
+create or replace function public.insert_synthetic_hole(
+  p_course_id uuid,
+  p_number integer,
+  p_par integer,
+  p_round_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_hole_id uuid;
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'not authenticated';
+  end if;
+
+  -- Caller must own the round they're materializing the hole for.
+  -- Stops a malicious client from inserting holes for arbitrary courses
+  -- by passing a course_id they don't own — they'd still need a round
+  -- on that course, and rounds.user_id is RLS-scoped.
+  if not exists (
+    select 1 from public.rounds r
+    where r.id = p_round_id
+      and r.user_id = v_user_id
+  ) then
+    raise exception 'not authorized';
+  end if;
+
+  -- Cap par to the table's CHECK range so a malformed payload returns
+  -- a clean error instead of tripping the constraint deep in the function.
+  if p_par < 3 or p_par > 6 then
+    raise exception 'par must be between 3 and 6';
+  end if;
+  if p_number < 1 or p_number > 18 then
+    raise exception 'number must be between 1 and 18';
+  end if;
+
+  insert into public.holes (course_id, number, par, stroke_index)
+  values (p_course_id, p_number, p_par, p_number)
+  on conflict (course_id, number) do nothing
+  returning id into v_hole_id;
+
+  -- ON CONFLICT DO NOTHING returns NULL on conflict — fetch the
+  -- existing row so the caller always gets a real id.
+  if v_hole_id is null then
+    select id into v_hole_id
+    from public.holes
+    where course_id = p_course_id
+      and number = p_number;
+  end if;
+
+  return v_hole_id;
+end;
+$$;
+
+revoke all on function public.insert_synthetic_hole(uuid, integer, integer, uuid) from public;
+grant execute on function public.insert_synthetic_hole(uuid, integer, integer, uuid) to authenticated;


### PR DESCRIPTION
## Summary

Fixes the CRITICAL/HIGH findings from the three pre-launch audits plus the deferred M1 items from each. Closes audit issues #220, #223, #224, #225, #226 and the H1 in the data audit.

7 commits, one per fix group:

1. **WHS handicap formula** (`packages/core/src/handicap.ts`) — replaces the legacy USGA formula with the official WHS Rule 5.2a table. Drops the retired 0.96 multiplier, adds the -2.0 / -1.0 low-round adjustments, caps at 54.0, slices to most-recent-20 for 20+ rounds. 24 tests cover every bracket transition.
2. **NaN guard in `interpolateBaseline`** (`packages/core/src/sg-baselines.ts`) — adds `Number.isFinite(distance)` check at top, return type `number → number | null`. Caller path through `getExpectedStrokes` already handles null. Stops NaN propagation into stored SG values.
3. **Mobile save gate** (`apps/mobile/.../useShotActions.ts` + `ShotLogger.tsx`) — adds `useRef`-based in-flight gate at top of `persistShot` (state-based gate has a race window between `setSaving(true)` and the next render). Save button now `disabled={saving}` with visual dim + "Saving…" label.
4. **Holes INSERT policy + RPC** (`supabase/migrations/0026_tighten_holes_policy.sql` + `useRoundActions.ts`) — drops the `created_by IS NULL` fallback that let any auth user inject hole rows on any of the 15K+ crawler-imported courses. Synthetic-holes path now goes through `insert_synthetic_hole` SECURITY DEFINER RPC that checks `auth.uid()` owns the round before bypassing RLS.
5. **Delete unused `getCourses`** (`packages/supabase/src/queries/courses.ts`) — unbounded query over all 15K+ rows with zero callers. Foot-gun removed.
6. **Lazy-load recharts** (`apps/web/src/pages/dashboard/components/SGTrendChart.tsx` + `vite.config.ts`) — extracts dashboard chart into its own lazy chunk. Adds `build.modulePreload.resolveDependencies` to strip recharts AND mapbox from the entry chunk's preload list. Recharts no longer ships on first paint; `dist/index.html` modulepreload list goes from `[recharts, core]` to `[core]`.
7. **Set `created_by` on user-created courses** — follow-up to #4 found by the cross-cutting code review. The new holes INSERT policy requires `c.created_by = auth.uid()`, so `createCourse` callers in `useCourses.ts` (web import + manual flows) and `apps/mobile/.../round/new.tsx` must stamp `user.id`. Without this, course creation breaks the moment 0026 ships.

## Verification

- `pnpm typecheck` — 3/3 pass
- `pnpm test` — 13 files, 294 tests pass (added 2 NaN guard tests, replaced handicap suite)
- `pnpm --filter web build` — succeeds; first-paint chunks now `index (462 KB / 129 KB gzip) + core (28 KB / 10 KB gzip) + CSS`. Recharts and Mapbox load lazily.
- Mobile `npm run typecheck` — pass
- `supabase db push --linked` — applied 0026 to linked project

## Specialist review summary

5 specialist agents reviewed in parallel (typescript-pro, sql-pro, frontend-developer, mobile-developer, code-reviewer). One REAL BUG surfaced (the `created_by` regression — fixed in commit 4cbd398). The remaining tuning concerns are deferred to follow-up issues:

- Migration `0026` skips `0025`. CLAUDE.md says no skipped numbers; spec explicitly named 0026. Rename if 0025 is reserved for in-flight work.
- `useRoundActions.ts` "course curation from completed rounds" comment cites no issue number — drop or link an issue.
- `useRoundData.ts` synthetic-mode comment still describes the predicate-based bug; trim on next touch.
- PuttingSheet's Save button has no visual `disabled` state during save. The ref-based gate inside `persistShot` blocks the duplicate insert regardless of which button fired it (correctness intact), but the visual feedback is inconsistent with `ShotLogger`. File a follow-up.
- `sg-baselines.test.ts` monotone-loop guards use plain `throw new Error` instead of `expect().not.toBeNull()`. Cosmetic.

## Notable design choice — `ensureRealHole` no longer seeds tee/pin coords

The `EnsureRealHoleOpts` parameter is gone (commit ffb1f28). Previously the round-review save passed session tee/pin overrides into the hole insert so a manually placed tee/pin would persist as the course's first real layout data ("every save curates the course"). The user spec for the new RPC takes only `(course_id, number, par, round_id)`, so this seeding path is dropped. Per-round overrides still live on `hole_scores.pin_lat/lng` (unaffected). File a follow-up issue if course-level seeding from the review save is wanted back.

## Test plan

- [ ] Sign in as a fresh user, complete onboarding, log a 9-hole round on a crawler-imported course (synthetic holes path) — verify shots save, hole_scores upsert, RPC inserts the real holes row
- [ ] Create a manual course via "Course not found? Add it →" — verify course row has `created_by = current user`, holes insert passes RLS
- [ ] Import a course via OpenGolfAPI search on web AND mobile — verify same
- [ ] Open the dashboard cold — verify SGTrendChart renders after a brief skeleton flash, recharts chunk loaded only after the lazy boundary resolves
- [ ] Mobile live round — log a shot, fast double-tap Save: confirm only one row hits `pending_shots`
- [ ] Calculate a handicap with 3, 5, 9, 20, 25 differentials — verify against the WHS table on usga.org