### PR TITLE
chore(mobile/ios): app config micro-fixes (#300 #302 #305)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -39,6 +39,14 @@ const config: ExpoConfig = {
       // false skips Apple's export-compliance prompt on every
       // TestFlight upload.
       ITSAppUsesNonExemptEncryption: false,
+      // Stubbed pre-emptively (#305). Not used at runtime today — Expo
+      // adds these automatically once expo-image-picker / expo-camera is
+      // imported, but declaring them upfront prevents an App Review
+      // rejection if either is added without a config bump.
+      NSCameraUsageDescription:
+        'OGA may use the camera to attach photos to round notes.',
+      NSPhotoLibraryAddUsageDescription:
+        'OGA may save round summary cards to your photo library.',
     },
   },
   android: {

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -145,7 +145,9 @@ export default function AppLayout() {
           borderTopColor: '#D9D2BF',
           paddingTop: 8,
           paddingBottom: 10,
-          height: 64,
+          // Height omitted (#300) so react-navigation/bottom-tabs adds the
+          // safe-area inset automatically — required for iPhone X+ home
+          // indicator clearance.
           elevation: 0,
           shadowOpacity: 0,
         },

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -190,7 +190,7 @@ function RootLayoutContent() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <StatusBar style="light" />
+      <StatusBar style="auto" />
       <ErrorBoundary>
         <Stack screenOptions={{ headerShown: false }} />
       </ErrorBoundary>


### PR DESCRIPTION
## Summary

Three small iOS config fixes bundled as one PR. All zero-risk on Android.

- **#305** — stub `NSCameraUsageDescription` + `NSPhotoLibraryAddUsageDescription` in `app.config.ts` so App Review can't reject if `expo-image-picker` / `expo-camera` lands without a config bump.
- **#302** — `<StatusBar style="light" />` → `"auto"` so the system color scheme drives the status bar (matches `userInterfaceStyle: 'automatic'` already in `app.config.ts`).
- **#300** — remove fixed `height: 64` from tab bar; react-navigation/bottom-tabs auto-adds the safe-area inset for iPhone X+ home indicator. Android keeps the same visible footprint via `paddingTop`/`paddingBottom`.

#304 was already addressed by PR #383 (`ITSAppUsesNonExemptEncryption: false`). Closing separately.

## Test plan

- [ ] CI green (typecheck, test, mobile-typecheck) — verified locally
- [ ] iOS device: status bar legible in both light and dark mode
- [ ] iOS device (iPhone X+): tab bar clears home indicator
- [ ] Android device: tab bar height visually unchanged