### PR TITLE
ci: use PAT for release-please so its PRs trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Switches `release-please.yml` from `GITHUB_TOKEN` to `RELEASE_PLEASE_TOKEN` (fine-grained PAT).
- Fixes release PRs (e.g. #354) being blocked from triggering required `typecheck` / `test` checks due to GitHub's recursive-workflow protection on `GITHUB_TOKEN`-authored PRs.

Secret `RELEASE_PLEASE_TOKEN` already configured in repo settings.

Once on main, the next release-please run will use the PAT; its release PR will trigger CI and merge through the rule normally. PR #354 will be superseded.