### PR TITLE
chore(seed): seed + wipe user_clubs in seed-demo.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ DECISIONS.md
 PHASE_1.md
 PHASE_2.md
 PHASES_3_TO_8.md
+docs/internal/

--- a/apps/web/e2e/bag.signed-in.spec.ts
+++ b/apps/web/e2e/bag.signed-in.spec.ts
@@ -6,7 +6,7 @@ test.describe('Bag (signed in)', () => {
     await expect(
       page.getByRole('heading', { name: /My bag\./i }),
     ).toBeVisible()
-    // Seeded via scripts/seed-demo.ts (user_clubs additions, TODO).
+    // Seeded via scripts/seed-demo.ts → DEFAULT_BAG (14 clubs).
     // Each row has a drag handle with aria-label "Drag to reorder".
     const dragHandles = page.getByRole('button', { name: /Drag to reorder/i })
     await expect(dragHandles).toHaveCount(14)

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -15,6 +15,7 @@
  */
 import 'dotenv/config'
 import { createClient } from '@supabase/supabase-js'
+import { DEFAULT_BAG } from '@oga/core'
 
 const URL = process.env.SUPABASE_URL ?? 'http://127.0.0.1:54321'
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
@@ -128,6 +129,23 @@ async function wipeDemoData(userId: string): Promise<void> {
     .delete()
     .eq('user_id', userId)
   if (planErr) throw planErr
+  const { error: clubsErr } = await supabase
+    .from('user_clubs')
+    .delete()
+    .eq('user_id', userId)
+  if (clubsErr) throw clubsErr
+}
+
+async function seedBag(userId: string): Promise<void> {
+  const rows = DEFAULT_BAG.map((c) => ({
+    user_id: userId,
+    club_type: c.club_type,
+    name: c.name,
+    sort_order: c.sort_order,
+    in_bag: true,
+  }))
+  const { error } = await supabase.from('user_clubs').insert(rows)
+  if (error) throw error
 }
 
 interface CourseRow {
@@ -350,6 +368,7 @@ async function main() {
   const userId = await ensureDemoUser()
   await ensureProfile(userId)
   await wipeDemoData(userId)
+  await seedBag(userId)
 
   const courses = await fetchCourses()
   if (courses.length < 3) {


### PR DESCRIPTION
## Summary

Closes the known gap from PR #364: `bag.signed-in` spec relied on a one-time SQL insert of the default 14-club bag on the dev project. Now \`pnpm seed:e2e\` produces a fully-reproducible fixture including the bag.

## Changes

- **\`scripts/seed-demo.ts\`** — new \`seedBag(userId)\` helper inserts \`DEFAULT_BAG\` rows (imported from \`@oga/core\`). Called after \`wipeDemoData\` in main.
- **\`wipeDemoData\`** — extended to also \`DELETE FROM user_clubs WHERE user_id = X\` so re-runs don't collide on the \`(user_id, club_type, loft)\` UNIQUE constraint.
- **\`apps/web/e2e/bag.signed-in.spec.ts\`** — comment updated to drop the TODO note about the missing seed.
- **\`.gitignore\`** — adds \`docs/internal/\` for the reference-doc split that lives alongside CLAUDE.md.

## Verification

- \`pnpm seed:e2e\` is idempotent: 14 clubs after first run, 14 clubs after second run.
- Full Playwright suite passes 20/20 in 6.6s with no other behavior changes.

## Test plan

- [ ] \`pnpm seed:e2e\` runs cleanly, produces 14 user_clubs rows for the e2e user
- [ ] Re-running leaves the count at 14 (no double-insert)
- [ ] \`bag.signed-in\` spec still passes against the seeded state