### PR TITLE
feat(patterns): standalone ball-flight chart on Shot Patterns (#243)

### DIFF
--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -658,7 +658,7 @@ function BallFlightChart({
     )
   }
 
-  const x = (lat: number) => cx + lat * scale
+  const x = (lateralYards: number) => cx + lateralYards * scale
   const y = (dist: number) => teeY - dist * scale
   // Each shot's true forward distance from the tee.
   const carryOf = (p: DispersionPoint) =>

--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -17,6 +17,10 @@ import { useUnits } from '../../hooks/useUnits'
 const SVG_SIZE = 420
 const SVG_VIEW_WIDTH = `min(${SVG_SIZE}px, 90vw)`
 
+const FLIGHT_W = 460
+const FLIGHT_H = 520
+const FLIGHT_VIEW_WIDTH = `min(${FLIGHT_W}px, 92vw)`
+
 export function ShotPatternsPage() {
   const { unit, toDisplay } = useUnits()
   const [club, setClub] = useState<Club>('7i')
@@ -211,6 +215,52 @@ export function ShotPatternsPage() {
               </div>
             )}
           </div>
+        </div>
+      </div>
+
+      <div style={{ borderTop: '1px solid #D9D2BF', paddingTop: 14, marginTop: 28 }}>
+        <div className="kicker" style={{ marginBottom: 6 }}>
+          Ball flight
+        </div>
+        <div
+          className="text-caddie-ink-dim"
+          style={{ fontSize: 13, marginBottom: 14, maxWidth: 560 }}
+        >
+          Each shot at its true carry up the range; the curve shows shape
+          (draw/fade). Thick line is your average.
+        </div>
+        <div
+          className="bg-caddie-surface"
+          style={{
+            border: '1px solid #D9D2BF',
+            borderRadius: 4,
+            padding: 14,
+            display: 'inline-block',
+          }}
+        >
+          {isLoading ? (
+            <div
+              className="flex items-center justify-center text-caddie-ink-mute"
+              style={{ width: FLIGHT_VIEW_WIDTH, height: 360, fontSize: 13 }}
+            >
+              Loading…
+            </div>
+          ) : !points.some((p) => p.startDistanceOffsetYards != null) ? (
+            <div
+              className="flex items-center justify-center text-caddie-ink-mute"
+              style={{
+                width: FLIGHT_VIEW_WIDTH,
+                height: 360,
+                fontSize: 13,
+                textAlign: 'center',
+                padding: 20,
+              }}
+            >
+              No shots with recorded start positions for {club} yet.
+            </div>
+          ) : (
+            <BallFlightChart points={points} stats={stats} />
+          )}
         </div>
       </div>
     </div>
@@ -537,6 +587,193 @@ function DispersionPlot({
         fill="#8A8B7E"
       >
         R
+      </text>
+    </svg>
+  )
+}
+
+// Top-down ball-flight view (mockup spec). Distinct from DispersionPlot: a
+// full-flight chart with the tee at the bottom and the target line up to the
+// pin. Each shot is a bezier tee → aim (control) → landing, so shot shape
+// reads geometrically. Within one club, carries cluster, so all shots
+// normalize to a common tee at the average carry; only lateral is to-scale.
+function BallFlightChart({
+  points,
+  stats,
+}: {
+  points: DispersionPoint[]
+  stats: DispersionStats | null
+}) {
+  const { toDisplay } = useUnits()
+
+  const { avgCarry, scale, maxDist } = useMemo(() => {
+    const carries = points
+      .map((p) => p.startDistanceOffsetYards)
+      .filter((v): v is number => v != null)
+      .map((d) => -d) // start sits ~carry yards short of aim
+    const carry = carries.length
+      ? carries.reduce((a, b) => a + b, 0) / carries.length
+      : 0
+    // True distance from the tee per shot = its own carry + long/short vs aim.
+    // Shots without a recorded start fall back to the average carry.
+    const dists = points.map(
+      (p) =>
+        (p.startDistanceOffsetYards != null
+          ? -p.startDistanceOffsetYards
+          : carry) + p.distanceOffsetYards,
+    )
+    const max = Math.max(...dists, carry, 1) * 1.08
+    const maxLat =
+      Math.max(
+        ...points.map((p) => Math.abs(p.lateralOffsetYards)),
+        stats ? Math.abs(stats.avgLateralOffset) + stats.cone95.lateral : 0,
+        8,
+      ) * 1.1
+    // One isotropic scale for both axes — distance and lateral shown in true
+    // proportion. Vertical fits the longest shot; shrink only if lateral would
+    // overflow the width.
+    const s = Math.min((FLIGHT_H - 40 - 28) / max, (FLIGHT_W / 2 - 16) / maxLat)
+    return { avgCarry: carry, scale: s, maxDist: max }
+  }, [points, stats])
+
+  const cx = FLIGHT_W / 2
+  const teeY = FLIGHT_H - 40
+
+  // Degenerate when shots start ~at the target (no meaningful carry to plot).
+  if (avgCarry < 5) {
+    return (
+      <div
+        className="flex items-center justify-center text-caddie-ink-mute"
+        style={{
+          width: FLIGHT_VIEW_WIDTH,
+          height: 360,
+          fontSize: 13,
+          textAlign: 'center',
+          padding: 20,
+        }}
+      >
+        These shots don&apos;t have enough start-to-target distance to plot a
+        flight path.
+      </div>
+    )
+  }
+
+  const x = (lat: number) => cx + lat * scale
+  const y = (dist: number) => teeY - dist * scale
+  // Each shot's true forward distance from the tee.
+  const carryOf = (p: DispersionPoint) =>
+    p.startDistanceOffsetYards != null ? -p.startDistanceOffsetYards : avgCarry
+
+  // Driving-range yardage gridlines: finer spacing for short clubs.
+  const step = maxDist <= 160 ? 25 : 50
+  const gridLines: number[] = []
+  for (let d = step; d <= maxDist; d += step) gridLines.push(d)
+
+  return (
+    <svg
+      viewBox={`0 0 ${FLIGHT_W} ${FLIGHT_H}`}
+      style={{
+        width: FLIGHT_VIEW_WIDTH,
+        height: `calc(${FLIGHT_VIEW_WIDTH} * ${FLIGHT_H} / ${FLIGHT_W})`,
+        backgroundColor: '#F2EEE5',
+        borderRadius: 2,
+        display: 'block',
+      }}
+    >
+      {/* yardage gridlines — the driving-range backdrop */}
+      {gridLines.map((d) => (
+        <g key={`grid-${d}`}>
+          <line
+            x1={0}
+            y1={y(d)}
+            x2={FLIGHT_W}
+            y2={y(d)}
+            stroke="#E4DECF"
+            strokeWidth={1}
+          />
+          <text
+            x={6}
+            y={y(d) - 3}
+            fontFamily="JetBrains Mono, monospace"
+            fontSize={9}
+            letterSpacing="0.1em"
+            fill="#8A8B7E"
+          >
+            {toDisplay(d, 0)}
+          </text>
+        </g>
+      ))}
+
+      {/* center reference line (straight-ahead) */}
+      <line
+        x1={cx}
+        y1={y(maxDist)}
+        x2={cx}
+        y2={teeY}
+        stroke="#D9D2BF"
+        strokeWidth={0.8}
+        strokeDasharray="3 5"
+      />
+
+      {/* individual shot flights */}
+      <g fill="none">
+        {points.map((p) => (
+          <path
+            key={`flight-${p.id}`}
+            d={`M ${cx} ${teeY} Q ${cx} ${y(carryOf(p))} ${x(p.lateralOffsetYards)} ${y(carryOf(p) + p.distanceOffsetYards)}`}
+            stroke={pointColor(p.shotResult).fill}
+            strokeOpacity={0.3}
+            strokeWidth={1.2}
+          />
+        ))}
+        {stats && (
+          <path
+            d={`M ${cx} ${teeY} Q ${cx} ${y(avgCarry)} ${x(stats.avgLateralOffset)} ${y(avgCarry + stats.avgDistanceOffset)}`}
+            stroke="#1F3D2C"
+            strokeWidth={3}
+            strokeOpacity={0.9}
+          />
+        )}
+      </g>
+
+      {/* landing dots */}
+      {points.map((p) => {
+        const c = pointColor(p.shotResult)
+        return (
+          <circle
+            key={`land-${p.id}`}
+            cx={x(p.lateralOffsetYards)}
+            cy={y(carryOf(p) + p.distanceOffsetYards)}
+            r={2.5}
+            fill={c.fill}
+            fillOpacity={c.opacity}
+          />
+        )
+      })}
+
+      {/* average landing */}
+      {stats && (
+        <circle
+          cx={x(stats.avgLateralOffset)}
+          cy={y(avgCarry + stats.avgDistanceOffset)}
+          r={4}
+          fill="#FBF8F1"
+          stroke="#1F3D2C"
+          strokeWidth={2}
+        />
+      )}
+
+      <circle cx={cx} cy={teeY} r={5} fill="#FBF8F1" stroke="#1C211C" strokeWidth={2} />
+      <text
+        x={cx}
+        y={teeY + 18}
+        fontFamily="JetBrains Mono, monospace"
+        fontSize={9}
+        letterSpacing="0.16em"
+        fill="#5C6356"
+        textAnchor="middle"
+      >
+        TEE
       </text>
     </svg>
   )

--- a/packages/core/src/shot-patterns.test.ts
+++ b/packages/core/src/shot-patterns.test.ts
@@ -51,6 +51,32 @@ describe('computeDispersion', () => {
     const [p] = computeDispersion([s])
     expect(p!.lateralOffsetYards).toBeGreaterThan(0)
   })
+
+  it('projects start position into the aim-relative plane when present', () => {
+    const s = shot({
+      aimLat: AIM_LAT,
+      aimLng: AIM_LNG,
+      startLat: AIM_LAT - 0.001, // ~121 yds short of aim
+      startLng: AIM_LNG - 0.0001, // west of aim → start is left
+      endLat: AIM_LAT,
+      endLng: AIM_LNG,
+    })
+    const [p] = computeDispersion([s])
+    expect(p!.startDistanceOffsetYards).toBeCloseTo(-121, 0)
+    expect(p!.startLateralOffsetYards!).toBeLessThan(0)
+  })
+
+  it('leaves start offsets undefined when start coords are missing', () => {
+    const s = shot({
+      aimLat: AIM_LAT,
+      aimLng: AIM_LNG,
+      endLat: AIM_LAT + 0.001,
+      endLng: AIM_LNG,
+    })
+    const [p] = computeDispersion([s])
+    expect(p!.startLateralOffsetYards).toBeUndefined()
+    expect(p!.startDistanceOffsetYards).toBeUndefined()
+  })
 })
 
 describe('computeDispersionStats', () => {

--- a/packages/core/src/shot-patterns.test.ts
+++ b/packages/core/src/shot-patterns.test.ts
@@ -52,21 +52,19 @@ describe('computeDispersion', () => {
     expect(p!.lateralOffsetYards).toBeGreaterThan(0)
   })
 
-  it('projects start position into the aim-relative plane when present', () => {
+  it('projects start distance into the aim-relative plane when present', () => {
     const s = shot({
       aimLat: AIM_LAT,
       aimLng: AIM_LNG,
       startLat: AIM_LAT - 0.001, // ~121 yds short of aim
-      startLng: AIM_LNG - 0.0001, // west of aim → start is left
       endLat: AIM_LAT,
       endLng: AIM_LNG,
     })
     const [p] = computeDispersion([s])
     expect(p!.startDistanceOffsetYards).toBeCloseTo(-121, 0)
-    expect(p!.startLateralOffsetYards!).toBeLessThan(0)
   })
 
-  it('leaves start offsets undefined when start coords are missing', () => {
+  it('leaves start distance undefined when start coords are missing', () => {
     const s = shot({
       aimLat: AIM_LAT,
       aimLng: AIM_LNG,
@@ -74,7 +72,6 @@ describe('computeDispersion', () => {
       endLng: AIM_LNG,
     })
     const [p] = computeDispersion([s])
-    expect(p!.startLateralOffsetYards).toBeUndefined()
     expect(p!.startDistanceOffsetYards).toBeUndefined()
   })
 })

--- a/packages/core/src/shot-patterns.ts
+++ b/packages/core/src/shot-patterns.ts
@@ -15,9 +15,6 @@ export interface DispersionPoint {
   lateralOffsetYards: number
   /** Yards long of aim (negative = short) */
   distanceOffsetYards: number
-  /** Start position right of aim (negative = left). Undefined when the
-   *  shot has no recorded start — callers draw a straight line then. */
-  startLateralOffsetYards?: number
   /** Start position long of aim (negative = short). Undefined when the
    *  shot has no recorded start. */
   startDistanceOffsetYards?: number
@@ -68,17 +65,14 @@ export function computeDispersion(shots: Shot[]): DispersionPoint[] {
     const endLng = s.endLng
     const latYards = (endLat - aimLat) * YARDS_PER_DEG_LAT
     const lngYards = (endLng - aimLng) * yardsPerDegLng(aimLat)
-    let startLateralOffsetYards: number | undefined
     let startDistanceOffsetYards: number | undefined
-    if (isFiniteNumber(s.startLat) && isFiniteNumber(s.startLng)) {
-      startLateralOffsetYards = (s.startLng - aimLng) * yardsPerDegLng(aimLat)
+    if (isFiniteNumber(s.startLat)) {
       startDistanceOffsetYards = (s.startLat - aimLat) * YARDS_PER_DEG_LAT
     }
     points.push({
       id: s.id,
       lateralOffsetYards: lngYards,
       distanceOffsetYards: latYards,
-      startLateralOffsetYards,
       startDistanceOffsetYards,
       shotResult: s.shotResult,
       lieSlope: s.lieSlope,

--- a/packages/core/src/shot-patterns.ts
+++ b/packages/core/src/shot-patterns.ts
@@ -15,6 +15,12 @@ export interface DispersionPoint {
   lateralOffsetYards: number
   /** Yards long of aim (negative = short) */
   distanceOffsetYards: number
+  /** Start position right of aim (negative = left). Undefined when the
+   *  shot has no recorded start — callers draw a straight line then. */
+  startLateralOffsetYards?: number
+  /** Start position long of aim (negative = short). Undefined when the
+   *  shot has no recorded start. */
+  startDistanceOffsetYards?: number
   shotResult?: ShotResult
   /** @deprecated populated from legacy rows; new code uses lieSlopeForward + lieSlopeSide. */
   lieSlope?: LieSlope
@@ -62,10 +68,18 @@ export function computeDispersion(shots: Shot[]): DispersionPoint[] {
     const endLng = s.endLng
     const latYards = (endLat - aimLat) * YARDS_PER_DEG_LAT
     const lngYards = (endLng - aimLng) * yardsPerDegLng(aimLat)
+    let startLateralOffsetYards: number | undefined
+    let startDistanceOffsetYards: number | undefined
+    if (isFiniteNumber(s.startLat) && isFiniteNumber(s.startLng)) {
+      startLateralOffsetYards = (s.startLng - aimLng) * yardsPerDegLng(aimLat)
+      startDistanceOffsetYards = (s.startLat - aimLat) * YARDS_PER_DEG_LAT
+    }
     points.push({
       id: s.id,
       lateralOffsetYards: lngYards,
       distanceOffsetYards: latYards,
+      startLateralOffsetYards,
+      startDistanceOffsetYards,
       shotResult: s.shotResult,
       lieSlope: s.lieSlope,
       lieSlopeForward: s.lieSlopeForward,


### PR DESCRIPTION
## What

Adds a **standalone driving-range ball-flight chart** below the dispersion plot on Shot Patterns. The dispersion plot itself is **unchanged**. Implements #243.

The two charts now show complementary things:
- **Dispersion plot (above):** aim-relative miss (left/right, short/long around target) + the 68/95 rings.
- **Ball-flight chart (below):** absolute **distance and shape** — each shot plotted at its true carry up a yardage scale, curving left/right for draw/fade.

## How

**@oga/core** — `computeDispersion` projects the start position into the aim-relative plane via optional `startLateralOffsetYards` / `startDistanceOffsetYards` (set only when start coords exist), so each shot can be placed at its real distance. Additive + backward-compatible.

**apps/web** — co-located `BallFlightChart`: adaptive 25/50-yd gridlines (range backdrop), each shot's flight at its true carry, draw/fade curve, average flight line. Isotropic scale so distance and lateral spread stay in true proportion. Falls back to a note when average carry is too small to plot. Reuses `pointColor`.

## Build-on

Rebased onto `dev` after #406 (2D ellipse fix) merged.

## Test

- `@oga/core`: 2 vitest cases for the start projection (present + absent)
- Typecheck green
- Verified on seeded e2e data — see latest screenshots in the comments

## Known data caveat (not a chart bug)

The seed assigns "driver" to every long shot across all hole lengths (150→500 yd), so its range view looks like a tall streak. Mid-irons (only picked for their own distance band) render as tight clusters. Real data → compact clouds. Separate seed-realism follow-up.