### PR TITLE
feat: landing page as React route + public Learn/Privacy

### DIFF
--- a/apps/web/src/components/landing/AppPreview.tsx
+++ b/apps/web/src/components/landing/AppPreview.tsx
@@ -1,0 +1,130 @@
+import { DemoMap } from './DemoMap'
+
+const DEMO_HOLE = {
+  number: 7,
+  par: 4,
+  yards: 387,
+  tee: { lat: 35.6234, lng: -97.5123 },
+  pin: { lat: 35.6271, lng: -97.5058 },
+}
+
+const DEMO_SHOTS = [
+  { shotNumber: 1, lat: 35.6234, lng: -97.5123 },
+  { shotNumber: 2, lat: 35.6251, lng: -97.5089 },
+  { shotNumber: 3, lat: 35.6263, lng: -97.5071 },
+]
+
+// Phone-shaped frame around a real Mapbox view of a fake hole 7. The
+// data is hardcoded but the rendering goes through the same Mapbox
+// satellite tiles + marker styling the live app uses, so what visitors
+// see on the marketing page is what the app actually shows on course.
+export function AppPreview() {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'center' }}>
+      <div
+        style={{
+          width: 320,
+          aspectRatio: '9 / 19',
+          borderRadius: 36,
+          background: '#1C211C',
+          border: '1px solid #9F9580',
+          padding: 14,
+          position: 'relative',
+        }}
+      >
+        <div
+          aria-hidden
+          style={{
+            position: 'absolute',
+            top: 14,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            width: 110,
+            height: 22,
+            background: '#1C211C',
+            borderRadius: '0 0 14px 14px',
+            zIndex: 4,
+          }}
+        />
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            borderRadius: 24,
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
+            background: '#28482e',
+          }}
+        >
+          <div
+            style={{
+              background: '#1C211C',
+              color: '#F2EEE5',
+              padding: '14px 16px 12px',
+              borderBottom: '1px solid rgba(242, 238, 229, 0.1)',
+            }}
+          >
+            <div
+              className="font-serif"
+              style={{
+                fontSize: 15,
+                fontStyle: 'italic',
+                fontWeight: 500,
+              }}
+            >
+              Lake Hefner South
+            </div>
+            <div
+              className="font-mono uppercase"
+              style={{
+                fontSize: 9,
+                letterSpacing: '0.18em',
+                color: 'rgba(242, 238, 229, 0.55)',
+                marginTop: 4,
+              }}
+            >
+              Hole {DEMO_HOLE.number} · Par {DEMO_HOLE.par} · {DEMO_HOLE.yards} yd
+            </div>
+          </div>
+          <div style={{ flex: 1, position: 'relative' }}>
+            <DemoMap
+              tee={DEMO_HOLE.tee}
+              pin={DEMO_HOLE.pin}
+              shots={DEMO_SHOTS}
+            />
+          </div>
+          <div
+            style={{
+              background: '#FBF8F1',
+              color: '#1C211C',
+              padding: '12px 16px',
+              borderTop: '1px solid #D9D2BF',
+            }}
+          >
+            <div
+              className="font-mono uppercase"
+              style={{
+                fontSize: 9,
+                letterSpacing: '0.18em',
+                color: '#8A8B7E',
+              }}
+            >
+              3 shots placed
+            </div>
+            <div
+              className="font-serif"
+              style={{
+                fontSize: 14,
+                fontStyle: 'italic',
+                marginTop: 4,
+              }}
+            >
+              42 yd to pin
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/landing/AppPreview.tsx
+++ b/apps/web/src/components/landing/AppPreview.tsx
@@ -1,4 +1,11 @@
-import { DemoMap } from './DemoMap'
+import { lazy, Suspense } from 'react'
+
+// Lazy-load DemoMap so mapbox-gl stays in its own chunk and out of the
+// landing-page first-paint critical path. The phone frame paints
+// immediately; the satellite tiles fill in once the chunk arrives.
+const DemoMap = lazy(() =>
+  import('./DemoMap').then((m) => ({ default: m.DemoMap })),
+)
 
 const DEMO_HOLE = {
   number: 7,
@@ -88,11 +95,13 @@ export function AppPreview() {
             </div>
           </div>
           <div style={{ flex: 1, position: 'relative' }}>
-            <DemoMap
-              tee={DEMO_HOLE.tee}
-              pin={DEMO_HOLE.pin}
-              shots={DEMO_SHOTS}
-            />
+            <Suspense fallback={<MapFallback />}>
+              <DemoMap
+                tee={DEMO_HOLE.tee}
+                pin={DEMO_HOLE.pin}
+                shots={DEMO_SHOTS}
+              />
+            </Suspense>
           </div>
           <div
             style={{
@@ -126,5 +135,18 @@ export function AppPreview() {
         </div>
       </div>
     </div>
+  )
+}
+
+function MapFallback() {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background:
+          'radial-gradient(circle at 70% 65%, #3e6a44 0%, #2c5034 45%, #244429 100%)',
+      }}
+    />
   )
 }

--- a/apps/web/src/components/landing/DemoMap.tsx
+++ b/apps/web/src/components/landing/DemoMap.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef } from 'react'
+import { mapboxgl, MAPBOX_TOKEN_PRESENT } from '../../lib/mapbox'
+
+interface DemoShot {
+  shotNumber: number
+  lat: number
+  lng: number
+}
+
+interface DemoMapProps {
+  tee: { lat: number; lng: number }
+  pin: { lat: number; lng: number }
+  shots: DemoShot[]
+}
+
+// Read-only Mapbox view used in the landing-page hero. Renders the
+// same satellite tiles + numbered shot markers + amber connecting line
+// the live RoundMap does, but without any of the round-tracking state
+// machinery — the goal is "looks like a real hole 7" with hardcoded
+// data.
+export function DemoMap({ tee, pin, shots }: DemoMapProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<mapboxgl.Map | null>(null)
+
+  useEffect(() => {
+    if (!containerRef.current || !MAPBOX_TOKEN_PRESENT) return
+    if (mapRef.current) return
+
+    const bounds = new mapboxgl.LngLatBounds(
+      [tee.lng, tee.lat],
+      [pin.lng, pin.lat],
+    )
+    for (const s of shots) bounds.extend([s.lng, s.lat])
+
+    const map = new mapboxgl.Map({
+      container: containerRef.current,
+      style: 'mapbox://styles/mapbox/satellite-streets-v12',
+      center: bounds.getCenter(),
+      zoom: 17,
+      interactive: false,
+      attributionControl: false,
+    })
+    mapRef.current = map
+
+    map.on('load', () => {
+      map.fitBounds(bounds, { padding: 28, animate: false, maxZoom: 18 })
+
+      const lineCoords: [number, number][] = []
+      for (const s of shots) lineCoords.push([s.lng, s.lat])
+      lineCoords.push([pin.lng, pin.lat])
+
+      const lineData: GeoJSON.Feature<GeoJSON.LineString> = {
+        type: 'Feature',
+        properties: {},
+        geometry: { type: 'LineString', coordinates: lineCoords },
+      }
+      map.addSource('demo-line', { type: 'geojson', data: lineData })
+      // Dark outline + amber line on top — same layering the live
+      // RoundMap uses, so the colors land on satellite tiles the same
+      // way they do in the real app.
+      map.addLayer({
+        id: 'demo-line-outline',
+        type: 'line',
+        source: 'demo-line',
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-color': '#1C211C', 'line-width': 4, 'line-opacity': 0.55 },
+      })
+      map.addLayer({
+        id: 'demo-line',
+        type: 'line',
+        source: 'demo-line',
+        layout: { 'line-join': 'round', 'line-cap': 'round' },
+        paint: { 'line-color': '#A66A1F', 'line-width': 2.5 },
+      })
+
+      for (const s of shots) {
+        const el = makeNumberedMarker(s.shotNumber)
+        new mapboxgl.Marker({ element: el, anchor: 'center' })
+          .setLngLat([s.lng, s.lat])
+          .addTo(map)
+      }
+
+      const pinEl = makePinMarker()
+      new mapboxgl.Marker({ element: pinEl, anchor: 'bottom' })
+        .setLngLat([pin.lng, pin.lat])
+        .addTo(map)
+    })
+
+    return () => {
+      map.remove()
+      mapRef.current = null
+    }
+  }, [tee, pin, shots])
+
+  return (
+    <div style={{ position: 'absolute', inset: 0 }}>
+      <div ref={containerRef} style={{ position: 'absolute', inset: 0 }} />
+      {!MAPBOX_TOKEN_PRESENT && (
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            background: '#28482e',
+            color: 'rgba(242,238,229,0.6)',
+            fontSize: 12,
+            padding: 16,
+            textAlign: 'center',
+            fontFamily: 'JetBrains Mono, monospace',
+            letterSpacing: '0.14em',
+            textTransform: 'uppercase',
+          }}
+        >
+          Map unavailable
+        </div>
+      )}
+    </div>
+  )
+}
+
+// Match the live RoundMap shot marker (apps/web/src/components/round/map/markerFactories.ts):
+// 24px amber circle with a cream border and the shot number in Inter 600.
+function makeNumberedMarker(n: number): HTMLElement {
+  const outer = document.createElement('div')
+  outer.style.display = 'flex'
+  outer.style.alignItems = 'center'
+  outer.style.justifyContent = 'center'
+  outer.style.pointerEvents = 'none'
+  const inner = document.createElement('div')
+  inner.style.cssText = [
+    'width:22px',
+    'height:22px',
+    'border-radius:999px',
+    'background:#A66A1F',
+    'color:#F2EEE5',
+    'font-family:Inter, sans-serif',
+    'font-weight:600',
+    'font-size:11px',
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'border:2px solid #FBF8F1',
+  ].join(';')
+  inner.textContent = String(n)
+  outer.appendChild(inner)
+  return outer
+}
+
+function makePinMarker(): HTMLElement {
+  const outer = document.createElement('div')
+  outer.style.pointerEvents = 'none'
+  outer.innerHTML = `
+    <svg width="20" height="28" viewBox="0 0 20 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <line x1="10" y1="2" x2="10" y2="22" stroke="#FBF8F1" stroke-width="1.5" />
+      <path d="M10 3 L17 6 L10 9 Z" fill="#A33A2A" stroke="#FBF8F1" stroke-width="0.75" stroke-linejoin="round"/>
+      <circle cx="10" cy="22" r="3" fill="#A33A2A" stroke="#FBF8F1" stroke-width="1.5" />
+    </svg>
+  `
+  return outer
+}

--- a/apps/web/src/components/landing/PublicArticleLayout.tsx
+++ b/apps/web/src/components/landing/PublicArticleLayout.tsx
@@ -1,0 +1,20 @@
+import { Outlet } from 'react-router-dom'
+
+// Padding wrapper for public content pages (Learn) so they read the
+// same way they did inside AppShell. Adds the ~120px top offset to
+// clear PublicNav and a centered max-width main column.
+export function PublicArticleLayout() {
+  return (
+    <main style={{ paddingTop: 120, paddingBottom: 80 }}>
+      <div
+        style={{
+          maxWidth: 760,
+          margin: '0 auto',
+          padding: '0 28px',
+        }}
+      >
+        <Outlet />
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/components/landing/PublicNav.tsx
+++ b/apps/web/src/components/landing/PublicNav.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+
+// Fixed top nav for marketing/public pages (LandingPage, PrivacyPage,
+// public Learn). Transparent on top of the page; backdrop appears as
+// the user scrolls. Auth-aware: signed-in visitors see "Go to app"
+// instead of the sign-up split, so the home page doubles as a cheap
+// re-entry point.
+export function PublicNav() {
+  const { user, loading } = useAuth()
+  const [scrolled, setScrolled] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 12)
+    window.addEventListener('scroll', onScroll, { passive: true })
+    onScroll()
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  return (
+    <nav
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 50,
+        transition: 'background-color 240ms ease, border-color 240ms ease',
+        borderBottom: scrolled
+          ? '1px solid #D9D2BF'
+          : '1px solid transparent',
+        background: scrolled ? 'rgba(242, 238, 229, 0.92)' : 'transparent',
+        backdropFilter: scrolled ? 'saturate(140%) blur(8px)' : 'none',
+        WebkitBackdropFilter: scrolled ? 'saturate(140%) blur(8px)' : 'none',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 1180,
+          margin: '0 auto',
+          padding: '14px 28px',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Link
+          to="/"
+          style={{
+            textDecoration: 'none',
+            color: '#1C211C',
+            display: 'flex',
+            flexDirection: 'column',
+            lineHeight: 1.05,
+          }}
+        >
+          <span
+            className="font-serif"
+            style={{ fontSize: 24, fontWeight: 500, fontStyle: 'italic' }}
+          >
+            OGA
+          </span>
+          <span
+            className="font-mono uppercase"
+            style={{
+              fontSize: 10,
+              letterSpacing: '0.16em',
+              color: '#8A8B7E',
+              marginTop: 4,
+            }}
+          >
+            Open Golf App
+          </span>
+        </Link>
+        <div style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
+          {!loading && user ? (
+            <Link
+              to="/dashboard"
+              style={{
+                ...btnBase,
+                background: '#1C211C',
+                color: '#F2EEE5',
+                border: '1px solid #1C211C',
+              }}
+            >
+              Go to app{' '}
+              <span className="font-serif" style={{ fontStyle: 'italic' }}>
+                →
+              </span>
+            </Link>
+          ) : (
+            <>
+              <Link
+                to="/login"
+                style={{
+                  ...btnBase,
+                  color: '#1C211C',
+                  border: '1px solid #9F9580',
+                  background: 'transparent',
+                }}
+                className="public-nav-ghost"
+              >
+                Sign in
+              </Link>
+              <Link
+                to="/signup"
+                style={{
+                  ...btnBase,
+                  background: '#1C211C',
+                  color: '#F2EEE5',
+                  border: '1px solid #1C211C',
+                }}
+              >
+                Sign up free
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+    </nav>
+  )
+}
+
+const btnBase = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  fontFamily: 'Inter, sans-serif',
+  fontWeight: 600,
+  fontSize: 13,
+  letterSpacing: '0.01em',
+  borderRadius: 2,
+  padding: '8px 14px',
+  textDecoration: 'none',
+  whiteSpace: 'nowrap',
+  transition: 'background-color 160ms ease, color 160ms ease, border-color 160ms ease',
+} as const

--- a/apps/web/src/components/landing/PublicShell.tsx
+++ b/apps/web/src/components/landing/PublicShell.tsx
@@ -1,0 +1,38 @@
+import { Suspense, type ReactNode } from 'react'
+import { Outlet } from 'react-router-dom'
+import { PublicNav } from './PublicNav'
+
+// Shell for public, unauthenticated routes. PublicNav is fixed-top so
+// children are responsible for their own top padding (Landing wants
+// full-bleed; content pages add ~120px to clear the nav).
+export function PublicShell({ children }: { children?: ReactNode }) {
+  return (
+    <div
+      className="bg-caddie-bg text-caddie-ink"
+      style={{ minHeight: '100vh' }}
+    >
+      <PublicNav />
+      <Suspense fallback={<RouteFallback />}>
+        {children ?? <Outlet />}
+      </Suspense>
+    </div>
+  )
+}
+
+function RouteFallback() {
+  return (
+    <div
+      style={{
+        minHeight: '60vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: 'Inter, sans-serif',
+        fontSize: 14,
+        color: '#5C6356',
+      }}
+    >
+      Loading…
+    </div>
+  )
+}

--- a/apps/web/src/components/landing/landing.css
+++ b/apps/web/src/components/landing/landing.css
@@ -1,0 +1,54 @@
+/* Landing page responsive collapses + reduced-motion guards. Inline
+ * styles handle the bulk of the visual layer; this file picks up
+ * what media queries can't cleanly express in JS-string CSS. */
+
+@media (max-width: 960px) {
+  .landing-hero-grid {
+    grid-template-columns: 1fr !important;
+    gap: 48px !important;
+  }
+  .landing-hero-grid > div:first-child {
+    text-align: left;
+  }
+  .landing-features,
+  .landing-learn {
+    grid-template-columns: 1fr !important;
+  }
+  .landing-sg {
+    grid-template-columns: 1fr !important;
+    gap: 36px !important;
+  }
+  .landing-stats {
+    grid-template-columns: 1fr !important;
+  }
+  .landing-stat {
+    border-right: none !important;
+    border-bottom: 1px solid #d9d2bf;
+  }
+  .landing-stat:last-child {
+    border-bottom: none;
+  }
+  .landing-footer {
+    grid-template-columns: 1fr !important;
+    text-align: center;
+  }
+  .landing-footer > div:last-child {
+    text-align: center !important;
+  }
+}
+
+@media (max-width: 560px) {
+  .landing-hero-preview {
+    display: none !important;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-hero-grid *,
+  .landing-features *,
+  .landing-sg *,
+  .landing-learn * {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ interface NavLinkDef {
 }
 
 const links: NavLinkDef[] = [
-  { to: '/', label: 'Dashboard', section: 'menu' },
+  { to: '/dashboard', label: 'Dashboard', section: 'menu' },
   { to: '/rounds', label: 'Rounds', section: 'menu' },
   { to: '/stats', label: 'Strokes Gained', section: 'menu' },
   { to: '/patterns', label: 'Shot Patterns', section: 'menu' },
@@ -45,7 +45,7 @@ function SidebarSection({
           to={l.to}
           // /settings would otherwise highlight when /settings/bag is active
           // because NavLink uses prefix matching by default.
-          end={l.to === '/' || l.to === '/settings'}
+          end={l.to === '/dashboard' || l.to === '/settings'}
           className={({ isActive }) =>
             [
               'transition-colors block',

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -19,7 +19,7 @@ export function LoginPage() {
       setError(signInError.message)
       return
     }
-    navigate('/')
+    navigate('/dashboard')
   }
 
   return (

--- a/apps/web/src/pages/landing/LandingPage.tsx
+++ b/apps/web/src/pages/landing/LandingPage.tsx
@@ -1,34 +1,896 @@
-// Stub. Real content lands in a follow-up commit ("feat: landing page
-// with app preview").
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useAuth } from '../../hooks/useAuth'
+import { AppPreview } from '../../components/landing/AppPreview'
+import '../../components/landing/landing.css'
+
+// Marketing page served at `/`. Public, auth-aware (CTAs swap to
+// "Go to app" when signed in). Real Mapbox preview via <AppPreview>.
 export function LandingPage() {
   return (
-    <main style={{ paddingTop: 140, minHeight: '100vh' }}>
+    <main style={{ paddingBottom: 0 }}>
+      <Hero />
+      <StatsBar />
+      <Features />
+      <SGSection />
+      <LearnSection />
+      <FinalCTA />
+      <Footer />
+    </main>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Hero
+// ---------------------------------------------------------------------------
+
+function Hero() {
+  const { user, loading } = useAuth()
+  const isAuthed = !loading && !!user
+
+  return (
+    <section
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        padding: '140px 0 80px',
+      }}
+    >
       <div
         style={{
           maxWidth: 1180,
           margin: '0 auto',
           padding: '0 28px',
+          width: '100%',
+          display: 'grid',
+          gap: 48,
+          alignItems: 'center',
+          gridTemplateColumns: 'minmax(0, 1.05fr) minmax(0, 0.95fr)',
+        }}
+        className="landing-hero-grid"
+      >
+        <div>
+          <span
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 8,
+              border: '1px solid #9F9580',
+              borderRadius: 999,
+              padding: '6px 12px',
+              fontSize: 12,
+              letterSpacing: '0.02em',
+              color: '#1C211C',
+              background: '#FBF8F1',
+            }}
+          >
+            <span
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: '50%',
+                background: '#1F3D2C',
+                boxShadow: '0 0 0 3px rgba(31, 61, 44, 0.18)',
+              }}
+            />
+            Free and open source
+          </span>
+          <div
+            className="kicker"
+            style={{ color: '#A66A1F', margin: '22px 0 14px' }}
+          >
+            Golf improvement platform
+          </div>
+          <h1
+            className="font-serif text-caddie-ink"
+            style={{
+              fontSize: 'clamp(44px, 7vw, 76px)',
+              fontWeight: 500,
+              fontStyle: 'italic',
+              lineHeight: 1.02,
+              letterSpacing: '-0.02em',
+              margin: '0 0 22px',
+            }}
+          >
+            Track every shot.
+            <br />
+            Understand your game.
+          </h1>
+          <p
+            className="text-caddie-ink-dim"
+            style={{
+              fontSize: 17,
+              lineHeight: 1.6,
+              maxWidth: 480,
+              margin: '0 0 28px',
+            }}
+          >
+            GPS shot tracking, strokes gained analysis, and coaching content —
+            built for golfers who want to get better, not just keep score.
+          </p>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 18,
+              flexWrap: 'wrap',
+            }}
+          >
+            {isAuthed ? (
+              <Link to="/dashboard" style={btnAccentLg}>
+                Go to app{' '}
+                <span className="font-serif" style={{ fontStyle: 'italic' }}>
+                  →
+                </span>
+              </Link>
+            ) : (
+              <Link to="/signup" style={btnAccentLg}>
+                Start tracking free{' '}
+                <span className="font-serif" style={{ fontStyle: 'italic' }}>
+                  →
+                </span>
+              </Link>
+            )}
+            <span
+              className="text-caddie-ink-mute"
+              style={{ fontSize: 13 }}
+            >
+              {isAuthed ? "You're signed in." : 'No subscription required.'}
+            </span>
+          </div>
+        </div>
+        <div className="landing-hero-preview" aria-hidden>
+          <AppPreview />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Stats bar
+// ---------------------------------------------------------------------------
+
+function StatsBar() {
+  return (
+    <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
+      <div
+        className="landing-stats"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          borderTop: '1px solid #D9D2BF',
+          borderBottom: '1px solid #D9D2BF',
         }}
       >
-        <h1
-          className="font-serif text-caddie-ink"
+        <Stat value="15,870" label="Courses in database" mono />
+        <Stat value="4" label="SG categories tracked" />
+        <Stat value="100%" label="Free, forever" mono />
+      </div>
+    </div>
+  )
+}
+
+function Stat({
+  value,
+  label,
+  mono,
+}: {
+  value: string
+  label: string
+  mono?: boolean
+}) {
+  return (
+    <div
+      className="landing-stat"
+      style={{
+        padding: '36px 24px',
+        textAlign: 'center',
+        borderRight: '1px solid #D9D2BF',
+      }}
+    >
+      <div
+        className={mono ? 'font-mono' : 'font-serif'}
+        style={{
+          fontSize: mono ? 36 : 44,
+          fontWeight: 500,
+          letterSpacing: '-0.01em',
+          lineHeight: 1,
+          color: '#1C211C',
+        }}
+      >
+        {value}
+      </div>
+      <div
+        className="font-mono uppercase"
+        style={{
+          fontSize: 10,
+          letterSpacing: '0.18em',
+          color: '#8A8B7E',
+          marginTop: 14,
+        }}
+      >
+        {label}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Features
+// ---------------------------------------------------------------------------
+
+const FEATURES = [
+  {
+    icon: TargetIcon,
+    title: 'Live GPS round tracking',
+    body: 'Track every shot on the map with GPS precision. Ball placement, aim points, and shot trails — live as you play.',
+  },
+  {
+    icon: BarsIcon,
+    title: 'Strokes gained analysis',
+    body: "Understand exactly where you're losing or gaining strokes — off the tee, approach, around the green, and putting.",
+  },
+  {
+    icon: TrendIcon,
+    title: 'Shot patterns + trends',
+    body: "See your miss patterns, club dispersion, and improvement trends across every round you've played.",
+  },
+] as const
+
+function Features() {
+  return (
+    <section style={{ padding: '100px 0' }}>
+      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
+        <div
+          className="landing-features"
           style={{
-            fontSize: 56,
-            fontWeight: 500,
-            fontStyle: 'italic',
-            letterSpacing: '-0.02em',
-            margin: 0,
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, 1fr)',
+            gap: 20,
           }}
         >
-          OGA
-        </h1>
-        <p
-          className="text-caddie-ink-dim"
-          style={{ fontSize: 16, marginTop: 12 }}
-        >
-          Open Golf App.
-        </p>
+          {FEATURES.map((f, i) => (
+            <FeatureCard key={f.title} index={i} {...f} />
+          ))}
+        </div>
       </div>
-    </main>
+    </section>
+  )
+}
+
+function FeatureCard({
+  icon: Icon,
+  title,
+  body,
+  index,
+}: {
+  icon: () => JSX.Element
+  title: string
+  body: string
+  index: number
+}) {
+  const { ref, visible } = useInView<HTMLElement>(0.15)
+  return (
+    <article
+      ref={ref}
+      style={{
+        border: '1px solid #D9D2BF',
+        borderRadius: 4,
+        padding: 28,
+        background: '#FBF8F1',
+        opacity: visible ? 1 : 0,
+        transform: visible ? 'translateY(0)' : 'translateY(20px)',
+        transition: `opacity 600ms ease ${index * 100}ms, transform 600ms ease ${index * 100}ms, border-color 200ms ease`,
+      }}
+    >
+      <div
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: 4,
+          background: '#1F3D2C',
+          color: '#F2EEE5',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginBottom: 22,
+        }}
+        aria-hidden
+      >
+        <Icon />
+      </div>
+      <h3
+        className="font-serif text-caddie-ink"
+        style={{
+          fontSize: 22,
+          fontWeight: 500,
+          fontStyle: 'italic',
+          margin: '0 0 10px',
+          lineHeight: 1.2,
+        }}
+      >
+        {title}
+      </h3>
+      <p
+        className="text-caddie-ink-dim"
+        style={{ margin: 0, fontSize: 14.5, lineHeight: 1.6 }}
+      >
+        {body}
+      </p>
+    </article>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// SG section
+// ---------------------------------------------------------------------------
+
+const SG_ROWS = [
+  { label: 'SG · Off tee', value: '+0.4', tone: 'pos' as const, fill: 22 },
+  { label: 'SG · Approach', value: '−1.2', tone: 'neg' as const, fill: 44 },
+  {
+    label: 'SG · Around green',
+    value: '−0.1',
+    tone: 'zero' as const,
+    fill: 6,
+  },
+  { label: 'SG · Putting', value: '+1.2', tone: 'pos' as const, fill: 48 },
+]
+
+function SGSection() {
+  const { ref, visible } = useInView<HTMLDivElement>(0.3)
+  return (
+    <section style={{ padding: '100px 0' }}>
+      <div
+        className="landing-sg"
+        style={{
+          maxWidth: 1180,
+          margin: '0 auto',
+          padding: '0 28px',
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 64,
+          alignItems: 'center',
+        }}
+      >
+        <div>
+          <div className="kicker" style={{ color: '#A66A1F', marginBottom: 12 }}>
+            Strokes gained
+          </div>
+          <h2
+            className="font-serif text-caddie-ink"
+            style={{
+              fontSize: 'clamp(32px, 4.4vw, 48px)',
+              fontWeight: 500,
+              fontStyle: 'italic',
+              lineHeight: 1.1,
+              letterSpacing: '-0.015em',
+              margin: 0,
+              maxWidth: 520,
+            }}
+          >
+            Know exactly where strokes are leaking.
+          </h2>
+          <p
+            className="text-caddie-ink-dim"
+            style={{
+              fontSize: 16,
+              lineHeight: 1.65,
+              margin: '18px 0 0',
+              maxWidth: 520,
+            }}
+          >
+            Most golfers practice their strengths. OGA shows you your
+            weaknesses — the specific categories where you're losing shots
+            to your handicap baseline, so you can practice what actually
+            matters.
+          </p>
+        </div>
+        <div
+          ref={ref}
+          style={{
+            border: '1px solid #D9D2BF',
+            borderRadius: 4,
+            padding: 28,
+            background: '#FBF8F1',
+          }}
+        >
+          {SG_ROWS.map((r, i) => (
+            <SGRow key={r.label} {...r} visible={visible} delayMs={i * 120} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function SGRow({
+  label,
+  value,
+  tone,
+  fill,
+  visible,
+  delayMs,
+}: {
+  label: string
+  value: string
+  tone: 'pos' | 'neg' | 'zero'
+  fill: number
+  visible: boolean
+  delayMs: number
+}) {
+  const valueColor =
+    tone === 'pos' ? '#1F3D2C' : tone === 'neg' ? '#A33A2A' : '#8A8B7E'
+  const fillColor = valueColor
+  return (
+    <div
+      style={{
+        padding: '14px 0',
+        borderBottom: '1px solid #D9D2BF',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          marginBottom: 8,
+        }}
+      >
+        <span
+          className="font-mono uppercase"
+          style={{
+            fontSize: 10,
+            letterSpacing: '0.18em',
+            color: '#8A8B7E',
+          }}
+        >
+          {label}
+        </span>
+        <span
+          className="font-serif"
+          style={{
+            fontSize: 16,
+            fontWeight: 500,
+            fontStyle: 'italic',
+            color: valueColor,
+          }}
+        >
+          {value}
+        </span>
+      </div>
+      <div
+        style={{
+          position: 'relative',
+          height: 6,
+          background: '#EBE5D6',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: tone === 'neg' ? undefined : '50%',
+            right: tone === 'neg' ? '50%' : undefined,
+            width: visible ? `${fill}%` : 0,
+            background: fillColor,
+            transition: `width 900ms cubic-bezier(0.2, 0.7, 0.2, 1) ${delayMs}ms`,
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Learn section
+// ---------------------------------------------------------------------------
+
+const LEARN_CARDS = [
+  {
+    section: 'On the course',
+    title: 'Course management',
+    slug: 'course-management',
+  },
+  {
+    section: 'Improving your game',
+    title: 'How to practice effectively',
+    slug: 'how-to-practice',
+  },
+  {
+    section: 'On the course',
+    title: 'The mental game',
+    slug: 'mental-game',
+  },
+]
+
+function LearnSection() {
+  return (
+    <section style={{ padding: '100px 0' }}>
+      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
+        <div style={{ marginBottom: 56 }}>
+          <div className="kicker" style={{ color: '#A66A1F', marginBottom: 12 }}>
+            Learn
+          </div>
+          <h2
+            className="font-serif text-caddie-ink"
+            style={{
+              fontSize: 'clamp(32px, 4.4vw, 48px)',
+              fontWeight: 500,
+              fontStyle: 'italic',
+              lineHeight: 1.1,
+              letterSpacing: '-0.015em',
+              margin: 0,
+            }}
+          >
+            A coach's column, built in.
+          </h2>
+        </div>
+        <div
+          className="landing-learn"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(3, 1fr)',
+            gap: 18,
+          }}
+        >
+          {LEARN_CARDS.map((c) => (
+            <Link
+              key={c.slug}
+              to={`/learn/${c.slug}`}
+              style={{
+                border: '1px solid #D9D2BF',
+                borderRadius: 4,
+                padding: 26,
+                background: '#FBF8F1',
+                textDecoration: 'none',
+                color: 'inherit',
+                display: 'block',
+                transition:
+                  'border-color 200ms ease, transform 200ms ease',
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.borderColor = '#9F9580'
+                e.currentTarget.style.transform = 'translateY(-2px)'
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.borderColor = '#D9D2BF'
+                e.currentTarget.style.transform = 'translateY(0)'
+              }}
+            >
+              <div
+                className="font-mono uppercase"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: '0.18em',
+                  color: '#8A8B7E',
+                  marginBottom: 12,
+                }}
+              >
+                {c.section}
+              </div>
+              <div
+                className="font-serif text-caddie-ink"
+                style={{
+                  fontSize: 22,
+                  fontWeight: 500,
+                  fontStyle: 'italic',
+                  lineHeight: 1.25,
+                }}
+              >
+                {c.title}
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Final CTA (inverted dark band)
+// ---------------------------------------------------------------------------
+
+function FinalCTA() {
+  const { user, loading } = useAuth()
+  const isAuthed = !loading && !!user
+  return (
+    <section
+      style={{
+        background: '#1C211C',
+        color: '#F2EEE5',
+        textAlign: 'center',
+        padding: '110px 0 100px',
+      }}
+    >
+      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
+        <div
+          className="kicker"
+          style={{ color: 'rgba(242, 238, 229, 0.55)', marginBottom: 18 }}
+        >
+          Open Golf App
+        </div>
+        <h2
+          className="font-serif"
+          style={{
+            fontSize: 'clamp(40px, 5vw, 60px)',
+            fontWeight: 500,
+            fontStyle: 'italic',
+            lineHeight: 1.05,
+            letterSpacing: '-0.015em',
+            margin: '0 0 18px',
+            color: '#F2EEE5',
+          }}
+        >
+          {isAuthed ? 'Welcome back.' : 'Start tracking free.'}
+        </h2>
+        <p
+          style={{
+            color: 'rgba(242, 238, 229, 0.65)',
+            fontSize: 16,
+            margin: '0 0 36px',
+          }}
+        >
+          {isAuthed
+            ? 'Pick up where you left off.'
+            : 'No subscription. No ads. Open source.'}
+        </p>
+        <Link
+          to={isAuthed ? '/dashboard' : '/signup'}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+            background: '#F2EEE5',
+            color: '#1C211C',
+            border: '1px solid #F2EEE5',
+            borderRadius: 2,
+            padding: '14px 22px',
+            fontFamily: 'Inter, sans-serif',
+            fontWeight: 600,
+            fontSize: 15,
+            letterSpacing: '0.01em',
+            textDecoration: 'none',
+          }}
+        >
+          {isAuthed ? 'Go to app' : 'Create your account'}{' '}
+          <span className="font-serif" style={{ fontStyle: 'italic' }}>
+            →
+          </span>
+        </Link>
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Footer
+// ---------------------------------------------------------------------------
+
+function Footer() {
+  return (
+    <footer
+      style={{
+        background: '#1C211C',
+        color: '#F2EEE5',
+        borderTop: '1px solid rgba(242, 238, 229, 0.12)',
+        padding: '32px 0',
+      }}
+    >
+      <div
+        className="landing-footer"
+        style={{
+          maxWidth: 1180,
+          margin: '0 auto',
+          padding: '0 28px',
+          display: 'grid',
+          gridTemplateColumns: '1fr auto 1fr',
+          gap: 24,
+          alignItems: 'center',
+        }}
+      >
+        <div
+          className="font-serif"
+          style={{ fontSize: 20, fontWeight: 500, fontStyle: 'italic' }}
+        >
+          OGA
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 24,
+            justifyContent: 'center',
+            flexWrap: 'wrap',
+          }}
+        >
+          <FooterLink href="https://github.com/cner-smith/opengolfapp" external>
+            GitHub
+          </FooterLink>
+          <FooterLink href="https://ko-fi.com/nartana" external>
+            Ko-fi
+          </FooterLink>
+          <FooterLink to="/privacy">Privacy</FooterLink>
+          <FooterLink to="/login">Sign in</FooterLink>
+        </div>
+        <div
+          style={{
+            textAlign: 'right',
+            fontSize: 12,
+            color: 'rgba(242, 238, 229, 0.55)',
+            letterSpacing: '0.02em',
+          }}
+        >
+          Free and open source · MIT License
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+function FooterLink({
+  href,
+  to,
+  external,
+  children,
+}: {
+  href?: string
+  to?: string
+  external?: boolean
+  children: React.ReactNode
+}) {
+  const style: React.CSSProperties = {
+    fontSize: 13,
+    color: 'rgba(242, 238, 229, 0.6)',
+    textDecoration: 'none',
+    transition: 'color 160ms ease',
+  }
+  const onEnter = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.currentTarget.style.color = '#F2EEE5'
+  }
+  const onLeave = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.currentTarget.style.color = 'rgba(242, 238, 229, 0.6)'
+  }
+  if (to) {
+    return (
+      <Link to={to} style={style} onMouseEnter={onEnter} onMouseLeave={onLeave}>
+        {children}
+      </Link>
+    )
+  }
+  return (
+    <a
+      href={href}
+      target={external ? '_blank' : undefined}
+      rel={external ? 'noreferrer noopener' : undefined}
+      style={style}
+      onMouseEnter={onEnter}
+      onMouseLeave={onLeave}
+    >
+      {children}
+    </a>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// IntersectionObserver hook. Sets `visible` true once the ref hits the
+// threshold. Always-true if reduce-motion is on so animations don't
+// hide behind the gate.
+function useInView<T extends Element>(threshold = 0.1) {
+  const ref = useRef<T | null>(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return
+    if (
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ) {
+      setVisible(true)
+      return
+    }
+    if (typeof IntersectionObserver === 'undefined') {
+      setVisible(true)
+      return
+    }
+    const obs = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setVisible(true)
+            obs.disconnect()
+            break
+          }
+        }
+      },
+      { threshold },
+    )
+    obs.observe(node)
+    return () => obs.disconnect()
+  }, [threshold])
+
+  return { ref, visible }
+}
+
+const btnAccentLg: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 8,
+  background: '#1F3D2C',
+  color: '#F2EEE5',
+  border: '1px solid #1F3D2C',
+  borderRadius: 2,
+  padding: '14px 22px',
+  fontFamily: 'Inter, sans-serif',
+  fontWeight: 600,
+  fontSize: 15,
+  letterSpacing: '0.01em',
+  textDecoration: 'none',
+  whiteSpace: 'nowrap',
+}
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+function TargetIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="3" />
+      <circle cx="12" cy="12" r="9" />
+    </svg>
+  )
+}
+
+function BarsIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <line x1="6" y1="20" x2="6" y2="10" />
+      <line x1="12" y1="20" x2="12" y2="4" />
+      <line x1="18" y1="20" x2="18" y2="14" />
+    </svg>
+  )
+}
+
+function TrendIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M3 17l4-4 4 4 4-6 6 6" />
+    </svg>
   )
 }

--- a/apps/web/src/pages/landing/LandingPage.tsx
+++ b/apps/web/src/pages/landing/LandingPage.tsx
@@ -1,0 +1,34 @@
+// Stub. Real content lands in a follow-up commit ("feat: landing page
+// with app preview").
+export function LandingPage() {
+  return (
+    <main style={{ paddingTop: 140, minHeight: '100vh' }}>
+      <div
+        style={{
+          maxWidth: 1180,
+          margin: '0 auto',
+          padding: '0 28px',
+        }}
+      >
+        <h1
+          className="font-serif text-caddie-ink"
+          style={{
+            fontSize: 56,
+            fontWeight: 500,
+            fontStyle: 'italic',
+            letterSpacing: '-0.02em',
+            margin: 0,
+          }}
+        >
+          OGA
+        </h1>
+        <p
+          className="text-caddie-ink-dim"
+          style={{ fontSize: 16, marginTop: 12 }}
+        >
+          Open Golf App.
+        </p>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/pages/landing/PrivacyPage.tsx
+++ b/apps/web/src/pages/landing/PrivacyPage.tsx
@@ -1,5 +1,8 @@
-// Stub. Real content lands in a follow-up commit ("feat: privacy
-// policy page").
+import type { ReactNode } from 'react'
+
+// Privacy policy. Plain language, no boilerplate. Mirrors the Learn
+// article styling (kicker → italic title → H3 / P / Hr blocks) so it
+// reads as part of the same editorial voice.
 export function PrivacyPage() {
   return (
     <main style={{ paddingTop: 120, paddingBottom: 80 }}>
@@ -10,6 +13,9 @@ export function PrivacyPage() {
           padding: '0 28px',
         }}
       >
+        <div className="kicker" style={{ marginBottom: 8 }}>
+          Privacy
+        </div>
         <h1
           className="font-serif text-caddie-ink"
           style={{
@@ -21,9 +27,204 @@ export function PrivacyPage() {
             margin: 0,
           }}
         >
-          Privacy.
+          What we collect, and why.
         </h1>
+        <p
+          className="text-caddie-ink-dim"
+          style={{ fontSize: 15, marginTop: 10, lineHeight: 1.55, maxWidth: 600 }}
+        >
+          OGA is free and open source. We collect the minimum data
+          required to run the service and never sell it.
+        </p>
+
+        <div style={{ marginTop: 36 }}>
+          <H3>What we collect</H3>
+          <P>
+            <strong>Account.</strong> Your email address and a hashed
+            password (or the OAuth identifier from your provider when you
+            sign in with one). That's it for account data — no name, no
+            phone, no address.
+          </P>
+          <P>
+            <strong>Profile.</strong> The fields you fill in during
+            onboarding: skill level, goal, handicap index, play frequency,
+            and the equipment you tell us you carry. You can edit or
+            delete any of this from <em>Settings</em>.
+          </P>
+          <P>
+            <strong>Round data.</strong> The rounds you log: courses
+            played, scores, hole-by-hole shot data, club used, lie type
+            and slope, putt outcomes, and the GPS coordinates of each
+            shot when you use the live tracker. We need this to compute
+            strokes gained, your handicap, and shot patterns.
+          </P>
+          <P>
+            <strong>GPS during live rounds.</strong> While you're tracking
+            a round, the app reads your device's GPS to place shots on the
+            map. The samples are stored as part of the round you saved —
+            we don't keep a continuous location stream, and we don't track
+            you when the app is closed or in the background.
+          </P>
+
+          <Hr />
+
+          <H3>How we use it</H3>
+          <P>
+            Your data exists for a single reason: to compute the things
+            the app shows you. Strokes gained, dispersion patterns, your
+            handicap index, and the practice plan that is calibrated to
+            them. We don't analyze it for any other purpose, and we don't
+            train models on it.
+          </P>
+          <P>
+            We don't run advertising. We don't share or sell your data to
+            anyone. There are no third-party trackers in the app.
+          </P>
+
+          <Hr />
+
+          <H3>Where it lives</H3>
+          <P>
+            All data is stored in a Postgres database hosted on{' '}
+            <ExtLink href="https://supabase.com">Supabase</ExtLink>. Their
+            privacy policy is{' '}
+            <ExtLink href="https://supabase.com/privacy">here</ExtLink>.
+            Maps are rendered via{' '}
+            <ExtLink href="https://www.mapbox.com">Mapbox</ExtLink> — they
+            see the bounding box of the area you're viewing in order to
+            serve the satellite tiles, but they don't see your shot
+            placements or any other round data.
+          </P>
+          <P>
+            Course geometry comes from{' '}
+            <ExtLink href="https://opengolfapi.org">OpenGolfAPI</ExtLink>{' '}
+            and{' '}
+            <ExtLink href="https://www.openstreetmap.org">
+              OpenStreetMap
+            </ExtLink>
+            ; queries to those services are scoped to the course you
+            select and don't include any account information.
+          </P>
+
+          <Hr />
+
+          <H3>Deleting your account and data</H3>
+          <P>
+            Open <em>Settings</em> and use the "Delete account" action.
+            That removes your profile, all rounds, all shot data, and all
+            user-attributed rows. Course geometry and other shared data
+            stays — it isn't yours to delete.
+          </P>
+          <P>
+            If something goes wrong with self-service deletion, open a
+            ticket on{' '}
+            <ExtLink href="https://github.com/cner-smith/opengolfapp/issues">
+              GitHub Issues
+            </ExtLink>{' '}
+            and we'll handle it manually.
+          </P>
+
+          <Hr />
+
+          <H3>Questions, complaints, corrections</H3>
+          <P>
+            The project is open source and run by one person.{' '}
+            <ExtLink href="https://github.com/cner-smith/opengolfapp/issues">
+              File an issue
+            </ExtLink>{' '}
+            if you want something changed, removed, or explained. There's
+            no support email; the issue tracker is the contact channel.
+          </P>
+        </div>
+
+        <Footnote>
+          Last reviewed: May 2026. Material changes will be noted at the
+          top of this page.
+        </Footnote>
       </div>
     </main>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Local primitives — same shape as Learn articles but kept inline so this
+// page doesn't pull in the article registry chunk.
+// ---------------------------------------------------------------------------
+
+function H3({ children }: { children: ReactNode }) {
+  return (
+    <h3
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 22,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        lineHeight: 1.2,
+        marginTop: 28,
+        marginBottom: 14,
+      }}
+    >
+      {children}
+    </h3>
+  )
+}
+
+function P({ children }: { children: ReactNode }) {
+  return (
+    <p
+      className="text-caddie-ink"
+      style={{ fontSize: 15, lineHeight: 1.65, marginBottom: 14 }}
+    >
+      {children}
+    </p>
+  )
+}
+
+function Hr() {
+  return (
+    <hr
+      style={{
+        border: 0,
+        borderTop: '1px solid #D9D2BF',
+        margin: '26px 0',
+      }}
+    />
+  )
+}
+
+function ExtLink({
+  href,
+  children,
+}: {
+  href: string
+  children: ReactNode
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer noopener"
+      style={{ color: '#1F3D2C', textDecoration: 'underline' }}
+    >
+      {children}
+    </a>
+  )
+}
+
+function Footnote({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 36,
+        lineHeight: 1.6,
+      }}
+    >
+      {children}
+    </div>
   )
 }

--- a/apps/web/src/pages/landing/PrivacyPage.tsx
+++ b/apps/web/src/pages/landing/PrivacyPage.tsx
@@ -1,0 +1,29 @@
+// Stub. Real content lands in a follow-up commit ("feat: privacy
+// policy page").
+export function PrivacyPage() {
+  return (
+    <main style={{ paddingTop: 120, paddingBottom: 80 }}>
+      <div
+        style={{
+          maxWidth: 760,
+          margin: '0 auto',
+          padding: '0 28px',
+        }}
+      >
+        <h1
+          className="font-serif text-caddie-ink"
+          style={{
+            fontSize: 38,
+            fontWeight: 500,
+            fontStyle: 'italic',
+            letterSpacing: '-0.015em',
+            lineHeight: 1.05,
+            margin: 0,
+          }}
+        >
+          Privacy.
+        </h1>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/pages/onboarding/OnboardingPage.tsx
+++ b/apps/web/src/pages/onboarding/OnboardingPage.tsx
@@ -95,7 +95,7 @@ export function OnboardingPage() {
       // Flip the gate AFTER the bag write so a failed bag save can't
       // strand the user on a half-completed onboarding.
       await updateProfile.mutateAsync({ onboarding_completed: true })
-      navigate('/', { replace: true })
+      navigate('/dashboard', { replace: true })
     } catch (err) {
       setError(toUserMessage(err))
     } finally {
@@ -109,7 +109,7 @@ export function OnboardingPage() {
     setSavingBag(true)
     try {
       await updateProfile.mutateAsync({ onboarding_completed: true })
-      navigate('/', { replace: true })
+      navigate('/dashboard', { replace: true })
     } catch (err) {
       setError(toUserMessage(err))
     } finally {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -4,6 +4,7 @@ import { AuthGuard } from './components/auth/AuthGuard'
 import { ProfileGuard } from './components/auth/ProfileGuard'
 import { AppShell } from './components/layout/AppShell'
 import { PublicShell } from './components/landing/PublicShell'
+import { PublicArticleLayout } from './components/landing/PublicArticleLayout'
 import { RouteErrorBoundary } from './components/errors/ErrorBoundary'
 import { LoginPage } from './pages/auth/LoginPage'
 import { SignupPage } from './pages/auth/SignupPage'
@@ -72,13 +73,21 @@ const errorElement = <RouteErrorBoundary />
 const routes: RouteObject[] = [
   // Public routes — no auth required. Visiting these signed-in is fine;
   // PublicNav swaps the sign-up CTA for "Go to app" so the home page
-  // doubles as a re-entry point.
+  // doubles as a re-entry point. Learn lives here so articles are
+  // crawlable and shareable without forcing readers through signup.
   {
     element: <PublicShell />,
     errorElement,
     children: [
       { path: '/', element: <LandingPage />, errorElement },
       { path: '/privacy', element: <PrivacyPage />, errorElement },
+      {
+        element: <PublicArticleLayout />,
+        children: [
+          { path: '/learn', element: <LearnPage />, errorElement },
+          { path: '/learn/:slug', element: <LearnArticlePage />, errorElement },
+        ],
+      },
     ],
   },
   { path: '/login', element: <LoginPage />, errorElement },
@@ -100,8 +109,6 @@ const routes: RouteObject[] = [
       { path: '/patterns', element: <ShotPatternsPage />, errorElement },
       { path: '/practice', element: <PracticePlanPage />, errorElement },
       { path: '/practice/drills', element: <DrillLibraryPage />, errorElement },
-      { path: '/learn', element: <LearnPage />, errorElement },
-      { path: '/learn/:slug', element: <LearnArticlePage />, errorElement },
       { path: '/settings', element: <SettingsPage />, errorElement },
       { path: '/settings/bag', element: <BagPage />, errorElement },
     ],

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -3,11 +3,13 @@ import { createBrowserRouter, Outlet, type RouteObject } from 'react-router-dom'
 import { AuthGuard } from './components/auth/AuthGuard'
 import { ProfileGuard } from './components/auth/ProfileGuard'
 import { AppShell } from './components/layout/AppShell'
+import { PublicShell } from './components/landing/PublicShell'
 import { RouteErrorBoundary } from './components/errors/ErrorBoundary'
 import { LoginPage } from './pages/auth/LoginPage'
 import { SignupPage } from './pages/auth/SignupPage'
 import { NotFoundPage } from './pages/errors/NotFoundPage'
 import { OnboardingPage } from './pages/onboarding/OnboardingPage'
+import { LandingPage } from './pages/landing/LandingPage'
 import { DashboardPage } from './pages/dashboard/DashboardPage'
 import { RoundsPage } from './pages/rounds/RoundsPage'
 import { NewRoundPage } from './pages/rounds/NewRoundPage'
@@ -39,6 +41,9 @@ const LearnArticlePage = lazy(() =>
     default: m.LearnArticlePage,
   })),
 )
+const PrivacyPage = lazy(() =>
+  import('./pages/landing/PrivacyPage').then((m) => ({ default: m.PrivacyPage })),
+)
 
 function RouteFallback() {
   return (
@@ -65,6 +70,17 @@ function ProtectedShell() {
 const errorElement = <RouteErrorBoundary />
 
 const routes: RouteObject[] = [
+  // Public routes — no auth required. Visiting these signed-in is fine;
+  // PublicNav swaps the sign-up CTA for "Go to app" so the home page
+  // doubles as a re-entry point.
+  {
+    element: <PublicShell />,
+    errorElement,
+    children: [
+      { path: '/', element: <LandingPage />, errorElement },
+      { path: '/privacy', element: <PrivacyPage />, errorElement },
+    ],
+  },
   { path: '/login', element: <LoginPage />, errorElement },
   { path: '/signup', element: <SignupPage />, errorElement },
   {
@@ -76,7 +92,7 @@ const routes: RouteObject[] = [
     element: <ProtectedShell />,
     errorElement,
     children: [
-      { path: '/', element: <DashboardPage />, errorElement },
+      { path: '/dashboard', element: <DashboardPage />, errorElement },
       { path: '/rounds', element: <RoundsPage />, errorElement },
       { path: '/rounds/new', element: <NewRoundPage />, errorElement },
       { path: '/rounds/:id', element: <RoundDetailPage />, errorElement },


### PR DESCRIPTION
## Summary
Replaces the standalone-HTML approach in PR #228 with a React route inside the existing Vite app. Marketing landing at `/`, real Mapbox preview, public Learn + Privacy.

## What changed
- `/` now renders `LandingPage` (public). `DashboardPage` moved to `/dashboard`. Sidebar/login/onboarding redirects updated.
- `/privacy` and `/learn` (+ `/learn/:slug`) moved outside `ProtectedShell` into a new `PublicShell` with `PublicNav` (auth-aware: signed-in visitors see "Go to app", everyone else sees Sign in / Sign up free).
- `AppPreview` renders a phone-shaped frame around `DemoMap` — a Mapbox satellite view of a fake hole 7 with hard-coded shot markers, connecting line, and pin. Same marker/line styling as the live `RoundMap`. Read-only (`interactive: false`).
- `DemoMap` is `React.lazy` so the mapbox-gl chunk stays out of the entry-route critical path; `AppPreview` paints the phone frame instantly with a tinted-green fallback while the chunk loads.
- Privacy policy: plain language, mirrors the Learn editorial style. Covers data collected, usage, hosting (Supabase / Mapbox / OpenGolfAPI), deletion path, GitHub Issues as the contact channel.

## Commits
1. `feat: public routes for landing, learn, privacy` — route plumbing + stubs
2. `feat: DemoMap component with real Mapbox + fake data`
3. `feat: landing page with app preview`
4. `feat: privacy policy page`
5. `fix: learn routes publicly accessible`

## Bundle impact
Landing entry chunk is ~480 KB (gzip ~133 KB). `mapbox` and `recharts` stay in their own chunks per `vite.config.ts` `manualChunks`; mapbox is pulled in lazily via `React.lazy` on `DemoMap`.

## Test plan
- [ ] `/` renders the landing page when signed-out — sign-up CTA visible.
- [ ] `/` renders the landing page when signed-in — "Go to app →" CTA replaces signup; final CTA section says "Welcome back."
- [ ] `/dashboard` (auth gated) still works; sidebar Dashboard link goes to `/dashboard`.
- [ ] `/login` after signing in redirects to `/dashboard`.
- [ ] `/onboarding` after completing redirects to `/dashboard`.
- [ ] `/privacy` opens publicly with PublicNav at top.
- [ ] `/learn` and `/learn/course-management` open publicly (no login required).
- [ ] Phone preview shows real satellite tiles + 3 numbered shot markers + amber line + red pin.
- [ ] Resize to <960px — hero stacks, features collapse to single column, phone hides at <560px.
- [ ] DevTools "Emulate prefers-reduced-motion: reduce" — feature cards/SG bars appear without transitions.
- [ ] Refresh on `/learn/course-management` while signed-out — article renders inside PublicShell.