### PR TITLE
feat(mobile): center-on-me button + course-gated GPS auto-center

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -294,6 +294,8 @@ export default function HoleScreen() {
           aim={finalState.aim}
           ball={finalState.ball}
           previousShots={data.previousShots}
+          gpsPosition={finalState.gpsPosition}
+          courseCenter={data.courseCenter}
           missingHoleLayout={data.tee == null && data.storedPin == null && data.roundPin == null}
           phase={
             pinPlacementOpen

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { Text, View } from 'react-native'
+import { Pressable, Text, View } from 'react-native'
 import Mapbox from '@rnmapbox/maps'
+import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import { runOnJS } from 'react-native-reanimated'
 import { distanceYards, ensureMapboxInitialized } from '../../lib/maps'
@@ -51,6 +52,17 @@ interface HoleMapProps {
    * not a bug.
    */
   missingHoleLayout?: boolean
+  /**
+   * Latest smoothed GPS position. Drives the recenter button (which
+   * camera-jumps to it) and the camera hook's auto-center-once
+   * behavior. Null until permission granted and a fix arrives.
+   */
+  gpsPosition?: LatLng | null
+  /**
+   * Course centroid (courses.lat/lng). Used as a proximity gate so
+   * auto-center only fires when the player is actually at the course.
+   */
+  courseCenter?: LatLng | null
   onSetAim: (loc: LatLng) => void
   onSetBall: (loc: LatLng) => void
   onPlacePin?: (loc: LatLng) => void
@@ -80,6 +92,8 @@ export function HoleMap({
   previousShots,
   phase = 'PLACE_BALL',
   missingHoleLayout = false,
+  gpsPosition,
+  courseCenter,
   onSetAim,
   onSetBall,
   onPlacePin,
@@ -98,7 +112,26 @@ export function HoleMap({
   const isAimPhase = phase === 'SET_AIM'
   const isPlaceBallPhase = phase === 'PLACE_BALL'
 
-  const cameraRef = useHoleCamera({ center, ball, pin, roundPin, phase, styleLoaded })
+  const cameraRef = useHoleCamera({
+    center,
+    ball,
+    pin,
+    roundPin,
+    phase,
+    styleLoaded,
+    gpsPosition,
+    courseCenter,
+  })
+
+  const recenterOnGps = useCallback(() => {
+    if (!gpsPosition || !cameraRef.current) return
+    cameraRef.current.setCamera({
+      centerCoordinate: toCoord(gpsPosition),
+      zoomLevel: 17,
+      pitch: 0,
+      animationDuration: 600,
+    })
+  }, [gpsPosition, cameraRef])
 
   const previousShotsLen = previousShots?.length ?? 0
   const { aimGhosts, aimGhostFeatures } = useAimGhosts({
@@ -406,6 +439,35 @@ export function HoleMap({
         {missingHoleLayout && !isPinMode && !isTeeMode && <MissingLayoutBanner />}
         {!isPinMode && pinDistance !== null && (
           <PinDistancePill display={toDisplay(pinDistance)} />
+        )}
+        {isPlaceBallPhase && (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Center map on my location"
+            disabled={!gpsPosition}
+            onPress={recenterOnGps}
+            hitSlop={8}
+            style={{
+              position: 'absolute',
+              right: 12,
+              bottom: 52,
+              width: 44,
+              height: 44,
+              borderRadius: 22,
+              backgroundColor: '#FBF8F1',
+              borderWidth: 1,
+              borderColor: '#1F3D2C',
+              alignItems: 'center',
+              justifyContent: 'center',
+              opacity: gpsPosition ? 1 : 0.5,
+            }}
+          >
+            <MaterialCommunityIcons
+              name="crosshairs-gps"
+              size={22}
+              color="#1F3D2C"
+            />
+          </Pressable>
         )}
       </View>
     </GestureDetector>

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -14,7 +14,24 @@ interface UseHoleCameraOpts {
   roundPin?: LatLng | null
   phase: HoleMapPhase
   styleLoaded: boolean
+  /**
+   * Latest smoothed GPS position from useHoleState. When present AND
+   * the player is within ~1000 m of the course centroid, the camera
+   * auto-centers on it once after the initial hole frame. Testing
+   * from the user's house won't trigger because the gating distance
+   * fails.
+   */
+  gpsPosition?: LatLng | null
+  /**
+   * Course centroid (courses.lat/lng). Required for the auto-center
+   * proximity check; absent → auto-center is skipped.
+   */
+  courseCenter?: LatLng | null
 }
+
+// 1000 m gating threshold for auto-center, expressed as yards because
+// the only haversine helper imported here returns yards. 1000 m / 0.9144.
+const AUTO_CENTER_GATE_YARDS = 1094
 
 // Owns every camera positioning side-effect for HoleMap. The hook
 // returns the camera ref so HoleMap can mount it on the Mapbox.Camera
@@ -26,6 +43,8 @@ export function useHoleCamera({
   roundPin,
   phase,
   styleLoaded,
+  gpsPosition,
+  courseCenter,
 }: UseHoleCameraOpts) {
   const cameraRef = useRef<Mapbox.Camera>(null)
   const cameraInitialized = useRef(false)
@@ -53,6 +72,39 @@ export function useHoleCamera({
     })
     cameraInitialized.current = true
   }, [styleLoaded, center.lat, center.lng])
+
+  // Auto-center on the player's GPS position once per hole, when (a) the
+  // initial hole frame has already shown and (b) the player is actually
+  // at this course. Gated by distance to course centroid so testing from
+  // home doesn't yank the camera to a parking lot 50 mi away.
+  const autoCenteredRef = useRef(false)
+  useEffect(() => {
+    // Reset on hole change (center prop moves to new tee/centroid). When
+    // the per-hole route is collapsed to one component (issue #264 fix),
+    // this is still the right reset signal.
+    autoCenteredRef.current = false
+  }, [center.lat, center.lng])
+  useEffect(() => {
+    if (!styleLoaded) return
+    if (!cameraInitialized.current) return
+    if (autoCenteredRef.current) return
+    if (!gpsPosition || !courseCenter) return
+    if (distanceYards(gpsPosition, courseCenter) > AUTO_CENTER_GATE_YARDS) return
+    if (!cameraRef.current) return
+    cameraRef.current.setCamera({
+      centerCoordinate: toCoord(gpsPosition),
+      zoomLevel: 17,
+      pitch: 0,
+      animationDuration: 800,
+    })
+    autoCenteredRef.current = true
+  }, [
+    styleLoaded,
+    gpsPosition?.lat,
+    gpsPosition?.lng,
+    courseCenter?.lat,
+    courseCenter?.lng,
+  ])
 
   // When entering pin mode, zoom in on the stored pin so the user is
   // looking at the green. Fires ONCE per PIN session — re-snapping on


### PR DESCRIPTION
## Summary
- Circular `crosshairs-gps` Pressable bottom-right on `HoleMap`, **PLACE_BALL phase only**. Tap animates the camera to the smoothed GPS position (`gpsPosition` from `useHoleState`). Disabled at 50% opacity until GPS converges.
- One-shot auto-center in `useHoleCamera` after the initial hole frame, **gated by distance ≤ 1000 m (1094 yd) from the course centroid**. Testing from home won't trigger because the proximity check fails.
- Auto-center ref resets on `center` prop change (hole change). Survives the future single-screen refactor of #264 because the reset signal is the same.

## Why
From Saturday's live test: without a way to recenter, once the camera drifted (or started on the tee while the player was at their ball), the player had to manually pinch-and-pan to find themselves. Combined with the LocationPuck shipped in #268, the player can now both **see** where they are and **return to it** with one tap.

Auto-center gating addresses your home-office testing case directly: 1000 m radius around the course centroid means launching the app at your house never yanks the camera to a course you happen to have an active round on.

## Files touched
- `apps/mobile/components/round/HoleMap.tsx` — new `gpsPosition`/`courseCenter` props, `recenterOnGps` callback, conditional Pressable.
- `apps/mobile/components/round/hooks/useHoleCamera.ts` — new opts, `AUTO_CENTER_GATE_YARDS = 1094` constant, hole-change reset effect, auto-center effect.
- `apps/mobile/app/(app)/round/[id]/hole/[number].tsx` — threads `finalState.gpsPosition` and `data.courseCenter` to `<HoleMap>`.

## Test plan
- [ ] Launch dev build at home, start a live round on a real course — camera should NOT auto-snap to your home (gate fails)
- [ ] At the course, start a live round — once GPS converges, camera auto-centers once on you
- [ ] Tap the crosshairs button anywhere → camera flies to current GPS
- [ ] Advance to next hole → camera re-frames the new tee, then auto-recenters once GPS converges (because the ref reset on hole change)
- [ ] Button is hidden in SET_AIM, PIN, and TEE phases
- [ ] Button is greyed/disabled before GPS has acquired
- [ ] Ball placement, Kalman behavior, `manuallyPlacedRef` flow all unchanged

## Stacked context
Third in the Saturday-bugs series:
- #268 LocationPuck — merged
- #269 Hole route noise cleanup — merged
- #270 SET_AIM/PIN camera snap-back — merged
- **this PR** — recenter UX
- Chunk D: dev↔preview parity audit (#265) — investigation, separate work
- Chunk E: single-MapView-per-round (#264 architectural fix) — separate larger PR