### PR TITLE
fix(eas): remove root app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,9 +1,0 @@
-{
-  "expo": {
-    "extra": {
-      "eas": {
-        "projectId": "f852bb53-02fc-46a1-b509-4b2170cb6d84"
-      }
-    }
-  }
-}


### PR DESCRIPTION
Root app.json committed in #255 confused EAS into treating the monorepo root as the Expo project, causing it to run pnpm install --frozen-lockfile from root instead of apps/mobile/. Full Expo config already lives in apps/mobile/app.json.