### PR TITLE
feat: --course-filter flag for multi-course OSM import

### DIFF
--- a/scripts/import-osm-course.ts
+++ b/scripts/import-osm-course.ts
@@ -45,6 +45,7 @@ interface Args {
   lng: number
   radius: number
   updateExisting: boolean
+  courseFilter: string | undefined
 }
 
 function parseArgs(argv: string[]): Args {
@@ -53,6 +54,7 @@ function parseArgs(argv: string[]): Args {
   let lng: number | undefined
   let radius: number | undefined
   let updateExisting = false
+  let courseFilter: string | undefined
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     const next = argv[i + 1]
@@ -70,17 +72,20 @@ function parseArgs(argv: string[]): Args {
       i++
     } else if (a === '--update-existing') {
       updateExisting = true
+    } else if (a === '--course-filter' && next != null) {
+      courseFilter = next
+      i++
     }
   }
   if (!name || lat == null || lng == null || radius == null) {
     throw new Error(
-      'Usage: tsx scripts/import-osm-course.ts --name "<Course Name>" --lat <lat> --lng <lng> --radius <meters> [--update-existing]',
+      'Usage: tsx scripts/import-osm-course.ts --name "<Course Name>" --lat <lat> --lng <lng> --radius <meters> [--update-existing] [--course-filter <substring>]',
     )
   }
   if (!Number.isFinite(lat) || !Number.isFinite(lng) || !Number.isFinite(radius)) {
     throw new Error('--lat, --lng, --radius must be numeric')
   }
-  return { name, lat, lng, radius, updateExisting }
+  return { name, lat, lng, radius, updateExisting, courseFilter }
 }
 
 // ---------------------------------------------------------------------------
@@ -201,7 +206,7 @@ interface ParsedHole {
   pathYards: number
 }
 
-function parseElements(resp: OverpassResponse): {
+function parseElements(resp: OverpassResponse, courseFilter?: string): {
   holes: ParsedHole[]
   greens: LatLon[]
   tees: LatLon[]
@@ -232,6 +237,7 @@ function parseElements(resp: OverpassResponse): {
     if (points.length === 0) continue
 
     if (golf === 'hole') {
+      if (courseFilter && !tags.name?.toLowerCase().includes(courseFilter.toLowerCase())) continue
       const refRaw = tags.ref ?? tags.name ?? ''
       const ref = parseInt(refRaw.replace(/\D/g, ''), 10)
       if (!Number.isFinite(ref) || ref < 1 || ref > 18) continue
@@ -442,7 +448,10 @@ async function main() {
     `Querying Overpass for "${args.name}" around ${args.lat},${args.lng} (r=${args.radius}m)…`,
   )
   const resp = await fetchOverpass(args)
-  const parsed = parseElements(resp)
+  if (args.courseFilter) {
+    console.log(`  Course filter: hole ways whose name contains "${args.courseFilter}" (case-insensitive)`)
+  }
+  const parsed = parseElements(resp, args.courseFilter)
   console.log(
     `OSM: ${parsed.holes.length} hole ways, ${parsed.greens.length} green polygons, ${parsed.tees.length} tee polygons`,
   )


### PR DESCRIPTION
## Summary

- Adds `--course-filter <substring>` flag to `scripts/import-osm-course.ts`
- Filters hole ways by their OSM `name` tag (case-insensitive) **before** deduplication
- Fixes multi-course facilities like Earlywine where North and South both have holes 1–18 — without this flag, dedup kept whichever set was closest to the query center and discarded the other

## Usage

```bash
npx tsx scripts/import-osm-course.ts \
  --name "North At Earlywine Golf Course" \
  --lat 35.3558 \
  --lng -97.5764 \
  --radius 2000 \
  --update-existing \
  --course-filter "north"
```

## Test plan

- [ ] Run without `--course-filter` on a single-course venue — behavior identical to before
- [ ] Run with `--course-filter "north"` on Earlywine — imports 18 North holes, dedup log shows 0 duplicates
- [ ] Run with `--course-filter "south"` on Earlywine — imports 18 South holes independently
- [ ] Run with a filter that matches nothing — script exits with "No hole ways found" error