### PR TITLE
fix(core): dispersion ellipses use 2D containment radii, not 1-D σ

### DIFF
--- a/packages/core/src/shot-patterns.test.ts
+++ b/packages/core/src/shot-patterns.test.ts
@@ -74,8 +74,9 @@ describe('computeDispersionStats', () => {
     expect(stats.avgLateralOffset).toBeCloseTo(11)
     expect(stats.dominantMiss).toBe('right')
     expect(stats.shotShape).toBe('fade')
-    expect(stats.cone68.lateral).toBeGreaterThan(0)
-    expect(stats.cone95.lateral).toBeCloseTo(stats.cone68.lateral * 1.96)
+    // 2D containment radii, not the 1-D 1σ / 1.96σ rule.
+    expect(stats.cone68.lateral).toBeCloseTo(stats.stdLateral * 1.5096, 3)
+    expect(stats.cone95.lateral).toBeCloseTo(stats.stdLateral * 2.4477, 3)
   })
 
   it('labels balanced patterns as straight', () => {

--- a/packages/core/src/shot-patterns.ts
+++ b/packages/core/src/shot-patterns.ts
@@ -88,6 +88,12 @@ function stdDev(xs: number[], avg: number): number {
 const DOMINANT_MISS_THRESHOLD_YARDS = 2
 const SHOT_SHAPE_THRESHOLD_YARDS = 3
 const MIN_SAMPLES_FOR_STATS = 5
+// 2D containment radii. The fraction of a bivariate-normal scatter inside an
+// axis-scaled ellipse is 1 − e^(−k²/2), so 68% / 95% containment needs
+// k = √(−2·ln(1−p)) — NOT the 1-D 1σ / 1.96σ rule, which here would enclose
+// only ~39% / ~85% of shots.
+const CONE_68_K = 1.5096 // √(−2 ln 0.32)
+const CONE_95_K = 2.4477 // √(−2 ln 0.05)
 
 export function computeDispersionStats(points: DispersionPoint[]): DispersionStats | null {
   if (points.length < MIN_SAMPLES_FOR_STATS) return null
@@ -118,8 +124,8 @@ export function computeDispersionStats(points: DispersionPoint[]): DispersionSta
     avgDistanceOffset: avgDist,
     stdLateral: stdLat,
     stdDistance: stdDist,
-    cone68: { lateral: stdLat, distance: stdDist },
-    cone95: { lateral: stdLat * 1.96, distance: stdDist * 1.96 },
+    cone68: { lateral: stdLat * CONE_68_K, distance: stdDist * CONE_68_K },
+    cone95: { lateral: stdLat * CONE_95_K, distance: stdDist * CONE_95_K },
     dominantMiss,
     shotShape,
     sampleSize: points.length,


### PR DESCRIPTION
## Problem

The Shot Patterns 68% / 95% dispersion ellipses used the **1-D** empirical-rule multipliers (`1σ`, `1.96σ`). But the plot is **2D** (lateral × distance). For a bivariate-normal scatter, the fraction inside an axis-scaled ellipse is `1 − e^(−k²/2)`, so the old rings actually enclosed:

| Ring | Old k | Shots actually inside |
|---|---|---|
| "68%" | 1.0 | **~39%** |
| "95%" | 1.96 | **~85%** |

The labels overpromised — the rings were drawn too small.

## Fix

Use the 2D containment radii `k = √(−2·ln(1−p))`:
- 68% → **1.5096σ**
- 95% → **2.4477σ**

`computeDispersionStats` now scales `cone68` / `cone95` by named `CONE_68_K` / `CONE_95_K` constants. Rendering consumers (`ShotPatternsPage`, mobile `patterns.tsx`) are unchanged — the ellipses just grow to their honest size.

## Test

Updated the cone assertion to check both rings against `stdLateral` with the corrected multipliers. Core suite green.

Surfaced during #404 review; landing first so the ball-flight rework builds on corrected ellipses.