### PR TITLE
chore(core): promote categorizeShot to @oga/core (#206)

### DIFF
--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef } from 'react'
+import type { ShotMarkerCategory } from '@oga/core'
 import { MAPBOX_TOKEN_PRESENT } from '../../lib/mapbox'
 import { useMapSetup } from './map/useMapSetup'
 import { useMapLayers } from './map/useMapLayers'
@@ -33,7 +34,7 @@ export interface ExistingShot {
   startLng: number | null
   aimLat?: number | null
   aimLng?: number | null
-  category?: 'tee' | 'approach' | 'around-green' | 'putt' | null
+  category?: ShotMarkerCategory | null
 }
 
 export interface PlacedPoint {

--- a/apps/web/src/pages/rounds/hooks/useRoundData.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import type { Database } from '@oga/supabase'
-import { getShotCategory } from '@oga/core'
+import { getShotMarkerCategory, type LieType } from '@oga/core'
 import type {
   ExistingShot,
   HoleGeo,
@@ -253,7 +253,14 @@ export function useRoundData({
         startLng: s.start_lng,
         aimLat: s.aim_lat,
         aimLng: s.aim_lng,
-        category: categorizeShot(s, activeHole?.par ?? 4),
+        category: getShotMarkerCategory(
+          {
+            lieType: (s.lie_type ?? undefined) as LieType | undefined,
+            distanceToTarget: s.distance_to_target ?? undefined,
+          },
+          activeHole?.par ?? 4,
+          s.shot_number,
+        ),
       }))
       .sort((a, b) => a.shotNumber - b.shotNumber)
   }, [activeHoleScore, shotsQuery.data, activeHole?.par])
@@ -284,37 +291,6 @@ export function useRoundData({
     missingHoleLayout,
     activeHoleShots,
   }
-}
-
-// Categorize a shot row for marker coloring on the map.
-function categorizeShot(
-  s: ShotRow,
-  par: number,
-): ExistingShot['category'] {
-  // Visual override: any tee-lie shot (incl. par 3) renders as a tee
-  // marker even though SG-wise par 3 tee shots count as approach.
-  if (s.lie_type === 'tee') return 'tee'
-  const cat = getShotCategory(
-    {
-      lieType:
-        (s.lie_type as
-          | 'tee'
-          | 'fairway'
-          | 'rough'
-          | 'sand'
-          | 'fringe'
-          | 'recovery'
-          | 'green'
-          | null) ?? undefined,
-      distanceToTarget: s.distance_to_target ?? undefined,
-    },
-    par,
-    s.shot_number,
-  )
-  if (cat === 'putting') return 'putt'
-  if (cat === 'around_green') return 'around-green'
-  if (cat === 'off_tee') return 'tee'
-  return 'approach'
 }
 
 export type { RoundRow }

--- a/packages/core/src/__tests__/shotMarkerCategory.test.ts
+++ b/packages/core/src/__tests__/shotMarkerCategory.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { getShotMarkerCategory } from '../sg-calculator'
+
+describe('getShotMarkerCategory', () => {
+  it('renders any tee-lie shot as a tee marker, even on a par 3', () => {
+    expect(getShotMarkerCategory({ lieType: 'tee', distanceToTarget: 160 }, 3, 1)).toBe('tee')
+  })
+
+  it('maps a green lie to a putt marker', () => {
+    expect(getShotMarkerCategory({ lieType: 'green', distanceToTarget: 5 }, 4, 3)).toBe('putt')
+  })
+
+  it('maps a near-green shot (≤ 30 yd) to around-green', () => {
+    expect(getShotMarkerCategory({ lieType: 'fringe', distanceToTarget: 20 }, 4, 3)).toBe('around-green')
+  })
+
+  it('maps a par-4 first shot off a non-tee lie to a tee marker (off_tee)', () => {
+    expect(getShotMarkerCategory({ lieType: 'fairway', distanceToTarget: 400 }, 4, 1)).toBe('tee')
+  })
+
+  it('maps a mid-range non-tee shot to an approach marker', () => {
+    expect(getShotMarkerCategory({ lieType: 'fairway', distanceToTarget: 150 }, 4, 2)).toBe('approach')
+  })
+})

--- a/packages/core/src/sg-calculator.ts
+++ b/packages/core/src/sg-calculator.ts
@@ -24,6 +24,26 @@ export function getShotCategory(
   return 'approach'
 }
 
+/** Round-map marker category — the display vocabulary the map uses, distinct
+ *  from the SG `ShotCategory`. */
+export type ShotMarkerCategory = 'tee' | 'approach' | 'around-green' | 'putt'
+
+// Maps a shot to its round-map marker category. Any tee-lie shot renders as a
+// tee marker even on a par 3, where SG counts the tee shot as approach — the
+// marker reflects what the player sees, not the SG category.
+export function getShotMarkerCategory(
+  shot: Pick<Shot, 'lieType' | 'distanceToTarget'>,
+  par: number,
+  shotNumber: number,
+): ShotMarkerCategory {
+  if (shot.lieType === 'tee') return 'tee'
+  const cat = getShotCategory(shot, par, shotNumber)
+  if (cat === 'putting') return 'putt'
+  if (cat === 'around_green') return 'around-green'
+  if (cat === 'off_tee') return 'tee'
+  return 'approach'
+}
+
 export function getExpectedStrokes(
   category: ShotCategory,
   distanceYards: number | undefined,

--- a/packages/core/src/sg-calculator.ts
+++ b/packages/core/src/sg-calculator.ts
@@ -28,9 +28,9 @@ export function getShotCategory(
  *  from the SG `ShotCategory`. */
 export type ShotMarkerCategory = 'tee' | 'approach' | 'around-green' | 'putt'
 
-// Maps a shot to its round-map marker category. Any tee-lie shot renders as a
-// tee marker even on a par 3, where SG counts the tee shot as approach — the
-// marker reflects what the player sees, not the SG category.
+// Any tee-lie shot renders as a tee marker even on a par 3, where SG counts
+// the tee shot as approach — the marker reflects what the player sees, not the
+// SG category.
 export function getShotMarkerCategory(
   shot: Pick<Shot, 'lieType' | 'distanceToTarget'>,
   par: number,


### PR DESCRIPTION
## What

Promotes the round-map shot-marker categorization out of `useRoundData` into `@oga/core` as `getShotMarkerCategory`, and exports the `ShotMarkerCategory` display type so the marker vocabulary has one source of truth.

Last of the PR #204 `@oga/core` promotion follow-ups with real work left. The siblings (#195, #205, #207) were already shipped and have been closed as completed; #196 was closed as obsolete (superseded by #160).

## Changes

- `packages/core/src/sg-calculator.ts` — `getShotMarkerCategory()` + `ShotMarkerCategory` type, next to `getShotCategory`. Keeps the tee-lie display override (a tee-lie shot renders as a tee marker even on a par 3, where SG counts it as approach).
- `packages/core/src/__tests__/shotMarkerCategory.test.ts` — 5 cases.
- `apps/web/src/pages/rounds/hooks/useRoundData.ts` — calls the core fn; local `categorizeShot` removed.
- `apps/web/src/components/round/RoundMap.tsx` — `ExistingShot.category` now references `ShotMarkerCategory` instead of a duplicate literal union.

## Verification

- `pnpm --filter @oga/core test` — 389 passed (incl. 5 new)
- `pnpm typecheck` — clean across core / supabase / web

Closes #206.