### PR TITLE
fix(web): Vercel SPA 404 fallback + stats chart legends + README url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ coverage/
 # misc
 *.tsbuildinfo
 
+# serena mcp server project metadata (local tooling, do not publish)
+.serena/
+
 # Internal planning + design docs — kept locally, not published to GitHub.
 CLAUDE.md
 DESIGN.md

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ better at golf shouldn't be paywalled.
 
 ## Live app
 
-- Web: https://opengolfapp-web.vercel.app
+- Web: https://oga.golf
 - Android: EAS development builds today; Play Store listing TBD
 - iOS: deferred — pending an Apple developer account
 

--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -145,7 +145,10 @@ export function ShotPatternsPage() {
                 {lieSlopeSide ? ` (${lieSlopeSide.replace('_', ' ')})` : ''}.
               </div>
             ) : (
-              <DispersionPlot points={points} stats={stats} />
+              <>
+                <DispersionPlot points={points} stats={stats} />
+                <PatternLegend hasEllipses={!!stats} />
+              </>
             )}
           </div>
 
@@ -317,6 +320,54 @@ function Stat({ label, value }: { label: string; value: string }) {
       >
         {value}
       </dd>
+    </div>
+  )
+}
+
+const DOT_LEGEND = [
+  { color: '#1C211C', label: 'Solid' },
+  { color: '#A66A1F', label: 'Push / pull' },
+  { color: '#A33A2A', label: 'Miss' },
+  { color: '#8A8B7E', label: 'Unspecified' },
+] as const
+
+const ELLIPSE_LEGEND = [
+  { fill: 'rgba(31,61,44,0.12)', dashed: false, label: '68% of shots' },
+  { fill: 'rgba(31,61,44,0.06)', dashed: true, label: '95% of shots' },
+] as const
+
+function PatternLegend({ hasEllipses }: { hasEllipses: boolean }) {
+  return (
+    <div style={{ marginTop: 12, display: 'flex', flexWrap: 'wrap', gap: '6px 14px' }}>
+      {DOT_LEGEND.map((item) => (
+        <span key={item.label} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+          <span
+            style={{
+              width: 8,
+              height: 8,
+              borderRadius: '50%',
+              background: item.color,
+              flexShrink: 0,
+            }}
+          />
+          <span className="kicker" style={{ color: '#8A8B7E' }}>{item.label}</span>
+        </span>
+      ))}
+      {hasEllipses &&
+        ELLIPSE_LEGEND.map((item) => (
+          <span key={item.label} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+            <svg width="14" height="10" style={{ flexShrink: 0 }}>
+              <ellipse
+                cx="7" cy="5" rx="6" ry="4"
+                fill={item.fill}
+                stroke="#1F3D2C"
+                strokeWidth="1"
+                strokeDasharray={item.dashed ? '3 2' : undefined}
+              />
+            </svg>
+            <span className="kicker" style={{ color: '#8A8B7E' }}>{item.label}</span>
+          </span>
+        ))}
     </div>
   )
 }

--- a/apps/web/src/pages/stats/sections/StrokesGainedSection.tsx
+++ b/apps/web/src/pages/stats/sections/StrokesGainedSection.tsx
@@ -23,11 +23,41 @@ const TOOLTIP_STYLE = {
 } as const
 
 const SG_SERIES = [
-  { key: 'offTee', label: 'Off tee', color: '#1F3D2C' },
-  { key: 'approach', label: 'Approach', color: '#A33A2A' },
-  { key: 'aroundGreen', label: 'Around green', color: '#A66A1F' },
-  { key: 'putting', label: 'Putting', color: '#5C6356' },
+  { key: 'offTee', label: 'Off tee', color: '#1F3D2C', dashed: false },
+  { key: 'approach', label: 'Approach', color: '#A33A2A', dashed: false },
+  { key: 'aroundGreen', label: 'Around green', color: '#A66A1F', dashed: false },
+  { key: 'putting', label: 'Putting', color: '#5C6356', dashed: true },
 ] as const
+
+function SGLegend() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        gap: 16,
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+        fontSize: 11,
+        fontFamily: 'Inter, sans-serif',
+        paddingTop: 8,
+      }}
+    >
+      {SG_SERIES.map((s) => (
+        <span key={s.key} style={{ display: 'flex', alignItems: 'center', gap: 6, color: '#5C6356' }}>
+          <svg width="16" height="10" style={{ flexShrink: 0 }}>
+            <line
+              x1="0" y1="5" x2="16" y2="5"
+              stroke={s.color}
+              strokeWidth="1.5"
+              strokeDasharray={s.dashed ? '4 3' : undefined}
+            />
+          </svg>
+          {s.label}
+        </span>
+      ))}
+    </div>
+  )
+}
 
 export function StrokesGainedSection({ data }: { data: DetailedStats }) {
   const series = SG_SERIES.map((s) => ({
@@ -84,14 +114,7 @@ export function StrokesGainedSection({ data }: { data: DetailedStats }) {
                   contentStyle={TOOLTIP_STYLE}
                   labelStyle={{ color: '#8A8B7E' }}
                 />
-                <Legend
-                  iconType="plainline"
-                  wrapperStyle={{
-                    fontSize: 11,
-                    color: '#5C6356',
-                    fontFamily: 'Inter, sans-serif',
-                  }}
-                />
+                <Legend content={<SGLegend />} />
                 {SG_SERIES.map((s) => (
                   <Line
                     key={s.key}
@@ -100,6 +123,7 @@ export function StrokesGainedSection({ data }: { data: DetailedStats }) {
                     name={s.label}
                     stroke={s.color}
                     strokeWidth={1.5}
+                    strokeDasharray={s.dashed ? '4 3' : undefined}
                     dot={{ r: 2.5, fill: s.color, strokeWidth: 0 }}
                     activeDot={{ r: 4 }}
                   />

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,8 @@
   "buildCommand": "pnpm --filter web build",
   "outputDirectory": "apps/web/dist",
   "installCommand": "pnpm install",
-  "framework": null
+  "framework": null,
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
 }


### PR DESCRIPTION
Three small, cohesive web-only changes bundled into one PR per request.

## 1. Vercel SPA 404 fallback (the prod 404 issue)

**The bug.** On prod, deep links and refreshes on routes other than `/` (e.g. `/learn`, `/rounds/:id`, `/stats`) returned Vercel's default 404. The SPA only recovered after navigating manually back to `/`. Shared URLs were effectively unusable.

**Cause.** `vercel.json` had `framework: null` and no `rewrites`. With `framework: null`, Vercel does NOT apply the implicit SPA fallback that the `vite` preset would have given for free. Any path with no matching file on disk hit Vercel's 404 instead of falling through to `index.html`.

**Fix.** Added:
\`\`\`json
\"rewrites\": [{ \"source\": \"/(.*)\", \"destination\": \"/index.html\" }]
\`\`\`
Built assets under `/assets/*` continue to serve directly (file matcher runs before rewrites). Only unknown paths fall through, letting React Router boot and resolve the URL client-side — i.e. exactly how every other Vite SPA on Vercel behaves.

## 2. README live-URL update

\`opengolfapp-web.vercel.app\` -> \`oga.golf\` (canonical production domain since 2026-05-07).

## 3. Stats chart legends (partial fix for #240)

- **Dispersion plot** (`ShotPatternsPage.tsx`): added a `PatternLegend` below the plot — dot legend for shot-result colors (Solid / Push-pull / Miss / Unspecified) plus an ellipse legend (68% solid ring / 95% dashed ring, gated on whether stats produced an ellipse). The colored dots and ellipse rings rendered with no key before this.
- **SG trend chart** (`StrokesGainedSection.tsx`): added a `dashed: boolean` field to `SG_SERIES`, made putting dashed (`strokeDasharray=\"4 3\"`), and replaced the default Recharts `<Legend>` with a custom `SGLegend` whose SVG segments mirror the actual line stroke (solid vs dashed). Off-tee and putting were previously near-impossible to distinguish.

Partially addresses #240 (off-tee vs putting differentiation); does not close it (the issue was filed broadly, and the dashed-putting choice is one of several possible interventions).

## 4. .gitignore

Added `.serena/` (local Serena MCP project metadata, never published).

## Test plan

- [ ] **404 fix.** After deploy: visit `https://oga.golf/learn` directly (new tab or paste into address bar). Should load the Learn page, not a Vercel 404. Refresh on `/rounds/:id`. Should reload the same view, not 404. Repeat with a deep stats route.
- [ ] **Dispersion legend.** Open `/patterns` with a club that has data and at least 5 shots logged (so ellipse fits). Confirm the new legend renders below the plot with both dot rows and ellipse rows. With <5 shots (no ellipse), confirm only the dot rows show.
- [ ] **SG trend legend.** Open `/stats` for a user with 3+ rounds. Confirm putting line is now visibly dashed, and the legend's putting entry mirrors the dashed style.
- [ ] **No regressions.** `pnpm typecheck` clean. Web build succeeds (`pnpm --filter web build`).