### PR TITLE
refactor(core): move SGBreakdown averaging to @oga/core (#195)

### DIFF
--- a/apps/mobile/components/home/SGBreakdown.tsx
+++ b/apps/mobile/components/home/SGBreakdown.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { Text, View } from 'react-native'
-import { formatSG } from '@oga/core'
+import { formatSG, sgBreakdown, type SGBreakdownKey, type SGRoundLike } from '@oga/core'
 
 const KICKER: import('react-native').TextStyle = {
   color: '#8A8B7E',
@@ -11,37 +11,15 @@ const KICKER: import('react-native').TextStyle = {
   textTransform: 'uppercase',
 }
 
-const SG_KEYS = [
-  { key: 'sg_off_tee', label: 'Off tee' },
-  { key: 'sg_approach', label: 'Approach' },
-  { key: 'sg_around_green', label: 'Around green' },
-  { key: 'sg_putting', label: 'Putting' },
-] as const
-
-interface SGRow {
-  sg_off_tee: number | null
-  sg_approach: number | null
-  sg_around_green: number | null
-  sg_putting: number | null
+const SG_LABELS: Record<SGBreakdownKey, string> = {
+  sg_off_tee: 'Off tee',
+  sg_approach: 'Approach',
+  sg_around_green: 'Around green',
+  sg_putting: 'Putting',
 }
 
-// Average each SG category across the rounds, then render a diverging
-// bar per category with the value floated at the bar end.
-export function SGBreakdown({ rounds }: { rounds: SGRow[] }) {
-  const { breakdown, maxAbs } = useMemo(() => {
-    const bd = SG_KEYS.map((c) => {
-      const values = rounds
-        .map((r) => r[c.key])
-        .filter((v): v is number => v !== null)
-      const avg =
-        values.length === 0
-          ? 0
-          : values.reduce((a, b) => a + b, 0) / values.length
-      return { ...c, value: Number(avg.toFixed(2)) }
-    })
-    const maxAbsValue = Math.max(...bd.map((b) => Math.abs(b.value)), 0.5)
-    return { breakdown: bd, maxAbs: maxAbsValue }
-  }, [rounds])
+export function SGBreakdown({ rounds }: { rounds: SGRoundLike[] }) {
+  const { breakdown, maxAbs } = useMemo(() => sgBreakdown(rounds), [rounds])
 
   return (
     <View style={{ marginBottom: 28 }}>
@@ -57,7 +35,7 @@ export function SGBreakdown({ rounds }: { rounds: SGRow[] }) {
       </View>
       <View style={{ gap: 14 }}>
         {breakdown.map((b) => (
-          <SGBar key={b.key} label={b.label} value={b.value} max={maxAbs} />
+          <SGBar key={b.key} label={SG_LABELS[b.key]} value={b.value} max={maxAbs} />
         ))}
       </View>
     </View>

--- a/packages/core/src/__tests__/sgBreakdown.test.ts
+++ b/packages/core/src/__tests__/sgBreakdown.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { sgBreakdown, type SGRoundLike } from '../stats'
+
+const row = (
+  offTee: number | null,
+  approach: number | null,
+  aroundGreen: number | null,
+  putting: number | null,
+): SGRoundLike => ({
+  sg_off_tee: offTee,
+  sg_approach: approach,
+  sg_around_green: aroundGreen,
+  sg_putting: putting,
+})
+
+describe('sgBreakdown', () => {
+  it('returns zeros and maxAbs floor of 0.5 for empty rounds', () => {
+    const { breakdown, maxAbs } = sgBreakdown([])
+    expect(breakdown.map((b) => b.value)).toEqual([0, 0, 0, 0])
+    expect(maxAbs).toBe(0.5)
+  })
+
+  it('treats all-null categories as 0 (rendered as neutral bar)', () => {
+    const { breakdown, maxAbs } = sgBreakdown([row(null, null, null, null)])
+    expect(breakdown.map((b) => b.value)).toEqual([0, 0, 0, 0])
+    expect(maxAbs).toBe(0.5)
+  })
+
+  it('averages non-null values per category, ignoring nulls', () => {
+    const rounds = [
+      row(0.4, -0.2, 0.1, -0.3),
+      row(0.6, null, 0.3, -0.1),
+      row(0.2, -0.4, null, -0.2),
+    ]
+    const { breakdown } = sgBreakdown(rounds)
+    expect(breakdown.find((b) => b.key === 'sg_off_tee')!.value).toBe(0.4)
+    expect(breakdown.find((b) => b.key === 'sg_approach')!.value).toBe(-0.3)
+    expect(breakdown.find((b) => b.key === 'sg_around_green')!.value).toBe(0.2)
+    expect(breakdown.find((b) => b.key === 'sg_putting')!.value).toBe(-0.2)
+  })
+
+  it('rounds each average to 2 decimal places', () => {
+    const { breakdown } = sgBreakdown([row(0.123456, null, null, null)])
+    expect(breakdown.find((b) => b.key === 'sg_off_tee')!.value).toBe(0.12)
+  })
+
+  it('reports maxAbs over the absolute values of all category averages', () => {
+    const { maxAbs } = sgBreakdown([row(0.1, -0.8, 0.3, -0.2)])
+    expect(maxAbs).toBe(0.8)
+  })
+
+  it('keeps maxAbs floor of 0.5 when all averages are below 0.5', () => {
+    const { maxAbs } = sgBreakdown([row(0.1, -0.2, 0.3, -0.1)])
+    expect(maxAbs).toBe(0.5)
+  })
+
+  it('returns category keys in the canonical off_tee → approach → around_green → putting order', () => {
+    const { breakdown } = sgBreakdown([])
+    expect(breakdown.map((b) => b.key)).toEqual([
+      'sg_off_tee',
+      'sg_approach',
+      'sg_around_green',
+      'sg_putting',
+    ])
+  })
+})

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -126,6 +126,54 @@ export function sgAverages(rounds: DetailedRound[]): SGAverages {
   return out
 }
 
+export type SGBreakdownKey =
+  | 'sg_off_tee'
+  | 'sg_approach'
+  | 'sg_around_green'
+  | 'sg_putting'
+
+export interface SGBreakdownEntry {
+  key: SGBreakdownKey
+  value: number
+}
+
+export interface SGBreakdownResult {
+  breakdown: SGBreakdownEntry[]
+  maxAbs: number
+}
+
+export interface SGRoundLike {
+  sg_off_tee: number | null
+  sg_approach: number | null
+  sg_around_green: number | null
+  sg_putting: number | null
+}
+
+const SG_BREAKDOWN_KEYS: readonly SGBreakdownKey[] = [
+  'sg_off_tee',
+  'sg_approach',
+  'sg_around_green',
+  'sg_putting',
+] as const
+
+// Empty/all-null category collapses to 0 (renders as a neutral bar at center).
+// `maxAbs` floored at 0.5 so low-magnitude values still render a visible bar
+// instead of disappearing into the axis.
+export function sgBreakdown(rounds: SGRoundLike[]): SGBreakdownResult {
+  const breakdown: SGBreakdownEntry[] = SG_BREAKDOWN_KEYS.map((key) => {
+    const values = rounds
+      .map((r) => r[key])
+      .filter((v): v is number => v !== null)
+    const avg =
+      values.length === 0
+        ? 0
+        : values.reduce((a, b) => a + b, 0) / values.length
+    return { key, value: Number(avg.toFixed(2)) }
+  })
+  const maxAbs = Math.max(...breakdown.map((b) => Math.abs(b.value)), 0.5)
+  return { breakdown, maxAbs }
+}
+
 export interface SGTrendPoint {
   date: string
   offTee: number

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -156,9 +156,8 @@ const SG_BREAKDOWN_KEYS: readonly SGBreakdownKey[] = [
   'sg_putting',
 ] as const
 
-// Empty/all-null category collapses to 0 (renders as a neutral bar at center).
-// `maxAbs` floored at 0.5 so low-magnitude values still render a visible bar
-// instead of disappearing into the axis.
+// null-only category treated as 0; maxAbs minimum of 0.5 prevents a zero-
+// range scale when every category has very low magnitude.
 export function sgBreakdown(rounds: SGRoundLike[]): SGBreakdownResult {
   const breakdown: SGBreakdownEntry[] = SG_BREAKDOWN_KEYS.map((key) => {
     const values = rounds


### PR DESCRIPTION
## Summary

Pure SG averaging math + `maxAbs` floor extracted from `apps/mobile/components/home/SGBreakdown.tsx` to `@oga/core/stats.ts`. The math lives next to existing `sgAverages`; the UI keeps its own label dictionary so the function returns DB-column keys (`sg_off_tee` etc.) instead of UI strings.

Behavior preserved exactly:
- Empty/all-null categories collapse to `0` (renders as a neutral bar at center).
- `maxAbs` floored at `0.5` so low-magnitude bars stay visible.
- Averages rounded to 2 decimal places.

## Test plan

- [x] `pnpm typecheck` — 3 packages clean
- [x] `pnpm test --filter @oga/core` — passes (7 new tests added for sgBreakdown)
- [ ] Mobile home screen renders the SG breakdown unchanged

Closes #195.