### PR TITLE
feat(db): drill corpus schema — 0030 (#18)

### DIFF
--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -39,6 +39,24 @@ export type Database = {
   }
   public: {
     Tables: {
+      course_submissions: {
+        Row: {
+          created_at: string
+          id: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
       course_tees: {
         Row: {
           course_id: string
@@ -157,36 +175,60 @@ export type Database = {
       drills: {
         Row: {
           category: string | null
+          contributor: string | null
           created_at: string
           description: string | null
+          drill_type: string
           duration_min: number | null
           facility: string[] | null
+          goals: string[]
           id: string
           instructions: string | null
           name: string
           skill_levels: string[] | null
+          source: string | null
+          source_url: string | null
+          target_template: Json | null
+          targets: string[]
+          verified: boolean
         }
         Insert: {
           category?: string | null
+          contributor?: string | null
           created_at?: string
           description?: string | null
+          drill_type?: string
           duration_min?: number | null
           facility?: string[] | null
+          goals?: string[]
           id?: string
           instructions?: string | null
           name: string
           skill_levels?: string[] | null
+          source?: string | null
+          source_url?: string | null
+          target_template?: Json | null
+          targets?: string[]
+          verified?: boolean
         }
         Update: {
           category?: string | null
+          contributor?: string | null
           created_at?: string
           description?: string | null
+          drill_type?: string
           duration_min?: number | null
           facility?: string[] | null
+          goals?: string[]
           id?: string
           instructions?: string | null
           name?: string
           skill_levels?: string[] | null
+          source?: string | null
+          source_url?: string | null
+          target_template?: Json | null
+          targets?: string[]
+          verified?: boolean
         }
         Relationships: []
       }
@@ -304,33 +346,42 @@ export type Database = {
         Row: {
           ai_insight: string | null
           based_on_rounds: number | null
+          coach_note: string | null
           completed_drill_ids: string[]
           drills: Json | null
+          feedback: string | null
           focus_areas: Json | null
           generated_at: string
           id: string
+          raw_model_output: Json | null
           user_id: string
           valid_until: string | null
         }
         Insert: {
           ai_insight?: string | null
           based_on_rounds?: number | null
+          coach_note?: string | null
           completed_drill_ids?: string[]
           drills?: Json | null
+          feedback?: string | null
           focus_areas?: Json | null
           generated_at?: string
           id?: string
+          raw_model_output?: Json | null
           user_id: string
           valid_until?: string | null
         }
         Update: {
           ai_insight?: string | null
           based_on_rounds?: number | null
+          coach_note?: string | null
           completed_drill_ids?: string[]
           drills?: Json | null
+          feedback?: string | null
           focus_areas?: Json | null
           generated_at?: string
           id?: string
+          raw_model_output?: Json | null
           user_id?: string
           valid_until?: string | null
         }
@@ -644,6 +695,15 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      insert_synthetic_hole: {
+        Args: {
+          p_course_id: string
+          p_number: number
+          p_par: number
+          p_round_id: string
+        }
+        Returns: string
+      }
       search_courses: {
         Args: { result_limit?: number; search_query: string }
         Returns: {
@@ -805,3 +865,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+

--- a/supabase/migrations/0030_drill_corpus.sql
+++ b/supabase/migrations/0030_drill_corpus.sql
@@ -12,7 +12,8 @@ alter table public.drills
     check (drill_type in ('warmup','technical','skill_game','pressure_game','putting')),
   add column if not exists target_template jsonb,                           -- measurement + skill scaling; resolved in @oga/core (engine track)
   add column if not exists source          text,                           -- instructional origin (PGA pro / book / video / study)
-  add column if not exists source_url      text,                           -- link to that origin (nullable: books/seminars have none)
+  add column if not exists source_url      text
+    check (source_url is null or source_url ~ '^https?://'),               -- link to origin (nullable; http(s) only — blocks javascript: etc. at the boundary)
   add column if not exists contributor     text,                           -- who added the drill to OGA (GH handle/name)
   add column if not exists verified        boolean not null default false; -- maintainer-vetted; retrieval gate requires true
 
@@ -21,6 +22,10 @@ create index if not exists drills_goals_gin   on public.drills using gin (goals)
 
 -- Feedback loop + generator output (read on the next generation, so bundled here).
 alter table public.practice_plans
-  add column if not exists feedback         text,   -- one untrusted free-text note per plan (<=500 chars, enforced in app)
+  -- One UNTRUSTED free-text note per plan (next-gen loop). DB-capped here so a
+  -- direct client write can't exceed it; MUST also be delimited/sanitized
+  -- before any prompt interpolation — preference-signal only, never able to
+  -- override rules/schema/drill set (spec D14). Treat as injection-prone input.
+  add column if not exists feedback         text check (char_length(feedback) <= 500),
   add column if not exists coach_note       text,   -- editorial "why this week" (OGA voice)
   add column if not exists raw_model_output jsonb;  -- persisted tool-call output for spot-check / regression

--- a/supabase/migrations/0030_drill_corpus.sql
+++ b/supabase/migrations/0030_drill_corpus.sql
@@ -1,0 +1,26 @@
+-- 0030_drill_corpus.sql
+-- AI practice plan (#18), corpus track. Enriches `drills` so retrieval can gate
+-- (goals/targets/drill_type), targets can scale (target_template, engine track),
+-- and provenance + contributions are tracked (source/contributor/verified).
+-- Bundles the practice_plans columns the generator reads/writes.
+-- Schema only — drill rows are authored in seed.sql (corpus track).
+
+alter table public.drills
+  add column if not exists goals           text[]  not null default '{}',   -- goal bands a drill suits (break_100 .. scratch)
+  add column if not exists targets         text[]  not null default '{}',   -- weakness tags (start_line, dispersion, lag, ...)
+  add column if not exists drill_type      text    not null default 'technical'
+    check (drill_type in ('warmup','technical','skill_game','pressure_game','putting')),
+  add column if not exists target_template jsonb,                           -- measurement + skill scaling; resolved in @oga/core (engine track)
+  add column if not exists source          text,                           -- instructional origin (PGA pro / book / video / study)
+  add column if not exists source_url      text,                           -- link to that origin (nullable: books/seminars have none)
+  add column if not exists contributor     text,                           -- who added the drill to OGA (GH handle/name)
+  add column if not exists verified        boolean not null default false; -- maintainer-vetted; retrieval gate requires true
+
+create index if not exists drills_targets_gin on public.drills using gin (targets);
+create index if not exists drills_goals_gin   on public.drills using gin (goals);
+
+-- Feedback loop + generator output (read on the next generation, so bundled here).
+alter table public.practice_plans
+  add column if not exists feedback         text,   -- one untrusted free-text note per plan (<=500 chars, enforced in app)
+  add column if not exists coach_note       text,   -- editorial "why this week" (OGA voice)
+  add column if not exists raw_model_output jsonb;  -- persisted tool-call output for spot-check / regression


### PR DESCRIPTION
## Summary

Schema for the AI practice plan's drill corpus (#18) — **PR 1 of 2** (the sourced drill seed is a separate follow-up).

**`drills` enrichment** so retrieval can gate precisely and contributions/provenance are tracked:
- `goals text[]` (goal bands a drill suits), `targets text[]` (weakness tags), each GIN-indexed
- `drill_type text` (checked: warmup/technical/skill_game/pressure_game/putting)
- `target_template jsonb` (skill-scaling for deterministic targets — resolved in `@oga/core`, engine track; left null for now)
- `source` + `source_url` (instructional origin — PGA pro / book / video / study; `source_url` nullable for books/seminars)
- `contributor` (who added the row to OGA — GH handle) + `verified boolean default false` (maintainer-vetted; the retrieval gate will require `verified = true`, so unvetted community PRs never auto-reach players)

**`practice_plans`** columns the generator reads/writes: `feedback` (one untrusted note per plan, next-gen loop), `coach_note` (editorial), `raw_model_output jsonb` (spot-check/regression).

Additive `add column if not exists` (idempotent, per 0029). RLS unaffected — `drills` stays publicly readable; `practice_plans` keeps its user-owned policies.

## Out of scope (follow-up)
- The sourced drill corpus itself (replacing the 24 AI-generated drills in `seed.sql`) — separate PR after a research deep-dive.
- `resolveTarget` / `target_template` authoring and the `verified` retrieval filter — engine track.

## Test plan
- `supabase migration up --local` applies 0030 cleanly; `gen types --local` regenerates `types.ts` (new columns present, diff purely additive).
- `pnpm typecheck` — clean (3/3).
- No app code consumes the new columns yet, so no runtime surface to exercise.

Refs #18.