### PR TITLE
feat(learn): final two articles — practice vs scoring round + fittings with a coach

### DIFF
--- a/apps/web/src/pages/learn/articles/FittingsWithCoachesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/FittingsWithCoachesArticle.tsx
@@ -1,0 +1,425 @@
+import type { CSSProperties, ReactNode } from 'react'
+
+export function FittingsWithCoachesArticle() {
+  return (
+    <article
+      id="fittings-with-coaches"
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 22,
+        marginBottom: 32,
+      }}
+    >
+      <div className="kicker" style={{ marginBottom: 14 }}>
+        Working with coaches · Draft
+      </div>
+      <h2
+        className="font-serif text-caddie-ink"
+        style={{
+          fontSize: 28,
+          fontWeight: 500,
+          fontStyle: 'italic',
+          letterSpacing: '-0.015em',
+          lineHeight: 1.15,
+          marginBottom: 18,
+        }}
+      >
+        A lesson changes the swing; a fitting fits it.
+      </h2>
+
+      <P>
+        The equipment guide on <em>golf fittings</em> covers what each fitting
+        measures and changes — driver, irons, wedges, putter, shaft, and ball —
+        and when each one is worth the money. This is the companion question from
+        the coaching side: who should fit you, how a fitting fits into working
+        with a coach, and how to time it so you're not fitting expensive
+        equipment to a swing you're about to change. The two appointments are
+        easy to confuse, and treating them as one is how golfers waste both.
+      </P>
+
+      <FitterTable />
+
+      <Hr />
+
+      <H3>Two different appointments</H3>
+      <P>
+        A lesson tries to change your swing. A fitting fits clubs to the swing
+        you actually have today — not the one you're hoping to build. That's the
+        line that confuses people: they want to "fix the slice first, then get
+        fit," and end up playing ill-fitting clubs for a year while they chase a
+        swing change.
+      </P>
+      <P>
+        The better order is usually the opposite. Properly fit equipment fits the
+        swing you bring tomorrow, and when you stop compensating for the wrong
+        gear, a coach's changes often come <em>faster</em>. Unless you are a brand
+        new golfer with nothing stable to measure, "fix it first" is mostly
+        backward — get fit to your current swing, then let lessons move it, and
+        re-check the specs when the swing has genuinely changed.
+      </P>
+
+      <Hr />
+
+      <H3>Who's actually fitting you</H3>
+      <P>
+        Not all fittings come from the same chair, and the chair matters. Three
+        people might fit you, and their incentives are not identical:
+      </P>
+      <ul style={UL_STYLE}>
+        <li>
+          <strong>Your coach or instructor.</strong> Already knows your typical
+          miss, your goals, and the change you're in the middle of. A fitting
+          run by — or coordinated with — your coach starts with all of that
+          context instead of a blank sheet. The catch: not every teaching pro is
+          a trained fitter, so ask what tools and data they actually use.
+        </li>
+        <li>
+          <strong>An independent fitter.</strong> Carries multiple brands and
+          gets paid for the fitting, not the badge on the head, so the
+          recommendation is brand-neutral. The catch: they meet you cold and only
+          see the swing you bring that hour — tell them what you're working on so
+          they don't fit you to a temporary flaw.
+        </li>
+        <li>
+          <strong>A brand (OEM) fitter.</strong> Deep on one manufacturer's
+          lineup and often free, which is great if you already want that brand.
+          The catch: the answer will be that brand, so treat it as fitting{' '}
+          <em>within</em> a line you've chosen, not an open comparison.
+        </li>
+      </ul>
+      <P>
+        The strongest setup is a team that talks. The Titleist Performance
+        Institute model makes this explicit — coach, fitness, and fitting aligned
+        on the same goals — and most club fitters, left alone, have no idea what
+        your instructor is trying to build. You are the one who has to connect
+        them.
+      </P>
+
+      <Hr />
+
+      <H3>Time it around your swing, not against it</H3>
+      <P>
+        The "fit the swing you have" rule has a wrinkle worth getting right.
+        Real swing changes are usually incremental and ongoing, not a single
+        overhaul on a Tuesday — so there is rarely a perfect "finished" moment to
+        fit. Waiting for one mostly means playing bad gear forever.
+      </P>
+      <P>
+        The actual danger is narrow: getting fit cold, in the middle of a major
+        rebuild, to a swing you're about to abandon. Avoid it with coordination,
+        not delay. Tell your coach before you book a fitting, and tell the fitter
+        what you're working on — a degree of lie or a shaft profile can either
+        support a change your coach is making or quietly fight it, and only the
+        two of them together can tell which.
+      </P>
+
+      <Hr />
+
+      <H3>The body comes first</H3>
+      <P>
+        Before the launch monitor, the right spec depends on what your body can
+        actually do. The textbook lie angle, shaft, and length assume a range of
+        motion you may or may not have; a mobility limit in the hips or shoulders
+        can make the "standard" recommendation wrong for you. This is the
+        body-swing connection the Titleist Performance Institute built its
+        certification around — a physical screen that correlates how you move
+        with how you should be fit and coached. A good coach-led fitting starts
+        there, not at the driver.
+      </P>
+
+      <Callout>
+        <strong>The one move:</strong> loop your coach in before you book the
+        fitting, and tell the fitter the exact change you're working on. A
+        fitting done in a vacuum optimizes launch and spin for one hour's swing;
+        a fitting that knows your coach's plan optimizes for the player you're
+        becoming.
+      </Callout>
+
+      <H3>Red flags</H3>
+      <P>
+        A coach-coordinated fitting should make your equipment quieter, not your
+        wallet lighter. Walk if you see these:
+      </P>
+      <ul style={UL_STYLE}>
+        <li>
+          <strong>A "fitting" that only ever lands on one brand</strong> — or one
+          that never asks what you currently play or what you're working on.
+        </li>
+        <li>
+          <strong>Gear pushed in the middle of a lesson.</strong> A purchase is a
+          separate appointment; your most expensive coaching minutes shouldn't go
+          to a sales pitch.
+        </li>
+        <li>
+          <strong>"Buy these and your slice is gone."</strong> Equipment can
+          remove a fight against your gear; it can't install a swing change. If
+          someone promises clubs will fix mechanics, they're selling, not
+          fitting.
+        </li>
+      </ul>
+
+      <P>
+        Get the order and the team right — body first, fit the swing you have,
+        coach and fitter on the same page — and a fitting stops being a gamble on
+        gear and becomes part of the same plan as your lessons.
+      </P>
+
+      <Sources />
+
+      <Footer />
+    </article>
+  )
+}
+
+const UL_STYLE: CSSProperties = {
+  listStyle: 'disc',
+  paddingLeft: 22,
+  maxWidth: 640,
+  marginBottom: 14,
+  fontSize: 15,
+  lineHeight: 1.6,
+  color: '#1C211C',
+}
+
+function H3({ children }: { children: ReactNode }) {
+  return (
+    <h3
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 22,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        lineHeight: 1.2,
+        marginBottom: 12,
+      }}
+    >
+      {children}
+    </h3>
+  )
+}
+
+function P({ children }: { children: ReactNode }) {
+  return (
+    <p
+      className="text-caddie-ink"
+      style={{ fontSize: 15, lineHeight: 1.6, maxWidth: 640, marginBottom: 14 }}
+    >
+      {children}
+    </p>
+  )
+}
+
+function Hr() {
+  return <div style={{ borderTop: '1px solid #D9D2BF', margin: '0 0 18px' }} />
+}
+
+// The three people who might fit you, set against the two things that actually
+// distinguish them — context and brand-neutrality — plus when each is the right
+// chair. Leads the article because the choice of fitter frames everything after.
+function FitterTable() {
+  const rows: { who: string; knows: string; neutral: string; best: string }[] = [
+    {
+      who: 'Your coach',
+      knows: 'Knows your swing & plan',
+      neutral: 'Depends on their tools',
+      best: "When you're mid-change",
+    },
+    {
+      who: 'Independent',
+      knows: 'Meets you cold',
+      neutral: 'Brand-neutral',
+      best: 'For an open comparison',
+    },
+    {
+      who: 'Brand (OEM)',
+      knows: 'Meets you cold',
+      neutral: 'One brand only',
+      best: "Once you've picked a brand",
+    },
+  ]
+  return (
+    <div
+      style={{
+        background: '#EBE5D6',
+        border: '1px solid #D9D2BF',
+        borderRadius: 2,
+        padding: '14px 18px',
+        maxWidth: 640,
+        marginBottom: 18,
+      }}
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '96px 1fr',
+          gap: '0 14px',
+        }}
+      >
+        {rows.map((r, i) => (
+          <Row key={r.who} first={i === 0} {...r} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Row({
+  who,
+  knows,
+  neutral,
+  best,
+  first,
+}: {
+  who: string
+  knows: string
+  neutral: string
+  best: string
+  first: boolean
+}) {
+  const wrap: CSSProperties = {
+    paddingTop: first ? 0 : 10,
+    marginTop: first ? 0 : 10,
+    borderTop: first ? 'none' : '1px solid #D9D2BF',
+  }
+  return (
+    <>
+      <div
+        className="font-serif text-caddie-ink"
+        style={{ ...wrap, fontSize: 15, fontStyle: 'italic' }}
+      >
+        {who}
+      </div>
+      <div style={wrap}>
+        <div className="text-caddie-ink" style={{ fontSize: 14, lineHeight: 1.45 }}>
+          {knows} · {neutral}
+        </div>
+        <div
+          className="text-caddie-ink-dim"
+          style={{ fontSize: 13, lineHeight: 1.45, marginTop: 2 }}
+        >
+          Best: {best}
+        </div>
+      </div>
+    </>
+  )
+}
+
+// A how-to-apply takeaway lifted out of the prose so the single move is
+// scannable on its own.
+function Callout({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        background: '#EBE5D6',
+        borderLeft: '3px solid #1F3D2C',
+        padding: '14px 16px',
+        marginBottom: 18,
+        maxWidth: 680,
+      }}
+    >
+      <div className="text-caddie-ink" style={{ fontSize: 14, lineHeight: 1.55 }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Sources() {
+  return (
+    <section style={{ borderTop: '1px solid #D9D2BF', paddingTop: 18, marginTop: 22 }}>
+      <div className="kicker" style={{ marginBottom: 12 }}>
+        Sources
+      </div>
+      <div style={{ display: 'grid', gap: 14, maxWidth: 640 }}>
+        <div>
+          <SrcLabel>Fit the swing you have, don't wait to "fix" it</SrcLabel>
+          <SrcBody>
+            <Src href="https://golf.com/gear/fix-your-swing-club-fitting/">
+              GOLF.com · why fixing your swing before a fitting is backward
+            </Src>{' '}
+            and{' '}
+            <Src href="https://scramble.golftec.com/blog/2015/06/fit-vs-fix-should-i-get-fit-for-clubs-or-fix-my-swing/">
+              GolfTEC · fit vs fix
+            </Src>{' '}
+            — fit to your current swing; properly fit gear tends to speed a
+            change up, not wait on it.
+          </SrcBody>
+        </div>
+        <div>
+          <SrcLabel>Coach and fitter should be aligned</SrcLabel>
+          <SrcBody>
+            <Src href="https://www.mytpi.com/certification">
+              Titleist Performance Institute · the team approach
+            </Src>{' '}
+            and{' '}
+            <Src href="https://www.dennissalesgolf.com/golf-drills-and-practice-blogs/2025/3/18/why-you-should-get-fit-by-your-instructor-not-just-a-club-fitter">
+              why getting fit by your instructor matters
+            </Src>{' '}
+            — most fitters, left alone, don't know your coach's plan; the player
+            has to connect them.
+          </SrcBody>
+        </div>
+        <div>
+          <SrcLabel>Your body shapes the right spec</SrcLabel>
+          <SrcBody>
+            <Src href="https://www.titleist.com/fitting/golf-club-fitting/titleist-performance-institute">
+              Titleist Performance Institute · the body-swing connection
+            </Src>{' '}
+            — a physical screen correlates how you move with how you should be fit
+            and coached, so the fitting starts with the body, not the driver.
+          </SrcBody>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function SrcLabel({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="font-mono uppercase"
+      style={{ fontSize: 10, letterSpacing: '0.14em', color: '#5C6356', marginBottom: 4 }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function SrcBody({ children }: { children: ReactNode }) {
+  return (
+    <div className="text-caddie-ink-dim" style={{ fontSize: 13, lineHeight: 1.55 }}>
+      {children}
+    </div>
+  )
+}
+
+function Src({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{ color: '#1F3D2C', textDecoration: 'underline' }}
+    >
+      {children}
+    </a>
+  )
+}
+
+function Footer() {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 1.6,
+      }}
+    >
+      Last reviewed May 2026 · Draft, needs coaching review
+    </div>
+  )
+}

--- a/apps/web/src/pages/learn/articles/PracticeVsScoringRoundArticle.tsx
+++ b/apps/web/src/pages/learn/articles/PracticeVsScoringRoundArticle.tsx
@@ -46,8 +46,9 @@ export function PracticeVsScoringRoundArticle() {
       <P>
         A practice round is reconnaissance. You are not trying to shoot a number
         — you are gathering the information that lets you commit on the day it
-        counts. Tour caddies walk a course for days before an event doing
-        exactly this; you can get most of the value in one honest loop.
+        counts. It's what tour players spend the days before a tournament doing
+        — more on their method below — and you can get most of the value in a
+        single honest loop.
       </P>
       <ul style={UL_STYLE}>
         <li>
@@ -77,6 +78,88 @@ export function PracticeVsScoringRoundArticle() {
           expectation you'll carry to the first tee for no reason. Drop a second
           ball, try the riskier line, hole out for the read — the round is for
           learning, not for a number.
+        </li>
+      </ul>
+
+      <Hr />
+
+      <H3>How the pros do it</H3>
+      <P>
+        The gold standard for this lives on tour, and the logic scales down to
+        any golfer. Pros don't see a tournament course cold on Thursday — they
+        arrive days early and play practice rounds Monday and Tuesday, with
+        Wednesday's pro-am often serving as one last relaxed look. By the time
+        the first round counts, they've already made every decision the course
+        is going to ask of them.
+      </P>
+      <P>
+        Most of that work is reconnaissance, not swing practice. The caddie
+        scouts the course — sometimes separately from the player — pacing off
+        yardages to landing zones and to each pin area, logging the wind, and
+        recording the club, speed, and spin from shots hit along the way. All of
+        it goes into a yardage book built on top of the detailed base book the
+        event supplies, until the player has a hole-by-hole plan: the club off
+        each tee, the number to leave on each approach, and the side that can't
+        be short-sided. Crucially, they practice approaches to the actual hole
+        locations planned for the four tournament days — not to wherever the flag
+        happens to sit that morning.
+      </P>
+      <P>
+        Greens are the one place the rules recently pushed pros back toward doing
+        their own homework. Since 2022, golf's governing bodies have let
+        tournaments require an approved yardage book whose green diagrams show
+        only minimal detail — major slopes and tiers, not a full contour map —
+        and the only extra notes allowed are ones the player or caddie made from
+        watching a ball actually roll. Even the best players in the world now
+        have to earn their green reads in the practice round, which is exactly
+        what you should be doing anyway.
+      </P>
+
+      <Hr />
+
+      <H3>Borrow the method, skip the budget</H3>
+      <P>
+        You don't have a caddie, four days, or a closed golf course — but the
+        method shrinks to fit an ordinary tee time. The goal is unchanged: walk
+        off knowing the course so that nothing in your next scoring round is a
+        first-time surprise.
+      </P>
+      <ul style={UL_STYLE}>
+        <li>
+          <strong>Go when it's quiet.</strong> An early or twilight tee time, or
+          a slow midweek afternoon, lets you drop a second ball and experiment
+          without a group breathing down your neck. Reconnaissance needs room to
+          fail.
+        </li>
+        <li>
+          <strong>Keep a notebook.</strong> A phone note or a cheap yardage book
+          is plenty. One line per hole: a stock layup number and the one place
+          the ball can't go — "7th: lay back to 110, water long-right, bail
+          short-left." You'll have forgotten it by next week otherwise.
+        </li>
+        <li>
+          <strong>Rehearse the in-between yardages.</strong> Every course keeps
+          handing you the same awkward numbers — a 40-yard pitch, a 215-yard par
+          3, a layup that leaves three-quarter wedge. Hit those on purpose so
+          they're rehearsed instead of improvised under pressure.
+        </li>
+        <li>
+          <strong>Learn the big greens from every side.</strong> Lag a putt from
+          the front, the back, and each edge of the largest greens to feel the
+          speed and the two or three breaks that actually matter. Speed surprises
+          cost more strokes than misread line.
+        </li>
+        <li>
+          <strong>Practice the misses, not the makes.</strong> Chip and play
+          bunker shots from the spots you tend to short-side yourself, not the
+          comfortable ones — those are the shots that wreck a scoring round, so
+          meet them here first.
+        </li>
+        <li>
+          <strong>No time for a full loop? Do it in reverse.</strong> After an
+          ordinary round, jot three notes per nine while the holes are fresh.
+          A handful of rounds like that builds the same course knowledge a
+          dedicated practice round would, just spread out over time.
         </li>
       </ul>
 
@@ -360,6 +443,35 @@ function Sources() {
             </Src>{' '}
             — treating a practice round as a performance is how golfers carry
             scoring anxiety into a day that was supposed to lower it.
+          </SrcBody>
+        </div>
+        <div>
+          <SrcLabel>How tour players turn recon into a plan</SrcLabel>
+          <SrcBody>
+            <Src href="https://www.golfmonthly.com/features/5-secrets-of-the-players-open-yardage-book">
+              Golf Monthly · inside a tour player's yardage book
+            </Src>{' '}
+            and{' '}
+            <Src href="https://golfingfocus.com/what-do-pros-have-in-their-yardage-books-things-have-changed/">
+              Golfing Focus · what pros carry in their yardage books
+            </Src>{' '}
+            — caddies pace off pin-zone yardages and log wind, club, and spin in
+            practice rounds, building a hole-by-hole game plan before round one.
+          </SrcBody>
+        </div>
+        <div>
+          <SrcLabel>Even the pros earn their green reads in practice</SrcLabel>
+          <SrcBody>
+            <Src href="https://www.pgatour.com/article/news/ground-rules/2021/11/02/new-rule-will-limit-information-players-can-use-for-reading-greens-yardage-book-pga-tour">
+              PGA TOUR · the green-reading-materials rule (Model Local Rule G-11,
+              effective 2022)
+            </Src>{' '}
+            and{' '}
+            <Src href="https://www.golfdigest.com/story/usga-randa-approve-model-local-rule-to-limit-use-of-green-reading-materials">
+              Golf Digest · USGA and R&amp;A on the limit
+            </Src>{' '}
+            — approved books now show only minimal green detail, and any extra
+            notes must come from a player or caddie watching a ball roll.
           </SrcBody>
         </div>
       </div>

--- a/apps/web/src/pages/learn/articles/PracticeVsScoringRoundArticle.tsx
+++ b/apps/web/src/pages/learn/articles/PracticeVsScoringRoundArticle.tsx
@@ -1,0 +1,418 @@
+import type { CSSProperties, ReactNode } from 'react'
+
+export function PracticeVsScoringRoundArticle() {
+  return (
+    <article
+      id="practice-vs-scoring-round"
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 22,
+        marginBottom: 32,
+      }}
+    >
+      <div className="kicker" style={{ marginBottom: 14 }}>
+        On the course · Draft
+      </div>
+      <h2
+        className="font-serif text-caddie-ink"
+        style={{
+          fontSize: 28,
+          fontWeight: 500,
+          fontStyle: 'italic',
+          letterSpacing: '-0.015em',
+          lineHeight: 1.15,
+          marginBottom: 18,
+        }}
+      >
+        Decide which round you're playing.
+      </h2>
+
+      <P>
+        A practice round and a scoring round use the same eighteen holes, but
+        they are two different jobs — and trying to do both at once does neither
+        well. The guide on{' '}
+        <em>how to practice effectively</em> makes the distinction in a
+        sentence: one is for information, the other is for performance. This is
+        the on-course version — what each round is actually for, how to run a
+        real practice round instead of just a casual one, and why the rounds
+        that blur the line teach you the least.
+      </P>
+
+      <ModeTable />
+
+      <Hr />
+
+      <H3>What a practice round is actually for</H3>
+      <P>
+        A practice round is reconnaissance. You are not trying to shoot a number
+        — you are gathering the information that lets you commit on the day it
+        counts. Tour caddies walk a course for days before an event doing
+        exactly this; you can get most of the value in one honest loop.
+      </P>
+      <ul style={UL_STYLE}>
+        <li>
+          <strong>Hit driver off the tees you're unsure about.</strong> You
+          learn whether your driver actually reaches the fairway bunker or the
+          dogleg trouble. You can always dial back to a 3-wood in competition —
+          but only if you know what driver does first.
+        </li>
+        <li>
+          <strong>Find where you can't miss.</strong> On every approach, note
+          the side that leaves a dead chip or a ball in the water. Course
+          management is mostly knowing the one place the ball can't go; the
+          practice round is where you find it.
+        </li>
+        <li>
+          <strong>Putt from the spots you'll actually face.</strong> Roll a few
+          from each likely pin area to learn the speed and the big breaks. The
+          green is where rounds are won, and it reads differently than it looks.
+        </li>
+        <li>
+          <strong>Play a ball from the rough and a bunker.</strong> A shot or
+          two from the conditions you'll meet tells you how this course's turf
+          and sand behave before they surprise you under pressure.
+        </li>
+        <li>
+          <strong>Don't keep score.</strong> A score on a practice round sets an
+          expectation you'll carry to the first tee for no reason. Drop a second
+          ball, try the riskier line, hole out for the read — the round is for
+          learning, not for a number.
+        </li>
+      </ul>
+
+      <Hr />
+
+      <H3>What a scoring round demands</H3>
+      <P>
+        A scoring round is performance. One ball, every shot counts, and the
+        only job is to post the lowest number you can with the game you brought.
+        That means the opposite of the practice round on almost every count.
+      </P>
+      <ul style={UL_STYLE}>
+        <li>
+          <strong>Full routine on every shot.</strong> The same pre-shot
+          sequence, even on the throwaway ones. A consistent pre-shot routine is
+          one of the most reliably effective mental tools in the game — a
+          meta-analysis across sports found routines measurably improve
+          performance, and they help most precisely when the pressure is on and
+          the mind wants to wander.
+        </li>
+        <li>
+          <strong>Commit, then accept.</strong> Pick the shot, commit to it, and
+          take the result without relitigating it. The experimenting was supposed
+          to happen in the practice round; here, a half-committed swing is the
+          worst of both worlds.
+        </li>
+        <li>
+          <strong>One ball, no mulligans.</strong> The score only means something
+          if it's the score you actually made. Play it down, count everything,
+          move on.
+        </li>
+        <li>
+          <strong>Manage, don't experiment.</strong> Aim at the fat of the green,
+          favor the safe miss, and save the new shot you've been working on for
+          the range. Even tour players aim at the center, not the pin, for
+          anything longer than a short iron.
+        </li>
+      </ul>
+
+      <Hr />
+
+      <H3>Why mixing them costs you both</H3>
+      <P>
+        The common mistake isn't choosing the wrong mode — it's failing to
+        choose, and drifting through the round half in each. You take the round
+        seriously enough to feel the nerves, but loosely enough to drop a second
+        ball when one goes sideways. The result is the worst of both: the anxiety
+        of performance without a real score to show for it, and the freedom of
+        practice without any of the information.
+      </P>
+      <P>
+        It also quietly ruins your data. If you track rounds to find where your
+        game leaks strokes, a dropped second ball or a "let me just try the cut
+        here" poisons the signal — the round no longer reflects the decisions and
+        misses you'd actually make. A round is only worth measuring if it was
+        played honestly: one ball, full commitment, every stroke counted.
+      </P>
+
+      <Hr />
+
+      <H3>The casual round is neither — and that's the trap</H3>
+      <P>
+        Most weekend rounds are neither a true practice round nor a true scoring
+        round. That's completely fine — golf is supposed to be fun, and most of
+        the time the goal is a good walk with friends. The trap is mistaking a
+        steady diet of casual rounds for improvement work. A casual round gives
+        you neither clean recon nor a trustworthy score; it just gives you a
+        pleasant afternoon, which is its own reward but not a feedback loop.
+      </P>
+      <P>
+        If you actually want to get better, some of your rounds have to be
+        honestly one or the other: a recon loop where you experiment freely and
+        keep notes, or a committed scoring round you track without fudging. The
+        line between them is the whole point.
+      </P>
+
+      <Callout>
+        <strong>The one habit:</strong> before you hit the first tee shot, decide
+        out loud which round this is. "This is a practice round" or "I'm playing
+        this one for score" — said before you start — is what keeps you from
+        drifting into the half-committed middle where neither version pays off.
+      </Callout>
+
+      <P>
+        The skill in golf isn't only swinging the club; it's knowing which game
+        you're playing on any given day and committing to it fully. Pick one
+        before you tee off, and both your scores and your practice get sharper
+        for it.
+      </P>
+
+      <Sources />
+
+      <Footer />
+    </article>
+  )
+}
+
+const UL_STYLE: CSSProperties = {
+  listStyle: 'disc',
+  paddingLeft: 22,
+  maxWidth: 640,
+  marginBottom: 14,
+  fontSize: 15,
+  lineHeight: 1.6,
+  color: '#1C211C',
+}
+
+function H3({ children }: { children: ReactNode }) {
+  return (
+    <h3
+      className="font-serif text-caddie-ink"
+      style={{
+        fontSize: 22,
+        fontWeight: 500,
+        fontStyle: 'italic',
+        lineHeight: 1.2,
+        marginBottom: 12,
+      }}
+    >
+      {children}
+    </h3>
+  )
+}
+
+function P({ children }: { children: ReactNode }) {
+  return (
+    <p
+      className="text-caddie-ink"
+      style={{ fontSize: 15, lineHeight: 1.6, maxWidth: 640, marginBottom: 14 }}
+    >
+      {children}
+    </p>
+  )
+}
+
+function Hr() {
+  return <div style={{ borderTop: '1px solid #D9D2BF', margin: '0 0 18px' }} />
+}
+
+// The two rounds set side by side across the dimensions that actually differ —
+// the comparison is the article's thesis, so it leads before the prose.
+function ModeTable() {
+  const rows: { dim: string; practice: string; scoring: string }[] = [
+    { dim: 'The job', practice: 'Gather information', scoring: 'Post a number' },
+    { dim: 'Balls', practice: 'Drop extras, experiment', scoring: 'One ball, no mulligans' },
+    { dim: 'Routine', practice: 'Loose', scoring: 'Full, every shot' },
+    { dim: 'Risk', practice: 'Try the dangerous line', scoring: 'Favor the safe miss' },
+    { dim: 'Score', practice: "Don't keep it", scoring: 'Count everything' },
+    {
+      dim: 'Success is',
+      practice: 'Walking off knowing the course',
+      scoring: 'The lowest number you can',
+    },
+  ]
+  return (
+    <div
+      style={{
+        background: '#EBE5D6',
+        border: '1px solid #D9D2BF',
+        borderRadius: 2,
+        padding: '14px 18px',
+        maxWidth: 640,
+        marginBottom: 18,
+      }}
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '92px 1fr 1fr',
+          gap: '0 14px',
+          alignItems: 'baseline',
+        }}
+      >
+        <div />
+        <div className="kicker" style={{ color: '#5C6356' }}>
+          Practice round
+        </div>
+        <div className="kicker" style={{ color: '#5C6356' }}>
+          Scoring round
+        </div>
+        {rows.map((r, i) => (
+          <Row key={r.dim} first={i === 0} {...r} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Row({
+  dim,
+  practice,
+  scoring,
+  first,
+}: {
+  dim: string
+  practice: string
+  scoring: string
+  first: boolean
+}) {
+  const cell: CSSProperties = {
+    paddingTop: first ? 12 : 9,
+    marginTop: first ? 10 : 0,
+    borderTop: first ? '1px solid #D9D2BF' : 'none',
+  }
+  return (
+    <>
+      <div
+        className="font-serif text-caddie-ink"
+        style={{ ...cell, fontSize: 13, fontStyle: 'italic' }}
+      >
+        {dim}
+      </div>
+      <div className="text-caddie-ink" style={{ ...cell, fontSize: 13, lineHeight: 1.45 }}>
+        {practice}
+      </div>
+      <div className="text-caddie-ink" style={{ ...cell, fontSize: 13, lineHeight: 1.45 }}>
+        {scoring}
+      </div>
+    </>
+  )
+}
+
+// A how-to-apply takeaway lifted out of the prose so the single decision is
+// scannable on its own.
+function Callout({ children }: { children: ReactNode }) {
+  return (
+    <div
+      style={{
+        background: '#EBE5D6',
+        borderLeft: '3px solid #1F3D2C',
+        padding: '14px 16px',
+        marginBottom: 18,
+        maxWidth: 680,
+      }}
+    >
+      <div className="text-caddie-ink" style={{ fontSize: 14, lineHeight: 1.55 }}>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function Sources() {
+  return (
+    <section style={{ borderTop: '1px solid #D9D2BF', paddingTop: 18, marginTop: 22 }}>
+      <div className="kicker" style={{ marginBottom: 12 }}>
+        Sources
+      </div>
+      <div style={{ display: 'grid', gap: 14, maxWidth: 640 }}>
+        <div>
+          <SrcLabel>A practice round is recon, not a score</SrcLabel>
+          <SrcBody>
+            <Src href="https://www.pga.com/story/prioritize-your-practice-sessions-to-prepare-for-a-big-golf-tournament">
+              PGA of America · preparing for a tournament
+            </Src>{' '}
+            and{' '}
+            <Src href="https://golfstateofmind.com/course-management-lessons-from-the-pga-tour/">
+              Golf State of Mind · course-management lessons from the PGA Tour
+            </Src>{' '}
+            — hit driver to learn the trouble, find the no-go side, default to
+            the center of the green, and keep score out of it.
+          </SrcBody>
+        </div>
+        <div>
+          <SrcLabel>Pre-shot routines help most under pressure</SrcLabel>
+          <SrcBody>
+            <Src href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2021.1944271">
+              International Review of Sport &amp; Exercise Psychology (2021) ·
+              meta-analysis of pre-performance routines
+            </Src>{' '}
+            — a consistent routine produces a measurable performance benefit, and
+            it matters most when the pressure invites distraction.
+          </SrcBody>
+        </div>
+        <div>
+          <SrcLabel>Why the practice mindset is a separate gear</SrcLabel>
+          <SrcBody>
+            <Src href="https://www.sportspsychologygolf.com/how-to-think-about-practice-rounds-in-golf/">
+              Golf Psychology (Dr. Patrick Cohn) · how to think about practice
+              rounds
+            </Src>{' '}
+            — treating a practice round as a performance is how golfers carry
+            scoring anxiety into a day that was supposed to lower it.
+          </SrcBody>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function SrcLabel({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="font-mono uppercase"
+      style={{ fontSize: 10, letterSpacing: '0.14em', color: '#5C6356', marginBottom: 4 }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function SrcBody({ children }: { children: ReactNode }) {
+  return (
+    <div className="text-caddie-ink-dim" style={{ fontSize: 13, lineHeight: 1.55 }}>
+      {children}
+    </div>
+  )
+}
+
+function Src({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{ color: '#1F3D2C', textDecoration: 'underline' }}
+    >
+      {children}
+    </a>
+  )
+}
+
+function Footer() {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 1.6,
+      }}
+    >
+      Last reviewed May 2026 · Draft, needs review
+    </div>
+  )
+}

--- a/apps/web/src/pages/learn/data/articleRegistry.ts
+++ b/apps/web/src/pages/learn/data/articleRegistry.ts
@@ -1,6 +1,7 @@
 import type { ComponentType } from 'react'
 import { BuildingYourBagArticle } from '../articles/BuildingYourBagArticle'
 import { CourseManagementArticle } from '../articles/CourseManagementArticle'
+import { FittingsWithCoachesArticle } from '../articles/FittingsWithCoachesArticle'
 import { GlossaryArticle } from '../articles/GlossaryArticle'
 import { GuideToFittingsArticle } from '../articles/GuideToFittingsArticle'
 import { HowToPracticeArticle } from '../articles/HowToPracticeArticle'
@@ -9,6 +10,7 @@ import { MeasurableGoalsArticle } from '../articles/MeasurableGoalsArticle'
 import { MentalGameArticle } from '../articles/MentalGameArticle'
 import { Operation36Article } from '../articles/Operation36Article'
 import { PracticeModesArticle } from '../articles/PracticeModesArticle'
+import { PracticeVsScoringRoundArticle } from '../articles/PracticeVsScoringRoundArticle'
 import { QuestionsForCoachArticle } from '../articles/QuestionsForCoachArticle'
 import { ReadingStatsArticle } from '../articles/ReadingStatsArticle'
 import { SelfDiagnosisArticle } from '../articles/SelfDiagnosisArticle'
@@ -37,6 +39,8 @@ const ARTICLE_COMPONENTS: Record<string, ComponentType> = {
   'questions-for-coach': QuestionsForCoachArticle,
   'swing-variations': SwingVariationsArticle,
   'understanding-your-swing': UnderstandingYourSwingArticle,
+  'practice-vs-scoring-round': PracticeVsScoringRoundArticle,
+  'fittings-with-coaches': FittingsWithCoachesArticle,
 }
 
 export function getArticleComponent(slug: string): ComponentType | null {

--- a/packages/core/src/learn.ts
+++ b/packages/core/src/learn.ts
@@ -163,7 +163,7 @@ export const LEARN_SECTIONS: LearnSection[] = [
         title: 'Practice round vs scoring round',
         description: 'Two different activities you should never mix.',
         status: 'draft',
-        words: 1050,
+        words: 1700,
       },
       {
         id: 'self-diagnosis',

--- a/packages/core/src/learn.ts
+++ b/packages/core/src/learn.ts
@@ -162,7 +162,8 @@ export const LEARN_SECTIONS: LearnSection[] = [
         id: 'practice-vs-scoring-round',
         title: 'Practice round vs scoring round',
         description: 'Two different activities you should never mix.',
-        status: 'soon',
+        status: 'draft',
+        words: 1050,
       },
       {
         id: 'self-diagnosis',
@@ -188,9 +189,10 @@ export const LEARN_SECTIONS: LearnSection[] = [
       },
       {
         id: 'fittings-with-coaches',
-        title: 'Guide to golf fittings (all types)',
-        description: 'Driver, iron, wedge, putter — what each fitting covers.',
-        status: 'soon',
+        title: 'Fittings and your coach',
+        description: 'Who should fit you, and timing a fitting around your lessons.',
+        status: 'draft',
+        words: 1000,
       },
       {
         id: 'questions-for-coach',


### PR DESCRIPTION
Builds the last two `soon` Learn-catalog stubs as drafts. **This completes the Learn catalog — no `soon` articles remain.**

## Articles

**`practice-vs-scoring-round`** (Section 4 · On the course)
The on-course companion to the `how-to-practice` "practice round vs scoring round" H3 (which is a ~250-word primer). Covers what each round is actually for, how to run a real practice round (recon, not a score), why mixing them costs both your score and your tracked data, and the casual-round trap. Leads with a two-mode comparison table.

**`fittings-with-coaches`** (Section 5 · Working with coaches) — re-scoped
The original stub scope ("Driver, iron, wedge, putter — what each fitting covers") was already **fully covered** by the existing `guide-to-fittings` article's "The six fittings, and what each one changes" section. Rather than duplicate, this is re-scoped to the *coaching-relationship* angle: who should fit you (coach / independent / OEM), timing a fitting around swing changes, the body-first TPI model, and keeping coach and fitter aligned. Catalog `title`/`description` updated to match the new scope.

## Mechanics
- Two new self-contained components in `apps/web/src/pages/learn/articles/`.
- Both registered in `articleRegistry.ts`.
- Both flipped `soon → draft` in `packages/core/src/learn.ts` (+ `words`); fittings entry also re-titled/re-described.
- `pnpm typecheck` clean; `pnpm --filter @oga/core test` green (389 tests, `learn.test.ts` included).

## Sourcing
Each article carries a Sources block with recognized authorities — PGA of America, a peer-reviewed pre-performance-routine meta-analysis, and Golf Psychology for the practice/scoring article; Titleist Performance Institute, GOLF.com, and GolfTEC for the fittings article.

Both ship as **draft** and stay draft until accuracy sign-off (footer says so).