### PR TITLE
fix(mobile): SecureStore chunked write — sentinel-last commit order (#345)

### DIFF
--- a/apps/mobile/lib/supabase.ts
+++ b/apps/mobile/lib/supabase.ts
@@ -2,18 +2,44 @@ import 'react-native-url-polyfill/auto'
 import * as SecureStore from 'expo-secure-store'
 import { createOgaClient } from '@oga/supabase'
 
-// expo-secure-store is backed by Android Keystore / iOS Keychain. Both
-// have a per-key payload limit (Android: 2048 bytes; iOS keychain is
-// looser). Supabase session JSON typically exceeds 2 KB once the access
-// token + refresh token + user metadata are all in there, which triggers
-// a "value larger than 2048 bytes" warning on Android and on some
-// devices fails outright.
+// expo-secure-store persists AES-GCM-encrypted blobs in
+// SharedPreferences on Android and Keychain on iOS. Neither has a
+// hard per-value size limit on modern devices — the legacy 2048-byte
+// Android Keystore constraint applies only to a pre-API-23 RSA-wrapped
+// path (HybridAESEncryptor) that is dead code in expo-secure-store on
+// SDK >= 23 (it throws IllegalStateException on init).
 //
-// The adapter chunks long values across `${key}_0`, `${key}_1`, …
-// keys with a sentinel `${key}_chunks` recording the count, and
-// reassembles on read. Values under the chunk size still write to the
-// raw key for back-compat with sessions stored before this fix.
+// The adapter still chunks long values across `${key}_0`, `${key}_1`,
+// … keys with a sentinel `${key}_chunks` recording the count, and
+// reassembles on read. The chunking is kept as belt-and-suspenders
+// defense against any unforeseen backend constraint and to keep
+// individual writes small; values under CHUNK_SIZE write directly to
+// the raw key for back-compat with sessions stored before chunking
+// was added.
+//
+// Write order: chunks first, sentinel last. The sentinel write is the
+// commit point — a process kill before that leaves the next read with
+// no sentinel, which falls through to the (cleared) raw-key path and
+// returns null cleanly. Supabase treats null as logged-out; user signs
+// in again. The previous "sentinel-first" order could leave a partial
+// chunk set behind a valid sentinel, which would reassemble into a
+// corrupt JWT and confuse Supabase auth (issue #345).
 const CHUNK_SIZE = 1800
+
+// Wipe any prior chunked layout (sentinel + all chunks) for the given
+// key. Used before any new write to avoid mixed-version reads and to
+// clean up orphans from a previous-larger write.
+async function clearChunkedKeys(key: string): Promise<void> {
+  const prevCountRaw = await SecureStore.getItemAsync(`${key}_chunks`)
+  if (!prevCountRaw) return
+  const prev = parseInt(prevCountRaw, 10)
+  if (Number.isFinite(prev) && prev > 0) {
+    for (let i = 0; i < prev; i++) {
+      await SecureStore.deleteItemAsync(`${key}_${i}`).catch(() => undefined)
+    }
+  }
+  await SecureStore.deleteItemAsync(`${key}_chunks`).catch(() => undefined)
+}
 
 const SecureStoreAdapter = {
   getItem: async (key: string): Promise<string | null> => {
@@ -37,26 +63,26 @@ const SecureStoreAdapter = {
       for (let i = 0; i < value.length; i += CHUNK_SIZE) {
         chunks.push(value.slice(i, i + CHUNK_SIZE))
       }
-      // Clear any previous unchunked write at this key so getItem
-      // doesn't see stale data from the back-compat fast-path branch.
+      // Clear the back-compat unchunked slot so it can't shadow the
+      // new chunked write on subsequent reads.
       await SecureStore.deleteItemAsync(key).catch(() => undefined)
+      // Wipe any prior chunked layout BEFORE writing the new chunks.
+      // A concurrent reader between this clear and the new commit
+      // sees no sentinel and falls through to the cleared raw-key
+      // path — clean null read rather than a mix of old and new
+      // chunk data. Also handles the previous-larger-write case
+      // (orphan chunks from a shrink).
+      await clearChunkedKeys(key)
+      // Chunks first.
+      for (const [i, chunk] of chunks.entries()) {
+        await SecureStore.setItemAsync(`${key}_${i}`, chunk)
+      }
+      // Sentinel last — the commit point. See module-level comment.
       await SecureStore.setItemAsync(`${key}_chunks`, String(chunks.length))
-      for (let i = 0; i < chunks.length; i++) {
-        await SecureStore.setItemAsync(`${key}_${i}`, chunks[i] ?? '')
-      }
     } else {
-      // Clear any chunks from a previous larger write so the next read
-      // doesn't reassemble stale fragments.
-      const prevCountRaw = await SecureStore.getItemAsync(`${key}_chunks`)
-      if (prevCountRaw) {
-        const prev = parseInt(prevCountRaw, 10)
-        if (Number.isFinite(prev)) {
-          for (let i = 0; i < prev; i++) {
-            await SecureStore.deleteItemAsync(`${key}_${i}`).catch(() => undefined)
-          }
-        }
-        await SecureStore.deleteItemAsync(`${key}_chunks`).catch(() => undefined)
-      }
+      // Unchunked path. Wipe any prior chunked layout, then write to
+      // the raw key.
+      await clearChunkedKeys(key)
       await SecureStore.setItemAsync(key, value)
     }
   },


### PR DESCRIPTION
## Summary

- `setItem` chunked-write path now writes the chunk-count sentinel LAST, after all chunks are persisted. The sentinel write is the commit point — a process kill before that leaves the next read with no sentinel, which falls through cleanly to the back-compat raw-key path.
- Extracted `clearChunkedKeys(key)` helper that wipes the prior chunked layout (sentinel + chunks) BEFORE writing the new layout. Removes the inline cleanup duplication and handles the previous-larger-write orphan case.
- Corrected the misleading comment claiming a 2048-byte Android Keystore limit; the actual backend on modern Android is SharedPreferences, which has no hard per-value cap.
- Replaced `chunks[i] ?? ''` with `chunks.entries()` so the chunk index/value pair comes pre-typed.

## Why

Previously the adapter wrote the sentinel FIRST:

```
${key}_chunks   = N        (sentinel)
${key}_0        = chunk
${key}_1        = chunk
...
```

If the OS killed the JS process between the sentinel write and the chunk loop completing (low-memory background kill during a token refresh, app suspension on iOS), the next read would find:

- `${key}_chunks` = N (full count)
- only M < N chunks actually written

The read path returns `null` on first missing chunk → Supabase treats the user as logged out and they must sign in again.

The new write order makes the kill window safer: a kill before the sentinel write leaves no sentinel, the read falls through to the raw-key path (cleared by `clearChunkedKeys` before chunks are written), and returns null cleanly. Same logout outcome, but the state is consistent and Supabase doesn't see a corrupt mid-decoded JWT.

## What about #344?

Closed as phantom in this session — the cited 2048-byte Android Keystore limit applies only to the legacy `HybridAESEncryptor` RSA path which `expo-secure-store` explicitly refuses to use on SDK ≥ 23 (`HybridAESEncryptor.kt:61` throws). Current backend (`SecureStoreModule.kt:91/183/235`) is SharedPreferences. Byte-chunking would defend against a non-existent platform constraint. The existing char-based chunking stays in place as belt-and-suspenders defense; the misleading comment is corrected by this PR.

## Per CLAUDE.md `repro before fix` rule

#345 is labeled `defensive` — no observed user repro of the mid-write race. The fix is speculative; explicitly acknowledged here. The new write order is strictly safer than the prior order regardless of whether the race condition is ever hit in production.

## Test plan

- [ ] **Android device:** sign in fresh, complete onboarding. Force-kill the app mid-session via the Profiler "Kill" button. Reopen. Confirm clean state — either valid session restored OR login screen (NOT a hung or crashing app).
- [ ] **Android (token refresh window):** wait for a token refresh (or trigger one), kill mid-refresh, reopen. Same expectation.
- [ ] **iOS QA:** deferred to #376 (first iOS dev build).

## Files

- `apps/mobile/lib/supabase.ts` — single file, +53 / -27

## Verification

`cd apps/mobile && npm run typecheck` — clean