### PR TITLE
feat(mobile): Shot Patterns share card + native share (#374)

### DIFF
--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useState } from 'react'
-import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Alert, Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
 import Svg, { Circle, Ellipse, Line, Rect, Text as SvgText } from 'react-native-svg'
+import { captureRef } from 'react-native-view-shot'
+import * as Sharing from 'expo-sharing'
 import {
   CLUBS,
   LIE_SLOPES,
@@ -12,6 +14,7 @@ import {
   type Club,
   type DispersionPoint,
   type DispersionStats,
+  type DistanceUnit,
   type LieSlope,
   type LieType,
   type Shot,
@@ -114,6 +117,37 @@ export default function Patterns() {
 
   const stats = useMemo(() => computeDispersionStats(points), [points])
 
+  const shareCardRef = useRef<View>(null)
+  const [sharing, setSharing] = useState(false)
+
+  // Capture the off-screen 1200×630 share card and hand it to the native
+  // share sheet via expo-sharing — same path as the scorecard share.
+  async function handleShare() {
+    if (sharing || !shareCardRef.current) return
+    setSharing(true)
+    try {
+      const uri = await captureRef(shareCardRef, {
+        format: 'png',
+        quality: 1,
+        result: 'tmpfile',
+      })
+      if (!(await Sharing.isAvailableAsync())) {
+        Alert.alert('Sharing unavailable', 'This device cannot share files.')
+        return
+      }
+      await Sharing.shareAsync(uri, {
+        mimeType: 'image/png',
+        dialogTitle: 'Share shot pattern',
+      })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[patterns/share]', err)
+      Alert.alert('Share failed', (err as Error).message)
+    } finally {
+      setSharing(false)
+    }
+  }
+
   return (
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
       <AppBar eyebrow={`Club ${club}`} title="Shot Patterns" />
@@ -157,6 +191,29 @@ export default function Patterns() {
             <>
               <DispersionPlot points={points} stats={stats} />
               <PatternLegend hasStats={!!stats} />
+              {stats && (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Export shot pattern image"
+                  accessibilityState={{ disabled: sharing }}
+                  onPress={handleShare}
+                  disabled={sharing}
+                  style={({ pressed }) => ({
+                    alignSelf: 'flex-start',
+                    marginTop: 14,
+                    paddingVertical: 9,
+                    paddingHorizontal: 14,
+                    borderWidth: 1,
+                    borderColor: '#1F3D2C',
+                    borderRadius: 2,
+                    opacity: pressed || sharing ? 0.6 : 1,
+                  })}
+                >
+                  <Text style={{ ...KICKER, color: '#1F3D2C' }}>
+                    {sharing ? 'Rendering…' : '↓ Export · 1200×630'}
+                  </Text>
+                </Pressable>
+              )}
             </>
           )}
         </Section>
@@ -216,6 +273,217 @@ export default function Patterns() {
           </View>
         )}
       </ScrollView>
+
+      {/* Off-screen render target for react-native-view-shot. Laid out
+          far off the left edge so it's never visible; collapsable={false}
+          keeps RN from optimising out the subtree the rasteriser reads. */}
+      {stats && (
+        <View
+          pointerEvents="none"
+          collapsable={false}
+          style={{ position: 'absolute', left: -10000, top: 0 }}
+        >
+          <View ref={shareCardRef} collapsable={false}>
+            <ShotPatternsShareCard
+              points={points}
+              stats={stats}
+              club={club}
+              unit={unit}
+              toDisplay={toDisplay}
+            />
+          </View>
+        </View>
+      )}
+    </View>
+  )
+}
+
+// Off-screen 1200×630 social share card — mobile parity of the web card
+// (apps/web ShotPatternsShareCard). Captured via react-native-view-shot.
+// Stats only — no username, email, or avatar.
+const SHARE_C = {
+  bg: '#FBF8F1',
+  surface: '#F2EEE5',
+  line: '#D9D2BF',
+  ink: '#1C211C',
+  inkDim: '#5C6356',
+  inkMute: '#8A8B7E',
+  accent: '#1F3D2C',
+} as const
+
+const SHARE_KICKER: import('react-native').TextStyle = {
+  fontWeight: '500',
+  letterSpacing: 2,
+  textTransform: 'uppercase',
+}
+
+function shareVerdict(stats: DispersionStats): string {
+  const { shotShape, dominantMiss } = stats
+  if (shotShape === 'straight' && dominantMiss === 'straight') return 'Dead straight'
+  if (dominantMiss === 'straight') return `A consistent ${shotShape}`
+  if (shotShape === 'straight') return `Straight, missing ${dominantMiss}`
+  return `A ${shotShape} that leaks ${dominantMiss}`
+}
+
+function ShotPatternsShareCard({
+  points,
+  stats,
+  club,
+  unit,
+  toDisplay,
+}: {
+  points: DispersionPoint[]
+  stats: DispersionStats
+  club: Club
+  unit: DistanceUnit
+  toDisplay: (yards: number, decimals?: number) => string
+}) {
+  const c = SHARE_C
+  return (
+    <View
+      style={{
+        width: 1200,
+        height: 630,
+        backgroundColor: c.bg,
+        paddingVertical: 44,
+        paddingHorizontal: 56,
+      }}
+    >
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          paddingBottom: 22,
+          borderBottomWidth: 1,
+          borderColor: c.line,
+        }}
+      >
+        <View>
+          <Text
+            style={{ ...SHARE_KICKER, fontSize: 14, color: c.inkMute, marginBottom: 8 }}
+          >
+            Open Golf App
+          </Text>
+          <Text
+            style={{
+              fontFamily: 'Fraunces-MediumItalic',
+              fontWeight: '500',
+              fontSize: 44,
+              color: c.ink,
+            }}
+          >
+            OGA
+          </Text>
+        </View>
+        <Text style={{ ...SHARE_KICKER, fontSize: 14, color: c.inkMute }}>
+          Shot Pattern
+        </Text>
+      </View>
+
+      <View
+        style={{
+          flex: 1,
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 48,
+          paddingVertical: 16,
+        }}
+      >
+        <View
+          style={{
+            padding: 14,
+            backgroundColor: c.surface,
+            borderWidth: 1,
+            borderColor: c.line,
+            borderRadius: 4,
+          }}
+        >
+          <DispersionPlot points={points} stats={stats} size={350} />
+        </View>
+
+        <View style={{ flex: 1 }}>
+          <Text
+            style={{ ...SHARE_KICKER, fontSize: 15, color: c.inkMute, marginBottom: 10 }}
+          >
+            {club}
+          </Text>
+          <Text
+            style={{
+              fontFamily: 'Fraunces-Medium',
+              fontWeight: '500',
+              fontSize: 46,
+              color: c.ink,
+              marginBottom: 30,
+            }}
+          >
+            {shareVerdict(stats)}
+          </Text>
+          <View style={{ flexDirection: 'row', gap: 40, marginBottom: 30 }}>
+            <ShareStat label="Sample" value={`${stats.sampleSize} shots`} c={c} />
+            <ShareStat
+              label="68% spread"
+              value={`±${toDisplay(stats.cone68.lateral, 1)} / ${toDisplay(stats.cone68.distance, 1)}`}
+              c={c}
+            />
+            <ShareStat label="Dominant miss" value={stats.dominantMiss} c={c} />
+          </View>
+          <Text
+            style={{
+              fontFamily: 'Fraunces-Medium',
+              fontSize: 22,
+              lineHeight: 33,
+              color: c.inkDim,
+            }}
+          >
+            {getAimCorrection(stats, unit)}
+          </Text>
+        </View>
+      </View>
+
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          paddingTop: 20,
+          borderTopWidth: 1,
+          borderColor: c.line,
+        }}
+      >
+        <Text style={{ ...SHARE_KICKER, fontSize: 15, color: c.accent }}>oga.golf</Text>
+        <Text style={{ ...SHARE_KICKER, fontSize: 13, color: c.inkMute }}>
+          Free forever · no paywalls
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+function ShareStat({
+  label,
+  value,
+  c,
+}: {
+  label: string
+  value: string
+  c: typeof SHARE_C
+}) {
+  return (
+    <View>
+      <Text style={{ ...SHARE_KICKER, fontSize: 12, color: c.inkMute, marginBottom: 6 }}>
+        {label}
+      </Text>
+      <Text
+        style={{
+          fontFamily: 'Fraunces-Medium',
+          fontWeight: '500',
+          fontSize: 26,
+          color: c.ink,
+        }}
+      >
+        {value}
+      </Text>
     </View>
   )
 }
@@ -370,12 +638,15 @@ function LegendEllipse({ opacity, label }: { opacity: number; label: string }) {
 function DispersionPlot({
   points,
   stats,
+  size: sizeProp,
 }: {
   points: DispersionPoint[]
   stats: DispersionStats | null
+  // Fixed size for the share card; omitted on-screen → responsive width.
+  size?: number
 }) {
   const { width: screenWidth } = useWindowDimensions()
-  const size = Math.min(SVG_SIZE, screenWidth - 56)
+  const size = sizeProp ?? Math.min(SVG_SIZE, screenWidth - 56)
 
   const maxAbs = Math.max(
     ...points.map((p) =>

--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -9,6 +9,7 @@ import {
   LIE_TYPES,
   computeDispersion,
   computeDispersionStats,
+  dispersionVerdict,
   filterDispersionByLie,
   getAimCorrection,
   type Club,
@@ -93,7 +94,7 @@ export default function Patterns() {
     getShotsByClub(supabase, user.id, club).then(({ data, error }) => {
       if (!active) return
       if (error) {
-        // eslint-disable-next-line no-console
+        // eslint-disable-next-line no-console -- dev diagnostic; mobile has no logger/toast primitive
         console.error('[patterns/getShotsByClub]', error.message)
       }
       setShots((data as ShotRowMin[] | null) ?? [])
@@ -140,7 +141,7 @@ export default function Patterns() {
         dialogTitle: 'Share shot pattern',
       })
     } catch (err) {
-      // eslint-disable-next-line no-console
+      // eslint-disable-next-line no-console -- dev diagnostic; the user sees the Alert below
       console.error('[patterns/share]', err)
       Alert.alert('Share failed', (err as Error).message)
     } finally {
@@ -317,14 +318,6 @@ const SHARE_KICKER: import('react-native').TextStyle = {
   textTransform: 'uppercase',
 }
 
-function shareVerdict(stats: DispersionStats): string {
-  const { shotShape, dominantMiss } = stats
-  if (shotShape === 'straight' && dominantMiss === 'straight') return 'Dead straight'
-  if (dominantMiss === 'straight') return `A consistent ${shotShape}`
-  if (shotShape === 'straight') return `Straight, missing ${dominantMiss}`
-  return `A ${shotShape} that leaks ${dominantMiss}`
-}
-
 function ShotPatternsShareCard({
   points,
   stats,
@@ -417,7 +410,7 @@ function ShotPatternsShareCard({
               marginBottom: 30,
             }}
           >
-            {shareVerdict(stats)}
+            {dispersionVerdict(stats)}
           </Text>
           <View style={{ flexDirection: 'row', gap: 40, marginBottom: 30 }}>
             <ShareStat label="Sample" value={`${stats.sampleSize} shots`} c={c} />

--- a/packages/core/src/shot-patterns.test.ts
+++ b/packages/core/src/shot-patterns.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest'
 import {
   computeDispersion,
   computeDispersionStats,
+  dispersionVerdict,
   filterDispersionByLie,
   getAimCorrection,
   type DispersionPoint,
+  type DispersionStats,
 } from './shot-patterns'
 import type { Shot } from './types'
 
@@ -155,5 +157,41 @@ describe('getAimCorrection', () => {
     )!
     expect(getAimCorrection(stats)).toContain('left')
     expect(getAimCorrection(stats)).toContain('8')
+  })
+})
+
+describe('dispersionVerdict', () => {
+  const stats = (overrides: Partial<DispersionStats>): DispersionStats => ({
+    avgLateralOffset: 0,
+    avgDistanceOffset: 0,
+    stdLateral: 0,
+    stdDistance: 0,
+    cone68: { lateral: 0, distance: 0 },
+    cone95: { lateral: 0, distance: 0 },
+    dominantMiss: 'straight',
+    shotShape: 'straight',
+    sampleSize: 10,
+    ...overrides,
+  })
+
+  it('calls a centered, straight pattern dead straight', () => {
+    expect(dispersionVerdict(stats({ shotShape: 'straight', dominantMiss: 'straight' }))).toBe(
+      'Dead straight',
+    )
+  })
+  it('names a consistent shape when the miss is straight', () => {
+    expect(dispersionVerdict(stats({ shotShape: 'fade', dominantMiss: 'straight' }))).toBe(
+      'A consistent fade',
+    )
+  })
+  it('reports a straight shape that still misses to a side', () => {
+    expect(dispersionVerdict(stats({ shotShape: 'straight', dominantMiss: 'left' }))).toBe(
+      'Straight, missing left',
+    )
+  })
+  it('describes a shape that leaks to its miss side', () => {
+    expect(dispersionVerdict(stats({ shotShape: 'draw', dominantMiss: 'right' }))).toBe(
+      'A draw that leaks right',
+    )
   })
 })

--- a/packages/core/src/shot-patterns.ts
+++ b/packages/core/src/shot-patterns.ts
@@ -197,3 +197,13 @@ export function getAimCorrection(
   const oppDir = stats.dominantMiss === 'right' ? 'left' : 'right'
   return `Aim ${value} ${noun} ${oppDir} of your target to center your pattern.`
 }
+
+// One-line plain-language verdict from the dispersion shape + dominant miss.
+// Lives here (not in an app) so the web and mobile share cards share one copy.
+export function dispersionVerdict(stats: DispersionStats): string {
+  const { shotShape, dominantMiss } = stats
+  if (shotShape === 'straight' && dominantMiss === 'straight') return 'Dead straight'
+  if (dominantMiss === 'straight') return `A consistent ${shotShape}`
+  if (shotShape === 'straight') return `Straight, missing ${dominantMiss}`
+  return `A ${shotShape} that leaks ${dominantMiss}`
+}


### PR DESCRIPTION
## What

Mobile parity for the web Shot Patterns share card (#374, web shipped in #428). Adds an **"↓ Export · 1200×630"** button on the mobile Shot Patterns screen (shown once a club has a pattern) that captures an off-screen 1200×630 card and opens the **native share sheet**.

## How

One file: `apps/mobile/app/(app)/patterns.tsx`.

- `captureRef` (react-native-view-shot) → `Sharing.shareAsync` (expo-sharing) with an `isAvailableAsync` fallback alert — the **same path as the scorecard share** (`round/[id]/index.tsx`). **No new deps** (both already pinned: `react-native-view-shot@3.8.0`, `expo-sharing@~12.0.1`).
- Co-located `ShotPatternsShareCard` reuses the in-file RN `DispersionPlot` (new optional `size` prop for a fixed, viewport-independent render). Mirrors the web card's **verified** layout (350px plot, same paddings) using the registered mobile fonts (`Fraunces-Medium` / `-MediumItalic`; kickers use the screen's system-font kicker style).
- Off-screen target uses the scorecard's pattern: `position: absolute; left: -10000` + `collapsable={false}`.
- Export button uses an `opacity` press-feedback in the `style` callback (the iOS `android_ripple` cross-platform rule). **No PII** — club + dispersion stats only.

File stays at 758 lines (under the 1000-line ceiling), so the card is co-located rather than extracted (unlike web, where the line budget forced a split).

## Verification

- ✅ `npm run typecheck` (mobile). No mobile lint script exists; typecheck is the CI gate.

## ⚠️ Testing notes — needs on-device QA (could not verify here, no emulator)

1. **react-native-svg inside a view-shot capture** — this is the app's **first** such case (the scorecard card is text/views, no SVG). view-shot has historically rendered SVG **blank** on some Android configs. **Verify the dispersion plot actually appears** in the shared image, not a blank panel.
2. **1200-wide off-screen layout** — confirm the card isn't clipped to screen width when captured.
3. **Output dimensions** — capture is at natural device-scaled size (1200×630 logical × density), matching the scorecard path; aspect is exactly 1200:630.
4. Fonts render (Fraunces medium/italic) and the footer isn't clipped (it was on web before the fix — same layout math here, but RN flexbox can differ).

Implements #374 (mobile half). Pairs with #428 (web).