### PR TITLE
fix(mobile): gate LocationPuck mount during modal-covered phases (#330)

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -73,6 +73,17 @@ interface HoleMapProps {
   onSetBall: (loc: LatLng) => void
   onPlacePin?: (loc: LatLng) => void
   onPlaceTee?: (loc: LatLng) => void
+  /**
+   * Whether to mount the Mapbox LocationPuck. The puck owns its own
+   * native GPS subscription that bypasses expo-location, and setting
+   * `visible={false}` keeps that subscription alive (verified in
+   * @rnmapbox/maps source — see PR notes for #330). Conditional
+   * mount/unmount is the only way to actually pause the drain. Pass
+   * true during PLACE_BALL and SET_AIM (player on course, puck is
+   * meaningful) and false during SHOT_DETAIL / PUTTING (modals cover
+   * the map).
+   */
+  showLocationPuck: boolean
 }
 
 function toCoord(l: LatLng): [number, number] {
@@ -109,6 +120,7 @@ export function HoleMap({
   onSetBall,
   onPlacePin,
   onPlaceTee,
+  showLocationPuck,
 }: HoleMapProps) {
   const { toDisplay } = useUnits()
   const mapViewRef = useRef<Mapbox.MapView>(null)
@@ -311,8 +323,10 @@ export function HoleMap({
           {/* Bearing intentionally not enabled — drives the magnetometer
               continuously, which costs ~2-4 %/hr over a 4-hour round, and
               the player's facing direction isn't UX-meaningful here (no
-              navigation, no panning relative to heading). */}
-          <Mapbox.LocationPuck visible />
+              navigation, no panning relative to heading).
+              Conditional mount (not visible={...}) is required to actually
+              pause the native GPS subscription — see HoleMapProps.showLocationPuck. */}
+          {showLocationPuck && <Mapbox.LocationPuck visible />}
 
           <BreadcrumbLayers
             previousShots={previousShots ?? []}

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -360,6 +360,10 @@ export default function LiveRoundSession({
                   ? 'SET_AIM'
                   : 'PLACE_BALL'
           }
+          showLocationPuck={
+            finalState.roundState !== 'SHOT_DETAIL' &&
+            finalState.roundState !== 'PUTTING'
+          }
           onSetAim={finalState.setAim}
           onSetBall={(loc) => {
             // Manual drag/tap is an explicit override. Freeze GPS


### PR DESCRIPTION
## Summary

- `<Mapbox.LocationPuck>` now conditionally mounts via a new `showLocationPuck: boolean` prop on `HoleMap`
- Caller (`LiveRoundSession`) passes `false` during `SHOT_DETAIL` / `PUTTING` (modals cover the map) and `true` otherwise (`PLACE_BALL` / `SET_AIM` — on course, puck is meaningful)
- Estimated battery savings: 4-7 %/hr during ~30-50% of round duration

## Why conditional render, not `visible={false}`

The open question in the issue is now closed by reading `@rnmapbox/maps` native source. `visible={false}` does NOT pause the GPS subscription on either platform:

- **Android** (`RNMBXNativeUserLocation.kt:128-148`): `visible=false` swaps in blank images via `LocationPuck2D(topImage=empty)`. The `enabled` flag — which gates `stopLocationManager()` — is only flipped by `addToMap` / `removeFromMap`. FusedLocationProviderClient stays live.
- **iOS** (`RNMBXNativeUserLocation.swift:143-153`): `visible=false` sets `puckType = .puck2D(...)` with blank images. CLLocationManager stays active. Only `puckType = .none` (on unmount) calls `stopUpdatingLocation()`.

Conditional render is mandatory. A code comment near the puck codifies this so future maintainers don't "simplify" to `visible={false}`.

## Why the gate covers SET_AIM too (not just PLACE_BALL)

The issue body's proposed `roundState === 'PLACE_BALL'` was too narrow. `SET_AIM` is when the player is lining up their shot — still on course, puck is still useful as a position reference. The actual optimization target is _modal-covered phases_: `SHOT_DETAIL` and `PUTTING`. Negative-form gate (`!== 'SHOT_DETAIL' && !== 'PUTTING'`) stays correct if new mid-shot states are added later.

## Test plan

- [ ] **Android device:** load a hole, confirm puck visible during PLACE_BALL and SET_AIM (long-press to drop aim). Tap ball to enter SHOT_DETAIL, confirm puck unmounts (close modal to verify). Return to PLACE_BALL, confirm puck re-mounts within ~100ms (cached last-known location).
- [ ] **Android dev menu battery:** rough estimate over a 30+ minute session vs. main to confirm the savings target.
- [ ] **iOS device (deferred until #376):** smoke test the re-centering behavior on PLACE_BALL re-entry — camera setup at `HoleMap.tsx:302-308` uses `defaultSettings` only with no `followUserLocation`, so should be unaffected.

## Files

- `apps/mobile/components/round/HoleMap.tsx` — new prop + conditional mount
- `apps/mobile/components/round/LiveRoundSession.tsx` — pass the prop

## Verification

`cd apps/mobile && npm run typecheck` — clean