### PR TITLE
fix(db): rate-limit user-submitted courses to block spam (#221)

### DIFF
--- a/supabase/migrations/0027_rate_limit_course_inserts.sql
+++ b/supabase/migrations/0027_rate_limit_course_inserts.sql
@@ -1,0 +1,98 @@
+-- Rate-limit user-submitted courses — security/spam audit (closes #221).
+--
+-- Migration 0001's INSERT policy on `courses` allows any authenticated
+-- user to insert unlimited rows. Migration 0014 added CHECK constraints
+-- on `name` (length + charset) to block the worst injection-shaped
+-- strings, but a single signed-up user can still write thousands of
+-- spam course rows that appear in every other user's fuzzy course
+-- search (migration 0018).
+--
+-- This migration caps non-service-role inserts at:
+--   - 10 per user per hour
+--   - 50 per user per day
+-- Service-role inserts (the OSM/OpenGolfAPI crawler and any future
+-- Edge Functions) bypass the check.
+--
+-- Mechanism: a `course_submissions` ledger table records every
+-- non-service-role insert via a BEFORE INSERT trigger on `courses`.
+-- The trigger counts recent rows in the ledger and raises if the
+-- caller exceeds either window. We don't FK the ledger to courses
+-- (the courses row doesn't exist yet at BEFORE-INSERT time), and we
+-- don't store course_id (the user-visible blast radius is purely
+-- about volume; per-course attribution belongs in the `created_by`
+-- column already on courses).
+
+create table public.course_submissions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now()
+);
+
+-- Trigger reads rows by (user_id, created_at desc) within hour/day
+-- windows on every insert; the composite index keeps the lookup at
+-- ~O(log n) instead of a full scan as the ledger grows.
+create index course_submissions_user_created_idx
+  on public.course_submissions (user_id, created_at desc);
+
+alter table public.course_submissions enable row level security;
+
+-- Users can read their own ledger so a future UI can show
+-- "you've submitted N courses today, K remaining". No other policies
+-- — inserts happen exclusively through the trigger below (security
+-- definer bypasses RLS), and there's never a reason for a client to
+-- write or update this table directly.
+create policy "Users read own submissions"
+  on public.course_submissions for select
+  using (auth.uid() = user_id);
+
+create or replace function public.rate_limit_course_inserts()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  hour_count int;
+  day_count int;
+begin
+  -- service_role bypass: crawler pipeline and Edge Functions
+  -- (anything running with the service-role JWT) skip the cap. The
+  -- crawler legitimately writes thousands of rows in a single run.
+  if auth.role() = 'service_role' then
+    return new;
+  end if;
+
+  if auth.uid() is null then
+    raise exception 'course insertion requires an authenticated user'
+      using errcode = '42501';
+  end if;
+
+  select count(*) into hour_count
+    from public.course_submissions
+    where user_id = auth.uid()
+      and created_at > now() - interval '1 hour';
+
+  if hour_count >= 10 then
+    raise exception 'rate_limit_exceeded: max 10 course submissions per hour'
+      using errcode = '42501';
+  end if;
+
+  select count(*) into day_count
+    from public.course_submissions
+    where user_id = auth.uid()
+      and created_at > now() - interval '1 day';
+
+  if day_count >= 50 then
+    raise exception 'rate_limit_exceeded: max 50 course submissions per day'
+      using errcode = '42501';
+  end if;
+
+  insert into public.course_submissions (user_id) values (auth.uid());
+  return new;
+end;
+$$;
+
+create trigger courses_rate_limit_before_insert
+  before insert on public.courses
+  for each row
+  execute function public.rate_limit_course_inserts();


### PR DESCRIPTION
Closes #221.

## Problem
Migration 0001's INSERT policy on \`public.courses\` is open to any authenticated user with no volume cap. Migration 0014 added CHECK constraints on \`name\` (length + charset) which closes injection-shaped payloads, but a single signed-up user can still write **thousands of spam rows** that appear in every other user's fuzzy course search (migration 0018's pg_trgm-backed RPC).

Real launch-blocker: one motivated bad actor can poison the course database for every user.

## Fix
New migration \`0027_rate_limit_course_inserts.sql\`:

1. **\`course_submissions\` ledger table** — \`(id, user_id, created_at)\`. Composite index on \`(user_id, created_at desc)\` keeps the trigger's window-counting at ~O(log n) as the ledger grows.
2. **BEFORE INSERT trigger on \`courses\`** that:
   - Bypasses the check entirely if \`auth.role() = 'service_role'\` (so the OSM/OpenGolfAPI crawler can still bulk-write — important; the crawler legitimately writes thousands of rows per state-by-state run).
   - Rejects unauthenticated callers (defense-in-depth; RLS catches this too).
   - Counts the caller's ledger rows in the last hour. Caps at **10/hour**.
   - Counts the caller's ledger rows in the last day. Caps at **50/day**.
   - Records the insert in the ledger and returns NEW.
3. **RLS on the ledger**: users can SELECT their own rows (lets a future UI show \"you've submitted N courses today, K remaining\"). No INSERT/UPDATE/DELETE policies — writes happen only through the security-definer trigger.

## Why a ledger table instead of counting against \`courses\` directly?
- \`courses.created_by\` is nullable today (15K+ crawler-imported rows have NULL) so we can't count by that column reliably until #72 backfills.
- Counting against \`courses.created_at\` + a hypothetical owner column would also fail to attribute creator on rows where the trigger fired but the insert later failed downstream — the ledger records intent at the moment the rate-limit fires.

## Limit choice (10/hr, 50/day)
A real user submitting a private/missing course once or twice a week stays orders of magnitude below the cap. A bad actor trying to spam a thousand rows hits the wall after 50 within a single 24-hour window. Easy to tune in a follow-up migration if either bound proves wrong in practice.

## Out of scope
- **Moderation queue** (the \`is_published\` flag approach from the priority-1 analysis). Better long-term answer but ships with real operational cost; deferred to v1.x.
- **Edge Function gatekeeper**. Right answer architecturally once #18 introduces our first Edge Function; revisit then.
- **Per-IP / unauthenticated rate limiting**. Trigger fires on \`auth.uid()\` and rejects anonymous inserts — anonymous spam is already blocked by RLS.

## Test plan
- [ ] Apply migration locally (\`npx supabase db push\`). Confirm \`pnpm test\` and \`pnpm typecheck\` stay green (no app code changes; this is purely SQL).
- [ ] As an authenticated user, insert 11 courses in <1 hour. 11th insert should fail with \`rate_limit_exceeded: max 10 course submissions per hour\`.
- [ ] As an authenticated user, insert 50 courses spread across a day, then attempt one more. 51st should fail with the daily cap message.
- [ ] As a service-role caller (e.g. \`scripts/crawl-courses.ts\`), insert 100+ rows. Trigger should pass through silently.
- [ ] Existing legitimate course-add flows (\`apps/web/src/hooks/useCourses.ts:98\` — the OpenGolfAPI scorecard import) still work for a normal user.
- [ ] After successful inserts, query \`select count(*) from course_submissions where user_id = auth.uid()\` — should reflect the inserts.