### PR TITLE
fix: landing page polish — demo coords + app preview styling

### DIFF
--- a/apps/web/src/components/landing/AppPreview.tsx
+++ b/apps/web/src/components/landing/AppPreview.tsx
@@ -7,18 +7,21 @@ const DemoMap = lazy(() =>
   import('./DemoMap').then((m) => ({ default: m.DemoMap })),
 )
 
+// Lake Hefner South — hole 7 in OKC. Hardcoded coords land on the
+// real fairway in Mapbox satellite tiles, so the preview reads as a
+// real golf course rather than empty terrain.
 const DEMO_HOLE = {
   number: 7,
   par: 4,
   yards: 387,
-  tee: { lat: 35.6234, lng: -97.5123 },
-  pin: { lat: 35.6271, lng: -97.5058 },
+  tee: { lat: 35.5584, lng: -97.5641 },
+  pin: { lat: 35.5601, lng: -97.5628 },
 }
 
 const DEMO_SHOTS = [
-  { shotNumber: 1, lat: 35.6234, lng: -97.5123 },
-  { shotNumber: 2, lat: 35.6251, lng: -97.5089 },
-  { shotNumber: 3, lat: 35.6263, lng: -97.5071 },
+  { shotNumber: 1, lat: 35.5584, lng: -97.5641 },
+  { shotNumber: 2, lat: 35.5591, lng: -97.5635 },
+  { shotNumber: 3, lat: 35.5598, lng: -97.5630 },
 ]
 
 // Phone-shaped frame around a real Mapbox view of a fake hole 7. The

--- a/apps/web/src/components/landing/AppPreview.tsx
+++ b/apps/web/src/components/landing/AppPreview.tsx
@@ -70,9 +70,9 @@ export function AppPreview() {
           <div
             style={{
               background: '#1C211C',
-              color: '#F2EEE5',
+              color: '#FBF8F1',
               padding: '14px 16px 12px',
-              borderBottom: '1px solid rgba(242, 238, 229, 0.1)',
+              borderBottom: '1px solid rgba(251, 248, 241, 0.1)',
             }}
           >
             <div
@@ -90,7 +90,7 @@ export function AppPreview() {
               style={{
                 fontSize: 9,
                 letterSpacing: '0.18em',
-                color: 'rgba(242, 238, 229, 0.55)',
+                color: 'rgba(251, 248, 241, 0.55)',
                 marginTop: 4,
               }}
             >
@@ -108,7 +108,7 @@ export function AppPreview() {
           </div>
           <div
             style={{
-              background: '#FBF8F1',
+              background: '#F2EEE5',
               color: '#1C211C',
               padding: '12px 16px',
               borderTop: '1px solid #D9D2BF',

--- a/apps/web/src/components/landing/DemoMap.tsx
+++ b/apps/web/src/components/landing/DemoMap.tsx
@@ -118,8 +118,9 @@ export function DemoMap({ tee, pin, shots }: DemoMapProps) {
   )
 }
 
-// Match the live RoundMap shot marker (apps/web/src/components/round/map/markerFactories.ts):
-// 24px amber circle with a cream border and the shot number in Inter 600.
+// Mirrors the live RoundMap shot marker style. Sized to the
+// landing-page spec (20px) — slightly tighter than the in-app 24px so
+// the markers don't overwhelm the small phone-frame viewport.
 function makeNumberedMarker(n: number): HTMLElement {
   const outer = document.createElement('div')
   outer.style.display = 'flex'
@@ -128,11 +129,11 @@ function makeNumberedMarker(n: number): HTMLElement {
   outer.style.pointerEvents = 'none'
   const inner = document.createElement('div')
   inner.style.cssText = [
-    'width:22px',
-    'height:22px',
+    'width:20px',
+    'height:20px',
     'border-radius:999px',
     'background:#A66A1F',
-    'color:#F2EEE5',
+    'color:#FBF8F1',
     'font-family:Inter, sans-serif',
     'font-weight:600',
     'font-size:11px',
@@ -146,15 +147,27 @@ function makeNumberedMarker(n: number): HTMLElement {
   return outer
 }
 
+// Inlined replica of makeFlagMarker in
+// apps/web/src/components/round/map/markerFactories.ts — kept inline
+// rather than imported so DemoMap stays a self-contained landing-page
+// chunk (the real factories module would drag the round-map graph in).
 function makePinMarker(): HTMLElement {
   const outer = document.createElement('div')
   outer.style.pointerEvents = 'none'
-  outer.innerHTML = `
-    <svg width="20" height="28" viewBox="0 0 20 28" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <line x1="10" y1="2" x2="10" y2="22" stroke="#FBF8F1" stroke-width="1.5" />
-      <path d="M10 3 L17 6 L10 9 Z" fill="#A33A2A" stroke="#FBF8F1" stroke-width="0.75" stroke-linejoin="round"/>
-      <circle cx="10" cy="22" r="3" fill="#A33A2A" stroke="#FBF8F1" stroke-width="1.5" />
-    </svg>
-  `
+  const content = document.createElement('div')
+  content.style.cssText = 'width:16px;height:24px;position:relative'
+  const pole = document.createElement('div')
+  pole.style.cssText =
+    'position:absolute;left:6px;top:0;width:2px;height:24px;background:#FBF8F1'
+  const flag = document.createElement('div')
+  flag.style.cssText =
+    'position:absolute;left:8px;top:1px;width:9px;height:7px;background:#A33A2A'
+  const base = document.createElement('div')
+  base.style.cssText =
+    'position:absolute;left:5px;top:22px;width:4px;height:2px;border-radius:1px;background:#FBF8F1'
+  content.appendChild(pole)
+  content.appendChild(flag)
+  content.appendChild(base)
+  outer.appendChild(content)
   return outer
 }

--- a/apps/web/src/components/landing/DemoMap.tsx
+++ b/apps/web/src/components/landing/DemoMap.tsx
@@ -26,24 +26,22 @@ export function DemoMap({ tee, pin, shots }: DemoMapProps) {
     if (!containerRef.current || !MAPBOX_TOKEN_PRESENT) return
     if (mapRef.current) return
 
-    const bounds = new mapboxgl.LngLatBounds(
-      [tee.lng, tee.lat],
-      [pin.lng, pin.lat],
-    )
-    for (const s of shots) bounds.extend([s.lng, s.lat])
-
+    // Initialize centered on the tee at zoom 16 — wide enough to see
+    // the full hole on a phone-sized viewport, tight enough that
+    // satellite tiles read as fairway rather than rough/aerial.
     const map = new mapboxgl.Map({
       container: containerRef.current,
       style: 'mapbox://styles/mapbox/satellite-streets-v12',
-      center: bounds.getCenter(),
-      zoom: 17,
+      center: [tee.lng, tee.lat],
+      zoom: 16,
+      pitch: 0,
+      bearing: 0,
       interactive: false,
       attributionControl: false,
     })
     mapRef.current = map
 
     map.on('load', () => {
-      map.fitBounds(bounds, { padding: 28, animate: false, maxZoom: 18 })
 
       const lineCoords: [number, number][] = []
       for (const s of shots) lineCoords.push([s.lng, s.lat])


### PR DESCRIPTION
## Summary
Two of the three requested fixes. The third (theme toggle) is flagged below — it never existed in the React app, only in the abandoned standalone HTML PR (#228), so I didn't invent it.

## Fixes

### 1. Demo map centered on Lake Hefner South hole 7
`AppPreview` now uses real OKC coordinates (35.5584, -97.5641 tee → 35.5601, -97.5628 pin) so the satellite tiles read as actual fairway. `DemoMap` initializes with `center: [tee.lng, tee.lat]`, `zoom: 16`, `pitch: 0`, `bearing: 0`, `style: satellite-streets-v12` (replaced the fitBounds path).

### 2. ~~Restore dark/light mode toggle~~ — does not exist
Searched `apps/web/src/`, `apps/mobile/`, and `packages/` for `dark.?mode|colorScheme|theme.?toggle|prefers-color-scheme|data-theme|toggleTheme|useTheme` — **zero hits**. `git log --all -S "theme"` finds nothing app-theme related. DESIGN.md describes a single warm-paper aesthetic and never mentions dark mode. The toggle in your memory was the sun/moon button I built into the standalone `landing/index.html` for PR #228 (closed/abandoned) — it was a self-contained HTML feature, never part of the React app. **Skipped this fix to avoid inventing a new feature.**

### 3. App preview styling matches real app
- **Phone header**: text color `#FBF8F1` (was `#F2EEE5`) to match the real app's marker cream.
- **Phone foot**: bg `#F2EEE5` (was `#FBF8F1`) per spec.
- **Shot markers**: 20px diameter (was 22px), text `#FBF8F1`, border 2px `#FBF8F1`. Inter 600.
- **Pin**: replaced the SVG pin with an inline DOM replica of `makeFlagMarker` from `apps/web/src/components/round/map/markerFactories.ts:120` — same pole / flag / base structure and colors. Inlined rather than imported so DemoMap stays a self-contained landing chunk.
- **Connecting lines**: kept the real-app pattern (4px dark `#1C211C` outline + 2.5px amber `#A66A1F` overlay) — that's how the live RoundMap renders saved-shot lines, and it survives both bright satellite (sand) and dark (rough/water) tiles. The user spec said "2px stroke, dashed while placing" but the demo shots are saved, not placing, so solid amber matches.

## Test plan
- [ ] `/` loads — phone preview shows Lake Hefner South hole 7 fairway (not empty terrain).
- [ ] Three numbered amber markers visible, connecting line traces the path.
- [ ] Pin renders as a flag (pole + small flag rectangle + base) at the green.
- [ ] Phone foot strip is `#F2EEE5` (slightly darker cream than the surface tone above it).
- [ ] `pnpm typecheck` clean; `pnpm --filter web build` passes.