### PR TITLE
fix(mobile): render Mapbox LocationPuck on live round map

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -252,6 +252,12 @@ export function HoleMap({
             }}
           />
 
+          <Mapbox.LocationPuck
+            visible
+            puckBearingEnabled
+            puckBearing="heading"
+          />
+
           <BreadcrumbLayers
             previousShots={previousShots ?? []}
             previousShotsLine={previousShotsLine}


### PR DESCRIPTION
## Summary
- Adds `<Mapbox.LocationPuck visible puckBearingEnabled puckBearing="heading" />` as a child of the `HoleMap` MapView. Six-line addition, no logic, no state, no prop changes.
- Player now has a blue dot showing where the OS thinks they are, independent of the ball marker.

## Why this matters
The only "where am I" signal on the live round map was the ball marker. Once the player taps to manually place the ball, `manuallyPlacedRef` in `useHoleState` freezes GPS updates for the rest of the PLACE_BALL cycle. Without a puck, there was no honest readout of OS-reported position — making field bugs ("GPS removed", #264 crashes) impossible to diagnose.

## Scope
This is intentionally the **smallest** of a series of small PRs for the Saturday live-test bugs. Two more chunks follow:
- Chunk B: stop SET_AIM / PIN camera snap-back (so pinch-zoom sticks).
- Chunk C: "center on me" floating button + course-gated auto-center.

Architectural memory-leak fix (#264 root cause: one MapView per hole route) is a separate larger ticket.

## Test plan
- [ ] Preview build on Android, start a live round at a real course
- [ ] Verify blue puck appears at GPS location once permission is granted
- [ ] Verify puck rotates with device heading
- [ ] Verify ball-marker placement still works unchanged
- [ ] Verify nothing renders differently when location permission is denied