### PR TITLE
chore(e2e): playwright + auth fixture + e2e seed script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,12 @@ coverage/
 # serena mcp server project metadata (local tooling, do not publish)
 .serena/
 
+# playwright e2e outputs + signed-in auth state
+apps/web/test-results/
+apps/web/playwright-report/
+apps/web/blob-report/
+apps/web/e2e/.auth/
+
 # Internal planning + design docs — kept locally, not published to GitHub.
 CLAUDE.md
 DESIGN.md

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -1,0 +1,52 @@
+import { test as setup } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+
+// One-time sign-in for signed-in specs. Calls auth.signInWithPassword
+// server-side (bypasses the Turnstile widget, which only fires in the
+// browser), then injects the resulting session into the browser's
+// localStorage under supabase-js's default key shape and snapshots
+// the storage state to e2e/.auth/user.json.
+//
+// Subsequent specs in the chromium-auth project load that snapshot via
+// `storageState`, so each test starts pre-authenticated without
+// re-running this login.
+const SUPABASE_URL = process.env.VITE_SUPABASE_URL
+const SUPABASE_ANON_KEY = process.env.VITE_SUPABASE_ANON_KEY
+const E2E_EMAIL = process.env.E2E_EMAIL
+const E2E_PASSWORD = process.env.E2E_PASSWORD
+
+setup('authenticate', async ({ page }) => {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !E2E_EMAIL || !E2E_PASSWORD) {
+    throw new Error(
+      'Missing Supabase or e2e creds. Expected VITE_SUPABASE_URL, ' +
+        'VITE_SUPABASE_ANON_KEY, E2E_EMAIL, E2E_PASSWORD in ' +
+        '.env.test.local at apps/web/.',
+    )
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  })
+
+  const { data, error } = await supabase.auth.signInWithPassword({
+    email: E2E_EMAIL,
+    password: E2E_PASSWORD,
+  })
+  if (error) throw error
+  if (!data.session) throw new Error('signInWithPassword returned no session')
+
+  const projectRef = new URL(SUPABASE_URL).hostname.split('.')[0]
+  const storageKey = `sb-${projectRef}-auth-token`
+
+  // localStorage is per-origin, so we have to be on the app's origin
+  // before setting it. Landing page is fine and doesn't require auth.
+  await page.goto('/')
+  await page.evaluate(
+    ({ key, value }) => {
+      window.localStorage.setItem(key, value)
+    },
+    { key: storageKey, value: JSON.stringify(data.session) },
+  )
+
+  await page.context().storageState({ path: 'e2e/.auth/user.json' })
+})

--- a/apps/web/e2e/learn.signed-in.spec.ts
+++ b/apps/web/e2e/learn.signed-in.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test'
+
+// Signed-in smoke for the #237 auth-aware Learn shell. Authentication
+// state is loaded from e2e/.auth/user.json (written by auth.setup.ts).
+test.describe('Learn — signed in', () => {
+  test('/learn renders AppShell with sidebar nav', async ({ page }) => {
+    await page.goto('/learn')
+    // The sidebar's hamburger only renders on mobile widths; on desktop
+    // (default Playwright viewport ~1280px), Sidebar is mounted directly
+    // and its top-level destinations are visible. "Dashboard" is the
+    // first authed-only link and is unique to AppShell.
+    await expect(
+      page.getByRole('link', { name: /^dashboard$/i }).first(),
+    ).toBeVisible()
+  })
+
+  test('/learn hides the public "Sign up free" CTA', async ({ page }) => {
+    await page.goto('/learn')
+    // PublicNav is gone for authed users on /learn, so its sign-up CTA
+    // should not be in the DOM. (Authed PublicNav swaps to "Go to app"
+    // on other public routes, but PublicNav itself isn't rendered here.)
+    await expect(
+      page.getByRole('link', { name: /sign up free/i }),
+    ).toHaveCount(0)
+  })
+})

--- a/apps/web/e2e/learn.spec.ts
+++ b/apps/web/e2e/learn.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test'
+
+// Smoke for the #237 auth-aware Learn shell, signed-out branch.
+// Signed-in cases live in a separate spec once the auth fixture is
+// in place (needs a Supabase test account + saved storageState).
+test.describe('Learn — signed out', () => {
+  test('/learn renders PublicNav with "Sign up free" CTA', async ({ page }) => {
+    await page.goto('/learn')
+    await expect(
+      page.getByRole('link', { name: /sign up free/i }),
+    ).toBeVisible()
+  })
+
+  test('/learn renders without the authenticated app sidebar', async ({
+    page,
+  }) => {
+    await page.goto('/learn')
+    // Sidebar nav items only exist in AppShell. If any of these are
+    // visible, we've regressed and signed-out users are inside the
+    // auth shell.
+    await expect(
+      page.getByRole('link', { name: /^dashboard$/i }),
+    ).toHaveCount(0)
+    await expect(
+      page.getByRole('link', { name: /^rounds$/i }),
+    ).toHaveCount(0)
+  })
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,6 +26,7 @@
     "recharts": "^2.12.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/mapbox-gl": "^3.5.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig, devices } from '@playwright/test'
+import dotenv from 'dotenv'
+
+// .env.test.local holds the Playwright Supabase creds + URL/anon key.
+// Gitignored at the repo root via .env.*.local. Without it, the auth
+// setup project skips and signed-in specs are skipped too.
+dotenv.config({ path: '.env.test.local' })
+
+// E2E config for the web app. `webServer` auto-starts Vite and reuses
+// an existing instance on 5173 so local iteration doesn't pay the boot
+// cost every run.
+//
+// Projects:
+//   setup         — runs *.setup.ts (Supabase sign-in → writes storageState)
+//   chromium      — *.spec.ts (signed-out)
+//   chromium-auth — *.signed-in.spec.ts (uses storageState from setup)
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.ts$/,
+    },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      testIgnore: /.*\.signed-in\.spec\.ts$/,
+    },
+    {
+      name: 'chromium-auth',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'e2e/.auth/user.json',
+      },
+      dependencies: ['setup'],
+      testMatch: /.*\.signed-in\.spec\.ts$/,
+    },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+})

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint apps/web/src packages/*/src --ext .ts,.tsx",
     "format": "prettier --write .",
     "seed:demo": "tsx scripts/seed-demo.ts",
+    "seed:e2e": "DOTENV_CONFIG_PATH=apps/web/.env.test.local tsx scripts/seed-demo.ts",
     "seed:my-data": "tsx scripts/seed-my-data.ts",
     "import:osm": "tsx scripts/import-osm-course.ts",
     "crawl:courses": "tsx scripts/crawl-courses.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
         specifier: ^2.12.7
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@types/mapbox-gl':
         specifier: ^3.5.0
         version: 3.5.0
@@ -789,6 +792,11 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@remix-run/router@1.23.2':
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
@@ -1554,6 +1562,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1977,6 +1990,16 @@ packages:
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -2951,6 +2974,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@remix-run/router@1.23.2': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -3766,6 +3793,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4135,6 +4165,14 @@ snapshots:
       confbox: 0.1.8
       mlly: 1.8.2
       pathe: 2.0.3
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.5.12):
     dependencies:

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -27,8 +27,12 @@ const supabase = createClient(URL, SERVICE_KEY, {
   auth: { autoRefreshToken: false, persistSession: false },
 })
 
-const DEMO_EMAIL = 'demo@oga.app'
-const DEMO_PASSWORD = 'ogademo123'
+// Defaults match the original demo user. Override via env (e.g. for
+// the Playwright e2e account against the dev project) — see
+// `pnpm seed:e2e` for the full invocation.
+const SEED_EMAIL = process.env.SEED_EMAIL ?? 'demo@oga.app'
+const SEED_PASSWORD = process.env.SEED_PASSWORD ?? 'ogademo123'
+const SEED_USERNAME = process.env.SEED_USERNAME ?? 'demo'
 
 // Course base coords (no real geometry on the seeded courses, so we
 // synthesize plausible lat/lng for shot dispersion).
@@ -76,14 +80,14 @@ function pickClubForDistance(yards: number): string {
 
 async function ensureDemoUser(): Promise<string> {
   const { data: list } = await supabase.auth.admin.listUsers({ perPage: 1000 })
-  const existing = list?.users?.find((u) => u.email === DEMO_EMAIL)
+  const existing = list?.users?.find((u) => u.email === SEED_EMAIL)
   if (existing) return existing.id
 
   const { data, error } = await supabase.auth.admin.createUser({
-    email: DEMO_EMAIL,
-    password: DEMO_PASSWORD,
+    email: SEED_EMAIL,
+    password: SEED_PASSWORD,
     email_confirm: true,
-    user_metadata: { username: 'demo' },
+    user_metadata: { username: SEED_USERNAME },
   })
   if (error || !data.user) throw error ?? new Error('createUser returned no user')
   return data.user.id
@@ -95,13 +99,17 @@ async function ensureProfile(userId: string): Promise<void> {
     .upsert(
       {
         id: userId,
-        username: 'demo',
+        username: SEED_USERNAME,
         handicap_index: 12.4,
         skill_level: 'developing',
         goal: 'break_80',
         play_frequency: 'weekly',
         facilities: ['range', 'short_game', 'putting'],
         play_style: 'mixed',
+        // Added in migration 0023; the script pre-dates it. Without
+        // this, ProfileGuard would bounce the seeded user to
+        // /onboarding on next sign-in.
+        onboarding_completed: true,
       },
       { onConflict: 'id' },
     )
@@ -365,7 +373,7 @@ async function main() {
 
   await insertPracticePlan(userId)
 
-  console.log(`Demo user ready — sign in as ${DEMO_EMAIL} / ${DEMO_PASSWORD}`)
+  console.log(`Seed user ready — sign in as ${SEED_EMAIL} / ${SEED_PASSWORD}`)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

Bootstraps Playwright e2e testing for the web app and ships the first specs alongside (Learn signed-out + signed-in, validating the auth-aware shell that just landed in #362).

## What's in

- **`apps/web/playwright.config.ts`** — auto-starts Vite dev server on 5173, reuses an existing instance, three projects:
  - `setup` runs `*.setup.ts` (one-time Supabase sign-in)
  - `chromium` runs `*.spec.ts` (signed-out)
  - `chromium-auth` runs `*.signed-in.spec.ts` (consumes storageState from setup)
- **`apps/web/e2e/auth.setup.ts`** — server-side sign-in via `auth.signInWithPassword` (bypasses Turnstile, which only fires from the browser widget), then injects the session into localStorage under supabase-js's default key shape and snapshots `e2e/.auth/user.json` (gitignored).
- **`apps/web/e2e/learn.spec.ts`** — 2 signed-out smoke tests for the Learn shell.
- **`apps/web/e2e/learn.signed-in.spec.ts`** — 2 signed-in tests verifying `AppShell` renders for authed users on `/learn` (the #362 fix).
- **`scripts/seed-demo.ts`** — parameterized via `SEED_EMAIL` / `SEED_PASSWORD` / `SEED_USERNAME` env vars; defaults preserved for the original demo user. Also adds `onboarding_completed: true` to the profile upsert — the script pre-dates migration 0023 and was producing seeded users that would have been bounced to `/onboarding` on signin.
- **`pnpm seed:e2e`** — same script, loads `apps/web/.env.test.local` instead of root `.env` so it targets the dev project's e2e account.

## Verification

5/5 specs pass locally in 3.6s against the dev project (`txquvfeyvkaetqlamqlz`) with the seeded e2e account:

```
✓ [chromium] learn.spec.ts — /learn renders PublicNav with "Sign up free" CTA
✓ [chromium] learn.spec.ts — /learn renders without the authenticated app sidebar
✓ [setup] auth.setup.ts — authenticate
✓ [chromium-auth] learn.signed-in.spec.ts — /learn renders AppShell with sidebar nav
✓ [chromium-auth] learn.signed-in.spec.ts — /learn hides the public "Sign up free" CTA
```

## Notes

- **Secrets stay local.** `apps/web/.env.test.local` (e2e creds + service role for dev) is gitignored via the existing `.env.*.local` pattern. `e2e/.auth/user.json` (storageState with active session) is gitignored explicitly. Neither is in this PR.
- **CI integration deferred.** Specs run locally only for now. Wiring Playwright into GitHub Actions is its own scoping conversation (needs CI-side env injection, browser caching, and a decision about which project to target).
- **Prod parity** is the next infra step when we want it — `.env.test.prod.local` + a mode switch in `playwright.config.ts` lands cleanly on top.

## Test plan

- [ ] `pnpm seed:e2e` runs cleanly and idempotently (re-run produces same final state)
- [ ] `pnpm exec playwright test` from `apps/web/` passes 5/5
- [ ] Learn signed-out + signed-in specs read sensibly