### PR TITLE
fix(mobile): collapse 6 dialog flags into one ActiveDialog union (#293)

### DIFF
--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -14,7 +14,9 @@ import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { useUnits } from '../../hooks/useUnits'
 import {
   FALLBACK_CENTER,
+  HOLE_SCOPED_DIALOGS,
   KICKER,
+  type ActiveDialog,
 } from './hole/types'
 import { useHoleData } from './hole/useHoleData'
 import { useHoleState } from './hole/useHoleState'
@@ -56,13 +58,10 @@ export default function LiveRoundSession({
   const [loggerOpen, setLoggerOpen] = useState(false)
   const [pinPlacementOpen, setPinPlacementOpen] = useState(false)
   const [teePlacementOpen, setTeePlacementOpen] = useState(false)
-  const [confirmDelete, setConfirmDelete] = useState(false)
   const [scorecardOpen, setScorecardOpen] = useState(false)
-  const [confirmLeave, setConfirmLeave] = useState(false)
-  const [confirmEnd, setConfirmEnd] = useState(false)
-  const [confirmExit, setConfirmExit] = useState(false)
-  const [onGreenPromptOpen, setOnGreenPromptOpen] = useState(false)
-  const [aimPromptOpen, setAimPromptOpen] = useState(false)
+  // One mutually-exclusive confirm dialog at a time. See ActiveDialog
+  // in ./hole/types for the full union + rationale (#293).
+  const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null)
   const [loggerInitial, setLoggerInitial] = useState<ShotLoggerValue>({})
 
   // Per-hole reset. useHoleState resets its own refs (Kalman, manual
@@ -73,12 +72,14 @@ export default function LiveRoundSession({
     setLoggerOpen(false)
     setPinPlacementOpen(false)
     setTeePlacementOpen(false)
-    setOnGreenPromptOpen(false)
-    setAimPromptOpen(false)
     setLoggerInitial({})
-    // Scorecard / confirm dialogs are session-level — don't reset them
-    // on hole change. A confirmDelete dialog mid-navigation should
-    // stay open.
+    // Clear only hole-scoped dialogs (onGreen / aim). Session-scoped
+    // confirms (delete / leave / end / exit) stay open across hole
+    // navigation — a confirmDelete dialog mid-navigation should not
+    // vanish out from under the user.
+    setActiveDialog(prev =>
+      prev !== null && HOLE_SCOPED_DIALOGS.has(prev) ? null : prev,
+    )
   }, [holeNumber])
 
   // External URL change → internal state. The scorecard hole-jump
@@ -136,11 +137,7 @@ export default function LiveRoundSession({
     setLoggerInitial,
     setPinPlacementOpen,
     setTeePlacementOpen,
-    setOnGreenPromptOpen,
-    setAimPromptOpen,
-    setConfirmDelete,
-    setConfirmEnd,
-    setConfirmExit,
+    setActiveDialog,
     // URL sync fires here — only on user-driven navigation (Next /
     // Prev / Finish), not on every render. A reactive useEffect that
     // depended on the parent's onHoleChange prop looped because the
@@ -234,7 +231,7 @@ export default function LiveRoundSession({
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Exit round and discard"
-          onPress={() => setConfirmExit(true)}
+          onPress={() => setActiveDialog('exit')}
           style={{
             backgroundColor: '#A33A2A',
             borderRadius: 2,
@@ -254,7 +251,7 @@ export default function LiveRoundSession({
           </Text>
         </Pressable>
         <ConfirmDialog
-          visible={confirmExit}
+          visible={activeDialog === 'exit'}
           title="Leave this round?"
           message="Nothing's been logged yet, so the round will be discarded."
           confirmLabel="Leave round"
@@ -262,7 +259,7 @@ export default function LiveRoundSession({
           destructive
           busy={actions.deleting}
           onConfirm={actions.handleExitFromError}
-          onCancel={() => setConfirmExit(false)}
+          onCancel={() => setActiveDialog(null)}
         />
       </View>
     )
@@ -284,7 +281,7 @@ export default function LiveRoundSession({
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Leave round and return home"
-          onPress={() => setConfirmLeave(true)}
+          onPress={() => setActiveDialog('leave')}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           style={{ padding: 6 }}
         >
@@ -317,7 +314,7 @@ export default function LiveRoundSession({
         <View style={{ alignItems: 'flex-end', gap: 6 }}>
           <Pressable
             accessibilityRole="button"
-            onPress={() => setConfirmEnd(true)}
+            onPress={() => setActiveDialog('end')}
             accessibilityLabel="End round early"
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           >
@@ -327,7 +324,7 @@ export default function LiveRoundSession({
           </Pressable>
           <Pressable
             accessibilityRole="button"
-            onPress={() => setConfirmDelete(true)}
+            onPress={() => setActiveDialog('delete')}
             accessibilityLabel="Delete round"
             hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
           >
@@ -475,11 +472,7 @@ export default function LiveRoundSession({
           }
         }}
         setScorecardOpen={setScorecardOpen}
-        confirmDelete={confirmDelete}
-        confirmLeave={confirmLeave}
-        confirmEnd={confirmEnd}
-        onGreenPromptOpen={onGreenPromptOpen}
-        aimPromptOpen={aimPromptOpen}
+        activeDialog={activeDialog}
         totalShotsThisHole={totalShotsThisHole}
         ending={actions.ending}
         deleting={actions.deleting}
@@ -490,14 +483,14 @@ export default function LiveRoundSession({
         onClosePuttingSheet={actions.closePuttingSheet}
         onSwapPuttingToShot={actions.swapPuttingToShot}
         onConfirmDelete={actions.handleDeleteRound}
-        onCancelDelete={() => setConfirmDelete(false)}
+        onCancelDelete={() => setActiveDialog(null)}
         onConfirmLeave={() => {
-          setConfirmLeave(false)
+          setActiveDialog(null)
           router.replace('/(app)')
         }}
-        onCancelLeave={() => setConfirmLeave(false)}
+        onCancelLeave={() => setActiveDialog(null)}
         onConfirmEnd={actions.handleEndRound}
-        onCancelEnd={() => setConfirmEnd(false)}
+        onCancelEnd={() => setActiveDialog(null)}
         onGreenYes={actions.handleOnGreenYes}
         onGreenNo={actions.handleOnGreenNo}
         onAimPromptConfirm={actions.handleAimPromptConfirm}

--- a/apps/mobile/components/round/hole/HoleModals.tsx
+++ b/apps/mobile/components/round/hole/HoleModals.tsx
@@ -14,7 +14,7 @@ import { ScorecardModal } from '../Scorecard'
 import { ConfirmDialog } from '../../ui/ConfirmDialog'
 import type { LatLng } from '../HoleMap'
 import { distanceYards } from '../../../lib/maps'
-import type { RoundState } from './types'
+import type { ActiveDialog, RoundState } from './types'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
@@ -41,12 +41,9 @@ interface HoleModalsProps {
   id: string | undefined
   onChangePar: (holeId: string, newPar: number) => Promise<void>
   setScorecardOpen: (open: boolean) => void
-  // Confirm dialogs
-  confirmDelete: boolean
-  confirmLeave: boolean
-  confirmEnd: boolean
-  onGreenPromptOpen: boolean
-  aimPromptOpen: boolean
+  // Confirm dialogs — one mutually-exclusive state. See ActiveDialog
+  // in ./types for the union (#293).
+  activeDialog: ActiveDialog
   totalShotsThisHole: number
   ending: boolean
   deleting: boolean
@@ -86,11 +83,7 @@ export function HoleModals(props: HoleModalsProps) {
     id,
     onChangePar,
     setScorecardOpen,
-    confirmDelete,
-    confirmLeave,
-    confirmEnd,
-    onGreenPromptOpen,
-    aimPromptOpen,
+    activeDialog,
     totalShotsThisHole,
     ending,
     deleting,
@@ -161,7 +154,7 @@ export function HoleModals(props: HoleModalsProps) {
       </Modal>
 
       <ConfirmDialog
-        visible={confirmDelete}
+        visible={activeDialog === 'delete'}
         title="Delete this round?"
         message="Hole scores and shots are removed too. This cannot be undone."
         confirmLabel="Delete"
@@ -172,7 +165,7 @@ export function HoleModals(props: HoleModalsProps) {
       />
 
       <ConfirmDialog
-        visible={confirmLeave}
+        visible={activeDialog === 'leave'}
         title="Leave round?"
         message="Your progress is saved and you can resume from the home screen."
         confirmLabel="Leave"
@@ -182,7 +175,7 @@ export function HoleModals(props: HoleModalsProps) {
       />
 
       <ConfirmDialog
-        visible={confirmEnd}
+        visible={activeDialog === 'end'}
         title={`End round after hole ${holeNumber}?`}
         message={`Your round will be saved with ${totalShotsThisHole > 0 ? holeNumber : holeNumber - 1} hole(s) of detail. SG and totals are computed from what's logged so far.`}
         confirmLabel="End round"
@@ -193,7 +186,7 @@ export function HoleModals(props: HoleModalsProps) {
       />
 
       <ConfirmDialog
-        visible={onGreenPromptOpen}
+        visible={activeDialog === 'onGreen'}
         title="On the green?"
         message="Within 30 yd of the pin — were you putting, or chipping/in a bunker?"
         confirmLabel="Yes, I'm putting"
@@ -203,7 +196,7 @@ export function HoleModals(props: HoleModalsProps) {
       />
 
       <ConfirmDialog
-        visible={aimPromptOpen}
+        visible={activeDialog === 'aim'}
         title="Set an aim point?"
         message="Your aim point is your start line — where you intend to start the ball, not where you want it to finish."
         confirmLabel="Set aim point →"

--- a/apps/mobile/components/round/hole/types.ts
+++ b/apps/mobile/components/round/hole/types.ts
@@ -9,6 +9,29 @@
 //   (player loops here for each successive putt).
 export type RoundState = 'PLACE_BALL' | 'SET_AIM' | 'SHOT_DETAIL' | 'PUTTING'
 
+// Mutually exclusive confirm dialog for the live-round screen. Only one
+// can be on screen at a time by construction — solves the "back button
+// only closes the topmost" race on Android (#293) and preempts iOS
+// UIKit's "one presented modal per presenter" silent-failure (which
+// drops the second modal with a console warning rather than crashing).
+export type ActiveDialog =
+  | 'delete'    // Delete round confirm
+  | 'leave'     // Leave round confirm
+  | 'end'       // End round confirm
+  | 'exit'      // Exit live mode (from error state) confirm
+  | 'onGreen'   // "On the green?" prompt
+  | 'aim'       // "Set aim point?" prompt
+  | null
+
+// Subset cleared on hole change. The other members are session-level —
+// a delete/leave/end/exit confirm mid-navigation stays open. Named so
+// the per-hole reset effect and the union stay in sync if a future
+// dialog is added.
+export const HOLE_SCOPED_DIALOGS: ReadonlySet<ActiveDialog> = new Set([
+  'onGreen',
+  'aim',
+])
+
 export const FALLBACK_CENTER = { lat: 40.0, lng: -75.0 } as const
 export const PIN_PROMPT_RADIUS_YARDS = 80
 

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -16,7 +16,7 @@ import { completeRound } from '../../../lib/completeRound'
 import type { LatLng } from '../HoleMap'
 import type { ShotLoggerValue } from '../ShotLogger'
 import type { PuttingValue } from '../PuttingSheet'
-import { PUTTING_RADIUS_YARDS } from './types'
+import { PUTTING_RADIUS_YARDS, type ActiveDialog } from './types'
 import type { UseHoleDataResult } from './useHoleData'
 import type { UseHoleStateResult } from './useHoleState'
 
@@ -31,11 +31,7 @@ interface UseShotActionsInput {
   setLoggerInitial: Dispatch<SetStateAction<ShotLoggerValue>>
   setPinPlacementOpen: Dispatch<SetStateAction<boolean>>
   setTeePlacementOpen: Dispatch<SetStateAction<boolean>>
-  setOnGreenPromptOpen: Dispatch<SetStateAction<boolean>>
-  setAimPromptOpen: Dispatch<SetStateAction<boolean>>
-  setConfirmDelete: Dispatch<SetStateAction<boolean>>
-  setConfirmEnd: Dispatch<SetStateAction<boolean>>
-  setConfirmExit: Dispatch<SetStateAction<boolean>>
+  setActiveDialog: Dispatch<SetStateAction<ActiveDialog>>
   // Hole navigation is callback-driven so the parent (LiveRoundSession)
   // can keep the MapView resident across hole changes. Direct router.replace
   // would fully unmount + remount the screen — see #264.
@@ -85,11 +81,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     setLoggerInitial,
     setPinPlacementOpen,
     setTeePlacementOpen,
-    setOnGreenPromptOpen,
-    setAimPromptOpen,
-    setConfirmDelete,
-    setConfirmEnd,
-    setConfirmExit,
+    setActiveDialog,
     onHoleChange,
   } = input
   const router = useRouter()
@@ -357,14 +349,14 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     setAim(null)
     const pinTarget = roundPin ?? storedPin ?? null
     if (pinTarget && distanceYards(ballSnapshot, pinTarget) <= PUTTING_RADIUS_YARDS) {
-      setOnGreenPromptOpen(true)
+      setActiveDialog('onGreen')
       return
     }
-    setAimPromptOpen(true)
+    setActiveDialog('aim')
   }
 
   function handleOnGreenYes() {
-    setOnGreenPromptOpen(false)
+    setActiveDialog(prev => (prev === 'onGreen' ? null : prev))
     // Drop straight into the dedicated PuttingSheet — there is no
     // club/lie picker on that sheet, so there is nothing for the
     // player to select after confirming "Yes, I'm putting". persistPutt
@@ -374,7 +366,10 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   }
 
   function handleOnGreenNo() {
-    setOnGreenPromptOpen(false)
+    // Transition onGreen → aim. Synchronous, so React batches the
+    // two setActiveDialog calls and only the final 'aim' commit
+    // is observable. No guard needed.
+    setActiveDialog('aim')
     // 'rough' is the safest near-green default — fairway/fringe/sand
     // are common but rough is the modal answer for "near green but
     // not putting". Player overrides in ShotLogger.
@@ -382,7 +377,6 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     // Route through the aim prompt — chips and pitches still benefit
     // from explicit aim capture for the shot-pattern dataset. Player
     // can skip aim from the prompt if they want.
-    setAimPromptOpen(true)
   }
 
   function confirmAim() {
@@ -397,12 +391,12 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   }
 
   function handleAimPromptConfirm() {
-    setAimPromptOpen(false)
+    setActiveDialog(prev => (prev === 'aim' ? null : prev))
     setRoundState('SET_AIM')
   }
 
   function handleAimPromptSkip() {
-    setAimPromptOpen(false)
+    setActiveDialog(prev => (prev === 'aim' ? null : prev))
     skipAim()
   }
 
@@ -460,7 +454,9 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       Alert.alert('End round failed', (err as Error).message)
     } finally {
       setEnding(false)
-      setConfirmEnd(false)
+      // Guard against clobbering a different dialog the user may have
+      // opened during the async window (TS agent feedback on #293).
+      setActiveDialog(prev => (prev === 'end' ? null : prev))
     }
   }
 
@@ -476,7 +472,9 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       router.replace('/(app)')
     } finally {
       setDeleting(false)
-      setConfirmDelete(false)
+      // Guard against clobbering a different dialog the user may have
+      // opened during the async window.
+      setActiveDialog(prev => (prev === 'delete' ? null : prev))
     }
   }
 
@@ -493,10 +491,12 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
         }
       } finally {
         setDeleting(false)
-        setConfirmExit(false)
+        // Guard against clobbering a different dialog the user may have
+        // opened during the async window.
+        setActiveDialog(prev => (prev === 'exit' ? null : prev))
       }
     } else {
-      setConfirmExit(false)
+      setActiveDialog(prev => (prev === 'exit' ? null : prev))
     }
     router.replace('/(app)')
   }


### PR DESCRIPTION
## Summary

- Six confirm dialogs across LiveRoundSession + HoleModals collapse to one mutually-exclusive `ActiveDialog` state. Two cannot be open at once by construction.
- All async-close paths in `useShotActions` are guarded with `prev === 'X' ? null : prev` so a `finally` block can't clobber an unrelated dialog the user opened during the async window.
- New `HOLE_SCOPED_DIALOGS` set keeps the per-hole reset effect in sync with the union definition.

## Why

Two failure modes:

- **Android:** back-button `onRequestClose` reaches the topmost Modal only. If two ConfirmDialogs are mounted simultaneously, back closes the wrong one, leaving the user stuck.
- **iOS (pre-ship):** UIKit's "one presented modal per presenter" rule means the second Modal is silently dropped with a console warning. The player taps a button and nothing visibly happens. Confirmed from RN source — affects every user who triggers two confirm surfaces in quick succession once iOS ships.

The state machine in `useShotActions` usually serializes the openings, but no invariant prevents two flags being true at once. The discriminated union forbids it at the type level.

## Design choices

- **`ActiveDialog` union in `hole/types.ts`** — colocated with `RoundState`, since both are screen-local state machines for the live-round cluster. Not project-level.
- **`HOLE_SCOPED_DIALOGS: ReadonlySet<ActiveDialog>`** — names the boundary "what is hole-scoped" so the per-hole reset effect and the union definition stay in sync. Adding a future dialog only requires editing the union and (if hole-scoped) the set.
- **Async-close guards** — every `setActiveDialog(null)` after `await` is `setActiveDialog(prev => prev === 'X' ? null : prev)`. Synchronous opens stay unguarded (B clobbering A is the intentional UX).
- **One inline ConfirmDialog in LiveRoundSession** (`activeDialog === 'exit'` for the error-state exit confirm) intentionally renders outside HoleModals — error and happy-path branches are mutually exclusive at the React layer, so no mount-order race between them.

## Out of scope

ShotLogger / PuttingSheet / ScorecardModal are also Modals controlled by independent state (`loggerOpen` / `roundState === 'PUTTING'` / `scorecardOpen`). A header-button tap mid-shot could still stack a ConfirmDialog on top of one of those on iOS. Filed at #380 (dialog audit) as part of the broader "should some of these dialogs even exist" question.

## Per CLAUDE.md `repro before fix` rule

- Android: no user repro of two simultaneously-visible dialogs. Mechanism documented (state-machine guards don't enforce mutual exclusion). `defensive` label warranted.
- iOS: mechanism confirmed from RN 0.74 source — UIKit silently drops the second Modal. Pre-ship, but the failure class is concrete. `bug` label warranted for iOS context.

## Test plan

- [ ] **Android device:** verify every confirm dialog still opens / cancels / confirms — delete, leave, end, exit, "on the green?", "set aim point?". Per-hole reset path: open onGreen prompt → change holes → verify it auto-closes.
- [ ] **Android:** open a session-level confirm (e.g. delete) → change holes → verify it stays open (session-level persistence).
- [ ] **Android async-clobber edge case:** tap "End round" → before the async settles, navigate UI that would open a different dialog → verify End's `finally` doesn't close that other dialog.
- [ ] **iOS QA:** deferred to #376 (first iOS dev build). Confirm two confirms can never stack via VoiceOver Actions menu.

## Files

- `apps/mobile/components/round/hole/types.ts` — new exports
- `apps/mobile/components/round/hole/useShotActions.ts` — props + sites
- `apps/mobile/components/round/hole/HoleModals.tsx` — prop swap
- `apps/mobile/components/round/LiveRoundSession.tsx` — state + plumbing

## Verification

`cd apps/mobile && npm run typecheck` — clean

## Related

- #380 — broader dialog audit (which of these confirms should exist at all)
- #376 — first iOS dev build for VoiceOver verification