### PR TITLE
fix(mobile): harden live-round map against crash vectors (#275, #276, #277)

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -79,6 +79,10 @@ function extractCoord(feature: unknown): LatLng | null {
   if (!Array.isArray(coords) || coords.length < 2) return null
   const [lng, lat] = coords as number[]
   if (typeof lat !== 'number' || typeof lng !== 'number') return null
+  // @rnmapbox/maps fires onDragEnd with NaN coords on Android when a
+  // PointAnnotation is dragged off the visible map. NaN passes typeof
+  // 'number' and then poisons the Kalman filter + DB writes downstream.
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
   return { lat, lng }
 }
 
@@ -148,10 +152,16 @@ export function HoleMap({
   // gate it to the SET_AIM phase so the ball-placement step isn't noisy.
   const dropAimFromScreenPoint = useCallback(
     async (x: number, y: number) => {
-      if (!mapViewRef.current) return
+      // Snapshot the ref before the await: if the user long-presses
+      // during a hole transition the native MapView can tear down
+      // mid-await and the post-await call lands on a released handle.
+      // Re-checking ref identity after the await catches that race.
+      const mapView = mapViewRef.current
+      if (!mapView) return
       if (!isAimPhase) return
       try {
-        const coord = await mapViewRef.current.getCoordinateFromView([x, y])
+        const coord = await mapView.getCoordinateFromView([x, y])
+        if (mapViewRef.current !== mapView) return
         if (coord && coord.length >= 2) {
           onSetAim({ lat: coord[1], lng: coord[0] })
         }

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -64,13 +64,20 @@ export function useHoleCamera({
     if (!styleLoaded) return
     if (cameraInitialized.current) return
     if (!cameraRef.current) return
-    cameraRef.current.setCamera({
-      centerCoordinate: toCoord(center),
-      zoomLevel: 17,
-      pitch: 0,
-      animationDuration: 400,
-    })
-    cameraInitialized.current = true
+    // setCamera throws on Android when the native camera handle has
+    // been released (e.g. hole transition mid-animation); the JS ref
+    // can stay truthy through teardown in @rnmapbox/maps 10.1.x.
+    try {
+      cameraRef.current.setCamera({
+        centerCoordinate: toCoord(center),
+        zoomLevel: 17,
+        pitch: 0,
+        animationDuration: 400,
+      })
+      cameraInitialized.current = true
+    } catch {
+      // native camera released — retry on next dep change
+    }
   }, [styleLoaded, center.lat, center.lng])
 
   // Auto-center on the player's GPS position once per hole, when (a) the
@@ -91,13 +98,17 @@ export function useHoleCamera({
     if (!gpsPosition || !courseCenter) return
     if (distanceYards(gpsPosition, courseCenter) > AUTO_CENTER_GATE_YARDS) return
     if (!cameraRef.current) return
-    cameraRef.current.setCamera({
-      centerCoordinate: toCoord(gpsPosition),
-      zoomLevel: 17,
-      pitch: 0,
-      animationDuration: 800,
-    })
-    autoCenteredRef.current = true
+    try {
+      cameraRef.current.setCamera({
+        centerCoordinate: toCoord(gpsPosition),
+        zoomLevel: 17,
+        pitch: 0,
+        animationDuration: 800,
+      })
+      autoCenteredRef.current = true
+    } catch {
+      // native camera released — try again on next GPS tick
+    }
   }, [
     styleLoaded,
     gpsPosition?.lat,
@@ -119,12 +130,16 @@ export function useHoleCamera({
     if (!cameraRef.current) return
     const target = roundPin ?? pin ?? null
     if (!target) return
-    cameraRef.current.setCamera({
-      centerCoordinate: toCoord(target),
-      zoomLevel: 19,
-      animationDuration: 400,
-    })
-    pinSnappedRef.current = true
+    try {
+      cameraRef.current.setCamera({
+        centerCoordinate: toCoord(target),
+        zoomLevel: 19,
+        animationDuration: 400,
+      })
+      pinSnappedRef.current = true
+    } catch {
+      // native camera released — retry on next pin change
+    }
   }, [isPinMode, roundPin?.lat, roundPin?.lng, pin?.lat, pin?.lng])
 
   // Mark whether we owe the camera a PLACE_BALL re-frame on the next
@@ -150,14 +165,18 @@ export function useHoleCamera({
     if (phase !== 'PLACE_BALL') return
     if (!cameraRef.current) return
     if (!ball) return
-    cameraRef.current.setCamera({
-      centerCoordinate: toCoord(ball),
-      zoomLevel: 17,
-      pitch: 0,
-      heading: 0,
-      animationDuration: 800,
-    })
-    reframePlaceBallRef.current = false
+    try {
+      cameraRef.current.setCamera({
+        centerCoordinate: toCoord(ball),
+        zoomLevel: 17,
+        pitch: 0,
+        heading: 0,
+        animationDuration: 800,
+      })
+      reframePlaceBallRef.current = false
+    } catch {
+      // native camera released — retry on next ball update
+    }
   }, [ball?.lat, ball?.lng, phase])
 
   // SET_AIM: rotate the camera so direction-of-play (ball → pin) is
@@ -195,14 +214,18 @@ export function useHoleCamera({
       : distYd >= 150 ? 16.5
       : distYd >= 80 ? 17
       : 17
-    cameraRef.current.setCamera({
-      centerCoordinate: toCoord(focus),
-      zoomLevel: zoom,
-      pitch: 20,
-      heading: bearing,
-      animationDuration: 1200,
-    })
-    aimSnappedRef.current = true
+    try {
+      cameraRef.current.setCamera({
+        centerCoordinate: toCoord(focus),
+        zoomLevel: zoom,
+        pitch: 20,
+        heading: bearing,
+        animationDuration: 1200,
+      })
+      aimSnappedRef.current = true
+    } catch {
+      // native camera released — retry on next aim/pin change
+    }
   }, [
     isAimPhase,
     ball?.lat,


### PR DESCRIPTION
## Summary

Three narrow, independent fixes for the random crashes observed during Saturday's live test. From the 2026-05-13 debug-hunter audit (Tier 1 crash drivers).

- **#275 — NaN guard in `extractCoord`** (`apps/mobile/components/round/HoleMap.tsx`)
  `@rnmapbox/maps` fires `onDragEnd` with NaN coords on Android when a `PointAnnotation` is dragged off the visible map. NaN passes `typeof 'number'` and slips through the existing check, poisons the Kalman filter, and trips a `double precision` insert error on shot save. Add `Number.isFinite` after the existing type guard.

- **#276 — try/catch around five `setCamera` sites** (`apps/mobile/components/round/hooks/useHoleCamera.ts`)
  `setCamera` throws on Android when the native camera handle has been released mid-animation but the JS ref hasn't yet been nulled. The `PLACE_BALL` reframe fires on `ball?.lat/lng` deps (~2 Hz GPS cadence) so it's the most likely to overlap a hole transition.

- **#277 — Snapshot `mapViewRef` before await** (`apps/mobile/components/round/HoleMap.tsx`)
  `dropAimFromScreenPoint` reads `mapViewRef.current` before the await, then dereferences it again after. A long-press during a hole transition can land `getCoordinateFromView` on a released native handle. Snapshot to local, re-check identity after the await.

The architectural fix is #264 (one resident MapView per round); these three are the durable backstops that should land regardless of how that lands.

## Test plan

- [x] `npm run typecheck` clean in `apps/mobile`
- [x] `pnpm typecheck` clean at repo root
- [ ] Device verification by user — three changes are individually trivial, but the failure modes only reproduce on hardware mid-round