### PR TITLE
fix(mobile): stabilize ShotLogger key + harden useHoleData fetch race (#284)

### DIFF
--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -435,6 +435,12 @@ export default function LiveRoundSession({
 
       <HoleModals
         shotNumber={data.shotNumber}
+        // Compound key: hole_score id + per-save counter. Changes
+        // only on a real "new shot entry" event — a legitimate save
+        // (counter bumps in useShotActions) or a hole change (id
+        // changes). Never on incidental shotNumber recomputation
+        // from background fetches or sync. See #284.
+        shotEntryKey={`${data.currentHoleScore?.id ?? 'init'}-${actions.shotEntrySeq}`}
         loggerOpen={loggerOpen}
         loggerInitial={loggerInitial}
         ball={finalState.ball}

--- a/apps/mobile/components/round/hole/HoleModals.tsx
+++ b/apps/mobile/components/round/hole/HoleModals.tsx
@@ -21,6 +21,12 @@ type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
 
 interface HoleModalsProps {
   shotNumber: number
+  // Stable identity for the ShotLogger form instance — composed of
+  // hole_score_id + a per-save counter (see #284). Changes only on a
+  // legitimate "new shot entry" event (save success or hole change),
+  // never on incidental shotNumber recomputation. Pass through to
+  // <ShotLogger key={...}> so the form remount is intentional.
+  shotEntryKey: string
   loggerOpen: boolean
   loggerInitial: ShotLoggerValue
   ball: LatLng | null
@@ -65,6 +71,7 @@ interface HoleModalsProps {
 export function HoleModals(props: HoleModalsProps) {
   const {
     shotNumber,
+    shotEntryKey,
     loggerOpen,
     loggerInitial,
     ball,
@@ -107,7 +114,7 @@ export function HoleModals(props: HoleModalsProps) {
   return (
     <>
       <ShotLogger
-        key={shotNumber}
+        key={shotEntryKey}
         visible={loggerOpen}
         shotNumber={shotNumber}
         isPutt={false}

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Database } from '@oga/supabase'
 import {
   pendingShotsForHoleScore,
@@ -149,9 +149,19 @@ export function useHoleData(
   // changes. Putts are counted as shots where club='putter' OR lie_type='green'.
   // Also pulls remote shot start coords so the on-map waypoint breadcrumb
   // survives a screen reload mid-hole.
+  //
+  // The original `let active = true` cleanup pattern protects against deps
+  // changing mid-fetch, but doesn't protect against two effect runs sharing
+  // the same `currentHoleScore.id` value (e.g. parent re-render that
+  // schedules a re-run without a value change, or a quick navigate-away-
+  // and-back). A monotonic nonce ref makes this race-free: every effect
+  // run claims a unique nonce; only the run whose nonce still matches the
+  // ref's latest value is allowed to commit setState. Stale fetches that
+  // resolve after a newer run started are silently dropped. (#284)
+  const fetchNonceRef = useRef(0)
   useEffect(() => {
     if (!currentHoleScore) return
-    let active = true
+    const myNonce = ++fetchNonceRef.current
     ;(async () => {
       const [shotsRes, local] = await Promise.all([
         supabase
@@ -161,7 +171,7 @@ export function useHoleData(
           .order('shot_number'),
         pendingShotsForHoleScore(currentHoleScore.id),
       ])
-      if (!active) return
+      if (myNonce !== fetchNonceRef.current) return
       const shots = shotsRes.data ?? []
       setRemoteShotCount(shots.length)
       setRemotePuttCount(
@@ -176,9 +186,6 @@ export function useHoleData(
       setRemoteShotStarts(starts)
       setPendingForHole(local)
     })()
-    return () => {
-      active = false
-    }
   }, [currentHoleScore?.id])
 
   // Derive local shot/putt counts from the pending array — single source

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -46,6 +46,12 @@ export interface UseShotActionsResult {
   saving: boolean
   ending: boolean
   deleting: boolean
+  // Monotonic counter that bumps once per successful persistShot.
+  // Used by HoleModals as the ShotLogger key so the form remounts
+  // (= resets) exactly when a shot saves — and not on incidental
+  // shotNumber recomputation from stale fetches or background sync.
+  // See #284 for the original symptom.
+  shotEntrySeq: number
   persistShot: (meta: ShotLoggerValue | null) => Promise<void>
   persistPutt: (v: PuttingValue) => Promise<void>
   persistRoundPin: (loc: LatLng) => Promise<void>
@@ -95,6 +101,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   const persistShotInFlightRef = useRef(false)
   const [ending, setEnding] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  const [shotEntrySeq, setShotEntrySeq] = useState(0)
 
   const {
     round,
@@ -207,6 +214,9 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
             : hs,
         ),
       )
+      // Bump only on success — a failed save (caught below) shouldn't
+      // remount the form and wipe the player's entry.
+      setShotEntrySeq((s) => s + 1)
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('shot save failed', err, payload)
@@ -481,6 +491,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     saving,
     ending,
     deleting,
+    shotEntrySeq,
     persistShot,
     persistPutt,
     persistRoundPin,


### PR DESCRIPTION
Closes #284. Two-commit PR; commits are individually reviewable.

## Summary

ShotLogger's form state was being wiped mid-entry when \`shotNumber\` recomputed at the wrong moment (e.g. a stale \`remoteShotCount\` fetch landing after the player opened the logger). Two complementary fixes:

1. **Underlying race** — replace \`let active = true\` cleanup pattern in \`useHoleData\` with a monotonic nonce ref so stale fetches can never overwrite fresh state, regardless of whether deps changed.
2. **Brittle key** — key ShotLogger on a compound \`(hole_score_id, shotEntrySeq)\` identity instead of the derived \`shotNumber\` so the remount only fires on real "new shot entry" events.

Either commit alone removes the user-visible symptom; both together remove the underlying brittleness AND the symptom.

## Commits

### Commit 1 — \`useHoleData.ts\`: nonce-based fetch guard
Per-effect-run nonce. Only the run whose nonce still matches the ref's latest value commits setState. Cycle-agnostic — protects against same-id re-runs (parent re-render, navigate-away-and-back, etc.) that the \`active\` flag pattern misses.

13 insertions / 6 deletions, 1 file.

### Commit 2 — ShotLogger key change
\`shotEntrySeq\` counter in \`useShotActions\` that bumps once per successful \`persistShot\`. Compound key \`\${currentHoleScore.id}-\${shotEntrySeq}\` passed through HoleModals to \`<ShotLogger key={...}>\`. The key changes only on legitimate save or hole change — never on incidental \`shotNumber\` recomputation.

\`shotNumber\` prop on HoleModals stays for the displayed "Shot 3" label, just no longer for component identity.

25 insertions / 1 deletion, 3 files.

## Cross-check

Independent verification by \`pr-review-toolkit:silent-failure-hunter\` agent before implementation:

- Confirmed the audit's claim about background sync triggering \`shotNumber\` change was wrong (\`syncPendingShots\` doesn't touch React state observable by \`useHoleData\`)
- Identified the **actual** trigger: stale \`setRemoteShotCount\` from an in-flight fetch that beats the cleanup flip
- Caught my own under-scoping — I initially planned \`key={shotEntrySeq}\` alone, but the agent noted ShotLogger stays mounted across hole changes (RN Modal hides via \`visible\`), so the key needs to include hole_score_id too. Pivoted to the compound form.
- Identified six adjacent silent-failure paths in this area — filed as #336, not in this PR.

## Companion close

#290 (persistShot stale closure on double-tap) closed as not-a-bug. Cross-check confirmed the existing \`persistShotInFlightRef\` gate plus React 18 auto-batching plus \`ShotLogger\` \`disabled={saving}\` adequately protect against the audit's mechanism. If a duplicate \`shot_number\` write actually occurs in the wild, reopen with a trace.

## Test plan

- [x] \`pnpm typecheck\` — 3/3 packages green
- [x] \`cd apps/mobile && npx tsc --noEmit\` — exit 0
- [ ] Manual: open ShotLogger on hole N, navigate to hole N+1 and back, confirm logger doesn't auto-reopen with stale state
- [ ] Manual: open ShotLogger mid-entry, wait for a background \`syncPendingShots\` to complete, confirm form state intact
- [ ] Manual: save shot 1, confirm logger remounts fresh for shot 2