### PR TITLE
feat(core): break_direction axes split — data + types (#340 PR 1/2)

### DIFF
--- a/packages/core/src/__tests__/breakDirection.test.ts
+++ b/packages/core/src/__tests__/breakDirection.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  combinedBreakDirection,
+  decombinedBreakDirection,
+  type BreakDirection,
+} from '../types'
+
+describe('combinedBreakDirection', () => {
+  it('returns horizontal value when only horizontal is set', () => {
+    expect(combinedBreakDirection({ horizontal: 'left_to_right' })).toBe('left_to_right')
+    expect(combinedBreakDirection({ horizontal: 'right_to_left' })).toBe('right_to_left')
+    expect(combinedBreakDirection({ horizontal: 'straight' })).toBe('straight')
+  })
+
+  it('returns vertical value when only vertical is set', () => {
+    expect(combinedBreakDirection({ vertical: 'uphill' })).toBe('uphill')
+    expect(combinedBreakDirection({ vertical: 'downhill' })).toBe('downhill')
+  })
+
+  it('prefers horizontal when both axes are set', () => {
+    expect(
+      combinedBreakDirection({ vertical: 'uphill', horizontal: 'left_to_right' }),
+    ).toBe('left_to_right')
+    expect(
+      combinedBreakDirection({ vertical: 'downhill', horizontal: 'right_to_left' }),
+    ).toBe('right_to_left')
+  })
+
+  it('returns null when both axes are null or absent', () => {
+    expect(combinedBreakDirection({})).toBeNull()
+    expect(combinedBreakDirection({ vertical: null, horizontal: null })).toBeNull()
+  })
+
+  it('drops `flat` vertical when horizontal is null — no legacy equivalent', () => {
+    expect(combinedBreakDirection({ vertical: 'flat' })).toBeNull()
+    expect(
+      combinedBreakDirection({ vertical: 'flat', horizontal: null }),
+    ).toBeNull()
+  })
+
+  it('still returns horizontal when flat vertical is combined with horizontal', () => {
+    expect(
+      combinedBreakDirection({ vertical: 'flat', horizontal: 'straight' }),
+    ).toBe('straight')
+  })
+})
+
+describe('decombinedBreakDirection', () => {
+  it('splits uphill onto the vertical axis', () => {
+    expect(decombinedBreakDirection('uphill')).toEqual({
+      vertical: 'uphill',
+      horizontal: null,
+    })
+  })
+
+  it('splits downhill onto the vertical axis', () => {
+    expect(decombinedBreakDirection('downhill')).toEqual({
+      vertical: 'downhill',
+      horizontal: null,
+    })
+  })
+
+  it('splits left_to_right / right_to_left / straight onto the horizontal axis', () => {
+    expect(decombinedBreakDirection('left_to_right')).toEqual({
+      vertical: null,
+      horizontal: 'left_to_right',
+    })
+    expect(decombinedBreakDirection('right_to_left')).toEqual({
+      vertical: null,
+      horizontal: 'right_to_left',
+    })
+    expect(decombinedBreakDirection('straight')).toEqual({
+      vertical: null,
+      horizontal: 'straight',
+    })
+  })
+
+  it('maps legacy single-letter `left` onto right_to_left horizontal', () => {
+    expect(decombinedBreakDirection('left')).toEqual({
+      vertical: null,
+      horizontal: 'right_to_left',
+    })
+  })
+
+  it('maps legacy single-letter `right` onto left_to_right horizontal', () => {
+    expect(decombinedBreakDirection('right')).toEqual({
+      vertical: null,
+      horizontal: 'left_to_right',
+    })
+  })
+
+  it('returns both nulls for null / undefined input', () => {
+    expect(decombinedBreakDirection(null)).toEqual({
+      vertical: null,
+      horizontal: null,
+    })
+    expect(decombinedBreakDirection(undefined)).toEqual({
+      vertical: null,
+      horizontal: null,
+    })
+  })
+})
+
+describe('combinedBreakDirection ∘ decombinedBreakDirection roundtrip', () => {
+  // The five canonical (non-legacy) values should roundtrip exactly.
+  const canonical: BreakDirection[] = [
+    'uphill',
+    'downhill',
+    'left_to_right',
+    'right_to_left',
+    'straight',
+  ]
+
+  it.each(canonical)('roundtrips %s', (value) => {
+    expect(combinedBreakDirection(decombinedBreakDirection(value))).toBe(value)
+  })
+
+  it('legacy `left` lossily roundtrips to right_to_left', () => {
+    expect(combinedBreakDirection(decombinedBreakDirection('left'))).toBe('right_to_left')
+  })
+
+  it('legacy `right` lossily roundtrips to left_to_right', () => {
+    expect(combinedBreakDirection(decombinedBreakDirection('right'))).toBe('left_to_right')
+  })
+})

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,6 +18,10 @@ export type GreenSpeed = 'slow' | 'medium' | 'fast'
 // Canonical 7-value vocabulary matching shots.break_direction in the DB.
 // `left` / `right` are legacy single-letter values from pre-split rows;
 // new code writes one of the explicit five.
+/** @deprecated Use {@link BreakDirectionVertical} and
+ *  {@link BreakDirectionHorizontal} — break direction is two independent
+ *  axes (slope + line), not one. Migration 0028 added the split columns;
+ *  this single-axis enum is kept only for back-compat reads. */
 export type BreakDirection =
   | 'left'
   | 'right'
@@ -26,6 +30,14 @@ export type BreakDirection =
   | 'right_to_left'
   | 'uphill'
   | 'downhill'
+
+// Two independent axes for shots.break_direction_vertical and
+// shots.break_direction_horizontal (migration 0028). A putt can break
+// both up/down AND L→R / R→L on the same line; the legacy
+// BreakDirection enum collapsed that into one value, losing half the
+// information. Either axis can be null when the player skipped it.
+export type BreakDirectionVertical = 'uphill' | 'downhill' | 'flat'
+export type BreakDirectionHorizontal = 'left_to_right' | 'right_to_left' | 'straight'
 
 export type PuttDistanceResult = 'short' | 'long'
 export type PuttDirectionResult = 'left' | 'right'
@@ -186,6 +198,56 @@ export function decombinedPuttResult(
   if (direction === 'left') parts.push('Missed left')
   else if (direction === 'right') parts.push('Missed right')
   return parts.join(', ')
+}
+
+/** Reconstruct legacy break_direction from the two new axes so writers
+ *  can keep the legacy column populated for back-compat. When both axes
+ *  are set, prefers horizontal — the more frequently-diagnostic axis
+ *  for putt line correction. `flat` vertical has no legacy equivalent
+ *  and is dropped if horizontal carries information.
+ *  Mirrors {@link combinedPuttResult} above. */
+export function combinedBreakDirection(args: {
+  vertical?: BreakDirectionVertical | null
+  horizontal?: BreakDirectionHorizontal | null
+}): BreakDirection | null {
+  if (args.horizontal === 'left_to_right') return 'left_to_right'
+  if (args.horizontal === 'right_to_left') return 'right_to_left'
+  if (args.horizontal === 'straight') return 'straight'
+  if (args.vertical === 'uphill') return 'uphill'
+  if (args.vertical === 'downhill') return 'downhill'
+  return null
+}
+
+/** Inverse of {@link combinedBreakDirection} — decompose a legacy
+ *  BreakDirection value into the two new axes for the read-path
+ *  fallback. Legacy single-letter `left` / `right` map onto the
+ *  break-from→to vocabulary the same way `mapBreakDirection()` in
+ *  round.ts does (left = breaks right-to-left, right = breaks
+ *  left-to-right). */
+export function decombinedBreakDirection(
+  legacy: BreakDirection | null | undefined,
+): {
+  vertical: BreakDirectionVertical | null
+  horizontal: BreakDirectionHorizontal | null
+} {
+  switch (legacy) {
+    case 'uphill':
+      return { vertical: 'uphill', horizontal: null }
+    case 'downhill':
+      return { vertical: 'downhill', horizontal: null }
+    case 'left_to_right':
+      return { vertical: null, horizontal: 'left_to_right' }
+    case 'right_to_left':
+      return { vertical: null, horizontal: 'right_to_left' }
+    case 'straight':
+      return { vertical: null, horizontal: 'straight' }
+    case 'left':
+      return { vertical: null, horizontal: 'right_to_left' }
+    case 'right':
+      return { vertical: null, horizontal: 'left_to_right' }
+    default:
+      return { vertical: null, horizontal: null }
+  }
 }
 
 export interface SGBreakdown {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,8 +20,7 @@ export type GreenSpeed = 'slow' | 'medium' | 'fast'
 // new code writes one of the explicit five.
 /** @deprecated Use {@link BreakDirectionVertical} and
  *  {@link BreakDirectionHorizontal} — break direction is two independent
- *  axes (slope + line), not one. Migration 0028 added the split columns;
- *  this single-axis enum is kept only for back-compat reads. */
+ *  axes (slope + line), not one. */
 export type BreakDirection =
   | 'left'
   | 'right'

--- a/supabase/migrations/0028_break_direction_axes.sql
+++ b/supabase/migrations/0028_break_direction_axes.sql
@@ -1,0 +1,36 @@
+-- Break direction splits into two independent axes — vertical
+-- (uphill/downhill/flat) and horizontal (L→R / R→L / straight). Either
+-- or both can be null. Legacy single-value break_direction is preserved
+-- on the existing column so existing reads keep working until consumers
+-- migrate. Same shape as migrations 0003 (lie_slope split) and 0006
+-- (putt_result split). See issue #340.
+alter table public.shots
+  add column break_direction_vertical text check (
+    break_direction_vertical is null
+    or break_direction_vertical in ('uphill', 'downhill', 'flat')
+  ),
+  add column break_direction_horizontal text check (
+    break_direction_horizontal is null
+    or break_direction_horizontal in ('left_to_right', 'right_to_left', 'straight')
+  );
+
+-- Backfill from legacy break_direction. Legacy single-letter `left` /
+-- `right` map onto the new break-from→to vocabulary the same way
+-- mapBreakDirection() in @oga/core/round.ts already handles them
+-- (left = breaks right-to-left, right = breaks left-to-right).
+update public.shots
+set
+  break_direction_vertical = case
+    when break_direction = 'uphill' then 'uphill'
+    when break_direction = 'downhill' then 'downhill'
+    else null
+  end,
+  break_direction_horizontal = case
+    when break_direction = 'left_to_right' then 'left_to_right'
+    when break_direction = 'right_to_left' then 'right_to_left'
+    when break_direction = 'straight' then 'straight'
+    when break_direction = 'left' then 'right_to_left'
+    when break_direction = 'right' then 'left_to_right'
+    else null
+  end
+where break_direction is not null;


### PR DESCRIPTION
## Summary

PR 1 of 2 for #340. Pure additive: migration + types + helpers + tests. Touches **zero consumers** — every existing read keeps going through the legacy `break_direction` column unchanged.

- **Migration `0028`** — adds `shots.break_direction_vertical` and `shots.break_direction_horizontal` with CHECK constraints + backfill from the legacy column. Legacy single-letter `left` / `right` map onto the break-from→to vocabulary the same way `mapBreakDirection()` in `@oga/core` already handles them.
- **Types** — `BreakDirection` marked `@deprecated`; new `BreakDirectionVertical` and `BreakDirectionHorizontal` types added.
- **Helpers** — `combinedBreakDirection` / `decombinedBreakDirection` in `@oga/core/types.ts`, mirroring the existing `combinedPuttResult` / `decombinedPuttResult` pattern. Precedence: horizontal wins when both axes are set (more frequently diagnostic for putt-line correction).
- **Tests** — 19 new tests in `breakDirection.test.ts` cover precedence, legacy letter mapping, and roundtrip behaviour for the five canonical values.

Mirrors migrations 0003 (lie_slope split) and 0006 (putt_result split). Same shape, same back-compat strategy.

## Why split into 2 PRs

This half is data-only and low-risk: nothing reads the new columns yet, so it can land cleanly even if PR 2 (mobile UI + write-path) needs iteration.

## What PR 2 will cover

- Mobile `PuttingSheet.tsx` UI redesign — two `Section`s replacing the single Break selector
- Mobile write-path — populate both new columns + derived legacy on save
- `shotRowToDraft` read-path update with legacy fallback
- Regenerate `packages/supabase/src/types.ts`
- Audit `sg.ts` / `stats.ts` / `shotInference.ts` consumers
- File companion issue for the identical web bug at `PuttFormFields.tsx:138-153`

## Test plan

- [x] `pnpm --filter=@oga/core test` — 352 tests pass (19 new)
- [x] `pnpm typecheck` — workspace green
- [ ] CI mobile typecheck — covered by `preview.yml`
- [ ] Manual `npx supabase db push` against the local stack once on a Supabase-ready dev machine