### PR TITLE
fix(mobile): allow about: scheme in auth WebView so iOS Turnstile completes (#405)

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -97,7 +97,7 @@ export default function Login() {
         {captchaEnabled && (
           <WebView
             source={{ uri: `https://oga.golf/captcha.html?siteKey=${encodeURIComponent(TURNSTILE_SITE_KEY ?? '')}` }}
-            originWhitelist={['https://*', 'http://*']}
+            originWhitelist={['https://*', 'http://*', 'about:']}
             onMessage={(event) => {
               try {
                 const msg = JSON.parse(event.nativeEvent.data)

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -106,7 +106,7 @@ export default function Signup() {
         {captchaEnabled && (
           <WebView
             source={{ uri: `https://oga.golf/captcha.html?siteKey=${encodeURIComponent(TURNSTILE_SITE_KEY ?? '')}` }}
-            originWhitelist={['https://*', 'http://*']}
+            originWhitelist={['https://*', 'http://*', 'about:']}
             onMessage={(event) => {
               try {
                 const msg = JSON.parse(event.nativeEvent.data)


### PR DESCRIPTION
## What
Adds the `about:` scheme to the auth WebView `originWhitelist` on the mobile signup + login screens — fixes the iOS-only Cloudflare Turnstile hang.

## Root cause
Turnstile renders its managed challenge into an `about:blank` / `about:srcdoc` iframe. On iOS, `react-native-webview`'s `originWhitelist` filters **all** sub-frame loads (Android only gates top-level navigation). The prior `['https://*','http://*']` silently cancelled the challenge frame, so the widget hung at "Verifying…" forever with no error callback. Web + Android were unaffected.

This corrects the original theory in #405 (third-party storage / `sharedCookiesEnabled`): that prop only bridges the app cookie jar, not iframe storage, and a storage failure would *error*, not hang.

## Fix
`originWhitelist={['https://*', 'http://*', 'about:']}` on both screens. Additive — cannot affect the working web/Android paths.

## Receipts
- Cloudflare mobile WebView docs — must allow `about:blank` / `about:srcdoc`: https://developers.cloudflare.com/turnstile/get-started/mobile-implementation/
- react-turnstile #60 — identical iOS-only "spins forever", fixed by whitelisting `about:`
- react-native-webview #2567 — on v13.10.5 (~our 13.8.6), `['*']` did not cover `about:`; explicit `'about:'` required

## Testing
No local repro (no iOS device at fix time). Validate on a **captcha-on** iOS build: restore the preview `EXPO_PUBLIC_TURNSTILE_SITE_KEY` env var, then `eas build -p ios --profile preview` — expect the widget to resolve and the submit button to enable.

Refs #405