### PR TITLE
fix(mobile): rounds list a11y — screen-reader-accessible delete (#286)

### DIFF
--- a/apps/mobile/app/(app)/rounds.tsx
+++ b/apps/mobile/app/(app)/rounds.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Pressable, ScrollView, Text, View } from 'react-native'
+import {
+  AccessibilityInfo,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native'
 import { Link } from 'expo-router'
 import { Swipeable } from 'react-native-gesture-handler'
 import { formatSG } from '@oga/core'
@@ -23,6 +29,15 @@ const KICKER: import('react-native').TextStyle = {
   fontWeight: '500',
   letterSpacing: 1.4,
   textTransform: 'uppercase',
+}
+
+// Screen-reader label for a round row. TalkBack and VoiceOver read visible
+// numbers but don't always interpret them; spell out what each field is.
+function buildA11yLabel(r: RoundRow): string {
+  const parts = [`Round at ${r.courses?.name ?? 'unnamed course'}`, r.played_at]
+  if (r.total_score != null) parts.push(`scored ${r.total_score}`)
+  if (r.sg_total != null) parts.push(`strokes gained ${formatSG(r.sg_total)}`)
+  return parts.join('. ') + '.'
 }
 
 export default function RoundsList() {
@@ -53,13 +68,20 @@ export default function RoundsList() {
   }, [user?.id])
 
   const handleDelete = useCallback(
-    async (id: string) => {
+    async (id: string, courseName: string) => {
       if (!user) return
       setDeleting(true)
       try {
         const { error } = await deleteRound(supabase, id, user.id)
         if (error) throw error
         setRounds((prev) => prev.filter((r) => r.id !== id))
+        // Delay so VoiceOver doesn't swallow the announce while focus
+        // shifts from the dismissing ConfirmDialog.
+        setTimeout(() => {
+          AccessibilityInfo.announceForAccessibility(
+            `Deleted round at ${courseName}`,
+          )
+        }, 120)
       } finally {
         setDeleting(false)
         setPendingDelete(null)
@@ -68,6 +90,16 @@ export default function RoundsList() {
     },
     [user],
   )
+
+  // Shared entry point for the three delete triggers: swipe-tap,
+  // long-press, and the custom 'delete' accessibility action.
+  const openDeleteFor = useCallback((r: RoundRow) => {
+    swipeRefs.current.get(r.id)?.close()
+    setPendingDelete({
+      id: r.id,
+      name: r.courses?.name ?? 'this round',
+    })
+  }, [])
 
   return (
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
@@ -93,13 +125,7 @@ export default function RoundsList() {
                 }}
                 renderRightActions={() => (
                   <Pressable
-                    onPress={() => {
-                      swipeRefs.current.get(r.id)?.close()
-                      setPendingDelete({
-                        id: r.id,
-                        name: r.courses?.name ?? 'this round',
-                      })
-                    }}
+                    onPress={() => openDeleteFor(r)}
                     style={{
                       backgroundColor: '#A33A2A',
                       justifyContent: 'center',
@@ -123,7 +149,17 @@ export default function RoundsList() {
               >
                 <Link href={`/(app)/round/${r.id}`} asChild>
                   <Pressable
-                    style={{
+                    onLongPress={() => openDeleteFor(r)}
+                    accessibilityLabel={buildA11yLabel(r)}
+                    accessibilityHint="Opens round detail"
+                    accessibilityActions={[
+                      { name: 'delete', label: 'Delete round' },
+                    ]}
+                    onAccessibilityAction={(e) => {
+                      if (e.nativeEvent.actionName === 'delete')
+                        openDeleteFor(r)
+                    }}
+                    style={({ pressed }) => ({
                       flexDirection: 'row',
                       justifyContent: 'space-between',
                       alignItems: 'center',
@@ -132,7 +168,8 @@ export default function RoundsList() {
                       borderBottomWidth: 1,
                       borderColor: '#D9D2BF',
                       backgroundColor: '#F2EEE5',
-                    }}
+                      opacity: pressed ? 0.7 : 1,
+                    })}
                   >
                     <View style={{ flex: 1, paddingRight: 12 }}>
                       <Text style={{ ...KICKER, marginBottom: 4 }}>
@@ -201,7 +238,8 @@ export default function RoundsList() {
         destructive
         busy={deleting}
         onConfirm={async () => {
-          if (pendingDelete) await handleDelete(pendingDelete.id)
+          if (pendingDelete)
+            await handleDelete(pendingDelete.id, pendingDelete.name)
         }}
         onCancel={() => setPendingDelete(null)}
       />


### PR DESCRIPTION
## Summary

- Swipe-to-delete is now reachable via TalkBack + VoiceOver via a custom `delete` accessibility action (rotor / context menu) and via `onLongPress`
- Each row carries a structured `accessibilityLabel` (course · date · score · SG) so screen readers don't read bare numbers without context
- Post-delete announcement via `AccessibilityInfo.announceForAccessibility` with a 120 ms delay to avoid the iOS modal-dismiss focus race
- Pre-existing-bug fixed in passing: row Pressable now has an iOS opacity fallback for the pressed state

## Why

WCAG 2.1 SC 2.5.1 Pointer Gestures (Level AA) requires every action to be reachable via a single pointer without path-based gestures. Swipe-only delete fails this. v1.0 accessibility blocker.

## How

Three delete triggers, all routing through a shared `openDeleteFor(r)`:

| Trigger | Audience |
|---|---|
| Existing swipe-tap | Default sighted users |
| `onLongPress` on row | Motor-impaired sighted users |
| Custom `delete` accessibility action | TalkBack + VoiceOver users |

`magicTap` was considered (and present in the canonical pattern documented earlier) but is iOS-only on Android TalkBack. The custom action surfaces reliably in both VoiceOver's Actions rotor and TalkBack's local context menu — that's the right cross-platform primitive.

## Test plan

- [ ] Android device with TalkBack enabled: navigate the rounds list, hear each row labeled with course/date/score/SG, open Actions menu via local context menu, select "Delete round", confirm dialog appears, complete delete, hear "Deleted round at ..." announcement
- [ ] Android: long-press a row, confirm delete dialog appears (sighted alternative path)
- [ ] Android: existing swipe-to-delete unchanged
- [ ] iOS (after #376 stands up iOS builds): VoiceOver Actions rotor exposes "Delete round"; two-finger swipe up reveals it; activate to fire delete
- [ ] Sighted users without screen reader: nothing changes visually except the row now dims to 0.7 opacity on press (iOS feedback parity with Android ripple)

## Files

- `apps/mobile/app/(app)/rounds.tsx` — single-file change

## Verification

`cd apps/mobile && npm run typecheck` — clean