### PR TITLE
fix(mobile): keep gpsPosition fresh at rest and after manual ball place

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/_hooks/useHoleState.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/_hooks/useHoleState.ts
@@ -108,24 +108,55 @@ export function useHoleState({
         const perm = await Location.requestForegroundPermissionsAsync()
         if (perm.status !== 'granted') return
         if (!active) return
+        // One-shot fix so gpsPosition (recenter button, nearPin prompt)
+        // populates within ~1 s of mount. watchPositionAsync below only
+        // fires on movement deltas, so a player standing still on the
+        // tee otherwise saw the recenter button greyed out indefinitely.
+        try {
+          const initial = await Location.getCurrentPositionAsync({
+            accuracy: Location.Accuracy.BestForNavigation,
+          })
+          if (active) {
+            setGpsPosition({
+              lat: initial.coords.latitude,
+              lng: initial.coords.longitude,
+            })
+          }
+        } catch {
+          // No initial fix yet — fall back to watchPositionAsync.
+        }
+        if (!active) return
         subscription = await Location.watchPositionAsync(
           {
             accuracy: Location.Accuracy.BestForNavigation,
             distanceInterval: 2,
+            // Heartbeat tick so gpsPosition refreshes even at rest. Pure
+            // distanceInterval gating meant the recenter button could
+            // never update once the player stopped walking.
+            timeInterval: 2000,
           },
           (loc) => {
             if (!active) return
-            // Manual placement freezes GPS-driven ball updates. Without
-            // this, the next reading after a drag would re-init the
-            // filter at the raw GPS point and snap ball back, wiping
-            // the player's refinement.
-            if (manuallyPlacedRef.current) return
             const rawPoint = {
               lat: loc.coords.latitude,
               lng: loc.coords.longitude,
               accuracy: loc.coords.accuracy ?? undefined,
               timestamp: loc.timestamp,
             }
+            // Always update gpsPosition (puck-adjacent recenter target +
+            // nearPin radius check) regardless of manual ball placement.
+            // The freeze below is solely about preventing GPS from
+            // clobbering the BALL marker after the player has dragged or
+            // tapped it. Using raw OS coords here, not Kalman-smoothed,
+            // because the manual-place handler re-anchors Kalman with a
+            // strong prior — using the smoothed value would lie for
+            // many readings after manual placement.
+            setGpsPosition({ lat: rawPoint.lat, lng: rawPoint.lng })
+            // Manual placement freezes GPS-driven ball updates. Without
+            // this, the next reading after a drag would re-init the
+            // filter at the raw GPS point and snap ball back, wiping
+            // the player's refinement.
+            if (manuallyPlacedRef.current) return
             kalmanStateRef.current = kalmanStateRef.current
               ? updateKalman(kalmanStateRef.current, rawPoint)
               : createKalmanState(rawPoint)
@@ -133,7 +164,6 @@ export function useHoleState({
               lat: kalmanStateRef.current.lat,
               lng: kalmanStateRef.current.lng,
             }
-            setGpsPosition(smoothed)
             setBall(smoothed)
           },
         )


### PR DESCRIPTION
## Summary
Three small fixes to the PLACE_BALL GPS subscription in `useHoleState.ts` so the recenter button (#271) and the `nearPin` prompt reflect the player's actual position.

1. **Seed `gpsPosition` immediately** via `Location.getCurrentPositionAsync()` before subscribing. `watchPositionAsync` only fires on movement deltas, so a player standing still on the tee saw the recenter button greyed out indefinitely.
2. **Add `timeInterval: 2000`** to `watchPositionAsync`. Even with no movement, the callback ticks every 2 s — keeps `gpsPosition` fresh while the player stands over a putt.
3. **Move the `manuallyPlacedRef` early-return below `setGpsPosition`** so the freeze stops only the BALL marker, not the puck/recenter target.

`setGpsPosition` now uses raw OS coords (not Kalman-smoothed). The manual ball-place handler in `[number].tsx` re-anchors Kalman with a strong prior, so a smoothed `gpsPosition` would lie about the player's position for many readings after a manual placement. Raw GPS (±3–10 m) is plenty for camera centering and the existing 80-yd `nearPin` radius. Ball Kalman behavior is unchanged.

## Why
From device testing: button is greyed out on hole-screen load, even with location permission granted and the Mapbox LocationPuck visible. Confirmed root cause: `watchPositionAsync(distanceInterval: 2)` never fires at rest, so `gpsPosition` stays `null`.

## Test plan
- [ ] Open hole screen at home (or any course-distance > 1000 m so auto-center won't fire). Within ~1 s the crosshairs button transitions from 50% opacity to full color and is pressable.
- [ ] Tap recenter → camera flies to your current position.
- [ ] Stand still for 30 s, then tap recenter — still works (heartbeat refresh).
- [ ] Tap to place ball, then walk a few steps, then tap recenter → camera flies to your *new* position (not the placed ball location).
- [ ] Ball-marker still freezes to manual placement after tap (Kalman behavior unchanged).

## Stacked context
This depends on the recenter button from #271 to be visible to test, but the underlying \`gpsPosition\` plumbing fix lands independently. The \`nearPin\` 80-yd radius check (\`useHoleState.ts:194\`) also benefits — previously it relied on the same frozen \`gpsPosition\`.