### PR TITLE
chore(e2e): Phase 3 — settings form validation specs

### DIFF
--- a/apps/web/e2e/settings-validation.signed-in.spec.ts
+++ b/apps/web/e2e/settings-validation.signed-in.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+
+// Phase 3 — form validation: SettingsPage inline guards.
+//
+// SettingsPage validates inputs BEFORE the DB write and renders the
+// error from setError() in the form's error slot. Failing tests don't
+// mutate profile state, so they live in chromium-auth (read-only)
+// rather than chromium-flows.
+//
+// Username constraint: /^[a-zA-Z0-9_-]{3,32}$/ — letters, numbers, -, _
+// Handicap constraint: -10 to 54, must be a number
+test.describe('Settings form (signed in, validation)', () => {
+  test('handicap > 54 shows out-of-range error', async ({ page }) => {
+    await page.goto('/settings')
+    const handicapInput = page.locator('input').nth(1)
+    await handicapInput.fill('99')
+    await page.getByRole('button', { name: /Save profile/i }).click()
+    await expect(
+      page.getByText(/Handicap must be between -10 and 54/i),
+    ).toBeVisible()
+  })
+
+  test('invalid username disables Save button', async ({ page }) => {
+    // Username regex is enforced via canSubmit, not via setError on
+    // submit (unlike handicap). Save button disables when the regex
+    // fails, so the test asserts the disabled state directly.
+    await page.goto('/settings')
+    const usernameInput = page.locator('input').nth(0)
+    // Two characters fails the {3,32} length constraint.
+    await usernameInput.fill('ab')
+    const saveBtn = page.getByRole('button', { name: /Save profile/i })
+    await expect(saveBtn).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## Summary

Adds settings-validation.signed-in.spec.ts covering the SettingsPage's two inline validation paths that fire BEFORE the DB write:

- **handicap > 54** → asserts \`Handicap must be between -10 and 54\` error becomes visible
- **invalid username** (regex \`/^[a-zA-Z0-9_-]{3,32}$/\` fail) → asserts Save button disables via the \`canSubmit\` short-circuit

Both tests run in \`chromium-auth\` (read-only project) because the validation BLOCKS the save mutation — no profile state changes.

## What's deferred

**Login + signup validation specs** were the third leg of Phase 3 but require disabling the Turnstile captcha widget to click the submit button. The button is gated on \`captchaToken !== null\` whenever \`VITE_TURNSTILE_SITE_KEY\` is set (which it is in \`apps/web/.env.local\`). Bypassing this needs separate infrastructure:

- a \`--mode=test\` Vite override that loads a test-only env file with \`VITE_TURNSTILE_SITE_KEY=\` empty, AND
- Playwright config changes to spawn Vite with that mode in \`webServer.command\`.

Tried it; \`pnpm dev -- --mode=test\` didn't pick the override up reliably and the rabbit hole is its own task. Filing as a follow-up.

## Verification

- \`pnpm exec playwright test\` — full suite 22/22 pass in 7.9s.
- Settings validation tests are read-only — no DB mutations means no afterEach cleanup needed, no risk of polluting flow tests that run in parallel.

## Test plan

- [ ] \`pnpm exec playwright test settings-validation\` passes 2/2
- [ ] No regressions in the existing 20 specs