### PR TITLE
fix(mobile): three remaining NaN propagation guards in live-round flow (#275)

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -169,7 +169,14 @@ export function HoleMap({
         const coord = await mapView.getCoordinateFromView([x, y])
         if (mapViewRef.current !== mapView) return
         if (coord && coord.length >= 2) {
-          onSetAim({ lat: coord[1], lng: coord[0] })
+          const lat = coord[1]
+          const lng = coord[0]
+          // NaN guard (#275). Long-press near Mapbox projection
+          // singularities (extreme zoom, off-tile area) can return
+          // non-finite coords; without this, aim flows to buildPayload
+          // as aim_lat/aim_lng and the shot save fails on sync.
+          if (!Number.isFinite(lat) || !Number.isFinite(lng)) return
+          onSetAim({ lat, lng })
         }
       } catch {
         // map not ready yet

--- a/apps/mobile/components/round/hole/useHoleState.ts
+++ b/apps/mobile/components/round/hole/useHoleState.ts
@@ -176,6 +176,14 @@ export function useHoleState({
               accuracy: loc.coords.accuracy ?? undefined,
               timestamp: loc.timestamp,
             }
+            // Defense-in-depth NaN guard (#275). Kalman's update path
+            // already drops corrupt readings safely, but gpsPosition
+            // bypasses the filter and flows directly to setPendingShotEnd
+            // via markBallHere — a NaN there hits Postgres as a double
+            // precision insert error and wedges the round.
+            if (!Number.isFinite(rawPoint.lat) || !Number.isFinite(rawPoint.lng)) {
+              return
+            }
             // Always update gpsPosition (puck-adjacent recenter target +
             // nearPin radius check) regardless of manual ball placement.
             // The freeze below is solely about preventing GPS from

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -316,6 +316,20 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       )
       return
     }
+    // NaN guard (#275). gpsPosition is the fallback when the player
+    // hasn't dragged a ball yet, and a corrupt GPS reading that slipped
+    // past upstream guards would otherwise propagate to setPendingShotEnd
+    // (NaN → SQLite → Postgres rejects on sync) and setBall (NaN
+    // poisons the next persistShot's start_lat).
+    if (!Number.isFinite(source.lat) || !Number.isFinite(source.lng)) {
+      // eslint-disable-next-line no-console
+      console.warn('[hole/markBallHere] non-finite source coord', source)
+      Alert.alert(
+        'GPS reading invalid',
+        'The location fix came back malformed. Try again, or tap the map to drop the ball manually.',
+      )
+      return
+    }
     const ballSnapshot = { lat: source.lat, lng: source.lng }
     manuallyPlacedRef.current = true
     const prevLocalId = lastSavedShotLocalIdRef.current


### PR DESCRIPTION
Companion to #318 (which plugged the most critical NaN site — \`extractCoord\`). This PR closes the three remaining propagation paths.

## Audit summary

**Already protected:**
- \`HoleMap.tsx:90\` — \`extractCoord\` (PR #318)
- \`useShotActions.ts:248\` — \`persistRoundPin\` finite guard
- \`useShotActions.ts:287\` — \`persistTee\` finite guard
- \`@oga/core/kalman.ts\` is bulletproof — \`createKalmanState\` throws on NaN, \`updateKalman\` returns prior state unchanged on NaN. Kalman cannot be poisoned.

**Three remaining unprotected propagation paths — all fixed here:**

| # | Site | Mechanism |
|---|---|---|
| 1 | \`useHoleState.ts\` GPS callback (rawPoint → \`setGpsPosition\`) | \`gpsPosition\` bypasses Kalman; flows directly to \`markBallHere\` → \`setPendingShotEnd\` |
| 2 | \`useShotActions.ts\` \`markBallHere\` (\`source = ball ?? gpsPosition\`) | Defense-in-depth: NaN in either input writes to SQLite and poisons \`ball\` for the next \`persistShot\` |
| 3 | \`HoleMap.tsx\` \`dropAimFromScreenPoint\` (\`getCoordinateFromView\`) | Bypasses extractCoord entirely; aim flows to \`buildPayload\` as \`aim_lat\`/\`aim_lng\` |

## Pattern

All three follow the same \`Number.isFinite\` pattern already established at the protected sites. No new helper extraction per the 3-caller rule.

\`\`\`ts
if (!Number.isFinite(lat) || !Number.isFinite(lng)) return
\`\`\`

Site 2 additionally surfaces a user-facing \`Alert\` since silently no-op'ing "Mark ball here" would leave the player wondering why nothing happened — the message hints at manual map placement as a recovery path.

## Files

- \`apps/mobile/components/round/hole/useHoleState.ts\` (+8)
- \`apps/mobile/components/round/hole/useShotActions.ts\` (+14)
- \`apps/mobile/components/round/HoleMap.tsx\` (+9 / -1)

30 insertions / 1 deletion.

## Test plan

- [x] \`pnpm typecheck\` — 3/3 packages green
- [x] \`cd apps/mobile && npx tsc --noEmit\` — exit 0
- [ ] Manual: verify "Mark ball here" still works in the normal path (finite \`gpsPosition\`)
- [ ] Cannot easily reproduce NaN on-device without dev hooks; relying on the same patch-and-watch approach as #318