### PR TITLE
fix(web,mobile): SG chart line color + pattern differentiation (#240)

### DIFF
--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
+import Svg, { Line as SvgLine } from 'react-native-svg'
 import {
   computeDetailedStats,
   DEFAULT_HANDICAP,
@@ -22,11 +23,10 @@ const CHART_HEIGHT = 260
 const CHART_BOTTOM = 28
 
 const SERIES = [
-  { key: 'sg_off_tee', label: 'Off tee', color: '#1F3D2C', dash: false },
-  { key: 'sg_approach', label: 'Approach', color: '#A33A2A', dash: false },
-  { key: 'sg_around_green', label: 'Around green', color: '#A66A1F', dash: false },
-  // Putting shares the green family with Off tee — dashed to distinguish.
-  { key: 'sg_putting', label: 'Putting', color: '#5C6356', dash: true },
+  { key: 'sg_off_tee', label: 'Off tee', color: '#1F3D2C', dash: '0' },
+  { key: 'sg_approach', label: 'Approach', color: '#A33A2A', dash: '6,3' },
+  { key: 'sg_around_green', label: 'Around green', color: '#A66A1F', dash: '2,3' },
+  { key: 'sg_putting', label: 'Putting', color: '#1C211C', dash: '6,3,2,3' },
 ] as const
 
 const KICKER: import('react-native').TextStyle = {
@@ -288,7 +288,7 @@ export default function Stats() {
                       data: {
                         stroke: s.color,
                         strokeWidth: 1.5,
-                        strokeDasharray: s.dash ? '5,3' : '0',
+                        strokeDasharray: s.dash,
                       },
                     }}
                   />
@@ -307,14 +307,17 @@ export default function Stats() {
                     key={s.key}
                     style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}
                   >
-                    {s.dash ? (
-                      <View style={{ flexDirection: 'row', gap: 2, alignItems: 'center' }}>
-                        <View style={{ width: 4, height: 2, backgroundColor: s.color }} />
-                        <View style={{ width: 4, height: 2, backgroundColor: s.color }} />
-                      </View>
-                    ) : (
-                      <View style={{ width: 10, height: 2, backgroundColor: s.color }} />
-                    )}
+                    <Svg width={16} height={4}>
+                      <SvgLine
+                        x1={0}
+                        y1={2}
+                        x2={16}
+                        y2={2}
+                        stroke={s.color}
+                        strokeWidth={1.5}
+                        strokeDasharray={s.dash}
+                      />
+                    </Svg>
                     <Text style={{ color: '#5C6356', fontSize: 11 }}>
                       {s.label}
                     </Text>

--- a/apps/web/src/pages/stats/sections/StrokesGainedSection.tsx
+++ b/apps/web/src/pages/stats/sections/StrokesGainedSection.tsx
@@ -23,10 +23,10 @@ const TOOLTIP_STYLE = {
 } as const
 
 const SG_SERIES = [
-  { key: 'offTee', label: 'Off tee', color: '#1F3D2C', dashed: false },
-  { key: 'approach', label: 'Approach', color: '#A33A2A', dashed: false },
-  { key: 'aroundGreen', label: 'Around green', color: '#A66A1F', dashed: false },
-  { key: 'putting', label: 'Putting', color: '#5C6356', dashed: true },
+  { key: 'offTee', label: 'Off tee', color: '#1F3D2C', dash: '0' },
+  { key: 'approach', label: 'Approach', color: '#A33A2A', dash: '6 3' },
+  { key: 'aroundGreen', label: 'Around green', color: '#A66A1F', dash: '2 3' },
+  { key: 'putting', label: 'Putting', color: '#1C211C', dash: '6 3 2 3' },
 ] as const
 
 function SGLegend() {
@@ -49,7 +49,7 @@ function SGLegend() {
               x1="0" y1="5" x2="16" y2="5"
               stroke={s.color}
               strokeWidth="1.5"
-              strokeDasharray={s.dashed ? '4 3' : undefined}
+              strokeDasharray={s.dash}
             />
           </svg>
           {s.label}
@@ -123,7 +123,7 @@ export function StrokesGainedSection({ data }: { data: DetailedStats }) {
                     name={s.label}
                     stroke={s.color}
                     strokeWidth={1.5}
-                    strokeDasharray={s.dashed ? '4 3' : undefined}
+                    strokeDasharray={s.dash}
                     dot={{ r: 2.5, fill: s.color, strokeWidth: 0 }}
                     activeDot={{ r: 4 }}
                   />


### PR DESCRIPTION
## Summary

Closes #240.

Putting line color sat in the same green family as off-tee (`#5C6356` olive-gray vs `#1F3D2C` forest), so the two lines visually collapsed on the SG trend chart. Putting moves to `#1C211C` (caddie-ink) and all four series gain a distinct stroke pattern.

## Per-series mapping

| Series | Color (before → after) | Stroke (before → after) |
|---|---|---|
| Off tee | `#1F3D2C` (unchanged) | solid (unchanged) |
| Approach | `#A33A2A` (unchanged) | solid → dashed `6 3` |
| Around green | `#A66A1F` (unchanged) | solid → dotted `2 3` |
| Putting | `#5C6356` → `#1C211C` | dashed `4 3` → dash-dot `6 3 2 3` |

## Why patterns, not just color

The design system caps the palette at `#1F3D2C` and its derivatives — no bright blues / purples available to break the green-family tie. Adding a distinct pattern per series:

- fixes the cited off-tee / putting collapse
- also addresses a latent deuteranopia issue where approach (brick) and around-green (amber) both read as yellow-brown to red-green colorblind users

## Files

- `apps/web/src/pages/stats/sections/StrokesGainedSection.tsx` — `SG_SERIES` table, SGLegend swatch, recharts `<Line>` props.
- `apps/mobile/app/(app)/stats.tsx` — `SERIES` table, VictoryLine `strokeDasharray`, legend swatch (now `<Svg><Line/></Svg>` via `react-native-svg`, already a direct dep). Removed obsolete "shares the green family" comment.

The 4-series color/pattern table is duplicated across web + mobile (5 lines × 2). Kept inline for now; if a third 4-series chart appears, that's the trigger to extract into `@oga/core`.

## Verification

- `pnpm typecheck` — clean.
- `pnpm --filter web build` — clean in 4.54s.
- `npm run typecheck` in `apps/mobile` — clean.
- Playwright `chromium-auth` capture confirms all 4 lines clearly distinguishable on the dev e2e fixture.

## Test plan

- [ ] Visit `/stats` signed in (web) — confirm chart legend shows 4 distinct stroke patterns, putting reads as dash-dot near-black (not olive-gray).
- [ ] Open mobile Stats tab — confirm legend + chart match web's 4-pattern scheme.
- [ ] Confirm no regression on the mobile home tab single-line SG total chart (unchanged).