### PR TITLE
refactor(core): move formatBandLabel to @oga/core (#207)

### DIFF
--- a/apps/web/src/pages/stats/components/StatTiles.tsx
+++ b/apps/web/src/pages/stats/components/StatTiles.tsx
@@ -1,6 +1,6 @@
-import { formatSG, type ApproachBandStat, type RecoveryRateStat } from '@oga/core'
+import { formatSG, formatBandLabel, type ApproachBandStat, type RecoveryRateStat } from '@oga/core'
 import { useUnits } from '../../../hooks/useUnits'
-import { fmtPct, formatBandLabel } from '../format'
+import { fmtPct } from '../format'
 
 export function SgTile({
   label,

--- a/apps/web/src/pages/stats/format.ts
+++ b/apps/web/src/pages/stats/format.ts
@@ -1,5 +1,3 @@
-import { YARDS_TO_METERS, type ApproachBandStat, type DistanceUnit } from '@oga/core'
-
 // Formatters — never return NaN/undefined to the DOM.
 
 export function fmtNumber(v: number | null, digits: number): string {
@@ -15,20 +13,4 @@ export function fmtInt(v: number | null): string {
 export function fmtPct(v: number | null): string {
   if (v == null || !Number.isFinite(v)) return '—'
   return `${v.toFixed(0)}%`
-}
-
-export function formatBandLabel(
-  band: ApproachBandStat,
-  unit: DistanceUnit,
-  toDisplay: (yards: number, decimals?: number) => string,
-): string {
-  if (!Number.isFinite(band.maxYards)) {
-    return `${toDisplay(band.minYards)}+`
-  }
-  // Show range as "min–max <unit>" by stripping the unit off the lower bound.
-  const upper = toDisplay(band.maxYards)
-  const lowerNumeric = unit === 'meters'
-    ? (band.minYards * YARDS_TO_METERS).toFixed(0)
-    : band.minYards.toFixed(0)
-  return `${lowerNumeric}–${upper}`
 }

--- a/packages/core/src/__tests__/formatBandLabel.test.ts
+++ b/packages/core/src/__tests__/formatBandLabel.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { formatBandLabel, type ApproachBandStat } from '../stats'
+
+const yardsFmt = (y: number) => `${y.toFixed(0)} yd`
+const metersFmt = (y: number) => `${(y * 0.9144).toFixed(0)} m`
+
+const band = (minYards: number, maxYards: number): ApproachBandStat => ({
+  key: 'b',
+  label: '',
+  minYards,
+  maxYards,
+  avgSg: null,
+  shots: 0,
+})
+
+describe('formatBandLabel', () => {
+  it('renders a finite range with the lower bound numeric-only and upper with unit', () => {
+    expect(formatBandLabel(band(50, 100), 'yards', yardsFmt)).toBe('50–100 yd')
+  })
+
+  it('renders an open-ended (Infinity) range with the lower bound + plus sign', () => {
+    expect(formatBandLabel(band(200, Infinity), 'yards', yardsFmt)).toBe('200 yd+')
+  })
+
+  it('converts the lower bound to meters when unit=meters', () => {
+    expect(formatBandLabel(band(50, 100), 'meters', metersFmt)).toBe('46–91 m')
+  })
+
+  it('converts the open-ended lower bound via the toDisplay callback', () => {
+    expect(formatBandLabel(band(200, Infinity), 'meters', metersFmt)).toBe('183 m+')
+  })
+})

--- a/packages/core/src/__tests__/formatBandLabel.test.ts
+++ b/packages/core/src/__tests__/formatBandLabel.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import { formatBandLabel, type ApproachBandStat } from '../stats'
+import { YARDS_TO_METERS } from '../units'
 
 const yardsFmt = (y: number) => `${y.toFixed(0)} yd`
-const metersFmt = (y: number) => `${(y * 0.9144).toFixed(0)} m`
+const metersFmt = (y: number) => `${(y * YARDS_TO_METERS).toFixed(0)} m`
 
 const band = (minYards: number, maxYards: number): ApproachBandStat => ({
   key: 'b',

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -165,10 +165,8 @@ export interface ApproachBandStat {
   shots: number
 }
 
-// Format an ApproachBandStat as a display label like "50–100 yd" or "200+ yd",
-// honoring the user's unit pref. `toDisplay` converts yards→unit and appends
-// the unit suffix. The lower bound is rendered numeric-only and the upper bound
-// carries the unit so the range reads as one phrase.
+// Lower bound is numeric-only and upper carries the unit so the range reads
+// as one phrase ("50–100 yd"), not two ("50 yd – 100 yd").
 export function formatBandLabel(
   band: ApproachBandStat,
   unit: DistanceUnit,

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -5,8 +5,9 @@ import {
 } from './sg-calculator'
 import { NEAR_GREEN_YARDS } from './constants'
 import type { LieSlopeForward, LieSlopeSide, LieType, ShotCategory, ShotResult } from './constants'
-import { METERS_TO_YARDS, haversineYards, toRadians } from './units'
+import { METERS_TO_YARDS, YARDS_TO_METERS, haversineYards, toRadians } from './units'
 import { RESULT_QUALITY } from './types'
+import type { DistanceUnit } from './types'
 import type { Database } from '@oga/supabase'
 
 type RoundRow = Database['public']['Tables']['rounds']['Row']
@@ -162,6 +163,25 @@ export interface ApproachBandStat {
   maxYards: number
   avgSg: number | null
   shots: number
+}
+
+// Format an ApproachBandStat as a display label like "50–100 yd" or "200+ yd",
+// honoring the user's unit pref. `toDisplay` converts yards→unit and appends
+// the unit suffix. The lower bound is rendered numeric-only and the upper bound
+// carries the unit so the range reads as one phrase.
+export function formatBandLabel(
+  band: ApproachBandStat,
+  unit: DistanceUnit,
+  toDisplay: (yards: number, decimals?: number) => string,
+): string {
+  if (!Number.isFinite(band.maxYards)) {
+    return `${toDisplay(band.minYards)}+`
+  }
+  const upper = toDisplay(band.maxYards)
+  const lowerNumeric = unit === 'meters'
+    ? (band.minYards * YARDS_TO_METERS).toFixed(0)
+    : band.minYards.toFixed(0)
+  return `${lowerNumeric}–${upper}`
 }
 
 // Per-shot SG for approach shots, bucketed by start distance to target.


### PR DESCRIPTION
## Summary

Pure display formatter for `ApproachBandStat` ranges. Lives in `packages/core/src/stats.ts` (not `units.ts`) because it consumes `ApproachBandStat` — putting it in `units.ts` would invert the existing `stats.ts → units.ts` dep direction.

- Add `formatBandLabel` + 4 tests to `@oga/core`
- Strip from `apps/web/src/pages/stats/format.ts` (drops 3 unused imports)
- Update `StatTiles.tsx` (the only consumer) to import from `@oga/core`

Closes #207.

## Test plan

- [x] `pnpm typecheck` — 3 packages clean
- [x] `pnpm test --filter @oga/core` — 302 tests pass (4 new)
- [ ] Web stats page renders bucket labels unchanged