### PR TITLE
feat(mobile): PuttingSheet break — split into slope + line axes (#340 PR 2/2)

### DIFF
--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -10,7 +10,9 @@ import {
 } from 'react-native'
 import {
   FEET_TO_CM,
-  type BreakDirection,
+  combinedBreakDirection,
+  type BreakDirectionHorizontal,
+  type BreakDirectionVertical,
   type GreenSpeed,
   type LieType,
   type PuttDirectionResult,
@@ -24,7 +26,8 @@ export interface PuttingValue {
   puttMade?: boolean
   puttDistanceResult?: PuttDistanceResult
   puttDirectionResult?: PuttDirectionResult
-  breakDirection?: BreakDirection
+  breakDirectionVertical?: BreakDirectionVertical
+  breakDirectionHorizontal?: BreakDirectionHorizontal
   puttSlopePct?: number // 0-4 intensity bucket
   greenSpeed?: GreenSpeed
   aimOffsetInches?: number
@@ -64,12 +67,15 @@ const DIRECTION_OPTIONS: { value: PuttDirectionResult; label: string }[] = [
   { value: 'right', label: 'Missed right' },
 ]
 
-const BREAK_OPTIONS: { value: BreakDirection; label: string }[] = [
+const BREAK_SLOPE_OPTIONS: { value: BreakDirectionVertical; label: string }[] = [
+  { value: 'uphill', label: 'Uphill' },
+  { value: 'flat', label: 'Flat' },
+  { value: 'downhill', label: 'Downhill' },
+]
+const BREAK_LINE_OPTIONS: { value: BreakDirectionHorizontal; label: string }[] = [
   { value: 'left_to_right', label: 'L → R' },
   { value: 'straight', label: 'Straight' },
   { value: 'right_to_left', label: 'R → L' },
-  { value: 'uphill', label: 'Uphill' },
-  { value: 'downhill', label: 'Downhill' },
 ]
 
 const SLOPE_INTENSITY_LABELS = ['Flat', 'Slight', 'Moderate', 'Strong', 'Severe']
@@ -104,7 +110,8 @@ export function PuttingSheet({
     puttMade: initial?.puttMade,
     puttDistanceResult: initial?.puttDistanceResult,
     puttDirectionResult: initial?.puttDirectionResult,
-    breakDirection: initial?.breakDirection ?? 'straight',
+    breakDirectionVertical: initial?.breakDirectionVertical,
+    breakDirectionHorizontal: initial?.breakDirectionHorizontal,
     puttSlopePct: initial?.puttSlopePct ?? 0,
     greenSpeed: initial?.greenSpeed,
     aimOffsetInches: initial?.aimOffsetInches ?? 0,
@@ -151,6 +158,20 @@ export function PuttingSheet({
       ...prev,
       puttMade: false,
       puttDirectionResult: prev.puttDirectionResult === v ? undefined : v,
+    }))
+  }
+
+  function setBreakSlope(v: BreakDirectionVertical) {
+    setValue((prev) => ({
+      ...prev,
+      breakDirectionVertical: prev.breakDirectionVertical === v ? undefined : v,
+    }))
+  }
+
+  function setBreakLine(v: BreakDirectionHorizontal) {
+    setValue((prev) => ({
+      ...prev,
+      breakDirectionHorizontal: prev.breakDirectionHorizontal === v ? undefined : v,
     }))
   }
 
@@ -248,7 +269,12 @@ export function PuttingSheet({
         <GreenDiagram
           distanceFt={distance}
           aimOffsetInches={value.aimOffsetInches ?? 0}
-          breakDirection={value.breakDirection ?? 'straight'}
+          breakDirection={
+            combinedBreakDirection({
+              vertical: value.breakDirectionVertical,
+              horizontal: value.breakDirectionHorizontal,
+            }) ?? 'straight'
+          }
           onAimChange={(n) => set('aimOffsetInches', n)}
         />
 
@@ -317,17 +343,36 @@ export function PuttingSheet({
           </Text>
         </Section>
 
-        <Section title="Break">
+        <Section title="Break (slope)">
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
-            {BREAK_OPTIONS.map((b) => (
+            {BREAK_SLOPE_OPTIONS.map((b) => (
               <Chip
                 key={b.value}
                 label={b.label}
-                active={value.breakDirection === b.value}
-                onPress={() => set('breakDirection', b.value)}
+                active={value.breakDirectionVertical === b.value}
+                onPress={() => setBreakSlope(b.value)}
               />
             ))}
           </View>
+          <Text style={{ ...KICKER, marginTop: 8, color: '#8A8B7E' }}>
+            Tap again to clear · leave blank if green was level
+          </Text>
+        </Section>
+
+        <Section title="Break (line)">
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+            {BREAK_LINE_OPTIONS.map((b) => (
+              <Chip
+                key={b.value}
+                label={b.label}
+                active={value.breakDirectionHorizontal === b.value}
+                onPress={() => setBreakLine(b.value)}
+              />
+            ))}
+          </View>
+          <Text style={{ ...KICKER, marginTop: 8, color: '#8A8B7E' }}>
+            Tap again to clear · leave blank if there was no break
+          </Text>
         </Section>
 
         <Section title="How much">

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -6,7 +6,8 @@ import {
   LIE_TYPES,
   SHOT_RESULTS,
   formatClubLabel,
-  type BreakDirection,
+  type BreakDirectionHorizontal,
+  type BreakDirectionVertical,
   type Club,
   type GreenSpeed,
   type LieSlopeForward,
@@ -29,7 +30,8 @@ export interface ShotLoggerValue {
   puttDistanceFt?: number
   puttSlopePct?: number
   greenSpeed?: GreenSpeed
-  breakDirection?: BreakDirection
+  breakDirectionVertical?: BreakDirectionVertical
+  breakDirectionHorizontal?: BreakDirectionHorizontal
   aimOffsetInches?: number
   notes?: string
 }
@@ -150,7 +152,8 @@ export function ShotLogger({
               puttDistanceFt: value.puttDistanceFt,
               puttSlopePct: value.puttSlopePct,
               greenSpeed: value.greenSpeed,
-              breakDirection: value.breakDirection,
+              breakDirectionVertical: value.breakDirectionVertical,
+              breakDirectionHorizontal: value.breakDirectionHorizontal,
               aimOffsetInches: value.aimOffsetInches,
               notes: value.notes,
             }}
@@ -164,7 +167,8 @@ export function ShotLogger({
                 puttDistanceFt: p.puttDistanceFt,
                 puttSlopePct: p.puttSlopePct,
                 greenSpeed: p.greenSpeed,
-                breakDirection: p.breakDirection,
+                breakDirectionVertical: p.breakDirectionVertical,
+                breakDirectionHorizontal: p.breakDirectionHorizontal,
                 aimOffsetInches: p.aimOffsetInches,
                 notes: p.notes,
               })

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -2,7 +2,11 @@ import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { Alert } from 'react-native'
 import { useRouter } from 'expo-router'
 import type { User } from '@supabase/supabase-js'
-import { combinedPuttResult, type LieType } from '@oga/core'
+import {
+  combinedBreakDirection,
+  combinedPuttResult,
+  type LieType,
+} from '@oga/core'
 import { deleteRound, getProfile } from '@oga/supabase'
 import { supabase } from '../../../lib/supabase'
 import {
@@ -153,7 +157,12 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
         : meta?.puttDirectionResult ?? null,
       putt_slope_pct: meta?.puttSlopePct ?? null,
       green_speed: meta?.greenSpeed ?? null,
-      break_direction: meta?.breakDirection ?? null,
+      break_direction: combinedBreakDirection({
+        vertical: meta?.breakDirectionVertical,
+        horizontal: meta?.breakDirectionHorizontal,
+      }),
+      break_direction_vertical: meta?.breakDirectionVertical ?? null,
+      break_direction_horizontal: meta?.breakDirectionHorizontal ?? null,
       aim_offset_yards:
         meta?.aimOffsetInches != null
           ? Math.round((meta.aimOffsetInches / 36) * 10) / 10
@@ -229,7 +238,8 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       puttDistanceFt: v.puttDistanceFt,
       puttSlopePct: v.puttSlopePct,
       greenSpeed: v.greenSpeed,
-      breakDirection: v.breakDirection,
+      breakDirectionVertical: v.breakDirectionVertical,
+      breakDirectionHorizontal: v.breakDirectionHorizontal,
       aimOffsetInches: v.aimOffsetInches,
       notes: v.notes,
     }

--- a/packages/core/src/__tests__/sg.test.ts
+++ b/packages/core/src/__tests__/sg.test.ts
@@ -267,6 +267,8 @@ describe('computeRoundSG (sg.ts) — DB row → result adapter', () => {
       ob: overrides.ob ?? false,
       aim_offset_yards: overrides.aim_offset_yards ?? null,
       break_direction: overrides.break_direction ?? null,
+      break_direction_vertical: overrides.break_direction_vertical ?? null,
+      break_direction_horizontal: overrides.break_direction_horizontal ?? null,
       putt_result: overrides.putt_result ?? null,
       putt_distance_result: overrides.putt_distance_result ?? null,
       putt_direction_result: overrides.putt_direction_result ?? null,

--- a/packages/core/src/__tests__/shotRowToDraft.test.ts
+++ b/packages/core/src/__tests__/shotRowToDraft.test.ts
@@ -27,6 +27,8 @@ const row = (overrides: Partial<ShotRow>): ShotRow =>
     putt_slope_pct: null,
     green_speed: null,
     break_direction: null,
+    break_direction_vertical: null,
+    break_direction_horizontal: null,
     aim_offset_yards: null,
     notes: null,
     ...overrides,
@@ -119,6 +121,48 @@ describe('shotRowToDraft', () => {
     it("defaults to 'straight' for null/unknown break_direction", () => {
       expect(shotRowToDraft(row({ break_direction: null })).breakDirection).toBe('straight')
       expect(shotRowToDraft(row({ break_direction: 'something_else' })).breakDirection).toBe('straight')
+    })
+  })
+
+  describe('break_direction axes (vertical + horizontal)', () => {
+    it('reads explicit break_direction_vertical / _horizontal columns', () => {
+      const draft = shotRowToDraft(row({
+        break_direction_vertical: 'uphill',
+        break_direction_horizontal: 'left_to_right',
+      }))
+      expect(draft.breakDirectionVertical).toBe('uphill')
+      expect(draft.breakDirectionHorizontal).toBe('left_to_right')
+    })
+
+    it('falls back to decombined legacy break_direction when new columns are null', () => {
+      const upRow = shotRowToDraft(row({ break_direction: 'uphill' }))
+      expect(upRow.breakDirectionVertical).toBe('uphill')
+      expect(upRow.breakDirectionHorizontal).toBeUndefined()
+
+      const ltrRow = shotRowToDraft(row({ break_direction: 'left_to_right' }))
+      expect(ltrRow.breakDirectionVertical).toBeUndefined()
+      expect(ltrRow.breakDirectionHorizontal).toBe('left_to_right')
+    })
+
+    it('decombines legacy single-letter `left` / `right` onto the horizontal axis', () => {
+      expect(shotRowToDraft(row({ break_direction: 'left' })).breakDirectionHorizontal).toBe('right_to_left')
+      expect(shotRowToDraft(row({ break_direction: 'right' })).breakDirectionHorizontal).toBe('left_to_right')
+    })
+
+    it('prefers explicit new columns over legacy decomposition', () => {
+      const draft = shotRowToDraft(row({
+        break_direction: 'uphill',
+        break_direction_vertical: 'downhill',
+        break_direction_horizontal: 'straight',
+      }))
+      expect(draft.breakDirectionVertical).toBe('downhill')
+      expect(draft.breakDirectionHorizontal).toBe('straight')
+    })
+
+    it('returns undefined for both axes when nothing is set', () => {
+      const draft = shotRowToDraft(row({}))
+      expect(draft.breakDirectionVertical).toBeUndefined()
+      expect(draft.breakDirectionHorizontal).toBeUndefined()
     })
   })
 

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -154,6 +154,7 @@ export function shotRowToDraft(s: ShotRow): DraftShot {
   else if (!shotResult && s.penalty) shotResult = 'penalty'
   const legacy = legacySlopeToAxes(s.lie_slope as LieSlope | null)
   const puttResult = s.putt_result as LegacyPuttResult | null
+  const breakAxes = decombinedBreakDirection(s.break_direction as BreakDirection | null)
   return {
     id: s.id,
     shotNumber: s.shot_number,
@@ -184,11 +185,11 @@ export function shotRowToDraft(s: ShotRow): DraftShot {
     breakDirection: mapBreakDirection(s.break_direction),
     breakDirectionVertical:
       (s.break_direction_vertical as BreakDirectionVertical | null) ??
-      decombinedBreakDirection(s.break_direction as BreakDirection | null).vertical ??
+      breakAxes.vertical ??
       undefined,
     breakDirectionHorizontal:
       (s.break_direction_horizontal as BreakDirectionHorizontal | null) ??
-      decombinedBreakDirection(s.break_direction as BreakDirection | null).horizontal ??
+      breakAxes.horizontal ??
       undefined,
     aimOffsetInches:
       s.aim_offset_yards != null ? Math.round(s.aim_offset_yards * 36) : 0,

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -6,11 +6,14 @@ import { inferShot, type InferredShot, type PlacedShot } from './shotInference'
 import type { Club, LieType, LieSlope, LieSlopeForward, LieSlopeSide, ShotResult } from './constants'
 import type {
   BreakDirection,
+  BreakDirectionHorizontal,
+  BreakDirectionVertical,
   GreenSpeed,
   LegacyPuttResult,
   PuttDirectionResult,
   PuttDistanceResult,
 } from './types'
+import { decombinedBreakDirection } from './types'
 import type { Database } from '@oga/supabase'
 
 type ShotRow = Database['public']['Tables']['shots']['Row']
@@ -129,7 +132,13 @@ export interface DraftShot {
   puttDirectionResult?: PuttDirectionResult
   puttSlopePct?: number
   greenSpeed?: GreenSpeed
+  /** @deprecated Use {@link DraftShot.breakDirectionVertical} and
+   *  {@link DraftShot.breakDirectionHorizontal}. Computed from the two
+   *  axes for back-compat with consumers (web `PuttFormFields`,
+   *  `GreenDiagram`) that still read this single-axis field. */
   breakDirection?: Exclude<BreakDirection, 'left' | 'right'>
+  breakDirectionVertical?: BreakDirectionVertical
+  breakDirectionHorizontal?: BreakDirectionHorizontal
   aimOffsetInches?: number
   notes?: string
 }
@@ -173,6 +182,14 @@ export function shotRowToDraft(s: ShotRow): DraftShot {
     puttSlopePct: s.putt_slope_pct ?? undefined,
     greenSpeed: (s.green_speed as GreenSpeed | null) ?? undefined,
     breakDirection: mapBreakDirection(s.break_direction),
+    breakDirectionVertical:
+      (s.break_direction_vertical as BreakDirectionVertical | null) ??
+      decombinedBreakDirection(s.break_direction as BreakDirection | null).vertical ??
+      undefined,
+    breakDirectionHorizontal:
+      (s.break_direction_horizontal as BreakDirectionHorizontal | null) ??
+      decombinedBreakDirection(s.break_direction as BreakDirection | null).horizontal ??
+      undefined,
     aimOffsetInches:
       s.aim_offset_yards != null ? Math.round(s.aim_offset_yards * 36) : 0,
     notes: s.notes ?? undefined,

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -483,6 +483,8 @@ export type Database = {
           aim_lng: number | null
           aim_offset_yards: number | null
           break_direction: string | null
+          break_direction_horizontal: string | null
+          break_direction_vertical: string | null
           club: string | null
           created_at: string
           distance_to_target: number | null
@@ -514,6 +516,8 @@ export type Database = {
           aim_lng?: number | null
           aim_offset_yards?: number | null
           break_direction?: string | null
+          break_direction_horizontal?: string | null
+          break_direction_vertical?: string | null
           club?: string | null
           created_at?: string
           distance_to_target?: number | null
@@ -545,6 +549,8 @@ export type Database = {
           aim_lng?: number | null
           aim_offset_yards?: number | null
           break_direction?: string | null
+          break_direction_horizontal?: string | null
+          break_direction_vertical?: string | null
           club?: string | null
           created_at?: string
           distance_to_target?: number | null


### PR DESCRIPTION
## Summary

PR 2 of 2 for #340. Wires PR #400's data layer (migration 0028 + the `combined` / `decombined` helpers) into the mobile shot logger so a putt on a sloped green can capture **both** axes simultaneously — slope (uphill / flat / downhill) AND line (L→R / straight / R→L).

Before: single-select chip group; player picks one axis, loses the other.
After: two independent chip rows, both nullable, same toggle-to-clear pattern as the Distance / Direction selectors right above them.

## What this PR changes

| Layer | File | Change |
|---|---|---|
| Types | `packages/supabase/src/types.ts` | Hand-added `break_direction_vertical` + `break_direction_horizontal` to `shots` Row / Insert / Update (matches what `supabase gen types` would emit after 0028). |
| Domain | `packages/core/src/round.ts` | `DraftShot` gains two-axis fields. `shotRowToDraft` reads the new columns with `decombinedBreakDirection` fallback. Legacy `breakDirection` kept `@deprecated` for web back-compat. |
| Tests | `packages/core/src/__tests__/shotRowToDraft.test.ts` | +5 tests covering new columns, legacy decomposition, single-letter mapping, new-over-legacy precedence, empty state. |
| Tests | `packages/core/src/__tests__/sg.test.ts` | Row-builder defaults for the two new required columns. |
| Mobile UI | `apps/mobile/components/round/PuttingSheet.tsx` | Single Break Section → two Sections (`Break (slope)` and `Break (line)`). |
| Mobile | `apps/mobile/components/round/ShotLogger.tsx` | `ShotLoggerValue` + pass-through. |
| Mobile | `apps/mobile/components/round/hole/useShotActions.ts` | Writes all three columns on save: `break_direction` (combined, back-compat), `break_direction_vertical`, `break_direction_horizontal`. |

## What's intentionally out of scope

- **GreenDiagram rendering both axes.** Still receives the legacy single-axis `BreakDirection` (via `combinedBreakDirection`). When both axes are set, the diagram shows the horizontal axis only (preferring it per the helper's precedence rule). v1.1 follow-up.
- **Web parity.** `apps/web/src/components/rounds/shots/PuttFormFields.tsx:138-153` has the identical single-select bug. Filed as a companion issue rather than bundled here — keeps this PR mobile-only and easy to review.
- **Backfill of old rows.** Migration 0028's `UPDATE` handles existing rows. New rows write all three columns. No second backfill pass needed.

## Verification

- [x] `pnpm --filter=@oga/core test` → **357 / 357** (5 new in `shotRowToDraft.test.ts`)
- [x] `pnpm typecheck` → workspace green
- [x] `cd apps/mobile && npm run typecheck` → green
- [ ] CI mobile typecheck via `preview.yml`
- [ ] Manual: log an uphill + R→L putt on a sloped green, confirm both axes persist on round detail

Closes #340 once dev → main releases.