### PR TITLE
fix(mobile): stop SET_AIM and PIN camera snap-back

### DIFF
--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -55,9 +55,15 @@ export function useHoleCamera({
   }, [styleLoaded, center.lat, center.lng])
 
   // When entering pin mode, zoom in on the stored pin so the user is
-  // looking at the green.
+  // looking at the green. Fires ONCE per PIN session — re-snapping on
+  // every pin drag wiped out the player's pinch-zoom.
+  const pinSnappedRef = useRef(false)
   useEffect(() => {
-    if (!isPinMode) return
+    if (!isPinMode) {
+      pinSnappedRef.current = false
+      return
+    }
+    if (pinSnappedRef.current) return
     if (!cameraRef.current) return
     const target = roundPin ?? pin ?? null
     if (!target) return
@@ -66,6 +72,7 @@ export function useHoleCamera({
       zoomLevel: 19,
       animationDuration: 400,
     })
+    pinSnappedRef.current = true
   }, [isPinMode, roundPin?.lat, roundPin?.lng, pin?.lat, pin?.lng])
 
   // Mark whether we owe the camera a PLACE_BALL re-frame on the next
@@ -106,8 +113,16 @@ export function useHoleCamera({
   // by ball→pin distance so a wedge frames the green tightly while a
   // par-5 still shows fairway + green. Fixed zoom 15 was too loose for
   // short approaches (≤120 yd compressed the shot into a tiny band).
+  //
+  // Fires ONCE per SET_AIM session — re-snapping on every aim drag or
+  // pin nudge wiped out the player's pinch-zoom.
+  const aimSnappedRef = useRef(false)
   useEffect(() => {
-    if (!isAimPhase) return
+    if (!isAimPhase) {
+      aimSnappedRef.current = false
+      return
+    }
+    if (aimSnappedRef.current) return
     if (!cameraRef.current) return
     if (!ball) return
     const target = roundPin ?? pin ?? null
@@ -135,6 +150,7 @@ export function useHoleCamera({
       heading: bearing,
       animationDuration: 1200,
     })
+    aimSnappedRef.current = true
   }, [
     isAimPhase,
     ball?.lat,


### PR DESCRIPTION
## Summary
- `useHoleCamera`'s SET_AIM (L109-146) and PIN (L59-69) effects called `setCamera` every time `ball`, `roundPin`, or `pin` lat/lng changed. Pinch-to-zoom during those phases was getting yanked back to the programmatic zoom on the next prop tick.
- Added per-phase \"snapped this session\" refs: `pinSnappedRef`, `aimSnappedRef`. Each resets on phase exit, bails if already snapped, and flips true after the one allowed `setCamera` call.

## Why
From Saturday's live-test report — the player couldn't keep a zoomed-in view during SET_AIM. Every aim-marker drag retriggered the bearing/zoom recompute and snapped the camera back. Same hazard for PIN-mode drags.

## Behavior
- Enter SET_AIM with ball + pin known → camera snaps once (bearing, tilt, distance-based zoom). Player can pinch / pan / rotate freely for the rest of the phase.
- Enter SET_AIM with ball known but no pin → snaps once with `focus = ball`, no bearing.
- Enter SET_AIM without a ball → no snap until ball appears, then snap once.
- Leave SET_AIM (save shot, exit to PLACE_BALL/PIN/TEE) → ref resets, next re-entry snaps fresh.
- Same logic for PIN mode at zoom 19.
- PLACE_BALL path is **unchanged** — it already used a one-shot reframe ref.

## Test plan
- [ ] Dev build: enter SET_AIM, pinch in tight on the green, drag the aim marker — camera should stay at user's chosen zoom
- [ ] Dev build: enter PIN mode, pinch in, drag the flag — camera stays at user's chosen zoom
- [ ] Leave SET_AIM, return — camera should re-snap to the framed view (not stuck at the last pinch)
- [ ] PLACE_BALL behavior unchanged (camera follows ball on PLACE_BALL entry, GPS deltas don't snap)