### PR TITLE
ci: use PAT for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary
- Lands #355 on `main`: `release-please.yml` now uses `RELEASE_PLEASE_TOKEN` instead of `GITHUB_TOKEN`.

After this merges, release-please will open a fresh `v0.3.1` release PR (replacing the superseded #354). That PR will trigger required `typecheck` + `test` checks and can be merged normally.