### PR TITLE
Mobile testing feedback: 13 fixes

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -137,7 +137,7 @@ export default function Home() {
           {firstName ? `Good round, ${firstName}.` : 'Good round.'}
         </Text>
         <Text style={{ color: '#5C6356', fontSize: 14, marginBottom: 22 }}>
-          Last {rounds.length || 0} round{rounds.length === 1 ? '' : 's'}
+          Last {trend.length} round{trend.length === 1 ? '' : 's'}
         </Text>
 
         {activeRound && <ResumeRoundBanner round={activeRound} />}

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -101,12 +101,16 @@ export default function Home() {
       .catch(() => undefined)
   }, [])
 
+  // Skip rounds with no sg_total — null → 0 would anchor the line
+  // at zero on rounds the user never finalized SG for, and the SG
+  // breakdown averages (which filter nulls) would no longer match.
   const trend = useMemo(
     () =>
-      [...rounds].reverse().map((r, i) => ({
-        x: i + 1,
-        y: r.sg_total ?? 0,
-      })),
+      [...rounds]
+        .reverse()
+        .flatMap((r, i) =>
+          r.sg_total == null ? [] : [{ x: i + 1, y: r.sg_total }],
+        ),
     [rounds],
   )
 

--- a/apps/mobile/app/(app)/learn/[article].tsx
+++ b/apps/mobile/app/(app)/learn/[article].tsx
@@ -42,7 +42,7 @@ export default function ArticleScreen() {
   return (
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
       <AppBar
-        eyebrow={found?.section.title ?? 'Yardage book'}
+        eyebrow={found?.section.title ?? 'Library'}
         title={found?.article.title ?? 'Article'}
         right={
           <Pressable onPress={() => router.back()}>

--- a/apps/mobile/app/(app)/learn/[article].tsx
+++ b/apps/mobile/app/(app)/learn/[article].tsx
@@ -42,7 +42,7 @@ export default function ArticleScreen() {
   return (
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
       <AppBar
-        eyebrow={found?.section.title ?? 'Library'}
+        eyebrow={found?.section.title ?? 'Learn'}
         title={found?.article.title ?? 'Article'}
         right={
           <Pressable onPress={() => router.back()}>

--- a/apps/mobile/app/(app)/learn/index.tsx
+++ b/apps/mobile/app/(app)/learn/index.tsx
@@ -22,7 +22,7 @@ export default function LearnScreen() {
   return (
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
       <AppBar
-        eyebrow="Yardage book"
+        eyebrow="Library"
         title="Learn"
         right={
           <Pressable onPress={() => router.back()}>

--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -154,7 +154,10 @@ export default function Patterns() {
               {lieSlope !== ANY ? ` (${lieSlope})` : ''}.
             </Text>
           ) : (
-            <DispersionPlot points={points} stats={stats} />
+            <>
+              <DispersionPlot points={points} stats={stats} />
+              <PatternLegend hasStats={!!stats} />
+            </>
           )}
         </Section>
 
@@ -309,6 +312,59 @@ function pointColor(result: string | undefined): { fill: string; opacity: number
     return { fill: '#A66A1F', opacity: 0.75 }
   if (result === undefined) return { fill: '#8A8B7E', opacity: 0.5 }
   return { fill: '#A33A2A', opacity: 0.8 }
+}
+
+function PatternLegend({ hasStats }: { hasStats: boolean }) {
+  return (
+    <View style={{ marginTop: 12, gap: 6 }}>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 10 }}>
+        <LegendDot color="#1C211C" label="Solid" />
+        <LegendDot color="#A66A1F" label="Push / pull" />
+        <LegendDot color="#A33A2A" label="Miss" />
+        <LegendDot color="#8A8B7E" label="Unspecified" />
+      </View>
+      {hasStats && (
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 10 }}>
+          <LegendEllipse opacity={0.12} label="68% of shots" />
+          <LegendEllipse opacity={0.06} label="95% of shots" />
+        </View>
+      )}
+    </View>
+  )
+}
+
+function LegendDot({ color, label }: { color: string; label: string }) {
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+      <View
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: 4,
+          backgroundColor: color,
+        }}
+      />
+      <Text style={{ color: '#5C6356', fontSize: 11 }}>{label}</Text>
+    </View>
+  )
+}
+
+function LegendEllipse({ opacity, label }: { opacity: number; label: string }) {
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 5 }}>
+      <View
+        style={{
+          width: 14,
+          height: 8,
+          borderRadius: 4,
+          backgroundColor: `rgba(31,61,44,${opacity})`,
+          borderWidth: 1,
+          borderColor: '#1F3D2C',
+        }}
+      />
+      <Text style={{ color: '#5C6356', fontSize: 11 }}>{label}</Text>
+    </View>
+  )
 }
 
 function DispersionPlot({

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -83,7 +83,7 @@ export default function Practice() {
               }}
             >
               <Text style={{ ...KICKER, color: '#5C6356', marginBottom: 6 }}>
-                Yardage book
+                Learn
               </Text>
               <Text
                 style={{

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -83,7 +83,7 @@ export default function Practice() {
               }}
             >
               <Text style={{ ...KICKER, color: '#5C6356', marginBottom: 6 }}>
-                Learn
+                Reference
               </Text>
               <Text
                 style={{

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -410,6 +410,7 @@ export default function HoleScreen() {
         onPersistPutt={actions.persistPutt}
         onCloseLogger={actions.closeLogger}
         onClosePuttingSheet={actions.closePuttingSheet}
+        onSwapPuttingToShot={actions.swapPuttingToShot}
         onConfirmDelete={actions.handleDeleteRound}
         onCancelDelete={() => setConfirmDelete(false)}
         onConfirmLeave={() => {

--- a/apps/mobile/app/(app)/round/[id]/hole/components/HoleModals.tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/components/HoleModals.tsx
@@ -1,6 +1,7 @@
 import { Modal, View } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import type { Database } from '@oga/supabase'
+import type { LieType } from '@oga/core'
 import {
   ShotLogger,
   type ShotLoggerValue,
@@ -48,6 +49,7 @@ interface HoleModalsProps {
   onPersistPutt: (v: PuttingValue) => Promise<void>
   onCloseLogger: () => void
   onClosePuttingSheet: () => void
+  onSwapPuttingToShot: (lieType: LieType) => void
   onConfirmDelete: () => void
   onCancelDelete: () => void
   onConfirmLeave: () => void
@@ -90,6 +92,7 @@ export function HoleModals(props: HoleModalsProps) {
     onPersistPutt,
     onCloseLogger,
     onClosePuttingSheet,
+    onSwapPuttingToShot,
     onConfirmDelete,
     onCancelDelete,
     onConfirmLeave,
@@ -143,6 +146,7 @@ export function HoleModals(props: HoleModalsProps) {
               }
               onSave={onPersistPutt}
               onClose={onClosePuttingSheet}
+              onChangeLie={onSwapPuttingToShot}
             />
           </View>
         </GestureHandlerRootView>

--- a/apps/mobile/app/(app)/round/[id]/hole/hooks/useShotActions.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/hooks/useShotActions.ts
@@ -2,7 +2,7 @@ import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { Alert } from 'react-native'
 import { useRouter } from 'expo-router'
 import type { User } from '@supabase/supabase-js'
-import { combinedPuttResult } from '@oga/core'
+import { combinedPuttResult, type LieType } from '@oga/core'
 import { deleteRound, getProfile } from '@oga/supabase'
 import { supabase } from '../../../../../../lib/supabase'
 import {
@@ -54,6 +54,7 @@ export interface UseShotActionsResult {
   handleAimPromptSkip: () => void
   closeLogger: () => void
   closePuttingSheet: () => void
+  swapPuttingToShot: (lieType: LieType) => void
   navigateHole: (delta: number) => void
   finishHole: () => void
   handleEndRound: () => Promise<void>
@@ -350,6 +351,17 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     setRoundState('PLACE_BALL')
   }
 
+  // Recover from a mistaken "Yes, I'm putting" tap. PuttingSheet has
+  // no club/lie picker — without this escape, a player who's actually
+  // chipping from the fringe or in a bunker has no way out except
+  // Close, which drops them back to PLACE_BALL and loses the ball
+  // position. Mirrors handleOnGreenNo's seed.
+  function swapPuttingToShot(lieType: LieType) {
+    setLoggerInitial({ lieType })
+    setRoundState('SHOT_DETAIL')
+    setLoggerOpen(true)
+  }
+
   function navigateHole(delta: number) {
     const next = holeNumber + delta
     if (next < 1 || next > 18) return
@@ -441,6 +453,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     handleAimPromptSkip,
     closeLogger,
     closePuttingSheet,
+    swapPuttingToShot,
     navigateHole,
     finishHole,
     handleEndRound,

--- a/apps/mobile/app/(app)/round/[id]/hole/hooks/useShotActions.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/hooks/useShotActions.ts
@@ -301,9 +301,12 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
 
   function handleOnGreenYes() {
     setOnGreenPromptOpen(false)
+    // Drop straight into the dedicated PuttingSheet — there is no
+    // club/lie picker on that sheet, so there is nothing for the player
+    // to select after confirming "Yes, I'm putting". persistPutt hard-
+    // codes club='putter' + lie='green' on the way to the DB.
     setLoggerInitial({ lieType: 'green', club: 'putter' })
-    setRoundState('SHOT_DETAIL')
-    setLoggerOpen(true)
+    setRoundState('PUTTING')
   }
 
   function handleOnGreenNo() {

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -423,15 +423,21 @@ export default function RoundIndex() {
             const score = hs?.score ?? null
             const d = score != null && score > 0 ? score - h.par : null
             return (
-              <View
+              <Pressable
                 key={h.id}
-                style={{
+                accessibilityRole="button"
+                accessibilityLabel={`Hole ${h.number}, par ${h.par}${score != null && score > 0 ? `, score ${score}` : ', not played'}`}
+                onPress={() =>
+                  router.push(`/(app)/round/${id}/hole/${h.number}?mode=past`)
+                }
+                style={({ pressed }) => ({
                   flexDirection: 'row',
                   paddingVertical: 10,
                   borderBottomWidth: 1,
                   borderColor: '#EBE5D6',
                   paddingHorizontal: 6,
-                }}
+                  backgroundColor: pressed ? '#EBE5D6' : 'transparent',
+                })}
               >
                 <Text
                   style={{
@@ -483,7 +489,7 @@ export default function RoundIndex() {
                 >
                   {d == null ? '—' : d === 0 ? 'E' : d > 0 ? `+${d}` : `${d}`}
                 </Text>
-              </View>
+              </Pressable>
             )
           })}
         </View>

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -417,6 +417,8 @@ export default function RoundIndex() {
             >
               +/−
             </Text>
+            {/* Header spacer for the row affordance arrow. */}
+            <Text style={{ width: 18, marginLeft: 6 }}> </Text>
           </View>
           {sortedHoles.map((h) => {
             const hs = scoresByHoleId.get(h.id)
@@ -488,6 +490,20 @@ export default function RoundIndex() {
                   }}
                 >
                   {d == null ? '—' : d === 0 ? 'E' : d > 0 ? `+${d}` : `${d}`}
+                </Text>
+                {/* Persistent affordance — pressed-only background gave
+                    no resting hint that rows were tappable. Arrow sits
+                    in muted ink so it doesn't fight the score columns. */}
+                <Text
+                  style={{
+                    width: 18,
+                    textAlign: 'right',
+                    fontSize: 14,
+                    color: '#8A8B7E',
+                    marginLeft: 6,
+                  }}
+                >
+                  →
                 </Text>
               </Pressable>
             )

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -8,6 +8,9 @@ import { useAuth } from '../../hooks/useAuth'
 import { AppBar } from '../../components/ui/AppBar'
 
 const N_OPTIONS = [5, 10, 20] as const
+// Pin x-axis to chart bottom regardless of where y=0 falls in domain.
+const CHART_HEIGHT = 260
+const CHART_BOTTOM = 28
 
 const SERIES = [
   { key: 'sg_off_tee', label: 'Off tee', color: '#1F3D2C' },
@@ -225,11 +228,12 @@ export default function Stats() {
 
             <Section kicker={`SG by category — last ${rounds.length} rounds`}>
               <VictoryChart
-                height={260}
+                height={CHART_HEIGHT}
                 width={screenWidth - 36}
-                padding={{ top: 16, right: 12, bottom: 28, left: 32 }}
+                padding={{ top: 16, right: 12, bottom: CHART_BOTTOM, left: 32 }}
               >
                 <VictoryAxis
+                  offsetY={CHART_HEIGHT - CHART_BOTTOM}
                   tickFormat={(t) =>
                     new Date(t).toLocaleDateString('en-US', {
                       month: 'short',

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -76,15 +76,21 @@ export default function Stats() {
   // ordered.map(...) inside <VictoryLine> previously rebuilt every
   // chart-data array on every parent render (window resize, focus,
   // etc.) and Victory then re-tessellated the lines.
+  // Skip rounds with null SG for a category — coercing null → 0
+  // here would anchor the line at zero on rounds where that
+  // category wasn't logged, and the by-the-numbers averages
+  // (which filter nulls) would no longer match what's drawn.
   const chartSeries = useMemo(() => {
     const ordered = [...rounds].reverse()
     return SERIES.map((s) => ({
       key: s.key,
       color: s.color,
-      data: ordered.map((r) => ({
-        x: new Date(r.played_at).getTime(),
-        y: r[s.key] ?? 0,
-      })),
+      data: ordered.flatMap((r) => {
+        const v = r[s.key]
+        return v == null
+          ? []
+          : [{ x: new Date(r.played_at).getTime(), y: v }]
+      }),
     }))
   }, [rounds])
 

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,10 +1,18 @@
-import { useEffect, useRef, useState } from 'react'
-import { Animated, StyleSheet, Text } from 'react-native'
+import { useEffect, useState } from 'react'
+import { Pressable, StyleSheet, Text } from 'react-native'
 import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import * as SplashScreen from 'expo-splash-screen'
 import { useFonts } from 'expo-font'
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated'
 import { AuthProvider } from '../contexts/AuthContext'
 import { useAuth } from '../hooks/useAuth'
 import { ErrorBoundary } from '../components/errors/ErrorBoundary'
@@ -20,6 +28,13 @@ void SplashScreen.preventAutoHideAsync().catch(() => {
   // refresh after a crash). Nothing to do.
 })
 
+const FADE_DURATION = 500
+const LOGO_DELAY = 300
+const TAGLINE_DELAY = 900
+const SUPPORT_DELAY = 1500
+const HOLD_BEFORE_DISMISS = 3500
+const FADE_OUT_DURATION = 350
+
 export default function RootLayout() {
   return (
     <AuthProvider>
@@ -29,48 +44,81 @@ export default function RootLayout() {
 }
 
 function RootLayoutContent() {
-  // Bundled Fraunces — `Fraunces9pt-SemiBold` upstream is the closest
-  // 500-ish weight to "Medium" available as a static instance, so we
-  // alias it under the family name the rest of the app references.
-  // The italic file is the SemiBoldItalic counterpart.
   const [fontsLoaded] = useFonts({
     'Fraunces-Medium': require('../assets/fonts/Fraunces-Medium.ttf'),
     'Fraunces-MediumItalic': require('../assets/fonts/Fraunces-MediumItalic.ttf'),
   })
   const { loading: authLoading } = useAuth()
 
-  // JS overlay handles the fade from splash → app once both fonts and
-  // auth are ready. Kept as RN's built-in Animated (not Reanimated) so
-  // it's mounted before any of our heavier UI work happens; one fewer
-  // worklet runtime to spin up during the first paint.
-  const overlayOpacity = useRef(new Animated.Value(1)).current
+  const overlayOpacity = useSharedValue(1)
+  const logoOpacity = useSharedValue(0)
+  const taglineOpacity = useSharedValue(0)
+  const supportOpacity = useSharedValue(0)
   const [overlayMounted, setOverlayMounted] = useState(true)
+  const [readyToDismiss, setReadyToDismiss] = useState(false)
 
-  // Hide the native splash as soon as fonts are loaded so the JS
-  // overlay (using actual Fraunces) takes over with no flash. The
-  // overlay itself stays opaque until auth resolves below.
   useEffect(() => {
     if (!fontsLoaded) return
     SplashScreen.hideAsync().catch(() => {})
+    logoOpacity.value = withDelay(
+      LOGO_DELAY,
+      withTiming(1, { duration: FADE_DURATION, easing: Easing.out(Easing.cubic) }),
+    )
+    taglineOpacity.value = withDelay(
+      TAGLINE_DELAY,
+      withTiming(1, { duration: FADE_DURATION, easing: Easing.out(Easing.cubic) }),
+    )
+    supportOpacity.value = withDelay(
+      SUPPORT_DELAY,
+      withTiming(1, { duration: FADE_DURATION, easing: Easing.out(Easing.cubic) }),
+    )
+  }, [fontsLoaded, logoOpacity, taglineOpacity, supportOpacity])
+
+  // Mark the overlay as ready to dismiss after the staged fade-ins
+  // settle. The actual dismiss waits on auth too — we never tear the
+  // overlay down while a profile fetch is still in flight.
+  useEffect(() => {
+    if (!fontsLoaded) return
+    const t = setTimeout(() => setReadyToDismiss(true), HOLD_BEFORE_DISMISS)
+    return () => clearTimeout(t)
   }, [fontsLoaded])
 
-  // Fade the overlay out once auth has settled. Profile loading
-  // continues inside (app)/_layout.tsx with its own ActivityIndicator
-  // — keeping the overlay up for it would double-gate the cold start.
   useEffect(() => {
-    if (!fontsLoaded || authLoading) return
-    Animated.timing(overlayOpacity, {
-      toValue: 0,
-      duration: 350,
-      useNativeDriver: true,
-    }).start(({ finished }) => {
-      if (finished) setOverlayMounted(false)
-    })
-  }, [fontsLoaded, authLoading, overlayOpacity])
+    if (!fontsLoaded || authLoading || !readyToDismiss) return
+    overlayOpacity.value = withTiming(
+      0,
+      { duration: FADE_OUT_DURATION, easing: Easing.out(Easing.cubic) },
+      (finished) => {
+        if (finished) runOnJS(setOverlayMounted)(false)
+      },
+    )
+  }, [fontsLoaded, authLoading, readyToDismiss, overlayOpacity])
 
-  // While fonts are still loading the native splash is up; rendering
-  // null here keeps the JS tree empty so we never flash a fallback
-  // serif "OGA" before the real font is ready.
+  const overlayStyle = useAnimatedStyle(() => ({
+    opacity: overlayOpacity.value,
+  }))
+  const logoStyle = useAnimatedStyle(() => ({
+    opacity: logoOpacity.value,
+  }))
+  const taglineStyle = useAnimatedStyle(() => ({
+    opacity: taglineOpacity.value,
+  }))
+  const supportStyle = useAnimatedStyle(() => ({
+    opacity: supportOpacity.value,
+  }))
+
+  // Tap-to-skip: collapse remaining timeouts and start the fade-out
+  // immediately, but only after fonts are ready (otherwise we'd unmount
+  // the overlay while the bundle is still booting and flash the system
+  // serif). Auth still gates the actual unmount inside the effect above.
+  const handleSkip = () => {
+    if (!fontsLoaded) return
+    logoOpacity.value = withTiming(1, { duration: 0 })
+    taglineOpacity.value = withTiming(1, { duration: 0 })
+    supportOpacity.value = withTiming(1, { duration: 0 })
+    setReadyToDismiss(true)
+  }
+
   if (!fontsLoaded) return null
 
   return (
@@ -81,15 +129,20 @@ function RootLayoutContent() {
       </ErrorBoundary>
       {overlayMounted && (
         <Animated.View
-          pointerEvents={authLoading ? 'auto' : 'none'}
-          style={[
-            StyleSheet.absoluteFill,
-            styles.overlay,
-            { opacity: overlayOpacity },
-          ]}
+          pointerEvents={authLoading || !readyToDismiss ? 'auto' : 'none'}
+          style={[StyleSheet.absoluteFill, styles.overlay, overlayStyle]}
         >
-          <Text style={styles.wordmark}>OGA</Text>
-          <Text style={styles.kicker}>OPEN GOLF APP</Text>
+          <Pressable onPress={handleSkip} style={styles.skipHit}>
+            <Animated.Text style={[styles.wordmark, logoStyle]}>
+              OGA
+            </Animated.Text>
+            <Animated.Text style={[styles.tagline, taglineStyle]}>
+              Track every shot.
+            </Animated.Text>
+            <Animated.Text style={[styles.support, supportStyle]}>
+              Free and open source · Ko-fi support appreciated
+            </Animated.Text>
+          </Pressable>
         </Animated.View>
       )}
     </GestureHandlerRootView>
@@ -99,9 +152,13 @@ function RootLayoutContent() {
 const styles = StyleSheet.create({
   overlay: {
     backgroundColor: '#1C211C',
+    zIndex: 9999,
+  },
+  skipHit: {
+    flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
-    zIndex: 9999,
+    paddingHorizontal: 32,
   },
   wordmark: {
     color: '#FBF8F1',
@@ -111,10 +168,18 @@ const styles = StyleSheet.create({
     letterSpacing: -2,
     lineHeight: 100,
   },
-  kicker: {
+  tagline: {
+    color: 'rgba(242,238,229,0.85)',
+    fontFamily: 'Fraunces-MediumItalic',
+    fontSize: 18,
+    fontStyle: 'italic',
+    marginTop: 18,
+  },
+  support: {
     color: 'rgba(242,238,229,0.45)',
     fontSize: 11,
-    letterSpacing: 4,
-    marginTop: 14,
+    letterSpacing: 1,
+    marginTop: 28,
+    textAlign: 'center',
   },
 })

--- a/apps/mobile/components/home/SGTrendChart.tsx
+++ b/apps/mobile/components/home/SGTrendChart.tsx
@@ -14,6 +14,13 @@ interface SGTrendChartProps {
   data: { x: number; y: number }[]
 }
 
+const HEIGHT = 200
+const BOTTOM = 28
+// Pin x-axis to chart bottom regardless of where y=0 falls.
+// Victory's independent axis defaults to crossing y=0 in domain space —
+// with negative SG values the line drifts into the middle of the plot.
+const X_AXIS_Y = HEIGHT - BOTTOM
+
 export function SGTrendChart({ data }: SGTrendChartProps) {
   const { width: screenWidth } = useWindowDimensions()
   return (
@@ -29,11 +36,12 @@ export function SGTrendChart({ data }: SGTrendChartProps) {
         <Text style={KICKER}>SG total trend</Text>
       </View>
       <VictoryChart
-        height={200}
+        height={HEIGHT}
         width={screenWidth - 36}
-        padding={{ top: 12, right: 16, bottom: 28, left: 32 }}
+        padding={{ top: 12, right: 16, bottom: BOTTOM, left: 32 }}
       >
         <VictoryAxis
+          offsetY={X_AXIS_Y}
           style={{
             axis: { stroke: '#D9D2BF' },
             tickLabels: {

--- a/apps/mobile/components/round/GreenDiagram.tsx
+++ b/apps/mobile/components/round/GreenDiagram.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { Text, View } from 'react-native'
 import Svg, { Circle, Ellipse, Line, Path } from 'react-native-svg'
 import {
@@ -66,6 +66,15 @@ export function GreenDiagram({
   const startOffset = useSharedValue(aimOffsetInches)
   const layoutWidth = useSharedValue(SVG_WIDTH)
 
+  // Mirror the committed prop into the shared value so the handle stays
+  // at its committed position after the gesture ends — useAnimatedProps
+  // reads `startOffset.value`, not the React prop, so without this sync
+  // the handle visually snapped back to its pre-drag position the moment
+  // `offsetX.value` reset to 0 in onEnd.
+  useEffect(() => {
+    startOffset.value = aimOffsetInches
+  }, [aimOffsetInches, startOffset])
+
   const pinY = breakDirection === 'uphill' ? 56 : breakDirection === 'downhill' ? 80 : 68
   const ballX = 150
   const ballY = 200
@@ -123,8 +132,14 @@ export function GreenDiagram({
         HANDLE_MAX_X,
       )
       const next = Math.round((targetCx - CENTER_X) / PX_PER_INCH)
-      runOnJS(commitOffset)(next)
+      // Bake the committed offset into the shared value before zeroing
+      // the live delta so the handle holds at its release position. The
+      // useEffect that syncs from the prop will land at the same value
+      // after React re-renders, but it runs a frame later — without this
+      // line the handle briefly snaps back to its pre-drag position.
+      startOffset.value = next
       offsetX.value = 0
+      runOnJS(commitOffset)(next)
     })
 
   // Worklet helpers — kept inline so each useAnimatedProps re-creates them

--- a/apps/mobile/components/round/GreenDiagram.tsx
+++ b/apps/mobile/components/round/GreenDiagram.tsx
@@ -65,6 +65,13 @@ export function GreenDiagram({
   const offsetX = useSharedValue(0)
   const startOffset = useSharedValue(aimOffsetInches)
   const layoutWidth = useSharedValue(SVG_WIDTH)
+  // Tracks whether a Pan is currently active so the prop-mirror effect
+  // below doesn't clobber `startOffset.value` mid-drag. Without this,
+  // a parent re-render during an active gesture (e.g. ShotLogger
+  // refreshing) would write the stale committed value back into the
+  // shared value while `offsetX.value` is non-zero, snapping the
+  // handle to a wrong position in the middle of a drag.
+  const isGestureActive = useSharedValue(false)
 
   // Mirror the committed prop into the shared value so the handle stays
   // at its committed position after the gesture ends — useAnimatedProps
@@ -72,8 +79,9 @@ export function GreenDiagram({
   // the handle visually snapped back to its pre-drag position the moment
   // `offsetX.value` reset to 0 in onEnd.
   useEffect(() => {
+    if (isGestureActive.value) return
     startOffset.value = aimOffsetInches
-  }, [aimOffsetInches, startOffset])
+  }, [aimOffsetInches, startOffset, isGestureActive])
 
   const pinY = breakDirection === 'uphill' ? 56 : breakDirection === 'downhill' ? 80 : 68
   const ballX = 150
@@ -115,6 +123,7 @@ export function GreenDiagram({
     .failOffsetY([-5, 5])
     .onBegin(() => {
       'worklet'
+      isGestureActive.value = true
       startOffset.value = aimOffsetInches
       offsetX.value = 0
     })
@@ -139,7 +148,15 @@ export function GreenDiagram({
       // line the handle briefly snaps back to its pre-drag position.
       startOffset.value = next
       offsetX.value = 0
+      isGestureActive.value = false
       runOnJS(commitOffset)(next)
+    })
+    .onFinalize(() => {
+      'worklet'
+      // Covers gesture cancellation (touch leaves the screen, parent
+      // takes over) — without this `isGestureActive` could stick true
+      // and the prop-mirror effect would never re-arm.
+      isGestureActive.value = false
     })
 
   // Worklet helpers — kept inline so each useAnimatedProps re-creates them

--- a/apps/mobile/components/round/Scorecard.tsx
+++ b/apps/mobile/components/round/Scorecard.tsx
@@ -139,13 +139,24 @@ export function ScorecardModal({
           </View>
           {sorted.map((h) => {
             const hs = scoresByHoleId.get(h.id)
-            const score = hs?.score ?? null
+            // Treat 0 the same as null — `hole_scores` rows can be
+            // pre-created with score=0 before any shots are logged, and
+            // counting those as played pulls the running total deeply
+            // under par for unplayed holes (the live round looked like
+            // -71 after hole 1).
+            const rawScore = hs?.score
+            const score = rawScore != null && rawScore > 0 ? rawScore : null
             if (score != null) {
               runningTotal += score
               runningPar += h.par
             }
             const diff = score != null ? score - h.par : null
             const active = h.number === currentHoleNumber
+            // Editable par only for holes that came back without any
+            // layout data — for OSM-mapped holes par is authoritative
+            // and should be display-only.
+            const isSynthetic = !h.yards && h.tee_lat == null
+            const parEditable = !!onChangePar && isSynthetic
             return (
               <Pressable
                 key={h.id}
@@ -173,13 +184,13 @@ export function ScorecardModal({
                 >
                   {h.number}
                 </Text>
-                {onChangePar ? (
+                {parEditable ? (
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel={`Par ${h.par}, tap to change`}
                     onPress={() => {
                       const next = h.par === 3 ? 4 : h.par === 4 ? 5 : 3
-                      onChangePar(h.id, next)
+                      onChangePar!(h.id, next)
                     }}
                     hitSlop={6}
                     style={{

--- a/apps/mobile/components/round/markers/FlagMarker.tsx
+++ b/apps/mobile/components/round/markers/FlagMarker.tsx
@@ -1,55 +1,33 @@
-import { View } from 'react-native'
+import Svg, { Circle, Rect } from 'react-native-svg'
 
-// Simple flag glyph: vertical pole with a rectangular cloth at the top
-// and a small base disk. PointAnnotation measures children via normal
-// flex layout — an absolutely-positioned version sometimes rendered as
-// a zero-size annotation on Android, leaving no visible flag at all.
-// This explicit-size column always has positive bounds.
+// Flag glyph rendered as SVG so PointAnnotation has a single
+// fixed-size native child to position. Earlier nested-flex versions
+// collapsed to a small white blip on Android — Mapbox's annotation
+// container measures only the outer view's bounds and the inner
+// row sometimes resolved to zero width before the first frame.
+//
+// Layout: 28x38 viewbox.
+//   Pole top (cream rect)  : x=3,  y=0,   w=3,  h=12
+//   Cloth (red rect)        : x=6,  y=0,   w=15, h=11
+//   Pole bottom             : x=3,  y=12,  w=3,  h=22
+//   Base disk (cream pill)  : x=0,  y=34,  w=9,  h=3
 export function FlagMarker({ tone }: { tone: 'dim' | 'strong' }) {
   const flagColor = tone === 'strong' ? '#A33A2A' : 'rgba(163,58,42,0.85)'
   const poleColor = '#FBF8F1'
   return (
-    <View
-      style={{
-        width: 28,
-        height: 38,
-        alignItems: 'flex-start',
-        justifyContent: 'flex-start',
-      }}
-    >
-      <View style={{ flexDirection: 'row', alignItems: 'flex-start' }}>
-        <View
-          style={{
-            width: 3,
-            height: 12,
-            backgroundColor: poleColor,
-          }}
-        />
-        <View
-          style={{
-            width: 15,
-            height: 11,
-            backgroundColor: flagColor,
-            borderTopRightRadius: 1,
-          }}
-        />
-      </View>
-      <View
-        style={{
-          width: 3,
-          height: 22,
-          backgroundColor: poleColor,
-        }}
+    <Svg width={28} height={38} viewBox="0 0 28 38">
+      <Rect x={3} y={0} width={3} height={34} fill={poleColor} />
+      <Rect
+        x={6}
+        y={0}
+        width={15}
+        height={11}
+        fill={flagColor}
+        rx={1}
+        ry={1}
       />
-      <View
-        style={{
-          width: 9,
-          height: 3,
-          marginLeft: -3,
-          borderRadius: 1.5,
-          backgroundColor: poleColor,
-        }}
-      />
-    </View>
+      <Rect x={0} y={34} width={9} height={3} rx={1.5} ry={1.5} fill={poleColor} />
+      <Circle cx={4.5} cy={35.5} r={1.5} fill={poleColor} />
+    </Svg>
   )
 }

--- a/apps/mobile/components/round/markers/FlagMarker.tsx
+++ b/apps/mobile/components/round/markers/FlagMarker.tsx
@@ -1,33 +1,44 @@
-import Svg, { Circle, Rect } from 'react-native-svg'
+import { View } from 'react-native'
+import Svg, { Rect } from 'react-native-svg'
 
-// Flag glyph rendered as SVG so PointAnnotation has a single
-// fixed-size native child to position. Earlier nested-flex versions
-// collapsed to a small white blip on Android — Mapbox's annotation
-// container measures only the outer view's bounds and the inner
-// row sometimes resolved to zero width before the first frame.
+// Flag glyph wrapped in an explicit-size View so PointAnnotation has
+// a plain native child to measure on Android. Earlier nested-flex
+// versions collapsed to a white blip; an unwrapped <Svg> child can
+// also measure as zero on older Android API levels because Mapbox's
+// annotation calls measure() before the SVG native view reports its
+// size. The 28x38 View is the load-bearing piece — the SVG is just
+// the glyph painted inside it.
 //
-// Layout: 28x38 viewbox.
-//   Pole top (cream rect)  : x=3,  y=0,   w=3,  h=12
-//   Cloth (red rect)        : x=6,  y=0,   w=15, h=11
-//   Pole bottom             : x=3,  y=12,  w=3,  h=22
-//   Base disk (cream pill)  : x=0,  y=34,  w=9,  h=3
+// Layout (28x38 viewbox):
+//   Pole (cream rect)       : x=3,  y=0,  w=3,  h=34
+//   Cloth (red rect)        : x=6,  y=0,  w=15, h=11
+//   Base disk (cream pill)  : x=0,  y=34, w=9,  h=3
 export function FlagMarker({ tone }: { tone: 'dim' | 'strong' }) {
   const flagColor = tone === 'strong' ? '#A33A2A' : 'rgba(163,58,42,0.85)'
   const poleColor = '#FBF8F1'
   return (
-    <Svg width={28} height={38} viewBox="0 0 28 38">
-      <Rect x={3} y={0} width={3} height={34} fill={poleColor} />
-      <Rect
-        x={6}
-        y={0}
-        width={15}
-        height={11}
-        fill={flagColor}
-        rx={1}
-        ry={1}
-      />
-      <Rect x={0} y={34} width={9} height={3} rx={1.5} ry={1.5} fill={poleColor} />
-      <Circle cx={4.5} cy={35.5} r={1.5} fill={poleColor} />
-    </Svg>
+    <View style={{ width: 28, height: 38 }}>
+      <Svg width={28} height={38} viewBox="0 0 28 38">
+        <Rect x={3} y={0} width={3} height={34} fill={poleColor} />
+        <Rect
+          x={6}
+          y={0}
+          width={15}
+          height={11}
+          fill={flagColor}
+          rx={1}
+          ry={1}
+        />
+        <Rect
+          x={0}
+          y={34}
+          width={9}
+          height={3}
+          rx={1.5}
+          ry={1.5}
+          fill={poleColor}
+        />
+      </Svg>
+    </View>
   )
 }

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -53,6 +53,12 @@ interface ShotEntryModalProps {
    *  null). Drives the mini-map's distance_to_target recalc on drag. */
   pinLat: number | null
   pinLng: number | null
+  /** True when the modal opens from the live-entry map view. The
+   *  per-shot mini-map stays hidden in that case — Mapbox occasionally
+   *  errors when a fresh map instance mounts inside an animating sheet
+   *  while the parent map view is also visible, and the live-entry
+   *  flow already has the round map behind the modal. */
+  liveEntry?: boolean
   onClose: () => void
 }
 
@@ -63,6 +69,7 @@ export function ShotEntryModal({
   holePar,
   pinLat,
   pinLng,
+  liveEntry = false,
   onClose,
 }: ShotEntryModalProps) {
   const { user } = useAuth()
@@ -391,11 +398,13 @@ export function ShotEntryModal({
             </div>
 
             <div className="flex flex-col" style={{ gap: 18 }}>
-              <ShotMiniMapPanel
-                editingRow={editingRow}
-                editingNext={editingNext}
-                onChangeStart={handleMiniMapDrag}
-              />
+              {!liveEntry && (
+                <ShotMiniMapPanel
+                  editingRow={editingRow}
+                  editingNext={editingNext}
+                  onChangeStart={handleMiniMapDrag}
+                />
+              )}
 
               {isPutt && (
                 <GreenDiagram

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -457,6 +457,7 @@ export function RoundDetailPage() {
             holePar={shotsModalFor.holePar}
             pinLat={pinLat}
             pinLng={pinLng}
+            liveEntry={view === 'map'}
             onClose={() => setShotsModalFor(null)}
           />
         )

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -65,6 +65,13 @@ export function RoundDetailPage() {
   const [view, setView] = useState<ViewMode>(() =>
     searchParams.get('view') === 'map' ? 'map' : 'scorecard',
   )
+  // Capture "session started in live mode" at mount. `view` is a
+  // runtime ViewTabs toggle — past-round reviewers can switch to the
+  // map tab and we don't want that to suppress the shot mini-map for
+  // them. The mini-map suppression is for genuine live entry only.
+  const [startedLive] = useState(
+    () => searchParams.get('view') === 'map',
+  )
   const [holeView, dispatchHoleView] = useReducer(holeViewReducer, HOLE_VIEW_INITIAL)
   const {
     activeHoleNumber,
@@ -457,7 +464,7 @@ export function RoundDetailPage() {
             holePar={shotsModalFor.holePar}
             pinLat={pinLat}
             pinLng={pinLng}
-            liveEntry={view === 'map'}
+            liveEntry={startedLive}
             onClose={() => setShotsModalFor(null)}
           />
         )


### PR DESCRIPTION
## Summary

Round of fixes from Android device testing. One commit per fix group.

### Charts (Home + Stats)
- Pin SG trend x-axis to chart bottom — Victory's independent axis defaulted to crossing y=0, drifting into the middle of the plot when SG dipped negative.
- Align by-the-numbers SG averages with the chart lines — chart was coercing null SG to 0, averages filtered nulls. Same set of rounds in both now.

### Patterns
- Add legend mapping dot colors to shot result groups (solid / push-pull / miss / unspecified).
- Label the 68% / 95% dispersion ellipses.

### Maps
- Render the pin flag as a single 28x38 SVG inside the PointAnnotation. The nested-flex version collapsed to a white pole-only blip on Android because PointAnnotation only measures the outer view's bounds.
- Web: hide the per-shot mini-map when ShotEntryModal opens from the live-entry map view (Mapbox occasionally errored when a fresh map mounted inside the animating sheet).

### Putting flow
- Green diagram aim handle holds at its release position — the shared value backing useAnimatedProps stayed at the pre-drag snapshot after onEnd zeroed offsetX.
- "Yes, I'm putting" now jumps straight into the dedicated PuttingSheet (roundState=PUTTING) instead of routing through the generic ShotLogger.

### Scorecard
- Editable par only on synthetic holes (no yards / no tee coords). OSM-mapped holes stay display-only.
- Treat score<=0 the same as null in totals and rendering — pre-created hole_scores rows with score=0 were dragging running totals deep under par.

### Polish
- Staged splash overlay (logo → tagline → support note) over ~3.5s, with tap-to-skip. Still gated on fonts + auth before unmounting.
- Practice tab "Yardage book" card renamed to "Learn"; Learn screens use "Library" as the eyebrow.
- Past round summary scorecard rows are now Pressable — tap a hole to open the hole detail in mode=past.

## Test plan
- [ ] `pnpm typecheck` — green
- [ ] `pnpm test` — 294 passed
- [ ] `pnpm --filter web build` — green
- [ ] `cd apps/mobile && npm run typecheck` — green
- [ ] Verify chart x-axis sits at the bottom even with negative SG values
- [ ] Verify SG card averages and chart lines reference the same rounds
- [ ] Verify pin flag visible on physical Android device
- [ ] Verify aim handle stays put after a drag in PuttingSheet
- [ ] Verify "Yes I'm putting" goes straight to the PuttingSheet
- [ ] Verify unplayed holes show — in scorecard and not 0 in running totals
- [ ] Verify splash plays through staged fades; tap dismisses early
- [ ] Verify past round hole rows navigate to hole detail