### PR TITLE
feat(web): Shot Patterns 1200×630 share card with native share (#374)

### DIFF
--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -72,8 +72,10 @@ export function ShotPatternsPage() {
     setExporting(true)
     setExportError(null)
     try {
-      // Mount the card on first export, then wait a paint for it to lay out
-      // before rasterising.
+      // The card is normally pre-mounted on the Export button's pointer-enter
+      // / focus (below), so the ref is ready here and the iOS share gesture
+      // token stays intact. Fallback: if a fast tap beat the mount, mount now
+      // and wait a paint — this rare path may forfeit the token (→ download).
       if (!shareCardRef.current) {
         setShowShareCard(true)
         await new Promise<void>((resolve) =>
@@ -200,6 +202,8 @@ export function ShotPatternsPage() {
               <button
                 type="button"
                 onClick={handleExport}
+                onPointerEnter={() => setShowShareCard(true)}
+                onFocus={() => setShowShareCard(true)}
                 disabled={exporting}
                 className="text-caddie-accent hover:bg-caddie-accent/10 disabled:opacity-40"
                 style={{

--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -55,6 +55,9 @@ export function ShotPatternsPage() {
   const shareCardRef = useRef<HTMLDivElement | null>(null)
   const [exporting, setExporting] = useState(false)
   const [exportError, setExportError] = useState<string | null>(null)
+  // Off-screen share card mounts lazily on first export so it isn't laid out
+  // on every club-chip re-render for users who never share.
+  const [showShareCard, setShowShareCard] = useState(false)
 
   // Rasterise the off-screen 1200×630 share card and open the native
   // share sheet (Web Share API), falling back to a download where file
@@ -65,11 +68,20 @@ export function ShotPatternsPage() {
   // the `await` before share() can expire the iOS-Safari gesture token —
   // in which case it simply degrades to the download path (same PNG).
   async function handleExport() {
-    const node = shareCardRef.current
-    if (!node || exporting) return
+    if (exporting) return
     setExporting(true)
     setExportError(null)
     try {
+      // Mount the card on first export, then wait a paint for it to lay out
+      // before rasterising.
+      if (!shareCardRef.current) {
+        setShowShareCard(true)
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        )
+      }
+      const node = shareCardRef.current
+      if (!node) throw new Error('share card not ready')
       const blob = await toBlob(node, {
         width: SHARE_CARD_W,
         height: SHARE_CARD_H,
@@ -96,7 +108,11 @@ export function ShotPatternsPage() {
       const link = document.createElement('a')
       link.href = url
       link.download = filename
+      // Firefox and older Safari only honour downloads from an anchor that's
+      // attached to the document; a detached element silently no-ops.
+      document.body.appendChild(link)
       link.click()
+      document.body.removeChild(link)
       setTimeout(() => URL.revokeObjectURL(url), 1000)
     } catch {
       setExportError('Could not export the image. Try again.')
@@ -363,7 +379,7 @@ export function ShotPatternsPage() {
       {/* Off-screen render target for the 1200×630 share card. Self-
           contained inline styles so the rasteriser needs no external
           stylesheet at capture time. */}
-      {stats && (
+      {showShareCard && stats && (
         <div
           aria-hidden
           style={{

--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
+import { toBlob } from 'html-to-image'
 import {
   CLUBS,
   LIE_TYPES,
@@ -13,13 +14,22 @@ import {
 import { useShotPatterns } from '../../hooks/useShotPatterns'
 import { LieSlopeGrid } from '../../components/forms/LieSlopeGrid'
 import { useUnits } from '../../hooks/useUnits'
-
-const SVG_SIZE = 420
-const SVG_VIEW_WIDTH = `min(${SVG_SIZE}px, 90vw)`
+import {
+  DispersionPlot,
+  pointColor,
+  SVG_VIEW_WIDTH,
+} from './components/DispersionPlot'
+import { ShotPatternsShareCard } from './components/ShotPatternsShareCard'
 
 const FLIGHT_W = 460
 const FLIGHT_H = 520
 const FLIGHT_VIEW_WIDTH = `min(${FLIGHT_W}px, 92vw)`
+
+// Social share card — 1200×630 is Twitter/Facebook's preferred OG image
+// size. Rendered off-screen, rasterised on Export. The plot inside is
+// drawn at a fixed pixel size so the capture is viewport-independent.
+const SHARE_CARD_W = 1200
+const SHARE_CARD_H = 630
 
 export function ShotPatternsPage() {
   const { unit, toDisplay } = useUnits()
@@ -41,6 +51,59 @@ export function ShotPatternsPage() {
 
   const points = data?.points ?? []
   const stats = data?.stats ?? null
+
+  const shareCardRef = useRef<HTMLDivElement | null>(null)
+  const [exporting, setExporting] = useState(false)
+  const [exportError, setExportError] = useState<string | null>(null)
+
+  // Rasterise the off-screen 1200×630 share card and open the native
+  // share sheet (Web Share API), falling back to a download where file
+  // sharing isn't supported or the share fails for any reason other than
+  // the user dismissing the sheet. Captures on click rather than ahead of
+  // time: the card is heavy and the club filter changes often, so
+  // pre-rasterising on every chip tap would be wasteful. The cost is that
+  // the `await` before share() can expire the iOS-Safari gesture token —
+  // in which case it simply degrades to the download path (same PNG).
+  async function handleExport() {
+    const node = shareCardRef.current
+    if (!node || exporting) return
+    setExporting(true)
+    setExportError(null)
+    try {
+      const blob = await toBlob(node, {
+        width: SHARE_CARD_W,
+        height: SHARE_CARD_H,
+        cacheBust: true,
+        backgroundColor: '#FBF8F1',
+      })
+      if (!blob) throw new Error('empty blob')
+      const filename = `oga-${club}-pattern.png`
+      const file = new File([blob], filename, { type: 'image/png' })
+      if (
+        typeof navigator.share === 'function' &&
+        navigator.canShare?.({ files: [file] })
+      ) {
+        try {
+          await navigator.share({ files: [file], title: 'OGA Shot Pattern' })
+          return
+        } catch (err) {
+          // User dismissed the sheet — not an error worth surfacing.
+          if ((err as Error).name === 'AbortError') return
+          // Any other share failure → fall through to the download path.
+        }
+      }
+      const url = URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = filename
+      link.click()
+      setTimeout(() => URL.revokeObjectURL(url), 1000)
+    } catch {
+      setExportError('Could not export the image. Try again.')
+    } finally {
+      setExporting(false)
+    }
+  }
 
   return (
     <div>
@@ -106,8 +169,41 @@ export function ShotPatternsPage() {
           paddingTop: 14,
         }}
       >
-        <div className="kicker" style={{ marginBottom: 14 }}>
-          Pattern
+        <div
+          className="flex items-center justify-between"
+          style={{ marginBottom: 14, gap: 12 }}
+        >
+          <div className="kicker">Pattern</div>
+          {stats && (
+            <div className="flex items-center" style={{ gap: 12 }}>
+              {exportError && (
+                <span className="text-caddie-neg" style={{ fontSize: 12 }}>
+                  {exportError}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={handleExport}
+                disabled={exporting}
+                className="text-caddie-accent hover:bg-caddie-accent/10 disabled:opacity-40"
+                style={{
+                  background: 'transparent',
+                  border: '1px solid #1F3D2C',
+                  borderRadius: 2,
+                  padding: '8px 12px',
+                  fontSize: 11,
+                  fontWeight: 500,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  fontFamily: '"JetBrains Mono", monospace',
+                  cursor: 'pointer',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {exporting ? 'Rendering…' : '↓ Export · 1200×630'}
+              </button>
+            </div>
+          )}
         </div>
         <div
           className="grid grid-cols-1 md:[grid-template-columns:minmax(0,auto)_minmax(0,1fr)]"
@@ -263,6 +359,31 @@ export function ShotPatternsPage() {
           )}
         </div>
       </div>
+
+      {/* Off-screen render target for the 1200×630 share card. Self-
+          contained inline styles so the rasteriser needs no external
+          stylesheet at capture time. */}
+      {stats && (
+        <div
+          aria-hidden
+          style={{
+            position: 'fixed',
+            left: -99999,
+            top: 0,
+            pointerEvents: 'none',
+          }}
+        >
+          <div ref={shareCardRef}>
+            <ShotPatternsShareCard
+              points={points}
+              stats={stats}
+              club={club}
+              unit={unit}
+              toDisplay={toDisplay}
+            />
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -419,176 +540,6 @@ function PatternLegend({ hasEllipses }: { hasEllipses: boolean }) {
           </span>
         ))}
     </div>
-  )
-}
-
-// Pattern point colors. Solid = ink (neutral, the goal); push/pull = warn
-// amber; misses = neg brick. Stays inside the editorial palette.
-function pointColor(result: string | undefined): { fill: string; opacity: number } {
-  if (result === 'solid') return { fill: '#1C211C', opacity: 0.75 }
-  if (result === 'push_right' || result === 'pull_left')
-    return { fill: '#A66A1F', opacity: 0.75 }
-  if (result === undefined) return { fill: '#8A8B7E', opacity: 0.5 }
-  return { fill: '#A33A2A', opacity: 0.8 }
-}
-
-function DispersionPlot({
-  points,
-  stats,
-}: {
-  points: DispersionPoint[]
-  stats: DispersionStats | null
-}) {
-  // Spread Math.max over every point ran on every render. Memoize the
-  // dispersion-derived geometry; chip-toggle re-renders no longer
-  // re-walk the points array.
-  const { maxAbs, range, scale, ticks } = useMemo(() => {
-    const max = Math.max(
-      ...points.map((p) =>
-        Math.max(Math.abs(p.lateralOffsetYards), Math.abs(p.distanceOffsetYards)),
-      ),
-      stats ? stats.cone95.lateral : 0,
-      stats ? stats.cone95.distance : 0,
-      20,
-    )
-    const r = max * 1.15
-    const s = (SVG_SIZE / 2) / r
-    const step = r > 50 ? 20 : r > 20 ? 10 : 5
-    const t: number[] = []
-    for (let v = step; v < r; v += step) {
-      t.push(v, -v)
-    }
-    return { maxAbs: max, range: r, scale: s, ticks: t }
-  }, [points, stats])
-
-  const cx = SVG_SIZE / 2
-  const cy = SVG_SIZE / 2
-
-  const px = (lat: number) => cx + lat * scale
-  const py = (dist: number) => cy - dist * scale
-
-  return (
-    <svg
-      width={SVG_VIEW_WIDTH}
-      height={SVG_VIEW_WIDTH}
-      viewBox={`0 0 ${SVG_SIZE} ${SVG_SIZE}`}
-      style={{ backgroundColor: '#F2EEE5', borderRadius: 2 }}
-    >
-      {ticks.map((t) => (
-        <g key={`v${t}`}>
-          <line
-            x1={px(t)}
-            y1={0}
-            x2={px(t)}
-            y2={SVG_SIZE}
-            stroke="#EBE5D6"
-            strokeWidth={1}
-          />
-          <line
-            x1={0}
-            y1={py(t)}
-            x2={SVG_SIZE}
-            y2={py(t)}
-            stroke="#EBE5D6"
-            strokeWidth={1}
-          />
-        </g>
-      ))}
-      <line x1={cx} y1={0} x2={cx} y2={SVG_SIZE} stroke="#9F9580" strokeWidth={1} />
-      <line x1={0} y1={cy} x2={SVG_SIZE} y2={cy} stroke="#9F9580" strokeWidth={1} />
-
-      {stats && (
-        <>
-          <ellipse
-            cx={px(stats.avgLateralOffset)}
-            cy={py(stats.avgDistanceOffset)}
-            rx={stats.cone95.lateral * scale}
-            ry={stats.cone95.distance * scale}
-            fill="rgba(31,61,44,0.06)"
-            stroke="#1F3D2C"
-            strokeDasharray="5 4"
-            strokeWidth={1}
-          />
-          <ellipse
-            cx={px(stats.avgLateralOffset)}
-            cy={py(stats.avgDistanceOffset)}
-            rx={stats.cone68.lateral * scale}
-            ry={stats.cone68.distance * scale}
-            fill="rgba(31,61,44,0.12)"
-            stroke="#1F3D2C"
-            strokeDasharray="4 3"
-            strokeWidth={1}
-          />
-        </>
-      )}
-
-      <circle cx={cx} cy={cy} r={3} fill="#A66A1F" />
-      <text
-        x={cx + 6}
-        y={cy + 14}
-        fontSize={10}
-        fontFamily="JetBrains Mono, monospace"
-        letterSpacing="0.14em"
-        fill="#A66A1F"
-      >
-        AIM
-      </text>
-
-      {points.map((p) => {
-        const c = pointColor(p.shotResult)
-        return (
-          <circle
-            key={p.id}
-            cx={px(p.lateralOffsetYards)}
-            cy={py(p.distanceOffsetYards)}
-            r={3.5}
-            fill={c.fill}
-            fillOpacity={c.opacity}
-          />
-        )
-      })}
-
-      <text
-        x={cx + 8}
-        y={14}
-        fontSize={9}
-        fontFamily="JetBrains Mono, monospace"
-        letterSpacing="0.14em"
-        fill="#8A8B7E"
-      >
-        LONG
-      </text>
-      <text
-        x={cx + 8}
-        y={SVG_SIZE - 6}
-        fontSize={9}
-        fontFamily="JetBrains Mono, monospace"
-        letterSpacing="0.14em"
-        fill="#8A8B7E"
-      >
-        SHORT
-      </text>
-      <text
-        x={6}
-        y={cy - 6}
-        fontSize={9}
-        fontFamily="JetBrains Mono, monospace"
-        letterSpacing="0.14em"
-        fill="#8A8B7E"
-      >
-        L
-      </text>
-      <text
-        x={SVG_SIZE - 14}
-        y={cy - 6}
-        fontSize={9}
-        fontFamily="JetBrains Mono, monospace"
-        letterSpacing="0.14em"
-        fill="#8A8B7E"
-      >
-        R
-      </text>
-    </svg>
   )
 }
 

--- a/apps/web/src/pages/patterns/components/DispersionPlot.tsx
+++ b/apps/web/src/pages/patterns/components/DispersionPlot.tsx
@@ -1,0 +1,183 @@
+import { useMemo } from 'react'
+import type { DispersionPoint, DispersionStats } from '@oga/core'
+
+export const SVG_SIZE = 420
+export const SVG_VIEW_WIDTH = `min(${SVG_SIZE}px, 90vw)`
+
+// Pattern point colors. Solid = ink (neutral, the goal); push/pull = warn
+// amber; misses = neg brick. Stays inside the editorial palette.
+export function pointColor(
+  result: string | undefined,
+): { fill: string; opacity: number } {
+  if (result === 'solid') return { fill: '#1C211C', opacity: 0.75 }
+  if (result === 'push_right' || result === 'pull_left')
+    return { fill: '#A66A1F', opacity: 0.75 }
+  if (result === undefined) return { fill: '#8A8B7E', opacity: 0.5 }
+  return { fill: '#A33A2A', opacity: 0.8 }
+}
+
+export function DispersionPlot({
+  points,
+  stats,
+  size,
+}: {
+  points: DispersionPoint[]
+  stats: DispersionStats | null
+  // Fixed pixel size for the share card (viewport-independent capture).
+  // Omitted on the page → responsive `min(420px, 90vw)`.
+  size?: number
+}) {
+  // Spread Math.max over every point ran on every render. Memoize the
+  // dispersion-derived geometry; chip-toggle re-renders no longer
+  // re-walk the points array.
+  const { scale, ticks } = useMemo(() => {
+    const max = Math.max(
+      ...points.map((p) =>
+        Math.max(Math.abs(p.lateralOffsetYards), Math.abs(p.distanceOffsetYards)),
+      ),
+      stats ? stats.cone95.lateral : 0,
+      stats ? stats.cone95.distance : 0,
+      20,
+    )
+    const r = max * 1.15
+    const s = (SVG_SIZE / 2) / r
+    const step = r > 50 ? 20 : r > 20 ? 10 : 5
+    const t: number[] = []
+    for (let v = step; v < r; v += step) {
+      t.push(v, -v)
+    }
+    return { scale: s, ticks: t }
+  }, [points, stats])
+
+  const cx = SVG_SIZE / 2
+  const cy = SVG_SIZE / 2
+
+  const px = (lat: number) => cx + lat * scale
+  const py = (dist: number) => cy - dist * scale
+
+  const renderDim = size ?? SVG_VIEW_WIDTH
+
+  return (
+    <svg
+      width={renderDim}
+      height={renderDim}
+      viewBox={`0 0 ${SVG_SIZE} ${SVG_SIZE}`}
+      style={{ backgroundColor: '#F2EEE5', borderRadius: 2 }}
+    >
+      {ticks.map((t) => (
+        <g key={`v${t}`}>
+          <line
+            x1={px(t)}
+            y1={0}
+            x2={px(t)}
+            y2={SVG_SIZE}
+            stroke="#EBE5D6"
+            strokeWidth={1}
+          />
+          <line
+            x1={0}
+            y1={py(t)}
+            x2={SVG_SIZE}
+            y2={py(t)}
+            stroke="#EBE5D6"
+            strokeWidth={1}
+          />
+        </g>
+      ))}
+      <line x1={cx} y1={0} x2={cx} y2={SVG_SIZE} stroke="#9F9580" strokeWidth={1} />
+      <line x1={0} y1={cy} x2={SVG_SIZE} y2={cy} stroke="#9F9580" strokeWidth={1} />
+
+      {stats && (
+        <>
+          <ellipse
+            cx={px(stats.avgLateralOffset)}
+            cy={py(stats.avgDistanceOffset)}
+            rx={stats.cone95.lateral * scale}
+            ry={stats.cone95.distance * scale}
+            fill="rgba(31,61,44,0.06)"
+            stroke="#1F3D2C"
+            strokeDasharray="5 4"
+            strokeWidth={1}
+          />
+          <ellipse
+            cx={px(stats.avgLateralOffset)}
+            cy={py(stats.avgDistanceOffset)}
+            rx={stats.cone68.lateral * scale}
+            ry={stats.cone68.distance * scale}
+            fill="rgba(31,61,44,0.12)"
+            stroke="#1F3D2C"
+            strokeDasharray="4 3"
+            strokeWidth={1}
+          />
+        </>
+      )}
+
+      <circle cx={cx} cy={cy} r={3} fill="#A66A1F" />
+      <text
+        x={cx + 6}
+        y={cy + 14}
+        fontSize={10}
+        fontFamily="JetBrains Mono, monospace"
+        letterSpacing="0.14em"
+        fill="#A66A1F"
+      >
+        AIM
+      </text>
+
+      {points.map((p) => {
+        const c = pointColor(p.shotResult)
+        return (
+          <circle
+            key={p.id}
+            cx={px(p.lateralOffsetYards)}
+            cy={py(p.distanceOffsetYards)}
+            r={3.5}
+            fill={c.fill}
+            fillOpacity={c.opacity}
+          />
+        )
+      })}
+
+      <text
+        x={cx + 8}
+        y={14}
+        fontSize={9}
+        fontFamily="JetBrains Mono, monospace"
+        letterSpacing="0.14em"
+        fill="#8A8B7E"
+      >
+        LONG
+      </text>
+      <text
+        x={cx + 8}
+        y={SVG_SIZE - 6}
+        fontSize={9}
+        fontFamily="JetBrains Mono, monospace"
+        letterSpacing="0.14em"
+        fill="#8A8B7E"
+      >
+        SHORT
+      </text>
+      <text
+        x={6}
+        y={cy - 6}
+        fontSize={9}
+        fontFamily="JetBrains Mono, monospace"
+        letterSpacing="0.14em"
+        fill="#8A8B7E"
+      >
+        L
+      </text>
+      <text
+        x={SVG_SIZE - 14}
+        y={cy - 6}
+        fontSize={9}
+        fontFamily="JetBrains Mono, monospace"
+        letterSpacing="0.14em"
+        fill="#8A8B7E"
+      >
+        R
+      </text>
+    </svg>
+  )
+}

--- a/apps/web/src/pages/patterns/components/ShotPatternsShareCard.tsx
+++ b/apps/web/src/pages/patterns/components/ShotPatternsShareCard.tsx
@@ -1,0 +1,196 @@
+import {
+  getAimCorrection,
+  type Club,
+  type DispersionPoint,
+  type DispersionStats,
+  type DistanceUnit,
+} from '@oga/core'
+import { DispersionPlot } from './DispersionPlot'
+
+// Off-screen 1200×630 social share card (Twitter/Facebook OG size).
+// Self-contained inline styles so the rasteriser needs no external
+// stylesheet at capture time. Stats only — no username, email, or avatar
+// ever reaches this card.
+const CARD_W = 1200
+const CARD_H = 630
+const PLOT_SIZE = 470
+
+const C = {
+  bg: '#FBF8F1',
+  surface: '#F2EEE5',
+  line: '#D9D2BF',
+  ink: '#1C211C',
+  inkDim: '#5C6356',
+  inkMute: '#8A8B7E',
+  accent: '#1F3D2C',
+} as const
+
+const KICKER: React.CSSProperties = {
+  fontFamily: '"JetBrains Mono", monospace',
+  fontWeight: 500,
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+}
+
+const SERIF = '"Fraunces", Georgia, serif'
+
+// One-line verdict from the dispersion shape + dominant miss.
+function verdictHeadline(stats: DispersionStats): string {
+  const { shotShape, dominantMiss } = stats
+  if (shotShape === 'straight' && dominantMiss === 'straight') return 'Dead straight'
+  if (dominantMiss === 'straight') return `A consistent ${shotShape}`
+  if (shotShape === 'straight') return `Straight, missing ${dominantMiss}`
+  return `A ${shotShape} that leaks ${dominantMiss}`
+}
+
+interface ShotPatternsShareCardProps {
+  points: DispersionPoint[]
+  stats: DispersionStats
+  club: Club
+  unit: DistanceUnit
+  toDisplay: (yards: number, decimals?: number) => string
+}
+
+export function ShotPatternsShareCard({
+  points,
+  stats,
+  club,
+  unit,
+  toDisplay,
+}: ShotPatternsShareCardProps) {
+  return (
+    <div
+      style={{
+        width: CARD_W,
+        height: CARD_H,
+        backgroundColor: C.bg,
+        color: C.ink,
+        fontFamily: 'Inter, system-ui, sans-serif',
+        padding: 56,
+        boxSizing: 'border-box',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          paddingBottom: 22,
+          borderBottom: `1px solid ${C.line}`,
+        }}
+      >
+        <div>
+          <div style={{ ...KICKER, fontSize: 12, color: C.inkMute, marginBottom: 8 }}>
+            Open Golf App
+          </div>
+          <div
+            style={{
+              fontFamily: SERIF,
+              fontStyle: 'italic',
+              fontWeight: 500,
+              fontSize: 44,
+              lineHeight: 1,
+              color: C.ink,
+            }}
+          >
+            OGA
+          </div>
+        </div>
+        <div style={{ ...KICKER, fontSize: 12, color: C.inkMute, textAlign: 'right' }}>
+          Shot Pattern
+        </div>
+      </header>
+
+      <div
+        style={{
+          display: 'flex',
+          gap: 48,
+          alignItems: 'center',
+          flex: 1,
+          paddingTop: 28,
+          paddingBottom: 28,
+        }}
+      >
+        <div
+          style={{
+            flexShrink: 0,
+            padding: 16,
+            backgroundColor: C.surface,
+            border: `1px solid ${C.line}`,
+            borderRadius: 4,
+            lineHeight: 0,
+          }}
+        >
+          <DispersionPlot points={points} stats={stats} size={PLOT_SIZE} />
+        </div>
+
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ ...KICKER, fontSize: 13, color: C.inkMute, marginBottom: 10 }}>
+            {club}
+          </div>
+          <div
+            style={{
+              fontFamily: SERIF,
+              fontWeight: 500,
+              fontSize: 46,
+              lineHeight: 1.1,
+              color: C.ink,
+              marginBottom: 30,
+            }}
+          >
+            {verdictHeadline(stats)}
+          </div>
+          <div style={{ display: 'flex', gap: 40, marginBottom: 30 }}>
+            <Stat label="Sample" value={`${stats.sampleSize} shots`} />
+            <Stat
+              label="68% spread"
+              value={`±${toDisplay(stats.cone68.lateral, 1)} / ${toDisplay(stats.cone68.distance, 1)}`}
+            />
+            <Stat label="Dominant miss" value={stats.dominantMiss} />
+          </div>
+          <div
+            style={{
+              fontFamily: SERIF,
+              fontSize: 22,
+              lineHeight: 1.5,
+              color: C.inkDim,
+              maxWidth: 540,
+            }}
+          >
+            {getAimCorrection(stats, unit)}
+          </div>
+        </div>
+      </div>
+
+      <footer
+        style={{
+          paddingTop: 20,
+          borderTop: `1px solid ${C.line}`,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+        }}
+      >
+        <div style={{ ...KICKER, fontSize: 13, color: C.accent }}>oga.golf</div>
+        <div style={{ ...KICKER, fontSize: 11, color: C.inkMute }}>
+          Free forever · no paywalls
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div style={{ ...KICKER, fontSize: 11, color: C.inkMute, marginBottom: 6 }}>
+        {label}
+      </div>
+      <div style={{ fontFamily: SERIF, fontWeight: 500, fontSize: 26, color: C.ink }}>
+        {value}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/patterns/components/ShotPatternsShareCard.tsx
+++ b/apps/web/src/pages/patterns/components/ShotPatternsShareCard.tsx
@@ -1,4 +1,5 @@
 import {
+  dispersionVerdict,
   getAimCorrection,
   type Club,
   type DispersionPoint,
@@ -35,15 +36,6 @@ const KICKER: React.CSSProperties = {
 }
 
 const SERIF = '"Fraunces", Georgia, serif'
-
-// One-line verdict from the dispersion shape + dominant miss.
-function verdictHeadline(stats: DispersionStats): string {
-  const { shotShape, dominantMiss } = stats
-  if (shotShape === 'straight' && dominantMiss === 'straight') return 'Dead straight'
-  if (dominantMiss === 'straight') return `A consistent ${shotShape}`
-  if (shotShape === 'straight') return `Straight, missing ${dominantMiss}`
-  return `A ${shotShape} that leaks ${dominantMiss}`
-}
 
 interface ShotPatternsShareCardProps {
   points: DispersionPoint[]
@@ -142,7 +134,7 @@ export function ShotPatternsShareCard({
               marginBottom: 30,
             }}
           >
-            {verdictHeadline(stats)}
+            {dispersionVerdict(stats)}
           </div>
           <div style={{ display: 'flex', gap: 40, marginBottom: 30 }}>
             <Stat label="Sample" value={`${stats.sampleSize} shots`} />

--- a/apps/web/src/pages/patterns/components/ShotPatternsShareCard.tsx
+++ b/apps/web/src/pages/patterns/components/ShotPatternsShareCard.tsx
@@ -13,7 +13,9 @@ import { DispersionPlot } from './DispersionPlot'
 // ever reaches this card.
 const CARD_W = 1200
 const CARD_H = 630
-const PLOT_SIZE = 470
+// Plot is square; the card is short (630). Sized so the header, plot
+// panel, and footer all fit the fixed height without clipping.
+const PLOT_SIZE = 350
 
 const C = {
   bg: '#FBF8F1',
@@ -66,7 +68,7 @@ export function ShotPatternsShareCard({
         backgroundColor: C.bg,
         color: C.ink,
         fontFamily: 'Inter, system-ui, sans-serif',
-        padding: 56,
+        padding: '44px 56px',
         boxSizing: 'border-box',
         display: 'flex',
         flexDirection: 'column',
@@ -109,14 +111,14 @@ export function ShotPatternsShareCard({
           gap: 48,
           alignItems: 'center',
           flex: 1,
-          paddingTop: 28,
-          paddingBottom: 28,
+          paddingTop: 16,
+          paddingBottom: 16,
         }}
       >
         <div
           style={{
             flexShrink: 0,
-            padding: 16,
+            padding: 14,
             backgroundColor: C.surface,
             border: `1px solid ${C.line}`,
             borderRadius: 4,

--- a/packages/core/src/shot-patterns.test.ts
+++ b/packages/core/src/shot-patterns.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   computeDispersion,
   computeDispersionStats,
+  dispersionVerdict,
   filterDispersionByLie,
   getAimCorrection,
   type DispersionPoint,
+  type DispersionStats,
 } from './shot-patterns'
 import type { Shot } from './types'
 
@@ -155,5 +157,41 @@ describe('getAimCorrection', () => {
     )!
     expect(getAimCorrection(stats)).toContain('left')
     expect(getAimCorrection(stats)).toContain('8')
+  })
+})
+
+describe('dispersionVerdict', () => {
+  const stats = (overrides: Partial<DispersionStats>): DispersionStats => ({
+    avgLateralOffset: 0,
+    avgDistanceOffset: 0,
+    stdLateral: 0,
+    stdDistance: 0,
+    cone68: { lateral: 0, distance: 0 },
+    cone95: { lateral: 0, distance: 0 },
+    dominantMiss: 'straight',
+    shotShape: 'straight',
+    sampleSize: 10,
+    ...overrides,
+  })
+
+  it('calls a centered, straight pattern dead straight', () => {
+    expect(dispersionVerdict(stats({ shotShape: 'straight', dominantMiss: 'straight' }))).toBe(
+      'Dead straight',
+    )
+  })
+  it('names a consistent shape when the miss is straight', () => {
+    expect(dispersionVerdict(stats({ shotShape: 'fade', dominantMiss: 'straight' }))).toBe(
+      'A consistent fade',
+    )
+  })
+  it('reports a straight shape that still misses to a side', () => {
+    expect(dispersionVerdict(stats({ shotShape: 'straight', dominantMiss: 'left' }))).toBe(
+      'Straight, missing left',
+    )
+  })
+  it('describes a shape that leaks to its miss side', () => {
+    expect(dispersionVerdict(stats({ shotShape: 'draw', dominantMiss: 'right' }))).toBe(
+      'A draw that leaks right',
+    )
   })
 })

--- a/packages/core/src/shot-patterns.ts
+++ b/packages/core/src/shot-patterns.ts
@@ -197,3 +197,13 @@ export function getAimCorrection(
   const oppDir = stats.dominantMiss === 'right' ? 'left' : 'right'
   return `Aim ${value} ${noun} ${oppDir} of your target to center your pattern.`
 }
+
+// One-line plain-language verdict from the dispersion shape + dominant miss.
+// Lives here (not in an app) so the web and mobile share cards share one copy.
+export function dispersionVerdict(stats: DispersionStats): string {
+  const { shotShape, dominantMiss } = stats
+  if (shotShape === 'straight' && dominantMiss === 'straight') return 'Dead straight'
+  if (dominantMiss === 'straight') return `A consistent ${shotShape}`
+  if (shotShape === 'straight') return `Straight, missing ${dominantMiss}`
+  return `A ${shotShape} that leaks ${dominantMiss}`
+}


### PR DESCRIPTION
## What

Adds an **"↓ Export · 1200×630"** button to the Shot Patterns page that renders a social share card (dispersion plot + verdict headline + sample size + 68% spread + dominant miss + aim-correction, in the OGA paper-editorial palette) and opens the **native share sheet**, falling back to a download. Implements #374 (web; mobile parity is a fast follow).

The button appears only once a club has a computed pattern (≥5 shots with aim + landing).

## Rendering path — Path A (`html-to-image`), reusing #201

The ticket's Decision-log picked Path B (bespoke SVG→canvas), but that predates #201. Since #201 shipped on `html-to-image` and the acceptance criteria require **"same rasterizer as #201 — no two paths,"** this uses the same `toBlob` + Web Share API + download path. One pipeline, not two (the issue calls two rasterizers "the worst outcome").

## Structure

- New `components/DispersionPlot.tsx` — extracted `DispersionPlot` + `pointColor` so the page **and** the share card share one plot (no duplicated SVG). This also keeps `ShotPatternsPage.tsx` under the 1000-line ceiling (was heading to ~1030 inline; now 741). Added an optional `size` prop so the card renders the plot at a **fixed, viewport-independent** size (the page's responsive `min(420px, 90vw)` would otherwise make the capture depend on window width).
- New `components/ShotPatternsShareCard.tsx` — the 1200×630 layout (split: plot left, verdict right).
- `ShotPatternsPage.tsx` — Export button + off-screen render target + capture handler.

## Notes / decisions

- **Capture-on-click, not pre-captured** (unlike #201). Pre-rasterising a heavy 1200×630 card on every club-chip tap would be wasteful, and the club filter changes often. Trade-off: the `await` before `share()` can expire the iOS-Safari gesture token — in which case it degrades to the **download** path (same 1200×630 PNG), which the AC explicitly allows ("downloads **or** shares").
- **No PII** — the card renders club + dispersion stats only; no username, email, or avatar.
- `AbortError` (user dismisses the sheet) is silent; a render failure surfaces a small inline message next to the button.

## Verification

- ✅ `pnpm typecheck`, ✅ `pnpm --filter web lint`, ✅ `pnpm --filter web build`.

## Testing notes

⚠️ **The card layout has not been visually verified yet** — it's a fixed-dimension marketing asset, so it wants a real look on the Vercel preview (pick a club with a pattern, hit Export). Native share is gesture-gated and untestable headless; **iOS Safari** is the key manual check (else it downloads). Happy to capture a screenshot via the `media`-branch tooling if you want one before merging.

Implements #374.

Out of scope (per ticket): mobile parity (fast follow), 1080×1080 Instagram variant.