### PR TITLE
fix(mobile): key PuttingSheet by shotEntryKey + drop reseed effect (#283)

### DIFF
--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import {
   KeyboardAvoidingView,
   Platform,
@@ -113,14 +113,6 @@ export function PuttingSheet({
   const [distanceText, setDistanceText] = useState(
     String(feetToInput(initial?.puttDistanceFt ?? initialDistanceFt ?? 0)),
   )
-
-  useEffect(() => {
-    if (initialDistanceFt != null && initial?.puttDistanceFt == null) {
-      setValue((v) => ({ ...v, puttDistanceFt: initialDistanceFt }))
-      setDistanceText(String(feetToInput(initialDistanceFt)))
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialDistanceFt, unit])
 
   function commitDistance(text: string) {
     setDistanceText(text)

--- a/apps/mobile/components/round/hole/HoleModals.tsx
+++ b/apps/mobile/components/round/hole/HoleModals.tsx
@@ -143,6 +143,7 @@ export function HoleModals(props: HoleModalsProps) {
         <GestureHandlerRootView style={{ flex: 1 }}>
           <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
             <PuttingSheet
+              key={shotEntryKey}
               shotNumber={shotNumber}
               initialDistanceFt={
                 ball && (roundPin ?? storedPin)


### PR DESCRIPTION
Closes #283. Companion to PR #337 (#284 ShotLogger key stability) — applies the same key-based remount pattern to PuttingSheet.

## Summary

Player's manual distance entry on PuttingSheet was being wiped while the sheet was open. The reseed effect at \`PuttingSheet.tsx:117-123\` fired whenever \`initialDistanceFt\` OR \`unit\` changed and overwrote the player's typed value.

**Two-line change:**
1. \`HoleModals.tsx\` — add \`key={shotEntryKey}\` to the PuttingSheet mount. Same compound key already plumbed through for ShotLogger in #284.
2. \`PuttingSheet.tsx\` — delete the entire reseed useEffect; lazy \`useState\` init at line 102-115 already handles seeding under key-based remount. \`useEffect\` dropped from imports.

9 deletions / 2 insertions.

## Audit correction

Audit claimed a stale-closure bug on \`initial?.puttDistanceFt\` being missing from the dep array. Reality: **\`initial\` is never passed** at the live-round mount (\`HoleModals.tsx:138-150\` only passes \`shotNumber\`, \`initialDistanceFt\`, \`onSave\`, \`onClose\`, \`onChangeLie\`). The eslint suppression was hiding vestigial code, not a real stale read.

Real failure modes:
- Player toggles ft/m unit profile mid-entry → effect fires → manual entry wiped
- Ball moves mid-entry (drag, GPS update routed through ball) → effect fires → manual entry wiped

The audit's "multi-putt navigation" scenario doesn't actually fail — between putts the entry is fresh, and the new auto-seed reflecting new ball-to-pin distance is desired.

## Cross-check

Independent verification by \`pr-review-toolkit:silent-failure-hunter\` before implementation:

- Confirmed \`initial\` prop is never passed at the bug-site mount
- Confirmed the second PuttingSheet mount inside ShotLogger (\`ShotLogger.tsx:143-183\`) is reached only when player flips \`lieType='green'\` inside the regular shot logger, NOT the on-green prompt flow — removing the effect has zero behavioral change there because that mount DOES pass \`initial?.puttDistanceFt\` which short-circuits the buggy branch
- Confirmed \`useState\` lazy init handles seeding cleanly under key-based remount; no race since \`roundState='PUTTING'\` and the \`shotEntrySeq\` bump from the previous persistShot are both committed before the Modal can open
- Confirmed \`shotEntrySeq\` bumps only on persistShot success — failed save preserves form state
- Confirmed audit's "multi-putt navigation" mechanism doesn't fail
- No tests cover PuttingSheet (\`grep\` confirmed); deletion is safe

## Known edge case explicitly NOT fixed

Unit profile toggle while sheet is open: \`distanceText\` (input display) keeps its old-unit representation until player retypes. \`value.puttDistanceFt\` (stored value) is always feet, so saved data is correct — only the input display lags. File as follow-up if QA surfaces it.

## Out-of-scope observation worth filing later

The \`initial\` prop on \`PuttingSheetProps\` is now load-bearing only for the ShotLogger-internal mount. Worth auditing whether that mount path is still needed or if it can be consolidated — but out of scope for #283.

## Test plan

- [x] \`pnpm typecheck\` — 3/3 packages green
- [x] \`cd apps/mobile && npx tsc --noEmit\` — exit 0
- [ ] Manual: open PuttingSheet for putt 1, type manual distance, toggle ft/m profile, confirm puttDistanceFt value preserved (display will lag — that's the known edge case)
- [ ] Manual: putt 1, save (Made/Missed), confirm putt 2's auto-seed reflects new ball position
- [ ] Manual: open PuttingSheet, tap Close without saving, re-trigger on-green prompt — confirm typed state persists (same shot, same key)