### PR TITLE
fix(csp): widen connect-src to *.mapbox.com for satellite tile fetches

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://api.mapbox.com https://events.mapbox.com https://vercel.live https://*.vercel.live; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.mapbox.com; font-src 'self' https://fonts.gstatic.com https://*.vercel.live; img-src 'self' data: blob: https://*.mapbox.com https://*.supabase.co https://*.pusher.com https://*.vercel.live; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://api.mapbox.com https://events.mapbox.com https://api.opengolfapi.org https://vercel.live https://*.vercel.live wss://*.pusher.com; frame-src 'self' https://vercel.live https://*.vercel.live; worker-src blob:;"
+      content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://api.mapbox.com https://events.mapbox.com https://vercel.live https://*.vercel.live https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.mapbox.com; font-src 'self' https://fonts.gstatic.com https://*.vercel.live; img-src 'self' data: blob: https://*.mapbox.com https://*.supabase.co https://*.pusher.com https://*.vercel.live; connect-src 'self' https://*.supabase.co wss://*.supabase.co https://*.mapbox.com https://api.opengolfapi.org https://vercel.live https://*.vercel.live wss://*.pusher.com; frame-src 'self' https://vercel.live https://*.vercel.live https://challenges.cloudflare.com; worker-src blob:;"
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary

- Mapbox GL v3 fetches raster satellite tiles via `fetch()` from various `*.mapbox.com` subdomains, not just `api.mapbox.com`
- The narrow `connect-src` was blocking those tile requests — markers and lines rendered but no satellite imagery loaded
- Fixed by replacing `https://api.mapbox.com https://events.mapbox.com` with `https://*.mapbox.com` in `connect-src`
- Also preserves the Cloudflare Turnstile entries (`challenges.cloudflare.com` in `script-src` and `frame-src`) that main had but dev was missing

## Test plan

- [ ] Deploy and visit landing page — satellite tiles should render in the phone mockup
- [ ] Verify Turnstile (CAPTCHA) still works on signup
- [ ] Check browser console for any remaining CSP violations