### PR TITLE
fix(mobile): pass AbortSignal to course search so fetches actually cancel (#291)

### DIFF
--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -128,7 +128,12 @@ export default function NewRound() {
     setSearching(true)
     Promise.allSettled([
       searchOpenGolfApi(term, ctrl.signal),
-      searchCourses(supabase, term, 10).then(({ data, error }) => {
+      searchCourses(supabase, term, 10, ctrl.signal).then(({ data, error }) => {
+        // Abort propagates here as a PostgrestError shape with code:'' and
+        // message starting "AbortError:" — but the cleanest gate is the
+        // signal itself, robust to postgrest-js error-shape drift. See
+        // #291.
+        if (ctrl.signal.aborted) return [] as CourseRow[]
         if (error) {
           // eslint-disable-next-line no-console
           console.warn('[round/new searchCourses]', error.message)

--- a/packages/supabase/src/queries/courses.ts
+++ b/packages/supabase/src/queries/courses.ts
@@ -8,17 +8,33 @@ type HoleInsert = Database['public']['Tables']['holes']['Insert']
 // the hole-map fallback; external_id keeps the OpenGolfAPI link reachable.
 const COURSE_COLUMNS = 'id, name, city, state, lat, lng, external_id'
 
-export function searchCourses(client: OgaSupabaseClient, query: string, limit = 10) {
+export function searchCourses(
+  client: OgaSupabaseClient,
+  query: string,
+  limit = 10,
+  signal?: AbortSignal,
+) {
   const trimmed = query.trim()
   if (!trimmed) {
-    return client.from('courses').select(COURSE_COLUMNS).order('name').limit(limit)
+    const builder = client
+      .from('courses')
+      .select(COURSE_COLUMNS)
+      .order('name')
+      .limit(limit)
+    return signal ? builder.abortSignal(signal) : builder
   }
   // search_courses RPC ranks by pg_trgm similarity (typo-tolerant) then
   // falls back to ILIKE substring. Migration 0018; trigram index from 0015.
-  return client.rpc('search_courses', {
+  const builder = client.rpc('search_courses', {
     search_query: trimmed,
     result_limit: limit,
   })
+  // Threading an AbortSignal makes the underlying fetch actually
+  // cancellable — postgrest-js v3+ honors it via PostgrestTransformBuilder
+  // (PostgrestBuilder.ts:317-324). Without this, the request runs to
+  // completion regardless of cancellation, retaining response buffers
+  // until the JS .then chain settles. Issue #291.
+  return signal ? builder.abortSignal(signal) : builder
 }
 
 export function getCourseById(client: OgaSupabaseClient, courseId: string) {


### PR DESCRIPTION
## Summary

- `searchCourses` in `@oga/supabase` now accepts an optional `signal?: AbortSignal` and chains `.abortSignal(signal)` on the postgrest builder.
- `apps/mobile/app/(app)/round/new.tsx` passes `ctrl.signal` to the search call.
- Inner `.then` bails on `ctrl.signal.aborted` before inspecting the error — robust to postgrest-js error-shape drift.

## Why

`Promise.allSettled([searchOpenGolfApi, searchCourses])` on every debounced keystroke. `searchOpenGolfApi` already honored the AbortSignal; `searchCourses` did not — its postgrest-js builder was returned without an `abortSignal()` chain. Under sustained typing on slow networks, each prior Supabase fetch continued to completion while a new query was in flight, holding response buffers and JS closures alive 3-5s past their usefulness.

postgrest-js v3+ (`apps/mobile/node_modules/@supabase/postgrest-js/src/PostgrestTransformBuilder.ts:598`) exposes `.abortSignal(signal)`. RN 0.74's network layer propagates the cancel to OkHttp's `cancel()` on Android and `[task cancel]` on iOS — the in-flight HTTP request is actually killed at the native layer.

## Honest framing on the OOM claim

The issue title mentions OOM on low-end Android. Worst-case math: 5 chars/sec × 3-5s latency × ~10KB Supabase response = ~100KB transient memory. That's not OOM territory on any Android device made in the last eight years.

The real win is:
- Native fetch cancellation reclaims response-parsing buffers immediately
- JS closures GC as soon as `Promise.allSettled` settles (which happens immediately on abort instead of waiting 3-5s)
- Stale-result protection becomes belt-and-suspenders (already correct via the existing `ctrl.signal.aborted` guard)

Filing as `bug` since the no-abort pattern is a real anti-pattern, but no observed user repro per CLAUDE.md `repro before fix` rule.

## Why not the issue's two proposed fixes

| Proposal | This PR | Reason |
|---|---|---|
| Add `componentMountedRef` check | Not needed | The existing `return () => ctrl.abort()` cleanup handles unmount; the outer `.then`'s `signal.aborted` guard handles stale results. |
| Migrate to `@tanstack/react-query` | Not needed | One optional param + one signal threading solves the same problem with zero new deps. |

## Why `ctrl.signal.aborted` not `error.code === '20'`

I initially proposed checking `error.code === '20'` for the abort path, but a cross-check against `apps/mobile/node_modules/@supabase/postgrest-js/src/PostgrestBuilder.ts:372-436` showed that postgrest-js produces `{ code: '', message: 'AbortError: ...' }` for aborted fetches — the Node `'20'` errno never reaches the JS error object. The cleanest, drift-resistant gate is `ctrl.signal.aborted`, mirroring the pattern already in use at the outer `.then`.

## Out of scope (worth tracking)

- **#339** — Recommend nearby courses (GPS-first new-round). Shrinks the keystroke-driven search surface for most users.
- A future "submit-not-type" UX where search runs on tap instead of debounce. Negative lines of code but a UX change, separate decision.
- Dropping the parallel `searchOpenGolfApi + searchCourses` fetch in favor of Supabase-only (with the existing crawler feeding it). Backend simplification, separate.

## Test plan

- [ ] **Android device:** type a long course name slowly enough to defeat debounce (>300ms between chars). Watch Android Studio's Profiler / `adb shell dumpsys meminfo <pkg>` — heap should stay flat between keystrokes. Without the fix, heap grows by Supabase-response-size per keystroke until the round-trip completes.
- [ ] **Android slow-network:** enable Network Throttling in Android Studio to "Slow 3G" and repeat. Memory benefit is most visible here.
- [ ] **Search still works:** verify the happy path — typing a course name still returns Supabase results within ~500ms on good network.
- [ ] **iOS QA:** deferred to #376.

## Files

- `packages/supabase/src/queries/courses.ts` — new `signal?: AbortSignal` param, `.abortSignal()` chain on both branches
- `apps/mobile/app/(app)/round/new.tsx` — pass `ctrl.signal`, gate inner `.then` on `ctrl.signal.aborted`

## Verification

- `pnpm typecheck` — clean (@oga/supabase + @oga/web)
- `cd apps/mobile && npm run typecheck` — clean