### PR TITLE
fix(mobile): quarantine corrupt pending shot payloads instead of infinite retry (#292)

### DIFF
--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -7,7 +7,13 @@ export type ShotPayload = Database['public']['Tables']['shots']['Insert']
 export interface PendingShot {
   local_id: number
   remote_id: string | null
-  status: 'pending' | 'synced'
+  // 'broken' = JSON.parse(payload) failed at least once; the row is
+  // quarantined so sync stops retrying it forever (#292). All reads
+  // filter `WHERE status = 'pending'` so broken rows become invisible
+  // to consumers. There's intentionally no CHECK constraint on this
+  // column — CREATE TABLE IF NOT EXISTS skips on existing installs, so
+  // a CHECK can't be retro-applied. The TypeScript union is the gate.
+  status: 'pending' | 'synced' | 'broken'
   payload: string
   created_at: number
 }
@@ -59,6 +65,26 @@ export async function markShotSynced(localId: number, remoteId: string): Promise
   )
 }
 
+// Quarantine a corrupt pending row so sync stops retrying it forever
+// (#292). Set when JSON.parse(row.payload) throws. The `WHERE status =
+// 'pending'` filter on every read keeps broken rows out of subsequent
+// passes. Internally try/catch'd so callers (which are already inside a
+// parse-fail catch) can't have the real failure masked by a downstream
+// marker-write failure — the parse error log is what actually surfaces
+// what went wrong.
+export async function markShotBroken(localId: number): Promise<void> {
+  try {
+    const db = await getDb()
+    await db.runAsync(
+      `UPDATE pending_shots SET status = 'broken' WHERE local_id = ?`,
+      localId,
+    )
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('[db/markShotBroken]', e)
+  }
+}
+
 export async function deletePendingShot(localId: number): Promise<void> {
   const db = await getDb()
   await db.runAsync(`DELETE FROM pending_shots WHERE local_id = ?`, localId)
@@ -89,11 +115,22 @@ export async function setPendingShotEnd(
     localId,
   )
   if (!row) return null
+  // Quarantined rows (set by an earlier parse-fail in this fn or by
+  // sync.ts) carry corrupt data; caller has nothing meaningful to do
+  // with them. Treat as "not found".
+  if (row.status === 'broken') return null
   if (row.status === 'pending') {
     let payload: ShotPayload
     try {
       payload = JSON.parse(row.payload)
-    } catch {
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.error(
+        '[db/payload-corrupt] local_id=%d msg=%s',
+        localId,
+        (e as Error).message,
+      )
+      await markShotBroken(localId)
       return null
     }
     payload.end_lat = lat

--- a/apps/mobile/lib/sync.ts
+++ b/apps/mobile/lib/sync.ts
@@ -1,6 +1,6 @@
 import { AppState } from 'react-native'
 import NetInfo from '@react-native-community/netinfo'
-import { listPendingShots, markShotSynced, type ShotPayload } from './db'
+import { listPendingShots, markShotBroken, markShotSynced, type ShotPayload } from './db'
 import { supabase } from './supabase'
 
 // Module-scope lock that survives a Fast Refresh and prevents two
@@ -51,9 +51,16 @@ export async function syncPendingShots(): Promise<{ synced: number; failed: numb
       for (const row of chunk) {
         try {
           payloads.push(JSON.parse(row.payload) as ShotPayload)
-        } catch {
-          // Malformed pending payload — skip; the row stays pending and
-          // will be retried (or hand-pruned) later.
+        } catch (e) {
+          // Malformed pending payload — quarantine so sync stops retrying
+          // it forever on every reconnect (#292).
+          // eslint-disable-next-line no-console
+          console.error(
+            '[db/payload-corrupt] local_id=%d msg=%s',
+            row.local_id,
+            (e as Error).message,
+          )
+          void markShotBroken(row.local_id)
         }
       }
       if (payloads.length === 0) {


### PR DESCRIPTION
Closes #292.

## Summary

Corrupted \`pending_shots.payload\` rows (rare — WAL replay after a crash, SQLite torn page) currently stay queued forever. Four sites \`JSON.parse(row.payload)\` with a silent \`catch {}\` and skip the row; sync retries it on every reconnect, \`pendingCount\` never reaches zero, no user-visible error.

This PR introduces \`status='broken'\` and marks rows on first parse failure in the two write/upload paths. All reads filter \`WHERE status = 'pending'\`, so broken rows become invisible to consumers naturally — the infinite-retry loop is broken.

## Scope

| File | Change |
|---|---|
| \`apps/mobile/lib/db.ts\` | Extend \`PendingShot.status\` union (\`'pending' \| 'synced' \| 'broken'\`); add \`markShotBroken\` (with internal try/catch so a marker-write failure can't mask the actual parse error for its caller); call from \`setPendingShotEnd\` parse-fail; treat existing broken rows as not-found in \`setPendingShotEnd\` |
| \`apps/mobile/lib/sync.ts\` | Call \`markShotBroken\` from the upload-loop parse-fail |

Both parse-fail sites also gained a \`console.error('[db/payload-corrupt] local_id=%d msg=%s', ...)\` log. Without this the bug stays silent for future debugging — the only signal something is wrong would be a stuck \`pendingCount\`.

## Sites intentionally NOT touched

\`useHoleData.ts:195-203\` and \`209-217\` (the two \`useMemo\` bodies that also parse payload). They keep their try/catch as belt-and-suspenders for the in-flight window between marker write and next \`pendingForHole\` refresh. **Side effects in a useMemo body would violate React purity** and re-fire on every render — the marker write needs to live in a write path, not a memo.

## No schema migration

- \`pending_shots\` is on-device SQLite, NOT Supabase Postgres.
- \`status\` column has no CHECK constraint (\`status TEXT NOT NULL DEFAULT 'pending'\`).
- \`CREATE TABLE IF NOT EXISTS\` skips on existing installs, so any retro-added CHECK wouldn't apply anyway.
- TypeScript union on \`PendingShot.status\` is the actual gate.

## Known minor race (documented in scope, not fixed here)

When \`markShotBroken\` fires during a background sync, the in-memory \`pendingForHole\` array in \`useHoleData\` keeps the now-broken row until the next \`currentHoleScore.id\` change refresh. Meanwhile \`localShotCount = pendingForHole.length\` (which doesn't parse payload) momentarily inflates \`shotNumber\` by 1. Self-corrects on next refresh. Not worth fixing in this scope.

## Verification

- [x] \`pnpm typecheck\` — 3/3 packages green
- [x] \`cd apps/mobile && npx tsc --noEmit\` — exit 0 (after extending union triggered a real bug at \`setPendingShotEnd\` line 140 returning broken-status row, fixed by treating broken as not-found at line 117)
- [x] Independent analysis by \`pr-review-toolkit:silent-failure-hunter\` agent before implementation — confirmed the 4 sites, schema claim, read-filter claim, and pushed back on scope (no \`last_error\` column, no CHECK constraint, no useMemo write)
- [ ] Manual: artificially corrupt a payload (\`UPDATE pending_shots SET payload='{not json' WHERE local_id=...\`) and confirm next sync marks it broken with the new log line; \`pendingCount\` correctly returns to zero on next legitimate sync

## Follow-up tickets worth filing

- Debug screen to surface/clear \`status='broken'\` rows (user-side cleanup affordance, not critical)
- Adjacent: \`hole_scores.shot_number\` race during marker write (the minor race noted above) — low impact