### PR TITLE
fix(eas): remove root app.json breaking EAS builds

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,9 +1,0 @@
-{
-  "expo": {
-    "extra": {
-      "eas": {
-        "projectId": "f852bb53-02fc-46a1-b509-4b2170cb6d84"
-      }
-    }
-  }
-}


### PR DESCRIPTION
## Summary

- Removes `app.json` that was accidentally committed to the monorepo root in #255. EAS was treating the root as the Expo project directory and running `pnpm install --frozen-lockfile` from there instead of `apps/mobile/`. Full Expo config already lives in `apps/mobile/app.json`.

## Test plan

- [ ] EAS build completes without `ERR_PNPM_NO_LOCKFILE`