### PR TITLE
fix(web,mobile): swap PuttingSheet Holed/Missed button order (#202)

### DIFF
--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -368,28 +368,6 @@ export function PuttingSheet({
         <View style={{ marginTop: 22 }}>
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel="Save putt as holed"
-            onPress={() => commit(true)}
-            style={{
-              backgroundColor: '#1F3D2C',
-              borderRadius: 2,
-              paddingVertical: 18,
-              alignItems: 'center',
-            }}
-          >
-            <Text
-              style={{
-                color: '#F2EEE5',
-                fontSize: 16,
-                fontWeight: '700',
-                letterSpacing: 0.4,
-              }}
-            >
-              Holed it →
-            </Text>
-          </Pressable>
-          <Pressable
-            accessibilityRole="button"
             accessibilityLabel="Save putt as missed"
             onPress={() => commit(false)}
             style={{
@@ -398,7 +376,6 @@ export function PuttingSheet({
               borderRadius: 2,
               paddingVertical: 14,
               alignItems: 'center',
-              marginTop: 10,
             }}
           >
             <Text
@@ -410,6 +387,29 @@ export function PuttingSheet({
               }}
             >
               Missed →
+            </Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Save putt as holed"
+            onPress={() => commit(true)}
+            style={{
+              backgroundColor: '#1F3D2C',
+              borderRadius: 2,
+              paddingVertical: 18,
+              alignItems: 'center',
+              marginTop: 10,
+            }}
+          >
+            <Text
+              style={{
+                color: '#F2EEE5',
+                fontSize: 16,
+                fontWeight: '700',
+                letterSpacing: 0.4,
+              }}
+            >
+              Holed it →
             </Text>
           </Pressable>
         </View>

--- a/apps/web/src/components/round/WebPuttingSheet.tsx
+++ b/apps/web/src/components/round/WebPuttingSheet.tsx
@@ -231,25 +231,6 @@ export function WebPuttingSheet({
       >
         <button
           type="button"
-          onClick={() => commit(true)}
-          className="bg-caddie-accent text-caddie-accent-ink"
-          style={{
-            flex: 1,
-            minWidth: 160,
-            borderRadius: 2,
-            padding: '14px 18px',
-            fontSize: 14,
-            fontWeight: 600,
-            letterSpacing: '0.02em',
-          }}
-        >
-          Holed it{' '}
-          <span className="font-serif" style={{ fontStyle: 'italic' }}>
-            →
-          </span>
-        </button>
-        <button
-          type="button"
           onClick={() => commit(false)}
           className="text-caddie-accent"
           style={{
@@ -265,6 +246,25 @@ export function WebPuttingSheet({
           }}
         >
           Missed{' '}
+          <span className="font-serif" style={{ fontStyle: 'italic' }}>
+            →
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={() => commit(true)}
+          className="bg-caddie-accent text-caddie-accent-ink"
+          style={{
+            flex: 1,
+            minWidth: 160,
+            borderRadius: 2,
+            padding: '14px 18px',
+            fontSize: 14,
+            fontWeight: 600,
+            letterSpacing: '0.02em',
+          }}
+        >
+          Holed it{' '}
           <span className="font-serif" style={{ fontStyle: 'italic' }}>
             →
           </span>


### PR DESCRIPTION
## Summary

Closes #202.

Two parallel "Holed / Missed" action button pairs had the primary positive action in the less-conventional position:

- `apps/web/src/components/round/WebPuttingSheet.tsx` — horizontal row, Holed was on the **left** (accent), Missed on the **right** (outline). Out of step with `ShotEntryModal.tsx` which already follows the iOS convention of primary positive action on the right.
- `apps/mobile/components/round/PuttingSheet.tsx` — vertical stack, Holed was on **top** (accent), Missed on **bottom** (outline). Primary now sits in the thumb zone for a bottom sheet.

## Mapping

| File | Layout | Before | After |
|---|---|---|---|
| WebPuttingSheet.tsx | horizontal row | Holed (L) / Missed (R) | Missed (L) / Holed (R) |
| PuttingSheet.tsx (mobile) | vertical stack | Holed (top) / Missed (bottom) | Missed (top) / Holed (bottom) |

The issue title doesn't specify web vs mobile, but the issue body literally describes "left/right" — which matched the web layout, not the mobile vertical stack. Fixing both: applying the same primary-in-conventional-position principle to each app's layout family.

## Files

- `apps/web/src/components/round/WebPuttingSheet.tsx` — swapped the two `<button>` blocks at the bottom of the sheet.
- `apps/mobile/components/round/PuttingSheet.tsx` — swapped the two `<Pressable>` blocks; `marginTop: 10` moves with the now-second button so spacing stays consistent.

No logic / handler / accessibility-label changes — pure visual reorder.

## Verification

- `pnpm typecheck` — clean.
- `pnpm --filter web build` — clean in 4.38s.
- `npm run typecheck` in `apps/mobile` — clean.
- No Playwright capture: the change is a pair-element source reorder with handlers and labels unchanged; verification is code-review-level. Will eyeball on next preview build / dev session.

## Test plan

- [ ] Web: open an existing round, log a putt — bottom-row reads "Missed" (left, outline) → "Holed it" (right, accent).
- [ ] Mobile: open an existing round on the green, open the putting sheet — bottom action stack reads "Missed" (top, outline) → "Holed it" (bottom, accent).
- [ ] No change to `ShotEntryModal` (already followed the convention).