### PR TITLE
fix(mobile): timeout-protect Location.requestForegroundPermissionsAsync at both call sites (#278)

### DIFF
--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -80,7 +80,19 @@ export default function NewRound() {
     setGps({ status: 'pending' })
     ;(async () => {
       try {
-        const perm = await Location.requestForegroundPermissionsAsync()
+        // expo-location's permission request can hang on Android if the
+        // activity is recreated mid-dialog. Race against a 10s timeout —
+        // same mechanism as useHoleState.ts; see #278.
+        const perm = await Promise.race([
+          Location.requestForegroundPermissionsAsync(),
+          new Promise<never>((_, rej) =>
+            setTimeout(() => rej(new Error('perm-timeout')), 10_000),
+          ),
+        ]).catch((e: Error) => {
+          // eslint-disable-next-line no-console
+          console.warn('[round/new perm-timeout]', e.message)
+          return { status: 'undetermined' as const }
+        })
         if (perm.status !== 'granted') {
           setGps({ status: 'denied' })
           return

--- a/apps/mobile/components/round/hole/useHoleState.ts
+++ b/apps/mobile/components/round/hole/useHoleState.ts
@@ -105,7 +105,24 @@ export function useHoleState({
     let subscription: Location.LocationSubscription | null = null
     ;(async () => {
       try {
-        const perm = await Location.requestForegroundPermissionsAsync()
+        // expo-location's permission request can hang on Android if the
+        // activity is recreated mid-dialog (rotation, theme change, OEM
+        // low-memory recycle). LocationHelpers.kt uses suspendCoroutine
+        // with no cancellation hook and no host-lifecycle cleanup, so
+        // the JS promise never settles. Race against a 10s timeout —
+        // matches PROFILE_FETCH_TIMEOUT_MS pattern in (app)/_layout.tsx.
+        // On timeout we treat as not-granted; user falls back to manual
+        // tap-to-place. See #278.
+        const perm = await Promise.race([
+          Location.requestForegroundPermissionsAsync(),
+          new Promise<never>((_, rej) =>
+            setTimeout(() => rej(new Error('perm-timeout')), 10_000),
+          ),
+        ]).catch((e: Error) => {
+          // eslint-disable-next-line no-console
+          console.warn('[useHoleState perm-timeout]', e.message)
+          return { status: 'undetermined' as const }
+        })
         if (perm.status !== 'granted') return
         if (!active) return
         // Last known fix first — instant, no satellite wait. Returns null


### PR DESCRIPTION
Closes #278.

## Summary

expo-location's permission request can hang indefinitely on Android when the activity is recreated mid-dialog. Cross-checked against native source — confirmed real bug with receipts. Two call sites awaited the unprotected promise; both now race against a 10s timeout.

## Native-source verification (via silent-failure-hunter agent)

| File | Line | Behavior |
|---|---|---|
| \`LocationHelpers.kt\` | 201-219 | Uses \`suspendCoroutine\` — **no cancellation hook** |
| \`PermissionsService.kt\` | 247-263 | Stashes listener in \`mCurrentPermissionListener\` |
| \`PermissionsService.kt\` | 344, 346 | \`onHostPause\` / \`onHostDestroy\` are both \`Unit\` — **no cleanup** |

If activity recreates mid-dialog: new \`PermissionAwareActivity\` instance, old listener never called back, coroutine continuation leaks, JS promise never settles.

Same hang family as #273 (which fixed \`getCurrentPositionAsync\` by making it fire-and-forget). Two missed permission-request sites get the equivalent fix here.

## Files

| Site | Function |
|---|---|
| \`apps/mobile/components/round/hole/useHoleState.ts:108\` | PLACE_BALL GPS subscription effect |
| \`apps/mobile/app/(app)/round/new.tsx:83\` | Course picker GPS-on-mount effect |

Both sites: \`Promise.race\` against 10s timeout, on timeout \`console.warn('[<area> perm-timeout]', ...)\` then return as not-granted. UX falls back to manual tap-to-place (already the design for denied permission).

## Why \`console.warn\` not silent catch

The audit's proposed \`catch(() => ({ status: 'undetermined' }))\` is the same silent-failure anti-pattern as the six sites consolidated in #336. Tagged \`console.warn\` matches the existing convention at \`round/new.tsx:120\` (\`'[round/new searchCourses]'\`) and gives Sentry / dev console searchable breadcrumbs.

## Known caveat (documented, NOT auto-fixed)

Per the cross-check: if a second permission request fires after the first hung (user navigates back, re-mounts), it queues behind the dead listener at \`mPendingPermissionCalls\` and **will hang again** until activity recreation flushes the listener. Our two call sites don't auto-retry — they require the user to navigate away (which typically recycles the activity). Adding auto-retry would worsen the queue-behind-dead-listener state.

## Adjacent silent-failure paths surfaced by cross-check (added to #336, NOT in this PR)

- \`useHoleState.ts:219-221\` — outer IIFE catch swallows \`watchPositionAsync\` rejection (silent dead map)
- \`useHoleState.ts:123-125\` — \`getLastKnownPositionAsync\` catch with \`// ignore\`
- \`round/new.tsx:96-98\` — bare \`catch { setGps({ status: 'denied' }) }\` conflates user-denied with API-threw

#336 now lists 9 sites (was 6).

## Test plan

- [x] \`pnpm typecheck\` — 3/3 packages green
- [x] \`cd apps/mobile && npx tsc --noEmit\` — exit 0
- [ ] Manual: rotate device while permission dialog is open, confirm fallback to manual tap-to-place after ~10s
- [ ] Manual: normal grant path (tap Allow quickly) still works without timeout firing

## Diff size

31 insertions / 2 deletions, 2 files.