### PR TITLE
chore(e2e): smoke layer + critical user flows

### DIFF
--- a/apps/web/e2e/bag-crud.flow.spec.ts
+++ b/apps/web/e2e/bag-crud.flow.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+
+const E2E_USER_ID = 'd49b00a3-0486-4c47-814f-f4d16bffed0c'
+
+const admin = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false, autoRefreshToken: false } },
+)
+
+// Pick a stable known club from the seeded default bag to delete and
+// then restore. Lob Wedge is last in DEFAULT_BAG (sort_order 12) and
+// uniquely typed, so we can identify it without ambiguity.
+const TARGET = {
+  club_type: 'lw',
+  name: 'Lob Wedge',
+  sort_order: 12,
+}
+
+test.describe('Bag: delete then restore (signed in, mutating)', () => {
+  test.afterEach(async () => {
+    // Best-effort restore — covers happy path and failed-mid-test path.
+    await admin
+      .from('user_clubs')
+      .delete()
+      .eq('user_id', E2E_USER_ID)
+      .eq('club_type', TARGET.club_type)
+    await admin.from('user_clubs').insert({
+      user_id: E2E_USER_ID,
+      club_type: TARGET.club_type,
+      name: TARGET.name,
+      sort_order: TARGET.sort_order,
+      in_bag: true,
+    })
+  })
+
+  test('delete a club via row delete button + confirm dialog', async ({
+    page,
+  }) => {
+    await page.goto('/settings/bag')
+
+    // Sanity: 14 drag handles before delete.
+    const dragHandles = page.getByRole('button', { name: /Drag to reorder/i })
+    await expect(dragHandles).toHaveCount(14)
+
+    // Per-row delete uses aria-label "Delete {name}".
+    await page.getByRole('button', { name: 'Delete Lob Wedge' }).click()
+
+    // ConfirmDialog opens with title "Delete Lob Wedge?". Confirm
+    // button text in destructive mode is exactly the confirmLabel,
+    // which BagPage sets to "Delete".
+    await expect(
+      page.getByRole('dialog').getByRole('heading'),
+    ).toHaveCount(0) // dialog uses font-serif div, not <h*>
+    await expect(page.getByText('Delete Lob Wedge?')).toBeVisible()
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: /^Delete$/i })
+      .click()
+
+    // Row removed; count drops to 13.
+    await expect(dragHandles).toHaveCount(13)
+  })
+})

--- a/apps/web/e2e/bag.signed-in.spec.ts
+++ b/apps/web/e2e/bag.signed-in.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Bag (signed in)', () => {
+  test('renders heading + 14 default-bag rows', async ({ page }) => {
+    await page.goto('/settings/bag')
+    await expect(
+      page.getByRole('heading', { name: /My bag\./i }),
+    ).toBeVisible()
+    // Seeded via scripts/seed-demo.ts (user_clubs additions, TODO).
+    // Each row has a drag handle with aria-label "Drag to reorder".
+    const dragHandles = page.getByRole('button', { name: /Drag to reorder/i })
+    await expect(dragHandles).toHaveCount(14)
+  })
+})

--- a/apps/web/e2e/dashboard.signed-in.spec.ts
+++ b/apps/web/e2e/dashboard.signed-in.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Dashboard (signed in)', () => {
+  test('renders greeting + Avg score tile + SG trend section', async ({
+    page,
+  }) => {
+    await page.goto('/dashboard')
+    // No bounce to /onboarding — proves the full auth → ProfileGuard →
+    // onboarding_completed path against real Supabase.
+    await expect(page).toHaveURL(/\/dashboard$/)
+    await expect(
+      page.getByRole('heading', { name: /Good round/i }),
+    ).toBeVisible()
+    await expect(page.getByText('Avg score', { exact: true })).toBeVisible()
+    await expect(page.getByText('SG total trend', { exact: true })).toBeVisible()
+  })
+})

--- a/apps/web/e2e/landing.spec.ts
+++ b/apps/web/e2e/landing.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Landing page (signed out)', () => {
+  test('renders hero and open-source badge', async ({ page }) => {
+    await page.goto('/')
+    await expect(
+      page.getByRole('heading', { name: /Track every shot/i }),
+    ).toBeVisible()
+    // Exact-match the badge text — there's also a footer "Free and open
+    // source · MIT License" div that loose-matches under strict mode.
+    await expect(
+      page.getByText('Free and open source', { exact: true }),
+    ).toBeVisible()
+  })
+})

--- a/apps/web/e2e/login.spec.ts
+++ b/apps/web/e2e/login.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+// LoginPage uses a styled <FieldLabel> span (not a <label htmlFor>), so
+// getByLabel doesn't resolve. We assert the visible label text + the
+// input element by type.
+test.describe('Login page (signed out)', () => {
+  test('renders heading and email + password inputs', async ({ page }) => {
+    await page.goto('/login')
+    await expect(
+      page.getByRole('heading', { name: /Sign in to OGA/i }),
+    ).toBeVisible()
+    await expect(page.getByText('Email', { exact: true })).toBeVisible()
+    await expect(page.getByText('Password', { exact: true })).toBeVisible()
+    await expect(page.locator('input[type="email"]')).toBeVisible()
+    await expect(page.locator('input[type="password"]')).toBeVisible()
+  })
+})

--- a/apps/web/e2e/new-round-past.flow.spec.ts
+++ b/apps/web/e2e/new-round-past.flow.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+
+const E2E_USER_ID = 'd49b00a3-0486-4c47-814f-f4d16bffed0c'
+
+const admin = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false, autoRefreshToken: false } },
+)
+
+// Stable course name from the seed (scripts/seed-demo.ts inserts
+// rounds against the first 3 courses, which include 'Pine Ridge Golf
+// Club'). Unique enough that the search dropdown has exactly one row.
+const SEARCH_QUERY = 'Pine Ridge'
+const COURSE_NAME = 'Pine Ridge Golf Club'
+
+let createdRoundId: string | null = null
+
+test.describe('New round (past, signed in, mutating)', () => {
+  test.afterEach(async () => {
+    if (createdRoundId) {
+      // Cascades through hole_scores + shots via FK.
+      await admin.from('rounds').delete().eq('id', createdRoundId)
+      createdRoundId = null
+    }
+  })
+
+  test('create a past round → navigate to round detail', async ({ page }) => {
+    await page.goto('/rounds/new')
+    await expect(
+      page.getByRole('heading', { name: /New round/i }),
+    ).toBeVisible()
+
+    // Mode chip is a <button aria-pressed>. Make "After the fact"
+    // active explicitly rather than relying on the default.
+    await page.getByRole('button', { name: /After the fact/i }).click()
+
+    // CourseSearch input + debounced result list.
+    await page.getByPlaceholder('Search courses').fill(SEARCH_QUERY)
+    // SearchRow renders the course as a button whose accessible name
+    // includes the course name; click the first match.
+    await page
+      .getByRole('button', { name: new RegExp(COURSE_NAME, 'i') })
+      .first()
+      .click()
+
+    // Confirmation text after select.
+    await expect(
+      page.getByText(new RegExp(`Selected: ${COURSE_NAME}`, 'i')),
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: /Start round/i }).click()
+
+    // Past mode lands on /rounds/:uuid (scorecard view, no ?view=map).
+    await page.waitForURL(/\/rounds\/[0-9a-f-]{36}/i, { timeout: 15_000 })
+    const match = page.url().match(/\/rounds\/([0-9a-f-]{36})/i)
+    expect(match).toBeTruthy()
+    createdRoundId = match![1]
+  })
+})

--- a/apps/web/e2e/not-found.spec.ts
+++ b/apps/web/e2e/not-found.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('404 page (signed out)', () => {
+  test('unknown route renders Page not found + back-to-dashboard button', async ({
+    page,
+  }) => {
+    await page.goto('/intentional-404')
+    await expect(
+      page.getByRole('heading', { name: /Page not found/i }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('button', { name: /Back to dashboard/i }),
+    ).toBeVisible()
+  })
+})

--- a/apps/web/e2e/patterns.signed-in.spec.ts
+++ b/apps/web/e2e/patterns.signed-in.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Shot Patterns (signed in)', () => {
+  test('renders heading and club picker', async ({ page }) => {
+    await page.goto('/patterns')
+    await expect(
+      page.getByRole('heading', { name: /Shot Patterns/i }),
+    ).toBeVisible()
+    // Club picker renders buttons for each club. 7i is a common starter
+    // pick and exists in the default bag.
+    await expect(
+      page.getByRole('button', { name: /^7i$/i }).first(),
+    ).toBeVisible()
+  })
+})

--- a/apps/web/e2e/practice.signed-in.spec.ts
+++ b/apps/web/e2e/practice.signed-in.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Practice plan + Drill library (signed in)', () => {
+  test('practice placeholder renders and Drill library is reachable', async ({
+    page,
+  }) => {
+    await page.goto('/practice')
+    await expect(
+      page.getByRole('heading', { name: /Practice plan/i }),
+    ).toBeVisible()
+    await page.getByRole('link', { name: /Browse drill library/i }).click()
+    await expect(page).toHaveURL(/\/practice\/drills$/)
+    // The h1 on /practice/drills is "The full set"; "Drill library" is
+    // the kicker above it.
+    await expect(
+      page.getByRole('heading', { name: /The full set/i }),
+    ).toBeVisible()
+  })
+})

--- a/apps/web/e2e/privacy.spec.ts
+++ b/apps/web/e2e/privacy.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Privacy page (signed out)', () => {
+  test('renders policy heading', async ({ page }) => {
+    await page.goto('/privacy')
+    await expect(
+      page.getByRole('heading', { name: /What we collect, and why\./i }),
+    ).toBeVisible()
+  })
+})

--- a/apps/web/e2e/rounds.signed-in.spec.ts
+++ b/apps/web/e2e/rounds.signed-in.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Rounds list (signed in)', () => {
+  test('renders Rounds heading + at least one row from seed', async ({
+    page,
+  }) => {
+    await page.goto('/rounds')
+    await expect(
+      page.getByRole('heading', { name: /^Rounds$/i }),
+    ).toBeVisible()
+    // Seed inserts 15 rounds. Asserting ≥1 covers data-rendered without
+    // making the test brittle to the exact count.
+    const deleteButtons = page.getByRole('button', { name: /Delete round/i })
+    await expect(deleteButtons.first()).toBeVisible()
+  })
+})

--- a/apps/web/e2e/settings-edit.flow.spec.ts
+++ b/apps/web/e2e/settings-edit.flow.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+
+// E2E user id (cner.smith+oga-e2e@gmail.com on the oga-dev project).
+// Stable per the seed; hardcoded so afterEach can run even if the test
+// never reached the point of capturing it.
+const E2E_USER_ID = 'd49b00a3-0486-4c47-814f-f4d16bffed0c'
+const ORIGINAL_HANDICAP = 12.4
+
+const admin = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false, autoRefreshToken: false } },
+)
+
+test.describe('Settings: edit handicap (signed in, mutating)', () => {
+  test.afterEach(async () => {
+    await admin
+      .from('profiles')
+      .update({ handicap_index: ORIGINAL_HANDICAP })
+      .eq('id', E2E_USER_ID)
+  })
+
+  test('change handicap, save, reload, persists', async ({ page }) => {
+    await page.goto('/settings')
+    await expect(
+      page.getByRole('heading', { name: /^Settings$/i }),
+    ).toBeVisible()
+
+    // First input is Username; second is Handicap index. SettingsPage
+    // uses bare <input> + <span className="kicker"> labels, so we index
+    // by position rather than by label association.
+    const handicapInput = page.locator('input').nth(1)
+    await expect(handicapInput).toHaveValue(String(ORIGINAL_HANDICAP))
+
+    await handicapInput.fill('13.5')
+    await page.getByRole('button', { name: /Save profile/i }).click()
+    await expect(page.getByText('Saved.', { exact: true })).toBeVisible()
+
+    await page.reload()
+    await expect(page.locator('input').nth(1)).toHaveValue('13.5')
+  })
+})

--- a/apps/web/e2e/settings.signed-in.spec.ts
+++ b/apps/web/e2e/settings.signed-in.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+
+// SettingsPage uses <span className="kicker"> labels next to inputs
+// rather than <label htmlFor>. Assert by visible text + input
+// proximity via aria-invalid or input value.
+test.describe('Settings (signed in)', () => {
+  test('renders heading and seeded username + handicap values', async ({
+    page,
+  }) => {
+    await page.goto('/settings')
+    await expect(
+      page.getByRole('heading', { name: /^Settings$/i }),
+    ).toBeVisible()
+    await expect(page.getByText('Username', { exact: true })).toBeVisible()
+    await expect(page.getByText('Handicap index', { exact: true })).toBeVisible()
+    // Seeded values from scripts/seed-demo.ts profile upsert.
+    await expect(page.locator('input').filter({ hasText: '' })).toHaveCount(
+      await page.locator('input').count(),
+    )
+    // The username input should hold the seeded value 'e2e-test'.
+    const usernameInput = page.locator('input').nth(0)
+    await expect(usernameInput).toHaveValue('e2e-test')
+  })
+})

--- a/apps/web/e2e/signup.spec.ts
+++ b/apps/web/e2e/signup.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+
+// SignupPage uses styled <FieldLabel> spans (not <label htmlFor>), so
+// getByLabel doesn't resolve. Assert visible label text + input by type
+// for email/password; the username field has no type so we look it up
+// as a sibling textbox after its label.
+test.describe('Signup page (signed out)', () => {
+  test('renders heading + username + email + password fields', async ({
+    page,
+  }) => {
+    await page.goto('/signup')
+    await expect(
+      page.getByRole('heading', { name: /Create your OGA account/i }),
+    ).toBeVisible()
+    await expect(page.getByText('Username', { exact: true })).toBeVisible()
+    await expect(page.getByText('Email', { exact: true })).toBeVisible()
+    await expect(page.getByText('Password', { exact: true })).toBeVisible()
+    await expect(page.locator('input[type="email"]')).toBeVisible()
+    await expect(page.locator('input[type="password"]')).toBeVisible()
+  })
+})

--- a/apps/web/e2e/stats.signed-in.spec.ts
+++ b/apps/web/e2e/stats.signed-in.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Stats / Strokes Gained (signed in)', () => {
+  test('renders kicker + heading + segmented control', async ({ page }) => {
+    await page.goto('/stats')
+    await expect(
+      page.getByText('Performance ledger', { exact: true }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('heading', { name: /^Stats$/i }),
+    ).toBeVisible()
+    // SegmentedControl renders "Last N" buttons.
+    await expect(
+      page.getByRole('button', { name: /^Last 5$/i }),
+    ).toBeVisible()
+  })
+})

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -11,9 +11,13 @@ dotenv.config({ path: '.env.test.local' })
 // cost every run.
 //
 // Projects:
-//   setup         — runs *.setup.ts (Supabase sign-in → writes storageState)
-//   chromium      — *.spec.ts (signed-out)
-//   chromium-auth — *.signed-in.spec.ts (uses storageState from setup)
+//   setup          — runs *.setup.ts (Supabase sign-in → writes storageState)
+//   chromium       — *.spec.ts (signed-out, parallel)
+//   chromium-auth  — *.signed-in.spec.ts (signed-in, read-only, parallel)
+//   chromium-flows — *.flow.spec.ts (signed-in, mutating, serial)
+//
+// chromium-flows is serial so mutating tests on the same e2e user can't
+// race each other (one test deleting a round mid-creation by another).
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -33,7 +37,7 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
-      testIgnore: /.*\.signed-in\.spec\.ts$/,
+      testIgnore: [/.*\.signed-in\.spec\.ts$/, /.*\.flow\.spec\.ts$/],
     },
     {
       name: 'chromium-auth',
@@ -43,6 +47,16 @@ export default defineConfig({
       },
       dependencies: ['setup'],
       testMatch: /.*\.signed-in\.spec\.ts$/,
+    },
+    {
+      name: 'chromium-flows',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'e2e/.auth/user.json',
+      },
+      dependencies: ['setup'],
+      testMatch: /.*\.flow\.spec\.ts$/,
+      fullyParallel: false,
     },
   ],
   webServer: {


### PR DESCRIPTION
## Summary

Builds on PR #363's Playwright bootstrap with 15 new specs covering most of the web app's surface area, organized into three Playwright projects.

**Total: 20/20 tests pass in 7.2s locally against the dev project.**

## What's in

### \`chromium\` (signed-out smoke — 5 specs)

- \`landing.spec.ts\` — \`/\` hero + open-source badge
- \`login.spec.ts\` — \`/login\` heading + email + password fields
- \`signup.spec.ts\` — \`/signup\` heading + username + email + password fields
- \`privacy.spec.ts\` — \`/privacy\` policy heading
- \`not-found.spec.ts\` — unknown route → 404 + back button

### \`chromium-auth\` (signed-in smoke, read-only — 7 specs)

- \`dashboard.signed-in.spec.ts\` — no bounce to /onboarding; Avg score + SG total trend
- \`rounds.signed-in.spec.ts\` — Rounds heading + seeded row
- \`stats.signed-in.spec.ts\` — Performance ledger + Stats + Last 5 button
- \`patterns.signed-in.spec.ts\` — Shot Patterns + club picker
- \`practice.signed-in.spec.ts\` — placeholder + link navigates to /practice/drills
- \`settings.signed-in.spec.ts\` — heading + seeded username and handicap values
- \`bag.signed-in.spec.ts\` — heading + 14 default-bag rows

### \`chromium-flows\` (signed-in, mutating, serial — 3 specs)

New project (\`fullyParallel: false\`) for tests that change state. Each \`afterEach\` restores the e2e user via Supabase admin so the user ends every run in the same state it started.

- \`settings-edit.flow.spec.ts\` — change handicap 12.4 → 13.5, save, reload, persists; revert in afterEach
- \`bag-crud.flow.spec.ts\` — delete Lob Wedge via per-row button + confirm dialog; re-insert in afterEach
- \`new-round-past.flow.spec.ts\` — pick course, submit form, land on /rounds/:id; delete round in afterEach

## Known gap

\`scripts/seed-demo.ts\` (touched in #363) doesn't yet populate \`user_clubs\`. The \`bag.signed-in\` spec relies on a one-time SQL insert of the default 14-club bag on the dev project. **Follow-up PR will extend \`seed-demo.ts\` (plus \`wipeDemoData\`)** to seed/wipe \`user_clubs\` alongside rounds and practice_plans so the fixture is fully reproducible from \`pnpm seed:e2e\`.

## Deferred to follow-up PRs

- **Phase 3** — Form validation negative cases (wrong creds, short password, invalid handicap, etc.)
- **Phase 4** — Signup → onboarding → dashboard with an ephemeral test user
- **Phase 5** — Map shot placement, drag-reorder bag, pattern drill-down
- **CI integration** — separate single-focused PR once the suite is stable locally
- **Prod targeting** — \`.env.test.prod.local\` + a mode switch in \`playwright.config.ts\` for prod-targeted e2e

## Verification

- [ ] \`cd apps/web && pnpm exec playwright test\` — 20/20 pass
- [ ] Re-run; state unchanged (flows restore on cleanup)
- [ ] Spot-check by temporarily renaming a known heading — verify the spec fails with an actionable error