### PR TITLE
fix(mobile): past-round scorecard polish — hide tap affordance on empty holes + refetch on focus (#247, #246)

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native'
 import { captureRef } from 'react-native-view-shot'
 import * as Sharing from 'expo-sharing'
-import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router'
 import { formatSG } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../../../lib/supabase'
@@ -97,21 +97,10 @@ export default function RoundIndex() {
         if (hsRes.error) throw hsRes.error
         setHoles(hRes.data ?? [])
         setHoleScores(hsRes.data ?? [])
-        // Fetch shots for all hole_scores in this round so the read-only
-        // hole drill-down sheet can render without a per-tap query. Past
-        // rounds are bounded (≤18 holes, max ~10 shots/hole), so a single
-        // pull on mount is fine.
-        const holeScoreIds = (hsRes.data ?? []).map((hs) => hs.id)
-        if (holeScoreIds.length > 0) {
-          const { data: shotData, error: shotErr } = await supabase
-            .from('shots')
-            .select('*')
-            .in('hole_score_id', holeScoreIds)
-            .order('shot_number')
-          if (!active) return
-          if (shotErr) throw shotErr
-          setShots(shotData ?? [])
-        }
+        // Shots are fetched in the useFocusEffect below — re-focus
+        // after an end-round (when pending shots are still syncing
+        // via fire-and-forget background sync) self-heals the count.
+        // See #246.
       } catch (err) {
         if (!active) return
         setError((err as Error).message)
@@ -135,6 +124,42 @@ export default function RoundIndex() {
   const sortedHoles = useMemo(
     () => [...holes].sort((a, b) => a.number - b.number),
     [holes],
+  )
+  // Drives the scorecard row's tap affordance — a row is only tappable
+  // if its hole has shots logged. Without this gate, the → arrow
+  // promises content; tap opens a sheet that reads "No shots logged
+  // for this hole." See #247.
+  const holeScoreIdsWithShots = useMemo(
+    () => new Set(shots.map((s) => s.hole_score_id)),
+    [shots],
+  )
+
+  // Refetch shots on screen focus. The end-round write order is:
+  // total_score + hole_scores first, then pending shot inserts trickle
+  // into the `shots` table via background sync. A player who reaches
+  // this screen mid-sync sees the totals row diverge from the per-hole
+  // drill-down sheet until a refetch. Initial mount fires this once
+  // (after holeScores populates and the callback identity changes),
+  // and every subsequent focus refires — so the common path
+  // (end-round → home → back to scorecard) self-heals. See #246.
+  useFocusEffect(
+    useCallback(() => {
+      if (holeScores.length === 0) return
+      let active = true
+      const holeScoreIds = holeScores.map((hs) => hs.id)
+      supabase
+        .from('shots')
+        .select('*')
+        .in('hole_score_id', holeScoreIds)
+        .order('shot_number')
+        .then(({ data, error }) => {
+          if (!active || error) return
+          setShots(data ?? [])
+        })
+      return () => {
+        active = false
+      }
+    }, [holeScores]),
   )
 
   // Stable across renders — passing an inline arrow caused
@@ -481,13 +506,18 @@ export default function RoundIndex() {
             const hs = scoresByHoleId.get(h.id)
             const score = hs?.score ?? null
             const d = score != null && score > 0 ? score - h.par : null
+            const hasShots = hs ? holeScoreIdsWithShots.has(hs.id) : false
             return (
               <Pressable
                 key={h.id}
-                accessibilityRole="button"
-                accessibilityLabel={`Hole ${h.number}, par ${h.par}${score != null && score > 0 ? `, score ${score}` : ', not played'}, view shots`}
-                onPress={() => setShotsForHole(h)}
-                android_ripple={{ color: '#EBE5D6' }}
+                accessibilityRole={hasShots ? 'button' : 'text'}
+                accessibilityLabel={
+                  hasShots
+                    ? `Hole ${h.number}, par ${h.par}, score ${score}, view shots`
+                    : `Hole ${h.number}, par ${h.par}${score != null && score > 0 ? `, score ${score}` : ', not played'}`
+                }
+                onPress={hasShots ? () => setShotsForHole(h) : undefined}
+                android_ripple={hasShots ? { color: '#EBE5D6' } : undefined}
                 style={{
                   flexDirection: 'row',
                   paddingVertical: 10,
@@ -546,9 +576,6 @@ export default function RoundIndex() {
                 >
                   {d == null ? '—' : d === 0 ? 'E' : d > 0 ? `+${d}` : `${d}`}
                 </Text>
-                {/* Persistent affordance — pressed-only background gave
-                    no resting hint that rows were tappable. Arrow sits
-                    in muted ink so it doesn't fight the score columns. */}
                 <Text
                   style={{
                     width: 18,
@@ -558,7 +585,7 @@ export default function RoundIndex() {
                     marginLeft: 6,
                   }}
                 >
-                  →
+                  {hasShots ? '→' : ''}
                 </Text>
               </Pressable>
             )


### PR DESCRIPTION
Closes #247, #246.

## Summary

Two related past-round scorecard bugs in `apps/mobile/app/(app)/round/[id]/index.tsx`:

- **#247** — The → arrow and "view shots" accessibility hint rendered on every hole row, including holes with no shots logged. Tap opened a sheet that read "No shots logged for this hole." — affordance lie. The arrow + tap handler + ripple + `accessibilityRole=button` are now gated on `holeScoreIdsWithShots.has(hs.id)`. Rows for not-played holes stay in the scorecard for visual completeness but are no longer interactive (`accessibilityRole=text`, no onPress).
- **#246** — Shot fetch moved from the mount-time useEffect into a `useFocusEffect`. End-round write order is `total_score` + `hole_scores` first, then pending shot inserts trickle into the `shots` table via fire-and-forget background sync. A player reaching this screen mid-sync saw the totals row diverge from the per-hole drill-down sheet until next remount. `useFocusEffect` fires on initial focus (after `holeScores` populates and the callback identity changes) plus every re-focus, so the common path (end-round → home → back to scorecard) self-heals without a manual refresh.

## Out of scope

- **Variant B** for #246 (also refetch when the per-hole sheet opens) — covers the "user sits on the scorecard waiting" case. Variant A covers the realistic end-round-then-bounce path; we'll add B only if the focus-only fix turns out to miss real cases.
- **\`useFocusEffect\` is not currently used for the round/holes/holeScores fetch** — those are stable once written, no race motivation. Only shots refetch on focus.
- **\`Co-Authored-By:\` trailer / \"Generated with Claude Code\" footer** are deliberately omitted per project policy.

## #242 status

Closed-in-spirit pre-session (see code comments at lines 56-59 and session memory obs 764, 2026-05-07). `onPress={() => setShotsForHole(h)}` opens the read-only sheet, never the live state machine. Will be commented "done" on the issue as part of this PR.

## Test plan

- [ ] **#247 — affordance gate.** View a past round with at least one zero-shot hole (any not-played hole on a partial round). Confirm: no → arrow on that row, no ripple on tap, screen reader announces "Hole N, par P, not played" without ", view shots".
- [ ] **#247 — normal hole still tappable.** Other rows still show → and open the sheet on tap.
- [ ] **#246 — refetch on focus.** End a live round, land on scorecard while pending shots are still syncing (slow network helps), confirm initial counts may be stale. Navigate to Home, back to scorecard — totals row and per-hole sheet now match.
- [ ] **#246 — no regression on cold load.** Open a completed round from the home list. Confirm shots load (just slightly later than before, since fetch is now in useFocusEffect rather than the mount effect).
- [ ] Mobile typecheck (already passing locally).