### PR TITLE
fix(mobile): hotfixes for #264 stranded after PR #326 was merged early

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/hole/_hooks/useShotActions.ts
+++ b/apps/mobile/app/(app)/round/[id]/hole/_hooks/useShotActions.ts
@@ -355,8 +355,10 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     // are common but rough is the modal answer for "near green but
     // not putting". Player overrides in ShotLogger.
     setLoggerInitial({ lieType: 'rough' })
-    setRoundState('SHOT_DETAIL')
-    setLoggerOpen(true)
+    // Route through the aim prompt — chips and pitches still benefit
+    // from explicit aim capture for the shot-pattern dataset. Player
+    // can skip aim from the prompt if they want.
+    setAimPromptOpen(true)
   }
 
   function confirmAim() {

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
   Alert,
@@ -137,6 +137,14 @@ export default function RoundIndex() {
     [holes],
   )
 
+  // Stable across renders — passing an inline arrow caused
+  // LiveRoundSession's onHoleChange-keyed effect to re-fire on every
+  // parent render, looping with router.setParams.
+  const syncHoleToUrl = useCallback(
+    (next: number) => router.setParams({ hole: String(next) }),
+    [router],
+  )
+
   // In-progress rounds mount the live session here — the path-segmented
   // hole route is deprecated, see #264. holeNumber is component state
   // inside LiveRoundSession; the ?hole= search param is just the URL
@@ -151,7 +159,7 @@ export default function RoundIndex() {
         roundId={id}
         initialHoleNumber={initialHole}
         mode={mode === 'past' ? 'past' : 'live'}
-        onHoleChange={(next) => router.setParams({ hole: String(next) })}
+        onHoleChange={syncHoleToUrl}
       />
     )
   }

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -124,6 +124,19 @@ export default function RoundIndex() {
     }
   }, [id])
 
+  // Hooks must run unconditionally before any branch return — these
+  // memos are needed by the read-only summary path below, but lifting
+  // them above the redirectToLive early-return keeps render-1 (loading)
+  // and render-2 (live-session mount) on the same hook count.
+  const scoresByHoleId = useMemo(
+    () => new Map(holeScores.map((hs) => [hs.hole_id, hs])),
+    [holeScores],
+  )
+  const sortedHoles = useMemo(
+    () => [...holes].sort((a, b) => a.number - b.number),
+    [holes],
+  )
+
   // In-progress rounds mount the live session here — the path-segmented
   // hole route is deprecated, see #264. holeNumber is component state
   // inside LiveRoundSession; the ?hole= search param is just the URL
@@ -142,15 +155,6 @@ export default function RoundIndex() {
       />
     )
   }
-
-  const scoresByHoleId = useMemo(
-    () => new Map(holeScores.map((hs) => [hs.hole_id, hs])),
-    [holeScores],
-  )
-  const sortedHoles = useMemo(
-    () => [...holes].sort((a, b) => a.number - b.number),
-    [holes],
-  )
 
   if (loading) {
     return (

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -63,6 +63,12 @@ interface HoleMapProps {
    * auto-center only fires when the player is actually at the course.
    */
   courseCenter?: LatLng | null
+  /**
+   * Active hole number, used as the hole-change signal for resident
+   * children (aim ghosts, anything else that needs to reset per hole).
+   * The map itself stays mounted across the whole round — see #264.
+   */
+  holeNumber: number
   onSetAim: (loc: LatLng) => void
   onSetBall: (loc: LatLng) => void
   onPlacePin?: (loc: LatLng) => void
@@ -98,6 +104,7 @@ export function HoleMap({
   missingHoleLayout = false,
   gpsPosition,
   courseCenter,
+  holeNumber,
   onSetAim,
   onSetBall,
   onPlacePin,
@@ -137,12 +144,11 @@ export function HoleMap({
     })
   }, [gpsPosition, cameraRef])
 
-  const previousShotsLen = previousShots?.length ?? 0
   const { aimGhosts, aimGhostFeatures } = useAimGhosts({
     ball,
     aim,
     phase,
-    previousShotsLen,
+    holeNumber,
   })
 
   // Mapbox's onLongPress wasn't firing reliably on Android (single-tap

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -41,7 +41,7 @@ export default function LiveRoundSession({
   roundId,
   initialHoleNumber,
   mode,
-  onHoleChange,
+  onHoleChange: syncHoleToUrl,
 }: LiveRoundSessionProps) {
   const isPastMode = mode === 'past'
   const router = useRouter()
@@ -81,12 +81,15 @@ export default function LiveRoundSession({
     // stay open.
   }, [holeNumber])
 
-  // URL sync — let the parent know we navigated. Not required for
-  // correctness (the route doesn't change), just keeps the address bar
-  // honest so a refresh / deep-link share lands on the right hole.
+  // External URL change → internal state. The scorecard hole-jump
+  // calls router.replace which updates the ?hole= search param;
+  // RoundIndex re-renders and passes a new initialHoleNumber. Without
+  // this sync, useState's initial-value semantics ignore the new prop
+  // and the player is stranded on the previous hole. setHoleNumber
+  // bails on no-op so this doesn't loop with the inline urlSync below.
   useEffect(() => {
-    onHoleChange?.(holeNumber)
-  }, [holeNumber, onHoleChange])
+    setHoleNumber(initialHoleNumber)
+  }, [initialHoleNumber])
 
   const data = useHoleData(roundId, holeNumber)
   const finalState = useHoleState({
@@ -138,7 +141,15 @@ export default function LiveRoundSession({
     setConfirmDelete,
     setConfirmEnd,
     setConfirmExit,
-    onHoleChange: (next) => setHoleNumber(next),
+    // URL sync fires here — only on user-driven navigation (Next /
+    // Prev / Finish), not on every render. A reactive useEffect that
+    // depended on the parent's onHoleChange prop looped because the
+    // prop was a new arrow on every parent render → effect re-fired →
+    // setParams → parent re-render → ...
+    onHoleChange: (next) => {
+      setHoleNumber(next)
+      syncHoleToUrl?.(next)
+    },
   })
 
   if (data.loading) {

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -349,6 +349,7 @@ export default function LiveRoundSession({
           previousShots={data.previousShots}
           gpsPosition={finalState.gpsPosition}
           courseCenter={data.courseCenter}
+          holeNumber={holeNumber}
           missingHoleLayout={data.tee == null && data.storedPin == null && data.roundPin == null}
           phase={
             pinPlacementOpen

--- a/apps/mobile/components/round/markers/AimGhost.tsx
+++ b/apps/mobile/components/round/markers/AimGhost.tsx
@@ -12,7 +12,13 @@ interface AimGhostHookOpts {
   ball: LatLng | null | undefined
   aim: LatLng | null | undefined
   phase: HoleMapPhase
-  previousShotsLen: number
+  // Explicit hole-change signal. The prior "previousShotsLen === 0"
+  // heuristic worked when HoleMap remounted per hole, but in the
+  // resident-MapView world (post-#264) it fires during the gap between
+  // ghost promotion (on phase exit SET_AIM) and shot persistence
+  // (which bumps previousShotsLen), wiping the ghost that just got
+  // captured.
+  holeNumber: number
 }
 
 interface AimGhostHookResult {
@@ -28,7 +34,7 @@ export function useAimGhosts({
   ball,
   aim,
   phase,
-  previousShotsLen,
+  holeNumber,
 }: AimGhostHookOpts): AimGhostHookResult {
   const [aimGhosts, setAimGhosts] = useState<
     { ball: LatLng; aim: LatLng }[]
@@ -57,17 +63,12 @@ export function useAimGhosts({
     ghostPhaseRef.current = phase
   }, [phase])
 
-  // Hole change is signalled by previousShots resetting to empty (the
-  // parent re-mounts a new hole with no prior shot starts). Clear ghosts
-  // so they don't bleed across holes. Guarded on aimGhosts.length > 0
-  // so the initial mount (where prevShotsLen and aimGhosts.length are
-  // both 0) doesn't schedule a no-op state update.
-  const ghostCount = aimGhosts.length
+  // Clear ghosts on hole change. The functional setter bails on an
+  // already-empty array so the initial mount doesn't enqueue a no-op
+  // state update.
   useEffect(() => {
-    if (previousShotsLen === 0 && ghostCount > 0) {
-      setAimGhosts([])
-    }
-  }, [previousShotsLen, ghostCount])
+    setAimGhosts((prev) => (prev.length === 0 ? prev : []))
+  }, [holeNumber])
 
   const aimGhostFeatures = useMemo<GeoJSON.FeatureCollection | null>(() => {
     if (aimGhosts.length === 0) return null


### PR DESCRIPTION
## Context

PR #326 was merged at 01:34 UTC with commits A/B/C. Three follow-up hotfixes were pushed to the same feature branch immediately after, during device testing, but never made it into dev because the merge had already happened. This PR brings them in.

Without these, the live-round flow throws on hole open and (depending on which one bites first) either crashes with a hook-count error, hangs on a loading spinner, or wipes aim ghosts the moment they're captured.

## Commits

- **\`8f0a6a4\`** — Hoist \`useMemo\`s above the \`redirectToLive\` early return in \`/round/[id]/index.tsx\`. The original code used \`<Redirect>\` which unmounted the screen instantly, so render 2 never happened and the trailing \`useMemo\`s didn't need to match. PR #326 replaced the redirect with an inline \`<LiveRoundSession>\` mount, which keeps the screen mounted across renders — exposing the hook-count mismatch.

- **\`da6063a\`** — Break the \`LiveRoundSession\` URL-sync loop. The original \`useEffect\` keyed on the parent's \`onHoleChange\` prop, which was a fresh inline arrow on every render of \`RoundIndex\` — re-firing the effect, calling \`setParams\`, re-rendering the parent, ... loop. Symptom was the new-round flow hanging on the spinner. Fix: drop the effect, sync inline from the user-action setter, stabilize the callback in \`RoundIndex\` with \`useCallback\`, add a prop-to-state effect for external URL changes (scorecard hole-jump).

- **\`0738341\`** — Two unrelated fixes bundled:
  - \`useAimGhosts\` used "\`previousShotsLen\` drops to 0" as a hole-change proxy, which was designed when HoleMap remounted per hole. In the resident-MapView world, it fires during the gap between ghost capture (on \`SET_AIM\` exit) and shot persist (which bumps \`previousShotsLen\`) — wiping the ghost that was just added. Threaded \`holeNumber\` through \`HoleMap\` → \`useAimGhosts\` as an explicit reset signal.
  - \`handleOnGreenNo\` bypassed the aim prompt. Routed through \`setAimPromptOpen(true)\` so chips and pitches get aim capture too.

## Verification

- [x] \`npm run typecheck\` (mobile) — clean
- [x] \`pnpm typecheck\` (workspace) — clean
- [x] Smoke tested on device while writing — new round loads, hole nav works, aim ghosts persist, green-prompt No routes through aim. (This is the testing you did before merging too early.)