### PR TITLE
fix(mobile/ios): declarative StatusBar in dark views (#393 auto-review blocker)

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
-import { setStatusBarStyle } from 'expo-status-bar'
+import { StatusBar } from 'expo-status-bar'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
@@ -21,17 +21,6 @@ export default function AppLayout() {
   const [profileState, setProfileState] = useState<ProfileState>('loading')
   const [retryNonce, setRetryNonce] = useState(0)
   const insets = useSafeAreaInsets()
-
-  // Loading + error views have a near-black background (#1C211C). Force
-  // light status bar icons while either is showing; restore auto once
-  // we're rendering the light-background Tabs tree.
-  useEffect(() => {
-    const dark =
-      authLoading ||
-      profileState === 'loading' ||
-      profileState === 'error'
-    setStatusBarStyle(dark ? 'light' : 'auto', true)
-  }, [authLoading, profileState])
 
   useEffect(() => {
     if (authLoading) return
@@ -82,6 +71,7 @@ export default function AppLayout() {
           justifyContent: 'center',
         }}
       >
+        <StatusBar style="light" animated />
         <ActivityIndicator color="#E8E4DC" />
       </View>
     )
@@ -98,6 +88,7 @@ export default function AppLayout() {
           padding: 28,
         }}
       >
+        <StatusBar style="light" animated />
         <Text
           style={{
             color: '#F2EEE5',


### PR DESCRIPTION
## Summary

Carries the declarative-scoped StatusBar fix that the #393 auto-reviewer flagged as a blocker but that landed after #393 was merged.

**The race the reviewer caught**: root \`<StatusBar style={overlayMounted ? 'light' : 'auto'}>\` in \`app/_layout.tsx\` re-fires \`auto\` to the native API when the splash overlay dismisses. The \`setStatusBarStyle\` \`useEffect\` in \`(app)/_layout.tsx\` keyed on \`[authLoading, profileState]\` doesn't re-fire at that moment, so the dark \`#1C211C\` loading view can render with dark status bar icons for up to the 10s \`PROFILE_FETCH_TIMEOUT_MS\`.

**Fix**: declarative \`<StatusBar style="light" animated />\` placed inside the loading view and error view JSX. Child components join expo-status-bar's mount stack and override the parent's \`auto\` push for as long as the dark view is mounted; cleanly unmount on transition to Tabs.

- Remove imperative \`setStatusBarStyle\` import + effect
- Add \`<StatusBar>\` import (declarative)
- Scoped \`<StatusBar style="light" animated />\` in loading view + error view returns

## Test plan

- [x] Mobile typecheck clean
- [ ] iOS device: status bar icons legible during splash → loading → tabs transition (no dark-on-dark window)
- [ ] iOS device: error view (force a profile-fetch timeout) renders light icons throughout