### PR TITLE
fix(mobile): URL-encode Turnstile site key + globalThis-guard WAL listener

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -96,7 +96,7 @@ export default function Login() {
         />
         {captchaEnabled && (
           <WebView
-            source={{ uri: `https://oga.golf/captcha.html?siteKey=${TURNSTILE_SITE_KEY}` }}
+            source={{ uri: `https://oga.golf/captcha.html?siteKey=${encodeURIComponent(TURNSTILE_SITE_KEY ?? '')}` }}
             originWhitelist={['https://*', 'http://*']}
             onMessage={(event) => {
               try {

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -105,7 +105,7 @@ export default function Signup() {
         />
         {captchaEnabled && (
           <WebView
-            source={{ uri: `https://oga.golf/captcha.html?siteKey=${TURNSTILE_SITE_KEY}` }}
+            source={{ uri: `https://oga.golf/captcha.html?siteKey=${encodeURIComponent(TURNSTILE_SITE_KEY ?? '')}` }}
             originWhitelist={['https://*', 'http://*']}
             onMessage={(event) => {
               try {

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -150,23 +150,34 @@ export async function setPendingShotEnd(
 // are also at risk if the OS kills the process before the next implicit
 // checkpoint. PASSIVE skips when readers hold the lock so a backgrounded
 // app can't stall a foregrounded one.
-AppState.addEventListener('change', (nextState: AppStateStatus) => {
-  if (nextState !== 'background' && nextState !== 'inactive') return
-  void (async () => {
-    try {
-      const db = await getDb()
-      await db.execAsync('PRAGMA wal_checkpoint(PASSIVE);')
-    } catch (e) {
-      // PASSIVE returns SQLITE_LOCKED if another statement on the
-      // connection is mid-execution at the moment AppState fires.
-      // Expected and recoverable — the next AppState transition or
-      // the implicit auto-checkpoint will flush. Don't log the noise.
-      if ((e as Error)?.message?.includes('locked')) return
-      // eslint-disable-next-line no-console
-      console.error('[db/wal_checkpoint]', e)
-    }
-  })()
-})
+//
+// globalThis guard so Metro Fast Refresh / bundle reload doesn't stack
+// duplicate listeners across the dev session. Module-scoped flags reset
+// on bundle eval; globalThis survives.
+declare global {
+  // eslint-disable-next-line no-var
+  var __ogaWalCheckpointInstalled: boolean | undefined
+}
+if (!globalThis.__ogaWalCheckpointInstalled) {
+  globalThis.__ogaWalCheckpointInstalled = true
+  AppState.addEventListener('change', (nextState: AppStateStatus) => {
+    if (nextState !== 'background' && nextState !== 'inactive') return
+    void (async () => {
+      try {
+        const db = await getDb()
+        await db.execAsync('PRAGMA wal_checkpoint(PASSIVE);')
+      } catch (e) {
+        // PASSIVE returns SQLITE_LOCKED if another statement on the
+        // connection is mid-execution at the moment AppState fires.
+        // Expected and recoverable — the next AppState transition or
+        // the implicit auto-checkpoint will flush. Don't log the noise.
+        if ((e as Error)?.message?.includes('locked')) return
+        // eslint-disable-next-line no-console
+        console.error('[db/wal_checkpoint]', e)
+      }
+    })()
+  })
+}
 
 export async function pendingShotsForHoleScore(holeScoreId: string): Promise<PendingShot[]> {
   const db = await getDb()


### PR DESCRIPTION
Two small mobile defensive cleanups.

## #294 — URL-encode Turnstile site key

\`apps/mobile/app/(auth)/login.tsx\` and \`signup.tsx\` interpolate the Cloudflare Turnstile site key directly into the WebView source URL. Current key is URL-safe (\`0x4AAAAA…\`), so this is genuinely defensive — but if Cloudflare ever issues a key with \`&\` / \`#\` / \`=\` the captcha would silently break and the auth form would be wedged with no error.

Wrapped both sites in \`encodeURIComponent(TURNSTILE_SITE_KEY ?? '')\`. One-character-feeling change per site.

## #289 (db side) — globalThis guard on AppState WAL-checkpoint listener

\`apps/mobile/lib/db.ts\` registered the AppState listener at module load with no guard. Metro Fast Refresh / bundle reload re-evaluates the module and stacks a duplicate listener each time during dev — each one holds a closure over the SQLite handle.

Wrapped in a \`globalThis.__ogaWalCheckpointInstalled\` guard. Module-scoped flags reset on bundle eval; globalThis survives across the dev session.

Note: \`sync.ts\` has a similar module-scoped \`listenersInstalled\` flag — the audit issue (#289) flagged that as also imperfect since it ALSO resets on Fast Refresh. Filing a comment on #289 to keep the sync.ts side scoped separately.

## Test plan

- [ ] \`pnpm typecheck\` and mobile \`npm run typecheck\` clean
- [ ] Open login on a dev build, repeatedly trigger Fast Refresh while AppState toggles — log should not show stacked \`[db/wal_checkpoint]\` errors from duplicate listeners
- [ ] Captcha widget still loads on login + signup (current key is URL-safe so behavior is unchanged)

Closes #294. Partially addresses #289 (db side); sync.ts side left for follow-up.