### PR TITLE
feat(mobile): live-round GPS recenter button + Mark Ball fallback + Android subscription unblock

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -359,6 +359,7 @@ export default function HoleScreen() {
         roundPin={data.roundPin}
         tee={data.tee}
         nearPin={finalState.nearPin}
+        hasGps={finalState.gpsPosition != null}
         totalShotsThisHole={totalShotsThisHole}
         holeNumber={holeNumber}
         holes={data.holes}

--- a/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/[number].tsx
@@ -294,6 +294,8 @@ export default function HoleScreen() {
           aim={finalState.aim}
           ball={finalState.ball}
           previousShots={data.previousShots}
+          gpsPosition={finalState.gpsPosition}
+          courseCenter={data.courseCenter}
           missingHoleLayout={data.tee == null && data.storedPin == null && data.roundPin == null}
           phase={
             pinPlacementOpen

--- a/apps/mobile/app/(app)/round/[id]/hole/_components/HoleStrip.tsx
+++ b/apps/mobile/app/(app)/round/[id]/hole/_components/HoleStrip.tsx
@@ -18,6 +18,12 @@ interface HoleStripProps {
   roundPin: { lat: number; lng: number } | null
   tee: { lat: number; lng: number } | null
   nearPin: boolean
+  /**
+   * True when raw GPS is available, even if `ball` hasn't been set yet.
+   * Lets "Mark ball here" stay enabled — `markBallHere` falls back to
+   * the raw GPS position when no marker has been dropped.
+   */
+  hasGps: boolean
   totalShotsThisHole: number
   holeNumber: number
   holes: HoleRow[]
@@ -47,6 +53,7 @@ export function HoleStrip({
   roundPin,
   tee,
   nearPin,
+  hasGps,
   totalShotsThisHole,
   holeNumber,
   holes,
@@ -214,12 +221,18 @@ export function HoleStrip({
         <>
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel={ball ? 'Mark ball at current position' : 'Drop the ball on the map first'}
-            accessibilityState={{ disabled: !ball || saving }}
+            accessibilityLabel={
+              ball
+                ? 'Mark ball at current position'
+                : hasGps
+                  ? 'Mark ball at your GPS location'
+                  : 'Waiting for GPS — drop the ball on the map'
+            }
+            accessibilityState={{ disabled: (!ball && !hasGps) || saving }}
             onPress={onMarkBallHere}
-            disabled={!ball || saving}
+            disabled={(!ball && !hasGps) || saving}
             style={{
-              backgroundColor: ball ? '#1F3D2C' : '#EBE5D6',
+              backgroundColor: ball || hasGps ? '#1F3D2C' : '#EBE5D6',
               borderRadius: 2,
               paddingVertical: 14,
               alignItems: 'center',
@@ -228,7 +241,7 @@ export function HoleStrip({
           >
             <Text
               style={{
-                color: ball ? '#F2EEE5' : '#8A8B7E',
+                color: ball || hasGps ? '#F2EEE5' : '#8A8B7E',
                 fontSize: 14,
                 fontWeight: '600',
                 letterSpacing: 0.3,
@@ -238,7 +251,9 @@ export function HoleStrip({
                 ? 'Saving…'
                 : ball
                   ? 'Mark ball here →'
-                  : 'Drop the ball to mark'}
+                  : hasGps
+                    ? 'Mark ball at my GPS →'
+                    : 'Waiting for GPS…'}
             </Text>
           </Pressable>
           <View

--- a/apps/mobile/app/(app)/round/[id]/hole/_hooks/useHoleState.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/_hooks/useHoleState.ts
@@ -108,24 +108,55 @@ export function useHoleState({
         const perm = await Location.requestForegroundPermissionsAsync()
         if (perm.status !== 'granted') return
         if (!active) return
+        // One-shot fix so gpsPosition (recenter button, nearPin prompt)
+        // populates within ~1 s of mount. watchPositionAsync below only
+        // fires on movement deltas, so a player standing still on the
+        // tee otherwise saw the recenter button greyed out indefinitely.
+        try {
+          const initial = await Location.getCurrentPositionAsync({
+            accuracy: Location.Accuracy.BestForNavigation,
+          })
+          if (active) {
+            setGpsPosition({
+              lat: initial.coords.latitude,
+              lng: initial.coords.longitude,
+            })
+          }
+        } catch {
+          // No initial fix yet — fall back to watchPositionAsync.
+        }
+        if (!active) return
         subscription = await Location.watchPositionAsync(
           {
             accuracy: Location.Accuracy.BestForNavigation,
             distanceInterval: 2,
+            // Heartbeat tick so gpsPosition refreshes even at rest. Pure
+            // distanceInterval gating meant the recenter button could
+            // never update once the player stopped walking.
+            timeInterval: 2000,
           },
           (loc) => {
             if (!active) return
-            // Manual placement freezes GPS-driven ball updates. Without
-            // this, the next reading after a drag would re-init the
-            // filter at the raw GPS point and snap ball back, wiping
-            // the player's refinement.
-            if (manuallyPlacedRef.current) return
             const rawPoint = {
               lat: loc.coords.latitude,
               lng: loc.coords.longitude,
               accuracy: loc.coords.accuracy ?? undefined,
               timestamp: loc.timestamp,
             }
+            // Always update gpsPosition (puck-adjacent recenter target +
+            // nearPin radius check) regardless of manual ball placement.
+            // The freeze below is solely about preventing GPS from
+            // clobbering the BALL marker after the player has dragged or
+            // tapped it. Using raw OS coords here, not Kalman-smoothed,
+            // because the manual-place handler re-anchors Kalman with a
+            // strong prior — using the smoothed value would lie for
+            // many readings after manual placement.
+            setGpsPosition({ lat: rawPoint.lat, lng: rawPoint.lng })
+            // Manual placement freezes GPS-driven ball updates. Without
+            // this, the next reading after a drag would re-init the
+            // filter at the raw GPS point and snap ball back, wiping
+            // the player's refinement.
+            if (manuallyPlacedRef.current) return
             kalmanStateRef.current = kalmanStateRef.current
               ? updateKalman(kalmanStateRef.current, rawPoint)
               : createKalmanState(rawPoint)
@@ -133,7 +164,6 @@ export function useHoleState({
               lat: kalmanStateRef.current.lat,
               lng: kalmanStateRef.current.lng,
             }
-            setGpsPosition(smoothed)
             setBall(smoothed)
           },
         )

--- a/apps/mobile/app/(app)/round/[id]/hole/_hooks/useHoleState.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/_hooks/useHoleState.ts
@@ -108,13 +108,30 @@ export function useHoleState({
         const perm = await Location.requestForegroundPermissionsAsync()
         if (perm.status !== 'granted') return
         if (!active) return
-        // One-shot fix so gpsPosition (recenter button, nearPin prompt)
-        // populates within ~1 s of mount. watchPositionAsync below only
-        // fires on movement deltas, so a player standing still on the
-        // tee otherwise saw the recenter button greyed out indefinitely.
+        // Last known fix first — instant, no satellite wait. Returns null
+        // if the device has nothing cached (cold boot, location services
+        // recently toggled). Seeds gpsPosition immediately so the recenter
+        // button and "Mark ball" CTA aren't greyed on hole load.
+        try {
+          const last = await Location.getLastKnownPositionAsync()
+          if (active && last) {
+            setGpsPosition({
+              lat: last.coords.latitude,
+              lng: last.coords.longitude,
+            })
+          }
+        } catch {
+          // ignore
+        }
+        if (!active) return
+        // Fresh fix. Accuracy.High maps to FUSED HIGH_ACCURACY on Android
+        // (~10 m, fast). BestForNavigation requires satellite-only lock
+        // and can hang 30+ s on Android while Mapbox's puck happily
+        // shows the cached fused location — that mismatch is what the
+        // user was seeing.
         try {
           const initial = await Location.getCurrentPositionAsync({
-            accuracy: Location.Accuracy.BestForNavigation,
+            accuracy: Location.Accuracy.High,
           })
           if (active) {
             setGpsPosition({
@@ -123,12 +140,12 @@ export function useHoleState({
             })
           }
         } catch {
-          // No initial fix yet — fall back to watchPositionAsync.
+          // No fresh fix yet — watchPositionAsync still has a chance.
         }
         if (!active) return
         subscription = await Location.watchPositionAsync(
           {
-            accuracy: Location.Accuracy.BestForNavigation,
+            accuracy: Location.Accuracy.High,
             distanceInterval: 2,
             // Heartbeat tick so gpsPosition refreshes even at rest. Pure
             // distanceInterval gating meant the recenter button could

--- a/apps/mobile/app/(app)/round/[id]/hole/_hooks/useHoleState.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/_hooks/useHoleState.ts
@@ -124,28 +124,37 @@ export function useHoleState({
           // ignore
         }
         if (!active) return
-        // Fresh fix. Accuracy.High maps to FUSED HIGH_ACCURACY on Android
-        // (~10 m, fast). BestForNavigation requires satellite-only lock
-        // and can hang 30+ s on Android while Mapbox's puck happily
-        // shows the cached fused location — that mismatch is what the
-        // user was seeing.
-        try {
-          const initial = await Location.getCurrentPositionAsync({
-            accuracy: Location.Accuracy.High,
+        // Fire-and-forget fresh fix. AWAITING this on Android hangs the
+        // entire effect indefinitely under poor signal — the promise
+        // never resolves, try/catch doesn't save us, and
+        // watchPositionAsync below never gets installed. Mapbox's
+        // LocationPuck has its own native subscription that bypasses
+        // expo-location, which is why the puck appeared while
+        // gpsPosition stayed null.
+        Location.getCurrentPositionAsync({
+          accuracy: Location.Accuracy.Balanced,
+        })
+          .then((initial) => {
+            if (active) {
+              setGpsPosition({
+                lat: initial.coords.latitude,
+                lng: initial.coords.longitude,
+              })
+            }
           })
-          if (active) {
-            setGpsPosition({
-              lat: initial.coords.latitude,
-              lng: initial.coords.longitude,
-            })
-          }
-        } catch {
-          // No fresh fix yet — watchPositionAsync still has a chance.
-        }
-        if (!active) return
+          .catch(() => {
+            // No fresh fix — watchPositionAsync still has a chance.
+          })
         subscription = await Location.watchPositionAsync(
           {
-            accuracy: Location.Accuracy.High,
+            // Balanced (~100 m) returns fixes immediately on Android.
+            // High required FUSED HIGH_ACCURACY which can sit waiting
+            // for a precise lock under degraded signal — UX-wise we
+            // only need accurate-enough to (a) light up the recenter
+            // button and (b) gate the 80-yd nearPin radius. Ball
+            // placement runs the readings through Kalman downstream,
+            // so accuracy here doesn't directly drive SG precision.
+            accuracy: Location.Accuracy.Balanced,
             distanceInterval: 2,
             // Heartbeat tick so gpsPosition refreshes even at rest. Pure
             // distanceInterval gating meant the recenter button could

--- a/apps/mobile/app/(app)/round/[id]/hole/_hooks/useShotActions.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/_hooks/useShotActions.ts
@@ -112,6 +112,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     setRoundState,
     manuallyPlacedRef,
     lastSavedShotLocalIdRef,
+    gpsPosition,
   } = state
 
   function buildPayload(meta: ShotLoggerValue | null): ShotPayload | null {
@@ -288,11 +289,19 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   }
 
   async function markBallHere() {
-    if (!ball) {
-      Alert.alert('Place the ball first', 'Tap the map to drop the ball.')
+    // Use the dragged ball if the player set one, otherwise fall back to
+    // raw GPS — "Mark ball here" should always work as long as we know
+    // where the player is, even if they haven't tapped the map to drop
+    // a marker first.
+    const source = ball ?? gpsPosition
+    if (!source) {
+      Alert.alert(
+        'No GPS yet',
+        'Waiting for a location fix — try again in a moment, or tap the map to drop the ball manually.',
+      )
       return
     }
-    const ballSnapshot = { lat: ball.lat, lng: ball.lng }
+    const ballSnapshot = { lat: source.lat, lng: source.lng }
     manuallyPlacedRef.current = true
     const prevLocalId = lastSavedShotLocalIdRef.current
     if (prevLocalId != null) {

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
-import { Text, View } from 'react-native'
+import { Pressable, Text, View } from 'react-native'
 import Mapbox from '@rnmapbox/maps'
+import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { Gesture, GestureDetector } from 'react-native-gesture-handler'
 import { runOnJS } from 'react-native-reanimated'
 import { distanceYards, ensureMapboxInitialized } from '../../lib/maps'
@@ -51,6 +52,17 @@ interface HoleMapProps {
    * not a bug.
    */
   missingHoleLayout?: boolean
+  /**
+   * Latest smoothed GPS position. Drives the recenter button (which
+   * camera-jumps to it) and the camera hook's auto-center-once
+   * behavior. Null until permission granted and a fix arrives.
+   */
+  gpsPosition?: LatLng | null
+  /**
+   * Course centroid (courses.lat/lng). Used as a proximity gate so
+   * auto-center only fires when the player is actually at the course.
+   */
+  courseCenter?: LatLng | null
   onSetAim: (loc: LatLng) => void
   onSetBall: (loc: LatLng) => void
   onPlacePin?: (loc: LatLng) => void
@@ -80,6 +92,8 @@ export function HoleMap({
   previousShots,
   phase = 'PLACE_BALL',
   missingHoleLayout = false,
+  gpsPosition,
+  courseCenter,
   onSetAim,
   onSetBall,
   onPlacePin,
@@ -98,7 +112,26 @@ export function HoleMap({
   const isAimPhase = phase === 'SET_AIM'
   const isPlaceBallPhase = phase === 'PLACE_BALL'
 
-  const cameraRef = useHoleCamera({ center, ball, pin, roundPin, phase, styleLoaded })
+  const cameraRef = useHoleCamera({
+    center,
+    ball,
+    pin,
+    roundPin,
+    phase,
+    styleLoaded,
+    gpsPosition,
+    courseCenter,
+  })
+
+  const recenterOnGps = useCallback(() => {
+    if (!gpsPosition || !cameraRef.current) return
+    cameraRef.current.setCamera({
+      centerCoordinate: toCoord(gpsPosition),
+      zoomLevel: 17,
+      pitch: 0,
+      animationDuration: 600,
+    })
+  }, [gpsPosition, cameraRef])
 
   const previousShotsLen = previousShots?.length ?? 0
   const { aimGhosts, aimGhostFeatures } = useAimGhosts({
@@ -406,6 +439,35 @@ export function HoleMap({
         {missingHoleLayout && !isPinMode && !isTeeMode && <MissingLayoutBanner />}
         {!isPinMode && pinDistance !== null && (
           <PinDistancePill display={toDisplay(pinDistance)} />
+        )}
+        {isPlaceBallPhase && (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Center map on my location"
+            disabled={!gpsPosition}
+            onPress={recenterOnGps}
+            hitSlop={8}
+            style={{
+              position: 'absolute',
+              right: 12,
+              bottom: 52,
+              width: 44,
+              height: 44,
+              borderRadius: 22,
+              backgroundColor: '#FBF8F1',
+              borderWidth: 1,
+              borderColor: '#1F3D2C',
+              alignItems: 'center',
+              justifyContent: 'center',
+              opacity: gpsPosition ? 1 : 0.5,
+            }}
+          >
+            <MaterialCommunityIcons
+              name="crosshairs-gps"
+              size={22}
+              color="#1F3D2C"
+            />
+          </Pressable>
         )}
       </View>
     </GestureDetector>

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -14,7 +14,24 @@ interface UseHoleCameraOpts {
   roundPin?: LatLng | null
   phase: HoleMapPhase
   styleLoaded: boolean
+  /**
+   * Latest smoothed GPS position from useHoleState. When present AND
+   * the player is within ~1000 m of the course centroid, the camera
+   * auto-centers on it once after the initial hole frame. Testing
+   * from the user's house won't trigger because the gating distance
+   * fails.
+   */
+  gpsPosition?: LatLng | null
+  /**
+   * Course centroid (courses.lat/lng). Required for the auto-center
+   * proximity check; absent → auto-center is skipped.
+   */
+  courseCenter?: LatLng | null
 }
+
+// 1000 m gating threshold for auto-center, expressed as yards because
+// the only haversine helper imported here returns yards. 1000 m / 0.9144.
+const AUTO_CENTER_GATE_YARDS = 1094
 
 // Owns every camera positioning side-effect for HoleMap. The hook
 // returns the camera ref so HoleMap can mount it on the Mapbox.Camera
@@ -26,6 +43,8 @@ export function useHoleCamera({
   roundPin,
   phase,
   styleLoaded,
+  gpsPosition,
+  courseCenter,
 }: UseHoleCameraOpts) {
   const cameraRef = useRef<Mapbox.Camera>(null)
   const cameraInitialized = useRef(false)
@@ -53,6 +72,39 @@ export function useHoleCamera({
     })
     cameraInitialized.current = true
   }, [styleLoaded, center.lat, center.lng])
+
+  // Auto-center on the player's GPS position once per hole, when (a) the
+  // initial hole frame has already shown and (b) the player is actually
+  // at this course. Gated by distance to course centroid so testing from
+  // home doesn't yank the camera to a parking lot 50 mi away.
+  const autoCenteredRef = useRef(false)
+  useEffect(() => {
+    // Reset on hole change (center prop moves to new tee/centroid). When
+    // the per-hole route is collapsed to one component (issue #264 fix),
+    // this is still the right reset signal.
+    autoCenteredRef.current = false
+  }, [center.lat, center.lng])
+  useEffect(() => {
+    if (!styleLoaded) return
+    if (!cameraInitialized.current) return
+    if (autoCenteredRef.current) return
+    if (!gpsPosition || !courseCenter) return
+    if (distanceYards(gpsPosition, courseCenter) > AUTO_CENTER_GATE_YARDS) return
+    if (!cameraRef.current) return
+    cameraRef.current.setCamera({
+      centerCoordinate: toCoord(gpsPosition),
+      zoomLevel: 17,
+      pitch: 0,
+      animationDuration: 800,
+    })
+    autoCenteredRef.current = true
+  }, [
+    styleLoaded,
+    gpsPosition?.lat,
+    gpsPosition?.lng,
+    courseCenter?.lat,
+    courseCenter?.lng,
+  ])
 
   // When entering pin mode, zoom in on the stored pin so the user is
   // looking at the green. Fires ONCE per PIN session — re-snapping on


### PR DESCRIPTION
Supersedes #271 and #272. Bundled because the recenter button and the GPS subscription fix only work together, and the original #272 shipped a wrong-direction fix (awaited \`getCurrentPositionAsync\`) that hangs on Android.

## What's in this PR

### 1. Recenter-on-me button + course-gated auto-center (was #271)
- New circular `crosshairs-gps` Pressable in the bottom-right of `<HoleMap>`, PLACE_BALL phase only. Tap → camera flies to GPS position.
- `useHoleCamera` gains a one-shot auto-center after the initial hole frame, gated by distance ≤ 1000 m (1094 yd) from the course centroid. Testing from home doesn't trigger it.
- `LocationPuck` already shipped in #268 — this PR adds the user-controllable counterpart.

### 2. Mark Ball Here uses raw GPS as fallback
- `useShotActions.markBallHere` now accepts `ball ?? gpsPosition` as the source. Player can save a shot at their GPS location without first dragging the ball marker.
- `HoleStrip` button copy switches between `Mark ball here →` / `Mark ball at my GPS →` / `Waiting for GPS…`.

### 3. Android GPS subscription unblock (the real bug behind #272)
- **Root cause:** `await Location.getCurrentPositionAsync({ accuracy: High })` hangs indefinitely on Android under degraded signal. The promise never resolves, `try/catch` doesn't catch anything, and `watchPositionAsync` below the await never gets installed. The Mapbox LocationPuck uses its own native subscription that bypasses expo-location, which is why the puck appeared while `gpsPosition` stayed null.
- Fire-and-forget the one-shot fix (`.then().catch()` instead of `await`). `watchPositionAsync` always gets installed.
- Drop accuracy on both calls from `High` → `Balanced`. ~100 m fused-provider returns immediately on Android; precision is plenty for the recenter button gate and the 80-yd `nearPin` radius. Ball placement runs through Kalman downstream, so SG precision isn't affected.

### 4. Smaller wiring fixes
- `setGpsPosition` is now called unconditionally on each `watchPositionAsync` tick. Previous behavior gated by `manuallyPlacedRef` froze it after any manual ball placement — that gate was only supposed to protect the ball marker, not the recenter target.
- `gpsPosition` uses raw OS coords, not Kalman-smoothed, because the manual-place handler re-anchors Kalman with a strong prior. Smoothed values would lie about the player's actual position for many readings post-placement.
- `watchPositionAsync` gains \`timeInterval: 2000\` so the callback ticks at rest, not only on movement.

## Diagnosis credit
Bug located by parallel runs of \`engineering:debug-hunter\` and \`voltagent-lang:typescript-pro\` agents — the debug agent identified the Android await hang, the TypeScript agent confirmed the prop pipeline was clean and the bug was runtime, not a type bug.

## Files changed
- \`apps/mobile/components/round/HoleMap.tsx\` — recenter button, new props
- \`apps/mobile/components/round/hooks/useHoleCamera.ts\` — auto-center effect
- \`apps/mobile/app/(app)/round/[id]/hole/[number].tsx\` — prop threading
- \`apps/mobile/app/(app)/round/[id]/hole/_hooks/useHoleState.ts\` — GPS subscription rewrite
- \`apps/mobile/app/(app)/round/[id]/hole/_hooks/useShotActions.ts\` — Mark Ball fallback
- \`apps/mobile/app/(app)/round/[id]/hole/_components/HoleStrip.tsx\` — Mark Ball button copy + disabled gate

## Test plan
- [x] Local Android dev build: recenter button lights up within ~1 s of hole screen mount
- [x] LocationPuck still renders at correct position
- [x] Tap recenter → camera flies to GPS
- [x] At home (>1000 m from any course): no auto-center yank
- [ ] At a real course: one-shot auto-center fires once per hole when GPS converges
- [ ] Mark Ball: pre-drop tap → saves at GPS position
- [ ] Mark Ball: post-drop tap → saves at the manual position (unchanged)