### PR TITLE
chore(mobile): GPS battery tuning round 1 — loosen intervals + drop puck bearing (#320)

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -301,11 +301,11 @@ export function HoleMap({
             }}
           />
 
-          <Mapbox.LocationPuck
-            visible
-            puckBearingEnabled
-            puckBearing="heading"
-          />
+          {/* Bearing intentionally not enabled — drives the magnetometer
+              continuously, which costs ~2-4 %/hr over a 4-hour round, and
+              the player's facing direction isn't UX-meaningful here (no
+              navigation, no panning relative to heading). */}
+          <Mapbox.LocationPuck visible />
 
           <BreadcrumbLayers
             previousShots={previousShots ?? []}

--- a/apps/mobile/components/round/hole/useHoleState.ts
+++ b/apps/mobile/components/round/hole/useHoleState.ts
@@ -155,11 +155,18 @@ export function useHoleState({
             // placement runs the readings through Kalman downstream,
             // so accuracy here doesn't directly drive SG precision.
             accuracy: Location.Accuracy.Balanced,
-            distanceInterval: 2,
+            // 5 m chosen over 2 m for battery — at a ~1.4 m/s walking pace
+            // that's still a fix every ~3.5 s while moving, and Kalman
+            // smooths the gap. The marker is tap/drag-confirmed before
+            // shot capture, so coarser auto-tracking is fine.
+            distanceInterval: 5,
             // Heartbeat tick so gpsPosition refreshes even at rest. Pure
             // distanceInterval gating meant the recenter button could
-            // never update once the player stopped walking.
-            timeInterval: 2000,
+            // never update once the player stopped walking. 5 s is plenty
+            // for that UX (the recenter button doesn't need sub-second
+            // refresh at rest) and keeps the GPS chip from being held
+            // warm by a 2 s polling cadence.
+            timeInterval: 5000,
           },
           (loc) => {
             if (!active) return


### PR DESCRIPTION
Partial progress on #320. (Resubmission — previous PR #333 closed for ordering reasons; this one is correctly based on `dev` after #328 merged.)

## Summary

Three low-risk GPS tuning changes targeting the battery drain audited in #320. Combined estimated savings: ~4-7 %/hr during live round (~15-30% less GPS drain over a 4-hour round).

| # | Change | Est. savings | Risk |
|---|---|---|---|
| 1 | `watchPositionAsync` `timeInterval` 2000ms → 5000ms | 15-25% of GPS active-at-rest | None — Kalman doesn't need 2s ticks; recenter UX fine at 5s |
| 2 | `watchPositionAsync` `distanceInterval` 2m → 5m | Marginal, compounds with #1 | Slightly less smooth marker drift while walking; tap/drag is canonical |
| 3 | Drop `puckBearingEnabled` + `puckBearing="heading"` on Mapbox `LocationPuck` | ~2-4 %/hr | UX: puck stops rotating with facing direction — no golf use case for it |

## Why not more in this PR

Higher-impact changes have higher risk and need device QA + measurement to evaluate. Split out as separate tickets:

- **#330** Conditional `<LocationPuck>` only during PLACE_BALL (~4-7 %/hr saved, biggest single win; needs Mapbox mount/unmount QA)
- **#331** Motion-aware accuracy — drop to `Low` when stationary (~45 min/round of standing time; needs motion detection plumbing)
- **#332** Dev-menu GPS fix-rate counter for measurement (unblocks honest before/after evaluation of #330/#331)

## Files touched

- `apps/mobile/components/round/hole/useHoleState.ts` — 2 line numerics + comment updates
- `apps/mobile/components/round/HoleMap.tsx` — drop 2 props from `<LocationPuck>` + comment

## Test plan

- [x] `pnpm typecheck` — 3/3 packages green
- [x] `cd apps/mobile && npx tsc --noEmit` — exit 0
- [ ] On-device: live round at least one hole, confirm:
  - Ball marker still tracks while walking (just less twitchy)
  - Recenter button updates correctly at rest
  - LocationPuck still shows position; no compass needle expected
  - No regression in nearPin (80yd green prompt) trigger