### PR TITLE
fix(web): set emailRedirectTo on signup so confirm email stays on origin (#347)

### DIFF
--- a/apps/web/src/pages/auth/SignupPage.tsx
+++ b/apps/web/src/pages/auth/SignupPage.tsx
@@ -40,6 +40,7 @@ export function SignupPage() {
       password,
       options: {
         data: { username },
+        emailRedirectTo: `${window.location.origin}/onboarding`,
         ...(captchaToken ? { captchaToken } : {}),
       },
     })


### PR DESCRIPTION
Closes #347.

## Symptom
Signup confirmation email sent from \`oga.golf\` redirected to \`localhost:5173\` instead of back to the production site. New users couldn't complete signup.

## Cause
\`apps/web/src/pages/auth/SignupPage.tsx\` was calling \`supabase.auth.signUp\` without an \`emailRedirectTo\` option. When omitted, Supabase falls back to the project's dashboard **Site URL** setting — which had drifted to \`http://localhost:5173\` from initial scaffolding.

## Fix
- **Supabase dashboard** (already done by Conner before this PR): Site URL set to \`https://oga.golf\` + Additional Redirect URLs include the prod domain.
- **This PR**: pin \`emailRedirectTo\` in code:
  \`\`\`ts
  emailRedirectTo: \`\${window.location.origin}/onboarding\`,
  \`\`\`
  Pulls the origin at call time, so the redirect works correctly on prod (\`oga.golf\`), Vercel previews (\`*.vercel.app\`), and local dev (\`localhost:5173\`) without any per-env config. The dashboard Additional Redirect URLs list still needs to allow each of those origins (already done).

## Why not mobile too
\`apps/mobile/app/(auth)/signup.tsx\` is intentionally untouched in this PR:
- No \`window\` on mobile, so \`window.location.origin\` doesn't apply.
- After the dashboard fix, the default Site URL handles the email link correctly for mobile too — the browser opens the website, which is the expected behavior today.
- A polished mobile flow (deep link back into the app via \`oga://onboarding\`) needs scheme config + a deep-link handler that's out of scope for this hotfix.

## Test plan
- [ ] Sign up with a throwaway email on \`oga.golf\` (prod). Confirm email link lands on \`https://oga.golf/onboarding\` with a confirmed session — not localhost.
- [ ] Sign up on a Vercel preview URL. Confirm email link lands on that same preview URL, not the prod URL or localhost.
- [ ] Sign up on local dev (\`localhost:5173\`). Confirm email link still works locally (requires \`http://localhost:5173/**\` in the Supabase dashboard Additional Redirect URLs allow-list).