### PR TITLE
fix(mobile/ios): address #389 cross-review findings (StatusBar, plist dedupe, tab bar)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -29,12 +29,11 @@ const config: ExpoConfig = {
     infoPlist: {
       NSLocationWhenInUseUsageDescription:
         'OGA uses your location during a round to track shots and yardages.',
-      // App-store-review note (#301): the app only calls
-      // requestForegroundPermissionsAsync(), so the Always key is inert
-      // at runtime but reviewers will flag it. Removed before App Store
-      // submission, kept for dev/ad-hoc builds for now.
-      NSLocationAlwaysAndWhenInUseUsageDescription:
-        'OGA uses your location during a round to track shots and yardages.',
+      // NSLocationAlwaysAndWhenInUseUsageDescription is injected by the
+      // expo-location plugin below (locationAlwaysAndWhenInUsePermission).
+      // Don't duplicate the key here — Info.plist with duplicate keys is
+      // undefined behavior. #301 tracks removing the Always permission
+      // entirely since OGA only uses requestForegroundPermissionsAsync().
       // No proprietary encryption beyond standard TLS/Keychain.
       // false skips Apple's export-compliance prompt on every
       // TestFlight upload.

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
+import { setStatusBarStyle } from 'expo-status-bar'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { ErrorBoundary } from '../../components/errors/ErrorBoundary'
@@ -18,6 +20,18 @@ export default function AppLayout() {
   const { user, loading: authLoading } = useAuth()
   const [profileState, setProfileState] = useState<ProfileState>('loading')
   const [retryNonce, setRetryNonce] = useState(0)
+  const insets = useSafeAreaInsets()
+
+  // Loading + error views have a near-black background (#1C211C). Force
+  // light status bar icons while either is showing; restore auto once
+  // we're rendering the light-background Tabs tree.
+  useEffect(() => {
+    const dark =
+      authLoading ||
+      profileState === 'loading' ||
+      profileState === 'error'
+    setStatusBarStyle(dark ? 'light' : 'auto', true)
+  }, [authLoading, profileState])
 
   useEffect(() => {
     if (authLoading) return
@@ -144,10 +158,12 @@ export default function AppLayout() {
           borderTopWidth: 1,
           borderTopColor: '#D9D2BF',
           paddingTop: 8,
-          paddingBottom: 10,
-          // Height omitted (#300) so react-navigation/bottom-tabs adds the
-          // safe-area inset automatically — required for iPhone X+ home
-          // indicator clearance.
+          // Explicit height + paddingBottom from safe-area insets (#300).
+          // Removing height entirely shrank the bar to 49 px on Android and
+          // older iPhones (no home indicator), so we set the visible content
+          // band ourselves and add `insets.bottom` for iPhone X+ clearance.
+          height: 54 + insets.bottom,
+          paddingBottom: insets.bottom + 10,
           elevation: 0,
           shadowOpacity: 0,
         },

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -190,7 +190,10 @@ function RootLayoutContent() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <StatusBar style="auto" />
+      {/* Splash overlay has a near-black background (#1C211C). Force light
+          icons while it's mounted; auto-resolve takes over for the rest of
+          the app where backgrounds are light. */}
+      <StatusBar style={overlayMounted ? 'light' : 'auto'} animated />
       <ErrorBoundary>
         <Stack screenOptions={{ headerShown: false }} />
       </ErrorBoundary>


### PR DESCRIPTION
## Summary

Three findings from a cross-review pass on PR #389 (the iOS micro-fixes bundle), bundled here as one same-area follow-up.

### 1. StatusBar dark-on-dark regression

\`<StatusBar style="auto"/>\` renders **black icons on a near-black background** (\`#1C211C\`) during three flows:
- Splash overlay in \`app/_layout.tsx\`
- Loading view in \`(app)/_layout.tsx\` (auth + profile fetch)
- Error view in \`(app)/_layout.tsx\` (profile fetch failure)

Fix: keep the global \`auto\` for the (light-background) app, scope \`light\` to the dark views.
- \`app/_layout.tsx\`: reactive root \`style={overlayMounted ? 'light' : 'auto'}\` so the effect re-fires when the overlay dismisses.
- \`(app)/_layout.tsx\`: \`setStatusBarStyle\` in a \`useEffect\` keyed on \`[authLoading, profileState]\`. Avoids expo-status-bar's last-mounted-wins-no-restore quirk.

### 2. Info.plist duplicate location key

\`NSLocationAlwaysAndWhenInUseUsageDescription\` was declared both in \`infoPlist\` and injected by the \`expo-location\` plugin via \`locationAlwaysAndWhenInUsePermission\`. Duplicate plist keys are undefined behavior (last-write-wins on most parsers, but not guaranteed). Removed the inline duplicate; plugin owns it. #301's larger cleanup (drop Always entirely) is unchanged.

### 3. Tab bar height shrunk on non-inset devices

Removing \`height\` entirely (#300, in #389) dropped Android + iPhone SE / 8 to 49 px (react-navigation/bottom-tabs default), a 15px shrink. Pivoted from "remove height entirely" to **explicit \`height: 54 + insets.bottom\`** via \`useSafeAreaInsets()\`. iPhone X+ still gets home-indicator clearance via \`insets.bottom\`; non-inset devices get the original visible footprint.

## Test plan

- [x] \`npm run typecheck\` mobile clean
- [ ] iOS device: confirm status bar icons stay legible during splash + loading
- [ ] iOS device (iPhone X+): tab bar still clears home indicator
- [ ] Android device: tab bar visible footprint unchanged
- [ ] iPhone SE / 8 (no notch): tab bar at original 64-ish height