### PR TITLE
feat(web): scorecard share via Web Share API, download fallback (#201)

### DIFF
--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -435,16 +435,12 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
     }
   }, [round.data, courseId, user, profile.data?.handicap_index, completeMutation, setCompleteError])
 
-  // Pre-rasterise the off-screen ShareableScorecardCard so the share
-  // handler can hand `navigator.share()` a ready Blob with NO awaited
-  // work in between the click and the share() call. The Web Share API
-  // needs a live user-activation token; an `await` inside the click
-  // handler expires that token on iOS Safari, so the capture has to
-  // already be done by click time. The card lives absolutely-positioned
-  // far off the left edge (the user never sees it) purely to give the
-  // rasteriser a real DOM node. 2x pixel ratio = crisp on retina without
-  // ballooning the file for group-chat shares. Recaptures whenever the
-  // round data or the light/dark tone changes so the Blob is never stale.
+  // Pre-rasterise the off-screen ShareableScorecardCard to a Blob so the
+  // share handler can hand `navigator.share()` a ready file with NO
+  // awaited work between the click and the share() call: the Web Share
+  // API needs a live user-activation token, and an `await` inside the
+  // click handler expires that token on iOS Safari. 2x pixel ratio keeps
+  // it crisp on retina without ballooning the file for group-chat shares.
   const shareBlobRef = useRef<Blob | null>(null)
   useEffect(() => {
     const node = shareCardRef.current
@@ -464,7 +460,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
     return () => {
       cancelled = true
     }
-  }, [shareCardRef, round.data, shareTone])
+  }, [round.data, shareTone])
 
   // Open the native share sheet (Web Share API) with the scorecard PNG,
   // falling back to a download where file-sharing isn't supported (most
@@ -491,7 +487,10 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
           backgroundColor: shareTone === 'dark' ? '#1C211C' : '#FBF8F1',
         })
       }
-      if (!blob) return
+      // toBlob resolves null (rather than throwing) when rasterisation
+      // fails — surface it through the same path as other share errors
+      // instead of a silent no-op.
+      if (!blob) throw new Error('Could not render the scorecard image.')
 
       const file = new File([blob], filename, { type: 'image/png' })
       if (typeof navigator.share === 'function' && navigator.canShare?.({ files: [file] })) {

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -1,9 +1,9 @@
-import { useCallback, type Dispatch, type RefObject } from 'react'
+import { useCallback, useEffect, useRef, type Dispatch, type RefObject } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQueryClient } from '@tanstack/react-query'
 import type { User } from '@supabase/supabase-js'
 import type { Database } from '@oga/supabase'
-import { toPng } from 'html-to-image'
+import { toBlob } from 'html-to-image'
 import {
   combinedPuttResult,
   DEFAULT_HANDICAP,
@@ -435,30 +435,84 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
     }
   }, [round.data, courseId, user, profile.data?.handicap_index, completeMutation, setCompleteError])
 
-  // Capture the off-screen ShareableScorecardCard via html-to-image and
-  // trigger a browser download. The card is rendered absolutely-
-  // positioned far off the left edge so the user never sees it; it
-  // exists only to hand a real DOM node to the rasteriser. 2x pixel
-  // ratio gives crisp output on retina screens without ballooning the
-  // file size for group-chat shares.
+  // Pre-rasterise the off-screen ShareableScorecardCard so the share
+  // handler can hand `navigator.share()` a ready Blob with NO awaited
+  // work in between the click and the share() call. The Web Share API
+  // needs a live user-activation token; an `await` inside the click
+  // handler expires that token on iOS Safari, so the capture has to
+  // already be done by click time. The card lives absolutely-positioned
+  // far off the left edge (the user never sees it) purely to give the
+  // rasteriser a real DOM node. 2x pixel ratio = crisp on retina without
+  // ballooning the file for group-chat shares. Recaptures whenever the
+  // round data or the light/dark tone changes so the Blob is never stale.
+  const shareBlobRef = useRef<Blob | null>(null)
+  useEffect(() => {
+    const node = shareCardRef.current
+    if (!node || !round.data) return
+    let cancelled = false
+    toBlob(node, {
+      pixelRatio: 2,
+      cacheBust: true,
+      backgroundColor: shareTone === 'dark' ? '#1C211C' : '#FBF8F1',
+    })
+      .then((blob) => {
+        if (!cancelled) shareBlobRef.current = blob
+      })
+      .catch(() => {
+        if (!cancelled) shareBlobRef.current = null
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [shareCardRef, round.data, shareTone])
+
+  // Open the native share sheet (Web Share API) with the scorecard PNG,
+  // falling back to a download where file-sharing isn't supported (most
+  // desktop Firefox, older browsers) or if share() fails for any reason
+  // other than the user dismissing the sheet.
   const handleShare = useCallback(async () => {
-    if (!shareCardRef.current || sharing) return
+    if (sharing) return
     setSharing(true)
     try {
-      const dataUrl = await toPng(shareCardRef.current, {
-        pixelRatio: 2,
-        cacheBust: true,
-        backgroundColor: shareTone === 'dark' ? '#1C211C' : '#FBF8F1',
-      })
       const courseSlug = (round.data?.courses?.name ?? 'round')
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/(^-|-$)/g, '')
       const date = round.data?.played_at ?? 'unknown-date'
+      const filename = `${courseSlug}-${date}-scorecard.png`
+
+      // Prefer the pre-captured Blob (keeps the gesture token alive). Only
+      // fall back to a fresh capture if the effect hasn't produced one yet.
+      let blob = shareBlobRef.current
+      if (!blob && shareCardRef.current) {
+        blob = await toBlob(shareCardRef.current, {
+          pixelRatio: 2,
+          cacheBust: true,
+          backgroundColor: shareTone === 'dark' ? '#1C211C' : '#FBF8F1',
+        })
+      }
+      if (!blob) return
+
+      const file = new File([blob], filename, { type: 'image/png' })
+      if (typeof navigator.share === 'function' && navigator.canShare?.({ files: [file] })) {
+        try {
+          await navigator.share({ files: [file], title: 'OGA Scorecard' })
+          return
+        } catch (err) {
+          // User dismissed the sheet — not an error worth surfacing.
+          if ((err as Error).name === 'AbortError') return
+          // Any other share failure → fall through to the download path.
+        }
+      }
+
+      // Download fallback. Build the object URL from the same Blob and
+      // revoke it once the download has had a tick to start.
+      const url = URL.createObjectURL(blob)
       const link = document.createElement('a')
-      link.href = dataUrl
-      link.download = `${courseSlug}-${date}-scorecard.png`
+      link.href = url
+      link.download = filename
       link.click()
+      setTimeout(() => URL.revokeObjectURL(url), 1000)
     } catch (err) {
       setCompleteError(toUserMessage(err))
     } finally {


### PR DESCRIPTION
## What

Switches the web scorecard share from auto-download to the **native share sheet** (Web Share API), with a download fallback. Implements #201.

Scope is **web-only** — mobile already opened the native sheet via `expo-sharing` (`apps/mobile/app/(app)/round/[id]/index.tsx`), so that half of #201 was already done.

## How

One file changed: `apps/web/src/pages/rounds/hooks/useRoundActions.ts`.

- **Pre-capture into a ref.** A `useEffect` rasterises the off-screen scorecard card to a `Blob` (via `html-to-image` `toBlob`) and stores it in a ref, recapturing whenever the round data or the light/dark tone toggle changes. This lets `handleShare` call `navigator.share()` with **no awaited work between the click and the share call** — the Web Share API needs a live user-activation token, and an `await` in the handler expires it on iOS Safari.
- **Share, then fall back.** When `navigator.canShare?.({ files: [file] })` is true → `navigator.share({ files, title })`. `AbortError` (user dismissed the sheet) is silent. On unsupported browsers (e.g. desktop Firefox) or any non-dismissal failure → the existing download path, rebuilt from the same `Blob` via `URL.createObjectURL` (revoked after a tick). The `${courseSlug}-${date}-scorecard.png` filename is preserved.
- If the pre-captured blob isn't ready yet, a fresh `await toBlob` capture covers it (download fallback path; gesture risk only applies there).

## Verification

- ✅ `pnpm typecheck` — `navigator.canShare` / `share({ files })` compile with no assertions.
- ✅ `pnpm --filter web lint`
- ✅ `pnpm --filter web build`

## Testing notes

⚠️ **No automated coverage.** Web Share is gesture-gated and the e2e env is desktop Chromium, so this can't be driven headless. **iOS Safari is the key manual-QA target** (it's where mobile-web native share matters most and where the gesture-token handling is exercised). Desktop Chrome/Edge/Safari and Android Chrome should show the native sheet; desktop Firefox should fall back to download.

Implements #201.