### PR TITLE
fix(core): derive session total_minutes server-side; drop ±20% model check

### DIFF
--- a/packages/core/src/practice-plan/storage.test.ts
+++ b/packages/core/src/practice-plan/storage.test.ts
@@ -119,4 +119,13 @@ describe('resolvePlanForStorage', () => {
     expect(out.focus_areas[0]!.article).toBeUndefined()
     expect(spy).toHaveBeenCalled()
   })
+
+  it('sets stored total_minutes to the sum of block minutes, overriding the model-emitted value', () => {
+    // Draft declares total_minutes=65 but blocks sum to 8+20+15=43.
+    // Storage must derive the real total from block minutes, not copy the model hint.
+    const mismatch: PlanDraft = structuredClone(draft)
+    mismatch.sessions[0]!.total_minutes = 65 // deliberately wrong; blocks still sum to 43
+    const out = resolvePlanForStorage(mismatch, ctx)
+    expect(out.drills.sessions[0]!.total_minutes).toBe(43) // 8+20+15
+  })
 })

--- a/packages/core/src/practice-plan/storage.ts
+++ b/packages/core/src/practice-plan/storage.ts
@@ -65,10 +65,8 @@ export interface PlanStoragePayload {
  *  An unresolved optional `article_ref` is dropped and logged (harmless —
  *  citations are optional). */
 export function resolvePlanForStorage(draft: PlanDraft, ctx: StorageCtx): PlanStoragePayload {
-  const sessions: StoredSession[] = draft.sessions.map((s) => ({
-    title: s.title,
-    total_minutes: s.total_minutes,
-    blocks: s.blocks.map((b) => {
+  const sessions: StoredSession[] = draft.sessions.map((s) => {
+    const blocks: StoredBlock[] = s.blocks.map((b) => {
       const drill = ctx.pool[b.drill_ref]
       const drillId = drill?.id
       if (drillId === undefined) {
@@ -89,8 +87,13 @@ export function resolvePlanForStorage(draft: PlanDraft, ctx: StorageCtx): PlanSt
         drill_id: drillId,
         target,
       }
-    }),
-  }))
+    })
+    return {
+      title: s.title,
+      total_minutes: blocks.reduce((acc, b) => acc + b.minutes, 0),
+      blocks,
+    }
+  })
 
   const focus_areas: StoredFocusArea[] = draft.focus_areas.map((f) => {
     const area: StoredFocusArea = { category: f.category, reason: f.reason }

--- a/packages/core/src/practice-plan/validation.test.ts
+++ b/packages/core/src/practice-plan/validation.test.ts
@@ -54,11 +54,14 @@ describe('validatePlanDraft', () => {
     expect(validatePlanDraft(bad, ctx).ok).toBe(false)
   })
 
-  it('rejects when block minutes diverge >20% from total_minutes', () => {
+  it('accepts a draft whose total_minutes disagrees with the block sum (server derives it)', () => {
+    // total_minutes is now server-derived from block minutes; the model's emitted value is
+    // ignored — a mismatch (65 declared vs 85 in blocks) must no longer reject.
     const bad = structuredClone(okDraft)
+    // S1 blocks sum to 43; set total_minutes to something wildly wrong
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- structuredClone(okDraft) preserves the full shape, so this indexed access is non-null
-    bad.sessions[0]!.total_minutes = 200
-    expect(validatePlanDraft(bad, ctx).ok).toBe(false)
+    bad.sessions[0]!.total_minutes = 65 // blocks still sum to 43 — mismatch, but should pass
+    expect(validatePlanDraft(bad, ctx).ok).toBe(true)
   })
 
   it('rejects the wrong session count', () => {
@@ -85,11 +88,14 @@ describe('validatePlanDraft', () => {
     expect(validatePlanDraft(bad, ctx).ok).toBe(false)
   })
 
-  it('rejects a non-positive total_minutes (no longer silently skipped)', () => {
+  it('rejects a zero block minutes (per-block positivity check remains)', () => {
+    // The per-block minutes check (D3-adjacent) is independent of the removed D4 total check.
+    // A block with minutes=0 must still fail even though total_minutes is no longer validated.
+    const bad = structuredClone(okDraft)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- structuredClone(okDraft) preserves the full shape, so this indexed access is non-null
-    const bad = structuredClone(okDraft); bad.sessions[0]!.total_minutes = 0
+    bad.sessions[0]!.blocks[1]!.minutes = 0
     const r = validatePlanDraft(bad, ctx)
-    expect(r.ok).toBe(false); expect(r.errors.join(' ')).toMatch(/total_minutes/)
+    expect(r.ok).toBe(false); expect(r.errors.join(' ')).toMatch(/invalid/)
   })
 
   it('rejects a negative block minutes', () => {

--- a/packages/core/src/practice-plan/validation.ts
+++ b/packages/core/src/practice-plan/validation.ts
@@ -9,7 +9,6 @@ export interface ValidationCtx {
   articlesLen: number // size of the published-article set; article_ref must index into it
 }
 
-const MINUTE_TOLERANCE = 0.2
 const MAX_OVERLAP = 0.6
 
 export function validatePlanDraft(
@@ -26,7 +25,6 @@ export function validatePlanDraft(
 
   const usedIds = new Set<string>()
   for (const s of draft.sessions) {
-    let sum = 0
     for (const b of s.blocks) {
       const drill = refOf(b.drill_ref)
       if (!drill) {
@@ -42,14 +40,8 @@ export function validatePlanDraft(
       if (!Number.isFinite(b.minutes) || b.minutes <= 0) {
         errors.push(`block ${b.id} minutes ${b.minutes} invalid (must be a finite number > 0)`)
       }
-      sum += b.minutes
     }
-    // D4: total_minutes must be positive and finite; sum of block minutes must be within 20%
-    if (!Number.isFinite(s.total_minutes) || s.total_minutes <= 0) {
-      errors.push(`session "${s.title}" total_minutes ${s.total_minutes} invalid (must be > 0)`)
-    } else if (Math.abs(sum - s.total_minutes) / s.total_minutes > MINUTE_TOLERANCE) {
-      errors.push(`session "${s.title}" minutes ${sum} vs total ${s.total_minutes} >20%`)
-    }
+    // total_minutes is server-derived (sum of block minutes) — not validated here
   }
 
   // D5: each of the top-2 weaknesses must have at least one non-warmup block covering it

--- a/supabase/functions/_shared/practice-plan/storage.ts
+++ b/supabase/functions/_shared/practice-plan/storage.ts
@@ -65,10 +65,8 @@ export interface PlanStoragePayload {
  *  An unresolved optional `article_ref` is dropped and logged (harmless —
  *  citations are optional). */
 export function resolvePlanForStorage(draft: PlanDraft, ctx: StorageCtx): PlanStoragePayload {
-  const sessions: StoredSession[] = draft.sessions.map((s) => ({
-    title: s.title,
-    total_minutes: s.total_minutes,
-    blocks: s.blocks.map((b) => {
+  const sessions: StoredSession[] = draft.sessions.map((s) => {
+    const blocks: StoredBlock[] = s.blocks.map((b) => {
       const drill = ctx.pool[b.drill_ref]
       const drillId = drill?.id
       if (drillId === undefined) {
@@ -89,8 +87,13 @@ export function resolvePlanForStorage(draft: PlanDraft, ctx: StorageCtx): PlanSt
         drill_id: drillId,
         target,
       }
-    }),
-  }))
+    })
+    return {
+      title: s.title,
+      total_minutes: blocks.reduce((acc, b) => acc + b.minutes, 0),
+      blocks,
+    }
+  })
 
   const focus_areas: StoredFocusArea[] = draft.focus_areas.map((f) => {
     const area: StoredFocusArea = { category: f.category, reason: f.reason }

--- a/supabase/functions/_shared/practice-plan/validation.ts
+++ b/supabase/functions/_shared/practice-plan/validation.ts
@@ -9,7 +9,6 @@ export interface ValidationCtx {
   articlesLen: number // size of the published-article set; article_ref must index into it
 }
 
-const MINUTE_TOLERANCE = 0.2
 const MAX_OVERLAP = 0.6
 
 export function validatePlanDraft(
@@ -26,7 +25,6 @@ export function validatePlanDraft(
 
   const usedIds = new Set<string>()
   for (const s of draft.sessions) {
-    let sum = 0
     for (const b of s.blocks) {
       const drill = refOf(b.drill_ref)
       if (!drill) {
@@ -42,14 +40,8 @@ export function validatePlanDraft(
       if (!Number.isFinite(b.minutes) || b.minutes <= 0) {
         errors.push(`block ${b.id} minutes ${b.minutes} invalid (must be a finite number > 0)`)
       }
-      sum += b.minutes
     }
-    // D4: total_minutes must be positive and finite; sum of block minutes must be within 20%
-    if (!Number.isFinite(s.total_minutes) || s.total_minutes <= 0) {
-      errors.push(`session "${s.title}" total_minutes ${s.total_minutes} invalid (must be > 0)`)
-    } else if (Math.abs(sum - s.total_minutes) / s.total_minutes > MINUTE_TOLERANCE) {
-      errors.push(`session "${s.title}" minutes ${sum} vs total ${s.total_minutes} >20%`)
-    }
+    // total_minutes is server-derived (sum of block minutes) — not validated here
   }
 
   // D5: each of the top-2 weaknesses must have at least one non-warmup block covering it


### PR DESCRIPTION
The deployed engine rejected a generated plan (caught in the dryRun smoke):

> session "…Approach Deep Dive" minutes 85 vs total 65 >20% → baseline

The model declared a 65-min session whose blocks summed to 85; `validatePlanDraft`'s ±20% rule rejected it, the repair retry didn't fix it → baseline. `total_minutes` is a **derived** value (the sum of block minutes), so — exactly as §10 already does for *targets* — the server should compute it rather than have the model emit a value that can disagree with the blocks.

## Fix (2 files + tests; schema untouched)
- `storage.ts` — `resolvePlanForStorage` now sets each session's `total_minutes = Σ block.minutes`, overriding the model's value. The stored/displayed session length is correct-by-construction.
- `validation.ts` — removed the D4 `total_minutes` finite/positive + ±20% checks (and the now-unused `MINUTE_TOLERANCE`/`sum`). The per-block `minutes > 0 && finite` check stays — that's what keeps the derived sum valid. All other checks (drill_ref/article_ref range, drill_type, session count, top-2 coverage, anti-repetition, coach_note length) are unchanged.
- The model still emits `total_minutes` (harmless hint); it's now ignored by validation and overridden in storage — so no schema re-touch / no new deploy risk.

## Verification
- `pnpm test` → 473 pass (incl. a new storage test: draft total 65 / blocks summing 43 → stored `total_minutes === 43`; and a validation test: a divergent session now passes). `pnpm typecheck` → clean. Drift-check OK (9 files; `validation.ts` + `storage.ts` re-vendored).
- **Final confirmation is the live deploy:** after merge + re-deploy, the dryRun should return a stored generated plan (no `reason: generation_failed`).

Follow-up to #435/#437; surfaced by the deploy smoke. No UI changes.