### PR TITLE
chore(mobile): globalThis sync guard + typed Href for 2 router calls

### DIFF
--- a/apps/mobile/app/(app)/learn/index.tsx
+++ b/apps/mobile/app/(app)/learn/index.tsx
@@ -54,7 +54,9 @@ export default function LearnScreen() {
           <SectionBlock
             key={section.id}
             section={section}
-            onSelect={(article) => router.push(`/(app)/learn/${article.id}`)}
+            onSelect={(article) =>
+              router.push({ pathname: '/(app)/learn/[article]', params: { article: article.id } })
+            }
           />
         ))}
       </ScrollView>

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -455,7 +455,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
         userId: user.id,
         handicap,
       })
-      router.replace(`/(app)/round/${round.id}`)
+      router.replace({ pathname: '/(app)/round/[id]', params: { id: round.id } })
     } catch (err) {
       Alert.alert('End round failed', (err as Error).message)
     } finally {

--- a/apps/mobile/lib/sync.ts
+++ b/apps/mobile/lib/sync.ts
@@ -108,9 +108,14 @@ export async function syncPendingShots(): Promise<{ synced: number; failed: numb
 // Auto-trigger sync on network reconnect and app foreground. Failures
 // previously stayed in the pending queue forever with no automatic
 // retry — a player who finished a round on a flaky connection would
-// see "synced" never tick up. Listeners are module-scope singletons
-// installed once at first import; we never need to remove them.
-let listenersInstalled = false
+// see "synced" never tick up. Listeners are global singletons; the
+// guard lives on globalThis (not module scope) so Metro Fast Refresh
+// / bundle reload doesn't stack duplicate listeners. Mirrors the
+// db.ts WAL-checkpoint pattern.
+declare global {
+  // eslint-disable-next-line no-var
+  var __ogaSyncInstalled: boolean | undefined
+}
 
 function fireAndForget() {
   syncPendingShots().catch((err) => {
@@ -120,8 +125,8 @@ function fireAndForget() {
 }
 
 export function installAutoSync(): void {
-  if (listenersInstalled) return
-  listenersInstalled = true
+  if (globalThis.__ogaSyncInstalled) return
+  globalThis.__ogaSyncInstalled = true
 
   NetInfo.addEventListener((state) => {
     if (state.isConnected && state.isInternetReachable) {


### PR DESCRIPTION
Two small mobile chores from the v0.3-era triage pass.

## #289 (sync side) — globalThis guard on AppState/NetInfo listeners

`apps/mobile/lib/sync.ts` used a module-scoped `let listenersInstalled = false` to gate the network/AppState listener install. Module-scope flags reset on Metro Fast Refresh / bundle reload, so the guard didn't actually prevent duplicates across dev-session reloads.

Replaced with `globalThis.__ogaSyncInstalled` — mirrors what PR #359 already shipped on the db.ts WAL-checkpoint listener. Fully closes #289 (db side + sync side).

## #325 (narrowed) — typed Href on the 2 remaining template-literal router calls

Most template-literal `router.push` / `router.replace` sites were swept by the post-#264 refactor. Two remained:

- `apps/mobile/app/(app)/learn/index.tsx:57` — `router.push(\`/(app)/learn/${article.id}\`)` → `router.push({ pathname: '/(app)/learn/[article]', params: { article: article.id } })`
- `apps/mobile/components/round/hole/useShotActions.ts:458` — `router.replace(\`/(app)/round/${round.id}\`)` → `router.replace({ pathname: '/(app)/round/[id]', params: { id: round.id } })`

Typed Href objects let Expo Router's typedRoutes catch a nullish param at build time instead of silently navigating to `/round/undefined`. `app.json` already has `experiments.typedRoutes: true`, so the new shape is statically checked.

## Test plan

- [x] Mobile typecheck clean
- [ ] Tap a Learn article on a dev build — navigates correctly to `/learn/[article]`
- [ ] End a round on a dev build — navigates correctly to `/round/[id]`
- [ ] Trigger Metro Fast Refresh while AppState toggles — no stacked `[sync]` triggers

Closes #289, closes #325.