### PR TITLE
fix(mobile): suppress phantom tabs from .ts hook/state files

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -220,6 +220,10 @@ export default function AppLayout() {
       <Tabs.Screen name="round/[id]/hole/[number]" options={{ href: null }} />
       <Tabs.Screen name="round/[id]/hole/components/HoleStrip" options={{ href: null }} />
       <Tabs.Screen name="round/[id]/hole/components/HoleModals" options={{ href: null }} />
+      <Tabs.Screen name="round/[id]/hole/hooks/useHoleData" options={{ href: null }} />
+      <Tabs.Screen name="round/[id]/hole/hooks/useHoleState" options={{ href: null }} />
+      <Tabs.Screen name="round/[id]/hole/hooks/useShotActions" options={{ href: null }} />
+      <Tabs.Screen name="round/[id]/hole/state/types" options={{ href: null }} />
     </Tabs>
     </UnitsProvider>
     </ErrorBoundary>


### PR DESCRIPTION
## Summary

- Expo Router (SDK 51) treats `.ts` files as routes, same as `.tsx`
- Four helper files in `round/[id]/hole/hooks/` and `hole/state/` were generating dead tabs in the tab bar
- Added `href: null` suppressions for all four routes in `(app)/_layout.tsx`

## Routes suppressed

- `round/[id]/hole/hooks/useHoleData`
- `round/[id]/hole/hooks/useHoleState`
- `round/[id]/hole/hooks/useShotActions`
- `round/[id]/hole/state/types`

## Test plan

- [ ] Confirm tab bar shows exactly 5 tabs: Home, Stats, Patterns, Practice, Profile
- [ ] Navigate to a round hole screen — no phantom tabs appear