### PR TITLE
fix(mobile): map rendering, GPS resume, tab suppression, CAPTCHA crash, bug fixes

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,9 @@
+{
+  "expo": {
+    "extra": {
+      "eas": {
+        "projectId": "f852bb53-02fc-46a1-b509-4b2170cb6d84"
+      }
+    }
+  }
+}

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -218,6 +218,8 @@ export default function AppLayout() {
       <Tabs.Screen name="round/new" options={{ href: null }} />
       <Tabs.Screen name="round/[id]/index" options={{ href: null }} />
       <Tabs.Screen name="round/[id]/hole/[number]" options={{ href: null }} />
+      <Tabs.Screen name="round/[id]/hole/components/HoleStrip" options={{ href: null }} />
+      <Tabs.Screen name="round/[id]/hole/components/HoleModals" options={{ href: null }} />
     </Tabs>
     </UnitsProvider>
     </ErrorBoundary>

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -163,7 +163,7 @@ export default function Home() {
           {firstName ? `Good round, ${firstName}.` : 'Good round.'}
         </Text>
         <Text style={{ color: '#5C6356', fontSize: 14, marginBottom: 22 }}>
-          Last {trend.length} round{trend.length === 1 ? '' : 's'}
+          Last {rounds.length} round{rounds.length === 1 ? '' : 's'}
         </Text>
 
         {rounds.length > 0 && (

--- a/apps/mobile/app/(app)/round/[id]/hole/hooks/useHoleState.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/hooks/useHoleState.ts
@@ -58,6 +58,7 @@ export function useHoleState({
   const lastSavedShotLocalIdRef = useRef<number | null>(null)
   const [roundState, setRoundState] = useState<RoundState>('PLACE_BALL')
   const [gpsPosition, setGpsPosition] = useState<LatLng | null>(null)
+  const [gpsNonce, setGpsNonce] = useState(0)
   // First-use hint that "aim point = start line, drag to adjust." Gated
   // by AsyncStorage so it only appears the first time the player ever
   // sets an aim point on this device, then auto-dismisses after 3s.
@@ -160,7 +161,7 @@ export function useHoleState({
       kalmanStateRef.current = null
       manuallyPlacedRef.current = false
     }
-  }, [currentHoleId, isPastMode, roundState])
+  }, [currentHoleId, isPastMode, roundState, gpsNonce])
 
   // Hole change resets the filter — covered by the watch effect's
   // cleanup, but explicit here in case the watch effect short-circuits
@@ -178,6 +179,8 @@ export function useHoleState({
       if (state === 'background' || state === 'inactive') {
         gpsSubscriptionRef.current?.remove()
         gpsSubscriptionRef.current = null
+      } else if (state === 'active') {
+        setGpsNonce((n) => n + 1)
       }
     })
     return () => sub.remove()

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -99,9 +99,13 @@ export default function Login() {
             source={{ uri: `https://oga.golf/captcha.html?siteKey=${TURNSTILE_SITE_KEY}` }}
             originWhitelist={['https://*', 'http://*']}
             onMessage={(event) => {
-              const msg = JSON.parse(event.nativeEvent.data)
-              if (msg.type === 'success') setCaptchaToken(msg.token)
-              else setCaptchaToken(null)
+              try {
+                const msg = JSON.parse(event.nativeEvent.data)
+                if (msg.type === 'success') setCaptchaToken(msg.token)
+                else setCaptchaToken(null)
+              } catch {
+                // ignore non-JSON WebView messages
+              }
             }}
             style={{ height: 65, marginBottom: 14 }}
             scrollEnabled={false}

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -108,9 +108,13 @@ export default function Signup() {
             source={{ uri: `https://oga.golf/captcha.html?siteKey=${TURNSTILE_SITE_KEY}` }}
             originWhitelist={['https://*', 'http://*']}
             onMessage={(event) => {
-              const msg = JSON.parse(event.nativeEvent.data)
-              if (msg.type === 'success') setCaptchaToken(msg.token)
-              else setCaptchaToken(null)
+              try {
+                const msg = JSON.parse(event.nativeEvent.data)
+                if (msg.type === 'success') setCaptchaToken(msg.token)
+                else setCaptchaToken(null)
+              } catch {
+                // ignore non-JSON WebView messages
+              }
             }}
             style={{ height: 65, marginBottom: 14 }}
             scrollEnabled={false}

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -98,7 +98,7 @@ export function HoleMap({
   const isAimPhase = phase === 'SET_AIM'
   const isPlaceBallPhase = phase === 'PLACE_BALL'
 
-  const cameraRef = useHoleCamera({ center, ball, pin, roundPin, phase })
+  const cameraRef = useHoleCamera({ center, ball, pin, roundPin, phase, styleLoaded })
 
   const previousShotsLen = previousShots?.length ?? 0
   const { aimGhosts, aimGhostFeatures } = useAimGhosts({

--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -82,6 +82,7 @@ export function PastHoleShotsSheet({
   }
 
   return (
+    <>
     <Modal
       visible={visible}
       transparent

--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -162,17 +162,29 @@ export function PastHoleShotsSheet({
         </View>
       </View>
 
-      {editingShot && (
-        <EditShotSheet
-          shot={editingShot}
-          clubs={clubs}
-          unit={unit}
-          saving={saving}
-          onSave={(updates) => handleSave(editingShot.id, updates)}
-          onClose={() => setEditingShot(null)}
-        />
-      )}
     </Modal>
+
+    <Modal
+      visible={visible && editingShot !== null}
+      transparent
+      animationType="slide"
+      onRequestClose={() => setEditingShot(null)}
+    >
+      <View style={{ flex: 1 }}>
+        <Pressable style={{ flex: 1 }} onPress={() => setEditingShot(null)} />
+        {editingShot && (
+          <EditShotSheet
+            shot={editingShot}
+            clubs={clubs}
+            unit={unit}
+            saving={saving}
+            onSave={(updates) => handleSave(editingShot.id, updates)}
+            onClose={() => setEditingShot(null)}
+          />
+        )}
+      </View>
+    </Modal>
+    </>
   )
 }
 
@@ -240,10 +252,6 @@ function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetPr
   return (
     <View
       style={{
-        position: 'absolute',
-        bottom: 0,
-        left: 0,
-        right: 0,
         backgroundColor: '#FBF8F1',
         borderTopLeftRadius: 12,
         borderTopRightRadius: 12,

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -13,6 +13,7 @@ interface UseHoleCameraOpts {
   pin?: LatLng | null
   roundPin?: LatLng | null
   phase: HoleMapPhase
+  styleLoaded: boolean
 }
 
 // Owns every camera positioning side-effect for HoleMap. The hook
@@ -24,6 +25,7 @@ export function useHoleCamera({
   pin,
   roundPin,
   phase,
+  styleLoaded,
 }: UseHoleCameraOpts) {
   const cameraRef = useRef<Mapbox.Camera>(null)
   const cameraInitialized = useRef(false)
@@ -40,6 +42,7 @@ export function useHoleCamera({
   // on the device because it framed grass at an angle before the player
   // had even decided what they were aiming at.
   useEffect(() => {
+    if (!styleLoaded) return
     if (cameraInitialized.current) return
     if (!cameraRef.current) return
     cameraRef.current.setCamera({
@@ -49,7 +52,7 @@ export function useHoleCamera({
       animationDuration: 400,
     })
     cameraInitialized.current = true
-  }, [center.lat, center.lng])
+  }, [styleLoaded, center.lat, center.lng])
 
   // When entering pin mode, zoom in on the stored pin so the user is
   // looking at the green.


### PR DESCRIPTION
## Summary

- **Map split rendering**: gate `useHoleCamera` init `setCamera` behind `styleLoaded` — on Hermes/production builds JS effects run before the Mapbox satellite style initializes, causing `defaultSettings` and `setCamera` to race and produce a blurry split-screen
- **GPS dead after background**: add `gpsNonce`; `AppState` `active` event increments it to re-trigger the GPS `useEffect` — subscription was removed on background and never re-created on foreground
- **EditShotSheet touch bleed**: move `EditShotSheet` into its own `<Modal>` for a separate native window layer; previously taps on the edit sheet fired `onClose` on the outer modal
- **Dead tab bar links**: suppress `HoleStrip` and `HoleModals` component routes with `href: null` in `_layout.tsx`
- **Turnstile crash**: wrap `onMessage` `JSON.parse` in try/catch on login and signup; non-JSON strings from the WebView crashed the JS thread
- **Home subtitle count**: `trend.length` → `rounds.length`
- **EAS config**: add `app.json` with EAS project ID

## Test plan

- [ ] Open a live round on a preview build — map loads sharp, no split
- [ ] Background mid-hole, return to foreground — ball marker resumes GPS
- [ ] Tap a shot row in past hole sheet, edit it — no tap-through to parent modal
- [ ] No dead "roun…" tabs in tab bar
- [ ] Login/signup with Turnstile — no crash on captcha load
- [ ] Home subtitle shows correct round count