### PR TITLE
fix: captcha token wired to both login and signup

### DIFF
--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -1,6 +1,16 @@
 import { useState, type FormEvent } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { Turnstile } from '@marsidev/react-turnstile'
 import { supabase } from '../../lib/supabase'
+
+// Vite exposes only env vars prefixed `VITE_` to the client bundle, so
+// the Turnstile site key has to follow that convention. Set
+// VITE_TURNSTILE_SITE_KEY in apps/web/.env.local for dev and in the
+// Vercel project's env vars for prod. Same constant pattern as
+// SignupPage so a missing env var fails identically on both pages.
+const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY as
+  | string
+  | undefined
 
 export function LoginPage() {
   const navigate = useNavigate()
@@ -8,15 +18,35 @@ export function LoginPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
+  // Token issued by Cloudflare Turnstile after the user passes the
+  // (usually invisible) challenge. Supabase's CAPTCHA setting applies
+  // to BOTH sign-in and sign-up by default, so signInWithPassword
+  // rejects with "captcha protection: request disallowed (no
+  // captcha_token found)" when this is missing.
+  const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  // Local-dev path: when no site key is configured we skip the widget
+  // so devs running against a local Supabase (CAPTCHA disabled) aren't
+  // blocked. Production deploys always have the env var set.
+  const captchaEnabled = Boolean(TURNSTILE_SITE_KEY)
+  const canSubmit = !loading && (!captchaEnabled || captchaToken !== null)
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
     setLoading(true)
     setError(null)
-    const { error: signInError } = await supabase.auth.signInWithPassword({ email, password })
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+      options: {
+        ...(captchaToken ? { captchaToken } : {}),
+      },
+    })
     setLoading(false)
     if (signInError) {
       setError(signInError.message)
+      // Turnstile tokens are single-use — clear after a failed sign-in
+      // so the widget reissues a fresh one for the retry.
+      setCaptchaToken(null)
       return
     }
     navigate('/dashboard')
@@ -65,6 +95,17 @@ export function LoginPage() {
             marginBottom: 14,
           }}
         />
+        {captchaEnabled && (
+          <div style={{ marginBottom: 14 }}>
+            <Turnstile
+              siteKey={TURNSTILE_SITE_KEY!}
+              onSuccess={(token) => setCaptchaToken(token)}
+              onError={() => setCaptchaToken(null)}
+              onExpire={() => setCaptchaToken(null)}
+              options={{ theme: 'auto' }}
+            />
+          </div>
+        )}
         {error && (
           <div
             className="text-caddie-neg"
@@ -75,7 +116,7 @@ export function LoginPage() {
         )}
         <button
           type="submit"
-          disabled={loading}
+          disabled={!canSubmit}
           className="w-full bg-caddie-accent text-caddie-accent-ink transition-opacity hover:opacity-90 disabled:opacity-50"
           style={{ borderRadius: 10, padding: '12px 16px', fontSize: 13, fontWeight: 500 }}
         >


### PR DESCRIPTION
## Root cause
\`LoginPage\` had no Turnstile integration at all. Supabase's CAPTCHA setting in *Auth → Bot and Abuse Protection* applies to **both** sign-in and sign-up by default, so \`signInWithPassword\` was rejected with:

> captcha protection: request disallowed (no captcha_token found)

The widget was on \`SignupPage\` but never on \`LoginPage\`.

## Fix
Mirror SignupPage's setup on LoginPage:
- Same \`VITE_TURNSTILE_SITE_KEY\` env var read.
- Same \`captchaToken\` state + \`canSubmit\` gate (button disabled until the widget calls \`onSuccess\`).
- Pass \`{ captchaToken }\` in \`signInWithPassword\` \`options\`.
- Reset token on error (Turnstile tokens are single-use; the widget reissues automatically when state clears).
- Local-dev short-circuit: when \`VITE_TURNSTILE_SITE_KEY\` is unset, skip the widget entirely so devs running against local Supabase (CAPTCHA disabled) aren't blocked.

Per CLAUDE.md's 3-caller rule, kept the captcha block inline rather than extracting a hook for two callers.

## Test plan
- [ ] With \`VITE_TURNSTILE_SITE_KEY\` set: open \`/login\`, Turnstile renders, sign-in button stays disabled until challenge passes, then submit succeeds.
- [ ] With \`VITE_TURNSTILE_SITE_KEY\` set: open \`/signup\`, same flow still works.
- [ ] Without env var (local dev with CAPTCHA off in Supabase): both pages submit immediately without the widget.
- [ ] After a wrong-password attempt: error displays, widget reissues a new token, retry works.
- [ ] \`pnpm typecheck\` clean; \`pnpm --filter web build\` passes.