### PR TITLE
fix(mobile): silence expected WAL lock log + use safe-area insets

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -10,6 +10,7 @@ import {
 import { captureRef } from 'react-native-view-shot'
 import * as Sharing from 'expo-sharing'
 import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { formatSG } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../../../lib/supabase'
@@ -42,6 +43,7 @@ export default function RoundIndex() {
     mode?: string
   }>()
   const router = useRouter()
+  const insets = useSafeAreaInsets()
 
   const [round, setRound] = useState<RoundRow | null>(null)
   const [holes, setHoles] = useState<HoleRow[]>([])
@@ -278,7 +280,7 @@ export default function RoundIndex() {
       <View
         style={{
           backgroundColor: '#1C211C',
-          paddingTop: 52,
+          paddingTop: insets.top + 14,
           paddingBottom: 14,
           paddingHorizontal: 18,
           flexDirection: 'row',

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -8,6 +8,7 @@ import {
   View,
 } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import * as Location from 'expo-location'
 import {
   formatLocation,
@@ -64,6 +65,7 @@ export default function NewRound() {
   const [showManualForm, setShowManualForm] = useState(false)
   const [gps, setGps] = useState<GpsState>({ status: 'idle' })
   const searchAbort = useRef<AbortController | null>(null)
+  const insets = useSafeAreaInsets()
 
   // Debounce 300ms.
   useEffect(() => {
@@ -337,7 +339,7 @@ export default function NewRound() {
   }
 
   return (
-    <View style={{ flex: 1, backgroundColor: '#F2EEE5', paddingTop: 52, paddingHorizontal: 18, paddingBottom: 18 }}>
+    <View style={{ flex: 1, backgroundColor: '#F2EEE5', paddingTop: insets.top + 14, paddingHorizontal: 18, paddingBottom: 18 }}>
       <Text style={{ ...KICKER, marginBottom: 6 }}>
         {mode === 'past' ? 'Log past round' : 'Start live round'}
       </Text>

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Alert, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import {
   DEFAULT_BAG,
   GOALS,
@@ -30,6 +31,7 @@ const GOAL_LABEL: Record<Goal, string> = {
 export default function MobileOnboarding() {
   const router = useRouter()
   const { user } = useAuth()
+  const insets = useSafeAreaInsets()
   const [skill, setSkill] = useState<SkillLevel | null>(null)
   const [handicap, setHandicap] = useState('15')
   const [goal, setGoal] = useState<Goal | null>(null)
@@ -109,7 +111,7 @@ export default function MobileOnboarding() {
   return (
     <ScrollView
       style={{ flex: 1, backgroundColor: '#F4F4F0' }}
-      contentContainerStyle={{ padding: 16, paddingTop: 48, paddingBottom: 32 }}
+      contentContainerStyle={{ padding: 16, paddingTop: insets.top + 14, paddingBottom: 32 }}
       keyboardShouldPersistTaps="handled"
     >
       <Text

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -157,6 +157,11 @@ AppState.addEventListener('change', (nextState: AppStateStatus) => {
       const db = await getDb()
       await db.execAsync('PRAGMA wal_checkpoint(PASSIVE);')
     } catch (e) {
+      // PASSIVE returns SQLITE_LOCKED if another statement on the
+      // connection is mid-execution at the moment AppState fires.
+      // Expected and recoverable — the next AppState transition or
+      // the implicit auto-checkpoint will flush. Don't log the noise.
+      if ((e as Error)?.message?.includes('locked')) return
       // eslint-disable-next-line no-console
       console.error('[db/wal_checkpoint]', e)
     }


### PR DESCRIPTION
Two small mobile cleanups from the v1.0 quick-win triage pass.

## #329 — silence expected SQLITE_LOCKED on WAL checkpoint

`apps/mobile/lib/db.ts` AppState listener runs `PRAGMA wal_checkpoint(PASSIVE)` when the app backgrounds. PASSIVE returns `SQLITE_LOCKED` if another statement on the connection is mid-execution at that moment — expected and recoverable (the next AppState transition or implicit auto-checkpoint will flush). Was logged as an error and looked alarming. Narrowed the catch to skip when the error message includes "locked"; everything else still logs.

## #285 — replace hardcoded paddingTop with safe-area insets

Three screens hardcoded `paddingTop: 48` or `52` for the status bar:

- `apps/mobile/app/(auth)/onboarding.tsx`
- `apps/mobile/app/(app)/round/new.tsx`
- `apps/mobile/app/(app)/round/[id]/index.tsx`

Replaced each with `insets.top + 14` (via `useSafeAreaInsets()` from `react-native-safe-area-context`), matching the existing convention in `apps/mobile/components/ui/AppBar.tsx:16`.

Effect:
- Tall-status-bar Android (Pixel 9 Pro XL ~68dp): header no longer clips under camera notch
- Budget Android (~24dp): ~28dp of map real estate reclaimed on the live-round and round-detail screens
- Cross-platform correct for iOS/iPad whenever those ship

## Test plan

- [ ] Visit Onboarding on a standard Android emulator — header sits naturally below the status bar, no clipping
- [ ] Open `round/new` (course picker) — same
- [ ] Open an existing past round → scorecard view — dark header sits naturally
- [ ] If available, repeat on a tall-status-bar device — content shifts down accordingly, no clipping
- [ ] Background and foreground the app a few times mid-shot-save — no `[db/wal_checkpoint]` red-text errors with "locked" messages

Closes #329, closes #285.