### PR TITLE
fix: captcha gate at submit not on button disable (hotfix)

### DIFF
--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -28,10 +28,17 @@ export function LoginPage() {
   // so devs running against a local Supabase (CAPTCHA disabled) aren't
   // blocked. Production deploys always have the env var set.
   const captchaEnabled = Boolean(TURNSTILE_SITE_KEY)
-  const canSubmit = !loading && (!captchaEnabled || captchaToken !== null)
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
+    // Captcha is gated at submit time, not via button-disable. Turnstile
+    // managed mode auto-solves invisibly; the token usually arrives
+    // before the user finishes typing, but if they slam Enter early we
+    // surface a recoverable message instead of leaving the button dead.
+    if (captchaEnabled && !captchaToken) {
+      setError('Please wait a moment and try again.')
+      return
+    }
     setLoading(true)
     setError(null)
     const { error: signInError } = await supabase.auth.signInWithPassword({
@@ -116,7 +123,7 @@ export function LoginPage() {
         )}
         <button
           type="submit"
-          disabled={!canSubmit}
+          disabled={loading}
           className="w-full bg-caddie-accent text-caddie-accent-ink transition-opacity hover:opacity-90 disabled:opacity-50"
           style={{ borderRadius: 10, padding: '12px 16px', fontSize: 13, fontWeight: 500 }}
         >

--- a/apps/web/src/pages/auth/SignupPage.tsx
+++ b/apps/web/src/pages/auth/SignupPage.tsx
@@ -29,10 +29,17 @@ export function SignupPage() {
   // always have the env var set, so this branch never short-circuits
   // CAPTCHA in real usage.
   const captchaEnabled = Boolean(TURNSTILE_SITE_KEY)
-  const canSubmit = !loading && (!captchaEnabled || captchaToken !== null)
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault()
+    // Captcha is gated at submit time, not via button-disable. Turnstile
+    // managed mode auto-solves invisibly; the token usually arrives
+    // before the user finishes typing, but if they slam Enter early we
+    // surface a recoverable message instead of leaving the button dead.
+    if (captchaEnabled && !captchaToken) {
+      setError('Please wait a moment and try again.')
+      return
+    }
     setLoading(true)
     setError(null)
     const { error: signUpError } = await supabase.auth.signUp({
@@ -116,7 +123,7 @@ export function SignupPage() {
         )}
         <button
           type="submit"
-          disabled={!canSubmit}
+          disabled={loading}
           className="w-full bg-caddie-accent text-caddie-accent-ink transition-opacity hover:opacity-90 disabled:opacity-50"
           style={{ borderRadius: 10, padding: '12px 16px', fontSize: 13, fontWeight: 500 }}
         >


### PR DESCRIPTION
## Hotfix to main
Branched from \`main\` per request — production sign-in/up button stays dead during the brief window before Turnstile's invisible challenge resolves and \`onSuccess\` fires.

## Fix
Move captcha gating from button-disable to submit-time on both \`LoginPage\` and \`SignupPage\`.

- \`disabled={loading}\` (was \`disabled={!canSubmit}\` which factored in \`captchaToken !== null\`).
- Removed the \`canSubmit\` derivation; the button is enabled as soon as form fields are valid.
- Early-return guard at the top of \`handleSubmit\`:
  \`\`\`ts
  if (captchaEnabled && !captchaToken) {
    setError('Please wait a moment and try again.')
    return
  }
  \`\`\`
- Local-dev short-circuit (\`captchaEnabled = false\` when \`VITE_TURNSTILE_SITE_KEY\` is unset) still works — the guard's \`captchaEnabled\` factor keeps dev paths unblocked.

## Note on workflow
This violates \`CLAUDE.md\`'s "no direct PRs to main" rule (work normally branches from \`dev\`). Treating as a hotfix per explicit request. Will need to be back-merged into \`dev\` afterwards so \`dev → main\` releases don't regress.

## Test plan
- [ ] Open \`/login\` in prod build — sign-in button enabled immediately. Type credentials, hit Enter before Turnstile resolves → "Please wait a moment and try again." error shows. Wait a beat, retry → succeeds.
- [ ] Same on \`/signup\`.
- [ ] In local dev with \`VITE_TURNSTILE_SITE_KEY\` unset → both pages submit instantly without the widget.
- [ ] After failed sign-in (wrong password) → error shows, fresh Turnstile token issues, retry works.
- [ ] \`pnpm typecheck\` clean; \`pnpm --filter web build\` passes.