### PR TITLE
fix(mobile): PuttingSheet 'Not a putt?' link >=44px hit target (#245)

### DIFF
--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -218,7 +218,7 @@ export function PuttingSheet({
               accessibilityLabel="Not a putt — switch to chip or bunker shot"
               onPress={() => onChangeLie('rough')}
               hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
-              style={{ marginTop: 4 }}
+              style={{ marginTop: 4, paddingVertical: 12 }}
             >
               <Text
                 style={{


### PR DESCRIPTION
## Summary

Closes #245.

The "Not a putt? Chip / bunker →" escape link in `apps/mobile/components/round/PuttingSheet.tsx` had a ~24×24 px effective tap target (12px text + hitSlop 6), below the 44×44 motor accessibility minimum.

## Fix

Added `paddingVertical: 12` to the Pressable's style.

```diff
-              style={{ marginTop: 4 }}
+              style={{ marginTop: 4, paddingVertical: 12 }}
```

| Metric | Before | After |
|---|---|---|
| Visible tap area | 12px (text only) | 36px (text + 24px padding) |
| Hit zone incl. hitSlop 6 | 24px | 48px |
| Status | fails (<44) | passes (≥44) |

## Why paddingVertical over a larger hitSlop

The issue suggested "increase hitSlop to at least 20, or wrap in a larger Pressable." Considered three approaches:

1. **Symmetric hitSlop 20** — one-line, but the link sits 4px below the "On the green." headline; a 20px upward hitSlop would extend 16px into the headline area. A tap on "green." could fire the escape link — surprising even if technically harmless.
2. **`paddingVertical: 12`** ← chosen — produces a *visible* tap target instead of an invisible hit slop, which is what WCAG 2.5.5 (Target Size) actually wants. Header grows 24px; GreenDiagram shifts down correspondingly.
3. **Asymmetric hitSlop top:12 bottom:24** — no layout change, but still some headline overlap and an invisible-only fix.

(2) gives the strongest accessibility story and avoids any "hidden hit zone" surprises.

## Scope

Mobile-only. `apps/web/src/components/round/WebPuttingSheet.tsx` has no equivalent — `onChangeLie` is a mobile-only prop (the web round flow handles lie correction differently).

## Verification

- `npm run typecheck` in `apps/mobile` — clean.
- Code review: single Pressable-style additive change, no behavior or label change.
- Visual confirmation deferred to the next preview build (mobile e2e not set up; Playwright is web-only here).

## Test plan

- [ ] Open mobile PuttingSheet (live round, on the green, after selecting an on-the-green prompt) — the "Not a putt? Chip / bunker →" link visibly has more vertical breathing room.
- [ ] Tap-test the link with a fingertip — registers cleanly without needing precise aim.
- [ ] GreenDiagram is still visible without scrolling on a phone-sized viewport (it shifts down ~24px).