### PR TITLE
feat(web): Practice plan page — render generated plan + Generate button (Track 3)

### DIFF
--- a/apps/web/src/hooks/useDrills.ts
+++ b/apps/web/src/hooks/useDrills.ts
@@ -1,6 +1,6 @@
-import { useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { ShotCategory } from '@oga/core'
-import { getDrills, getLatestPracticePlan } from '@oga/supabase'
+import { getDrills, getDrillsByIds, getLatestPracticePlan } from '@oga/supabase'
 import { supabase } from '../lib/supabase'
 import { useAuth } from './useAuth'
 
@@ -28,6 +28,36 @@ export function useLatestPracticePlan() {
       const { data, error } = await getLatestPracticePlan(supabase, user!.id)
       if (error) throw error
       return data
+    },
+  })
+}
+
+export function useGeneratePlan() {
+  const { user } = useAuth()
+  const qc = useQueryClient()
+  return useMutation<void, Error>({
+    mutationFn: async () => {
+      const { error } = await supabase.functions.invoke('generate-practice-plan', { body: {} })
+      if (error) throw error
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['practice-plan', user?.id] })
+    },
+  })
+}
+
+export function useDrillsByIds(ids: string[]) {
+  const sortedIds = [...ids].sort()
+  return useQuery({
+    queryKey: ['drills-by-ids', sortedIds],
+    enabled: ids.length > 0,
+    queryFn: async () => {
+      const { data, error } = await getDrillsByIds(supabase, ids)
+      if (error) throw error
+      const drills = data ?? []
+      const byId: Record<string, (typeof drills)[number]> = {}
+      for (const d of drills) byId[d.id] = d
+      return byId
     },
   })
 }

--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -89,27 +89,52 @@ function normalizeCategoryProse(text: string): string {
     .replace(/\baround_green\b/gi, 'around the green')
 }
 
-// Tiny markdown-ish renderer scoped to the drill `instructions` format:
-// split on blank lines into paragraphs, convert `**bold**` to <strong>.
-// Not a general markdown parser — bold + paragraphs only.
+// Tiny markdown-ish renderer scoped to the drill `instructions` format.
+// Segmentation: splits into paragraphs on either (a) a blank line or
+// (b) the boundary immediately before a **Header.** token — so the
+// continuous seed format `**Why.** … **Setup.** … **How.** …` produces
+// one paragraph per section rather than one wall of text.
+// Inline tokens: `**bold**` → <strong>, `*italic*` → <em>.
+// No dangerouslySetInnerHTML — all text nodes + React elements only.
 function renderInstructions(text: string): React.ReactNode {
-  const paragraphs = text.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean)
-  return paragraphs.map((para, pi) => (
+  // Step 1: split on blank lines first, then within each chunk split
+  // before any **Header** token (lookahead keeps the token in the next segment).
+  const rawSegments = text
+    .split(/\n\s*\n/)
+    .flatMap((chunk) =>
+      chunk
+        .trim()
+        // Split at the position immediately before a **…** token that isn't
+        // at the very start of the chunk (so a leading header stays in chunk[0]).
+        .split(/(?=\*\*[^*]+\*\*)/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+    )
+
+  // Inline tokenizer: handle both **bold** and *italic* (single asterisk).
+  function renderInline(para: string): React.ReactNode[] {
+    return para.split(/(\*\*[^*]+\*\*|\*[^*]+\*)/g).map((part, i) => {
+      if (/^\*\*[^*]+\*\*$/.test(part)) {
+        return (
+          <strong key={i} className="text-caddie-ink" style={{ fontWeight: 600 }}>
+            {part.slice(2, -2)}
+          </strong>
+        )
+      }
+      if (/^\*[^*]+\*$/.test(part)) {
+        return <em key={i}>{part.slice(1, -1)}</em>
+      }
+      return part
+    })
+  }
+
+  return rawSegments.map((para, pi) => (
     <p
       key={pi}
       className="font-serif text-caddie-ink-dim"
       style={{ fontSize: 15, lineHeight: 1.6, marginTop: pi === 0 ? 0 : 12 }}
     >
-      {para.split(/(\*\*[^*]+\*\*)/g).map((part, i) => {
-        const m = /^\*\*([^*]+)\*\*$/.exec(part)
-        return m ? (
-          <strong key={i} className="text-caddie-ink" style={{ fontWeight: 600 }}>
-            {m[1]}
-          </strong>
-        ) : (
-          part
-        )
-      })}
+      {renderInline(para)}
     </p>
   ))
 }
@@ -429,6 +454,7 @@ function DrillCard({
               type="button"
               onClick={() => setOpen((o) => !o)}
               aria-expanded={open}
+              aria-controls={`drill-detail-${block.id}`}
               className="font-serif text-caddie-ink hover:opacity-80"
               style={{
                 display: 'flex',
@@ -522,7 +548,7 @@ function DrillCard({
 
       {/* Expanded — full-width instructions, hairline-separated, no shadow */}
       {canExpand && open ? (
-        <div style={{ borderTop: `1px solid ${LINE}`, marginTop: 16, paddingTop: 16, maxWidth: 660 }}>
+        <div id={`drill-detail-${block.id}`} style={{ borderTop: `1px solid ${LINE}`, marginTop: 16, paddingTop: 16, maxWidth: 660 }}>
           {renderInstructions(instructions)}
           {drill?.source ? (
             <div

--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -1,7 +1,18 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import type { PlanCategory, BlockType, StoredBlock, StoredSession, StoredFocusArea } from '@oga/core'
 import { useDrillsByIds, useGeneratePlan, useLatestPracticePlan } from '../../hooks/useDrills'
 import { toUserMessage } from '../../lib/errors'
+
+// Resolved drill row from useDrillsByIds (shape mirrors getDrillsByIds' select).
+type ResolvedDrill = {
+  name: string
+  description: string | null
+  instructions: string | null
+  facility: string[] | null
+  source: string | null
+  source_url: string | null
+}
 
 // ---------------------------------------------------------------------------
 // Stored-plan shapes. The generated Supabase types store `drills` and
@@ -68,6 +79,39 @@ function asDrills(value: unknown): PlanDrills {
 
 function asFocusAreas(value: unknown): StoredFocusArea[] {
   return Array.isArray(value) ? (value as StoredFocusArea[]) : []
+}
+
+// UI safety net: rewrite any leaked raw snake_case category enums in displayed
+// prose. `approach`/`putting` are already readable words and left untouched.
+function normalizeCategoryProse(text: string): string {
+  return text
+    .replace(/\boff_tee\b/gi, 'off the tee')
+    .replace(/\baround_green\b/gi, 'around the green')
+}
+
+// Tiny markdown-ish renderer scoped to the drill `instructions` format:
+// split on blank lines into paragraphs, convert `**bold**` to <strong>.
+// Not a general markdown parser — bold + paragraphs only.
+function renderInstructions(text: string): React.ReactNode {
+  const paragraphs = text.split(/\n\s*\n/).map((p) => p.trim()).filter(Boolean)
+  return paragraphs.map((para, pi) => (
+    <p
+      key={pi}
+      className="font-serif text-caddie-ink-dim"
+      style={{ fontSize: 15, lineHeight: 1.6, marginTop: pi === 0 ? 0 : 12 }}
+    >
+      {para.split(/(\*\*[^*]+\*\*)/g).map((part, i) => {
+        const m = /^\*\*([^*]+)\*\*$/.exec(part)
+        return m ? (
+          <strong key={i} className="text-caddie-ink" style={{ fontWeight: 600 }}>
+            {m[1]}
+          </strong>
+        ) : (
+          part
+        )
+      })}
+    </p>
+  ))
 }
 
 // ---------------------------------------------------------------------------
@@ -297,7 +341,7 @@ function ReasoningPanel({ note }: { note: string }) {
           className="font-serif text-caddie-ink"
           style={{ fontSize: 17, lineHeight: 1.6 }}
         >
-          {note}
+          {normalizeCategoryProse(note)}
         </p>
       </div>
     </section>
@@ -324,7 +368,7 @@ function FocusAreas({ areas }: { areas: StoredFocusArea[] }) {
               className="text-caddie-ink-dim"
               style={{ fontSize: 15, lineHeight: 1.5, marginTop: 4 }}
             >
-              {area.reason}
+              {normalizeCategoryProse(area.reason)}
             </p>
             {area.article ? (
               <Link
@@ -348,98 +392,165 @@ function FocusAreas({ areas }: { areas: StoredFocusArea[] }) {
 function DrillCard({
   index,
   block,
-  drillName,
-  facilities,
+  drill,
 }: {
   index: number
   block: StoredBlock
-  drillName: string
-  facilities: string[]
+  drill: ResolvedDrill | undefined
 }) {
+  const [open, setOpen] = useState(false)
+  const drillName = drill?.name ?? 'Drill'
+  const facilities = drill?.facility ?? []
+  const instructions = drill?.instructions?.trim() || drill?.description?.trim() || ''
+  const canExpand = instructions.length > 0
+
   return (
-    <div
-      style={{
-        display: 'grid',
-        gridTemplateColumns: 'auto 1fr auto',
-        gap: 18,
-        alignItems: 'start',
-        borderBottom: `1px solid ${LINE}`,
-        padding: '18px 0',
-      }}
-    >
-      {/* Left — numeral */}
+    <div style={{ borderBottom: `1px solid ${LINE}`, padding: '18px 0' }}>
       <div
-        className="font-serif text-caddie-ink-mute"
-        style={{ fontSize: 28, fontStyle: 'italic', lineHeight: 1, minWidth: 36 }}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'auto 1fr auto',
+          gap: 18,
+          alignItems: 'start',
+        }}
       >
-        {String(index).padStart(2, '0')}
-      </div>
-
-      {/* Center — name + why + equipment */}
-      <div>
+        {/* Left — numeral */}
         <div
-          className="font-serif text-caddie-ink"
-          style={{ fontSize: 19, fontStyle: 'italic', lineHeight: 1.2 }}
+          className="font-serif text-caddie-ink-mute"
+          style={{ fontSize: 28, fontStyle: 'italic', lineHeight: 1, minWidth: 36 }}
         >
-          {drillName}
+          {String(index).padStart(2, '0')}
         </div>
-        {block.rationale ? (
-          <p
-            className="font-serif text-caddie-ink-dim"
-            style={{ fontSize: 15, lineHeight: 1.5, marginTop: 6 }}
-          >
-            {block.rationale}
-          </p>
-        ) : null}
-        {facilities.length > 0 ? (
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
-            {facilities.map((f) => (
+
+        {/* Center — name (expand affordance) + why + equipment */}
+        <div>
+          {canExpand ? (
+            <button
+              type="button"
+              onClick={() => setOpen((o) => !o)}
+              aria-expanded={open}
+              className="font-serif text-caddie-ink hover:opacity-80"
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: 8,
+                fontSize: 19,
+                fontStyle: 'italic',
+                lineHeight: 1.2,
+                textAlign: 'left',
+                cursor: 'pointer',
+                background: 'none',
+                border: 'none',
+                padding: 0,
+              }}
+            >
+              <span>{drillName}</span>
               <span
-                key={f}
-                className="font-mono bg-caddie-surface-2 text-caddie-ink-dim"
-                style={{
-                  fontSize: 10,
-                  letterSpacing: '0.04em',
-                  textTransform: 'uppercase',
-                  padding: '3px 8px',
-                  borderRadius: 2,
-                }}
+                className="font-mono text-caddie-ink-mute"
+                aria-hidden="true"
+                style={{ fontSize: 15, fontStyle: 'normal', lineHeight: 1 }}
               >
-                {FACILITY_LABEL[f] ?? f}
+                {open ? '−' : '+'}
               </span>
-            ))}
+            </button>
+          ) : (
+            <div
+              className="font-serif text-caddie-ink"
+              style={{ fontSize: 19, fontStyle: 'italic', lineHeight: 1.2 }}
+            >
+              {drillName}
+            </div>
+          )}
+          {block.rationale ? (
+            <p
+              className="font-serif text-caddie-ink-dim"
+              style={{ fontSize: 15, lineHeight: 1.5, marginTop: 6 }}
+            >
+              {block.rationale}
+            </p>
+          ) : null}
+          {facilities.length > 0 ? (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
+              {facilities.map((f) => (
+                <span
+                  key={f}
+                  className="font-mono bg-caddie-surface-2 text-caddie-ink-dim"
+                  style={{
+                    fontSize: 10,
+                    letterSpacing: '0.04em',
+                    textTransform: 'uppercase',
+                    padding: '3px 8px',
+                    borderRadius: 2,
+                  }}
+                >
+                  {FACILITY_LABEL[f] ?? f}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        {/* Right — minutes + type tag + optional target */}
+        <div style={{ textAlign: 'right', minWidth: 72 }}>
+          <div
+            className="font-serif text-caddie-ink"
+            style={{ fontSize: 22, fontStyle: 'italic', lineHeight: 1 }}
+          >
+            {block.minutes} min
           </div>
-        ) : null}
+          <div
+            className="font-mono text-caddie-accent"
+            style={{
+              fontSize: 9,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              marginTop: 6,
+            }}
+          >
+            {BLOCK_TYPE_LABEL[block.type] ?? block.type}
+          </div>
+          {block.target != null ? (
+            <div
+              className="font-mono text-caddie-ink-dim"
+              style={{ fontSize: 10, letterSpacing: '0.04em', marginTop: 10 }}
+            >
+              Target: {block.target}
+            </div>
+          ) : null}
+        </div>
       </div>
 
-      {/* Right — minutes + type tag + optional target */}
-      <div style={{ textAlign: 'right', minWidth: 72 }}>
-        <div
-          className="font-serif text-caddie-ink"
-          style={{ fontSize: 22, fontStyle: 'italic', lineHeight: 1 }}
-        >
-          {block.minutes} min
+      {/* Expanded — full-width instructions, hairline-separated, no shadow */}
+      {canExpand && open ? (
+        <div style={{ borderTop: `1px solid ${LINE}`, marginTop: 16, paddingTop: 16, maxWidth: 660 }}>
+          {renderInstructions(instructions)}
+          {drill?.source ? (
+            <div
+              className="font-mono text-caddie-ink-mute"
+              style={{
+                fontSize: 10,
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+                marginTop: 14,
+              }}
+            >
+              via{' '}
+              {drill.source_url ? (
+                <a
+                  href={drill.source_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-caddie-accent hover:opacity-80"
+                >
+                  {drill.source}
+                </a>
+              ) : (
+                drill.source
+              )}
+            </div>
+          ) : null}
         </div>
-        <div
-          className="font-mono text-caddie-accent"
-          style={{
-            fontSize: 9,
-            letterSpacing: '0.12em',
-            textTransform: 'uppercase',
-            marginTop: 6,
-          }}
-        >
-          {BLOCK_TYPE_LABEL[block.type] ?? block.type}
-        </div>
-        {block.target != null ? (
-          <div
-            className="font-mono text-caddie-ink-dim"
-            style={{ fontSize: 10, letterSpacing: '0.04em', marginTop: 10 }}
-          >
-            Target: {block.target}
-          </div>
-        ) : null}
-      </div>
+      ) : null}
     </div>
   )
 }
@@ -451,7 +562,7 @@ function SessionSection({
 }: {
   session: StoredSession
   sessionNumber: number
-  drillsById: Record<string, { name: string; facility: string[] | null }>
+  drillsById: Record<string, ResolvedDrill>
 }) {
   const blocks = [...session.blocks].sort((a, b) => a.order - b.order)
   return (
@@ -473,8 +584,7 @@ function SessionSection({
               key={block.id ?? `${block.drill_id}-${i}`}
               index={i + 1}
               block={block}
-              drillName={drill?.name ?? 'Drill'}
-              facilities={drill?.facility ?? []}
+              drill={drill}
             />
           )
         })}

--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -1,83 +1,592 @@
 import { Link } from 'react-router-dom'
+import { useDrillsByIds, useGeneratePlan, useLatestPracticePlan } from '../../hooks/useDrills'
+import { toUserMessage } from '../../lib/errors'
 
-export function PracticePlanPage() {
+// ---------------------------------------------------------------------------
+// Stored-plan shapes. The generated Supabase types store `drills` and
+// `focus_areas` as `Json | null`; the engine writes the structured shapes
+// below (see the AI-plan engine spec). We narrow them here so the render
+// code is type-safe without trusting the loose Json type.
+// ---------------------------------------------------------------------------
+
+type PlanCategory = 'off_tee' | 'approach' | 'around_green' | 'putting'
+
+type BlockType = 'warmup' | 'technical' | 'skill_game' | 'pressure_game' | 'putting'
+
+type FocusArea = {
+  category: PlanCategory
+  reason: string
+  article?: { title: string; slug: string } | null
+}
+
+type PlanBlock = {
+  id: string
+  order: number
+  type: BlockType
+  drill_id: string
+  minutes: number
+  rationale: string
+  target: number | null
+}
+
+type PlanSession = {
+  title: string
+  total_minutes: number
+  blocks: PlanBlock[]
+}
+
+type PlanDrills = { sessions: PlanSession[] }
+
+const CATEGORY_LABEL: Record<PlanCategory, string> = {
+  off_tee: 'Off the tee',
+  approach: 'Approach',
+  around_green: 'Around the green',
+  putting: 'Putting',
+}
+
+const BLOCK_TYPE_LABEL: Record<BlockType, string> = {
+  warmup: 'Warm-up',
+  technical: 'Technical',
+  skill_game: 'Skill game',
+  pressure_game: 'Pressure game',
+  putting: 'Putting',
+}
+
+const FACILITY_LABEL: Record<string, string> = {
+  range: 'Range',
+  short_game: 'Short game',
+  putting: 'Putting green',
+  sim: 'Simulator',
+}
+
+const ACCENT = '#1F3D2C'
+const LINE = '#D9D2BF'
+
+// ---------------------------------------------------------------------------
+// Date helpers. `valid_until` is a date string (YYYY-MM-DD); we compare it to
+// today's local date, not a timestamp, so a plan stays "current" through the
+// whole of its final day regardless of the user's clock time.
+// ---------------------------------------------------------------------------
+
+function todayDateString(): string {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return ''
+  // Parse a bare date string as local, not UTC, to avoid an off-by-one day.
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value) ? new Date(`${value}T00:00:00`) : new Date(value)
+  if (Number.isNaN(parsed.getTime())) return ''
+  return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+function asDrills(value: unknown): PlanDrills {
+  if (value && typeof value === 'object' && Array.isArray((value as PlanDrills).sessions)) {
+    return value as PlanDrills
+  }
+  return { sessions: [] }
+}
+
+function asFocusAreas(value: unknown): FocusArea[] {
+  return Array.isArray(value) ? (value as FocusArea[]) : []
+}
+
+// ---------------------------------------------------------------------------
+// Shared bits
+// ---------------------------------------------------------------------------
+
+function PrimaryButton({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick: () => void
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="bg-caddie-accent text-caddie-accent-ink hover:opacity-90 disabled:opacity-60"
+      style={{
+        fontSize: 14,
+        fontWeight: 600,
+        letterSpacing: '0.02em',
+        padding: '12px 16px',
+        borderRadius: 2,
+        cursor: disabled ? 'default' : 'pointer',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
+function GenerateButton({
+  label,
+  onGenerate,
+  isPending,
+}: {
+  label: string
+  onGenerate: () => void
+  isPending: boolean
+}) {
+  return (
+    <PrimaryButton onClick={onGenerate} disabled={isPending}>
+      {isPending ? (
+        'Generating…'
+      ) : (
+        <>
+          {label}{' '}
+          <span className="font-serif" style={{ fontStyle: 'italic' }}>
+            →
+          </span>
+        </>
+      )}
+    </PrimaryButton>
+  )
+}
+
+function PageHeading() {
+  return (
+    <>
+      <div className="kicker" style={{ marginBottom: 8 }}>
+        Today's focus
+      </div>
+      <h1
+        className="font-serif text-caddie-ink"
+        style={{ fontSize: 28, fontWeight: 500, fontStyle: 'italic', lineHeight: 1.15 }}
+      >
+        Practice plan
+      </h1>
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// States
+// ---------------------------------------------------------------------------
+
+function LoadingState() {
   return (
     <div>
       <div style={{ marginBottom: 28 }}>
-        <div className="kicker" style={{ marginBottom: 8 }}>
-          Today's focus
-        </div>
-        <h1
-          className="font-serif text-caddie-ink"
-          style={{ fontSize: 28, fontWeight: 500, lineHeight: 1.15 }}
-        >
-          Practice plan
-        </h1>
-        <p
-          className="text-caddie-ink-dim"
-          style={{ fontSize: 15, marginTop: 6, maxWidth: 560 }}
-        >
-          A drill checklist that follows the math of your strokes gained,
-          calibrated to your skill level and goal.
-        </p>
+        <PageHeading />
       </div>
-
+      <div
+        style={{ height: 10, width: 280, background: '#EBE5D6', marginBottom: 18 }}
+      />
       <div
         className="bg-caddie-surface"
-        style={{
-          border: '1px solid #D9D2BF',
-          borderRadius: 4,
-          padding: '40px 32px',
-          maxWidth: 640,
-        }}
+        style={{ border: `1px solid ${LINE}`, borderRadius: 4, height: 120, marginBottom: 32 }}
+      />
+      {[0, 1].map((i) => (
+        <div key={i} style={{ borderTop: `1px solid ${LINE}`, paddingTop: 18, marginBottom: 32 }}>
+          <div style={{ height: 10, width: 140, background: '#EBE5D6', marginBottom: 18 }} />
+          {[0, 1].map((j) => (
+            <div
+              key={j}
+              className="bg-caddie-surface"
+              style={{ border: `1px solid ${LINE}`, borderRadius: 4, height: 96, marginBottom: 12 }}
+            />
+          ))}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function NoPlanState({
+  onGenerate,
+  isPending,
+  errorNotice,
+}: {
+  onGenerate: () => void
+  isPending: boolean
+  errorNotice: React.ReactNode
+}) {
+  return (
+    <div>
+      <div style={{ marginBottom: 28 }}>
+        <PageHeading />
+      </div>
+      <div
+        className="bg-caddie-surface"
+        style={{ border: `1px solid ${LINE}`, borderRadius: 4, padding: '40px 32px', maxWidth: 640 }}
       >
         <div className="kicker" style={{ marginBottom: 12 }}>
-          Coming in phase 5
+          No plan yet
         </div>
         <h2
           className="font-serif text-caddie-ink"
-          style={{
-            fontSize: 22,
-            fontWeight: 500,
-            fontStyle: 'italic',
-            lineHeight: 1.2,
-          }}
+          style={{ fontSize: 22, fontWeight: 500, fontStyle: 'italic', lineHeight: 1.2 }}
         >
-          A column, not a checklist.
+          A week built from your own numbers.
         </h2>
         <p
           className="font-serif text-caddie-ink"
-          style={{
-            fontSize: 17,
-            lineHeight: 1.55,
-            marginTop: 14,
-          }}
+          style={{ fontSize: 17, lineHeight: 1.55, marginTop: 14, maxWidth: 520 }}
         >
-          Once you have logged enough rounds, this page will read you a
-          short opinion: <em>where the strokes are leaking</em>, and
-          three drills sized to your facilities and time.
+          Generate a week of practice sized to your strokes gained — which drills,
+          in what order, with the reasoning behind each one.
         </p>
         <div style={{ marginTop: 22 }}>
-          <Link
-            to="/practice/drills"
-            className="text-caddie-accent hover:opacity-80"
-            style={{
-              border: '1px solid #1F3D2C',
-              padding: '10px 14px',
-              fontSize: 13,
-              fontWeight: 600,
-              letterSpacing: '0.02em',
-              borderRadius: 2,
-              display: 'inline-block',
-            }}
-          >
-            Browse drill library{' '}
-            <span className="font-serif" style={{ fontStyle: 'italic' }}>
-              →
-            </span>
-          </Link>
+          <GenerateButton
+            label="Generate this week's plan"
+            onGenerate={onGenerate}
+            isPending={isPending}
+          />
         </div>
+        {errorNotice}
       </div>
+    </div>
+  )
+}
+
+function ErrorNotice({ error }: { error: unknown }) {
+  return (
+    <div
+      className="text-caddie-neg"
+      style={{
+        marginTop: 18,
+        border: `1px solid ${LINE}`,
+        borderRadius: 4,
+        padding: '12px 14px',
+        fontSize: 13,
+        background: '#FBF8F1',
+      }}
+    >
+      {toUserMessage(error)}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Plan sections
+// ---------------------------------------------------------------------------
+
+function PlanHeader({
+  kicker,
+  insight,
+  generateLabel,
+  onGenerate,
+  isPending,
+}: {
+  kicker: string
+  insight: string
+  generateLabel: string | null
+  onGenerate: () => void
+  isPending: boolean
+}) {
+  return (
+    <div
+      className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3"
+      style={{ marginBottom: 28 }}
+    >
+      <div>
+        <div className="kicker" style={{ marginBottom: 8 }}>
+          {kicker}
+        </div>
+        <h1
+          className="font-serif text-caddie-ink"
+          style={{ fontSize: 28, fontWeight: 500, fontStyle: 'italic', lineHeight: 1.15, maxWidth: 640 }}
+        >
+          {insight}
+        </h1>
+      </div>
+      {generateLabel ? (
+        <GenerateButton label={generateLabel} onGenerate={onGenerate} isPending={isPending} />
+      ) : null}
+    </div>
+  )
+}
+
+function ReasoningPanel({ note }: { note: string }) {
+  return (
+    <section style={{ marginBottom: 32 }}>
+      <div className="kicker" style={{ marginBottom: 12 }}>
+        The reasoning
+      </div>
+      <div
+        className="bg-caddie-surface"
+        style={{ border: `1px solid ${LINE}`, borderRadius: 4, padding: '22px 24px', maxWidth: 720 }}
+      >
+        <p
+          className="font-serif text-caddie-ink"
+          style={{ fontSize: 17, lineHeight: 1.6 }}
+        >
+          {note}
+        </p>
+      </div>
+    </section>
+  )
+}
+
+function FocusAreas({ areas }: { areas: FocusArea[] }) {
+  if (areas.length === 0) return null
+  return (
+    <section style={{ borderTop: `1px solid ${LINE}`, paddingTop: 18, marginBottom: 32 }}>
+      <div className="kicker" style={{ marginBottom: 18 }}>
+        What to work on
+      </div>
+      <div style={{ display: 'grid', gap: 14, maxWidth: 720 }}>
+        {areas.map((area, i) => (
+          <div key={`${area.category}-${i}`}>
+            <div
+              className="font-serif text-caddie-ink"
+              style={{ fontSize: 17, fontWeight: 500 }}
+            >
+              {CATEGORY_LABEL[area.category] ?? area.category}
+            </div>
+            <p
+              className="text-caddie-ink-dim"
+              style={{ fontSize: 15, lineHeight: 1.5, marginTop: 4 }}
+            >
+              {area.reason}
+            </p>
+            {area.article ? (
+              <Link
+                to={`/learn/${area.article.slug}`}
+                className="text-caddie-accent hover:opacity-80"
+                style={{ display: 'inline-block', marginTop: 6, fontSize: 13, fontWeight: 600 }}
+              >
+                {area.article.title}{' '}
+                <span className="font-serif" style={{ fontStyle: 'italic' }}>
+                  →
+                </span>
+              </Link>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function DrillCard({
+  index,
+  block,
+  drillName,
+  facilities,
+}: {
+  index: number
+  block: PlanBlock
+  drillName: string
+  facilities: string[]
+}) {
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'auto 1fr auto',
+        gap: 18,
+        alignItems: 'start',
+        borderBottom: `1px solid ${LINE}`,
+        padding: '18px 0',
+      }}
+    >
+      {/* Left — numeral */}
+      <div
+        className="font-serif text-caddie-ink-mute"
+        style={{ fontSize: 28, fontStyle: 'italic', lineHeight: 1, minWidth: 36 }}
+      >
+        {String(index).padStart(2, '0')}
+      </div>
+
+      {/* Center — name + why + equipment */}
+      <div>
+        <div
+          className="font-serif text-caddie-ink"
+          style={{ fontSize: 19, fontStyle: 'italic', lineHeight: 1.2 }}
+        >
+          {drillName}
+        </div>
+        {block.rationale ? (
+          <p
+            className="font-serif text-caddie-ink-dim"
+            style={{ fontSize: 15, lineHeight: 1.5, marginTop: 6 }}
+          >
+            {block.rationale}
+          </p>
+        ) : null}
+        {facilities.length > 0 ? (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
+            {facilities.map((f) => (
+              <span
+                key={f}
+                className="font-mono bg-caddie-surface-2 text-caddie-ink-dim"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: '0.04em',
+                  textTransform: 'uppercase',
+                  padding: '3px 8px',
+                  borderRadius: 2,
+                }}
+              >
+                {FACILITY_LABEL[f] ?? f}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {/* Right — minutes + type tag + optional target */}
+      <div style={{ textAlign: 'right', minWidth: 72 }}>
+        <div
+          className="font-serif text-caddie-ink"
+          style={{ fontSize: 22, fontStyle: 'italic', lineHeight: 1 }}
+        >
+          {block.minutes} min
+        </div>
+        <div
+          className="font-mono text-caddie-accent"
+          style={{
+            fontSize: 9,
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            marginTop: 6,
+          }}
+        >
+          {BLOCK_TYPE_LABEL[block.type] ?? block.type}
+        </div>
+        {block.target != null ? (
+          <div
+            className="font-mono text-caddie-ink-mute"
+            style={{ fontSize: 10, letterSpacing: '0.04em', marginTop: 6 }}
+          >
+            target: {block.target}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function SessionSection({
+  session,
+  sessionNumber,
+  drillsById,
+}: {
+  session: PlanSession
+  sessionNumber: number
+  drillsById: Record<string, { name: string; facility: string[] | null }>
+}) {
+  const blocks = [...session.blocks].sort((a, b) => a.order - b.order)
+  return (
+    <section style={{ borderTop: `1px solid ${LINE}`, paddingTop: 18, marginBottom: 32 }}>
+      <div className="kicker" style={{ marginBottom: 8 }}>
+        Session {sessionNumber} · {session.total_minutes} min
+      </div>
+      <h2
+        className="font-serif text-caddie-ink"
+        style={{ fontSize: 22, fontWeight: 500, lineHeight: 1.2, marginBottom: 8 }}
+      >
+        {session.title}
+      </h2>
+      <div>
+        {blocks.map((block, i) => {
+          const drill = drillsById[block.drill_id]
+          return (
+            <DrillCard
+              key={block.id ?? `${block.drill_id}-${i}`}
+              index={i + 1}
+              block={block}
+              drillName={drill?.name ?? 'Drill'}
+              facilities={drill?.facility ?? []}
+            />
+          )
+        })}
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function PracticePlanPage() {
+  const planQuery = useLatestPracticePlan()
+  const generate = useGeneratePlan()
+
+  const plan = planQuery.data
+  const drills = asDrills(plan?.drills)
+  const focusAreas = asFocusAreas(plan?.focus_areas)
+
+  // Resolve every block's drill UUID → row in one query.
+  const drillIds = drills.sessions.flatMap((s) => s.blocks.map((b) => b.drill_id))
+  const drillsByIds = useDrillsByIds(drillIds)
+  const drillsById = drillsByIds.data ?? {}
+
+  const onGenerate = () => generate.mutate()
+  const errorNotice = generate.error ? <ErrorNotice error={generate.error} /> : null
+
+  if (planQuery.isLoading) {
+    return <LoadingState />
+  }
+
+  if (!plan) {
+    return (
+      <NoPlanState
+        onGenerate={onGenerate}
+        isPending={generate.isPending}
+        errorNotice={errorNotice}
+      />
+    )
+  }
+
+  // Plan exists. Decide current vs. soft-expired by comparing date strings
+  // (lexicographic comparison is correct for ISO YYYY-MM-DD).
+  const today = todayDateString()
+  const isExpired = !!plan.valid_until && plan.valid_until < today
+
+  const kicker = isExpired
+    ? `Last week's plan · valid through ${formatDate(plan.valid_until)}`
+    : `Practice plan · week of ${formatDate(plan.generated_at)}${plan.valid_until ? ` · valid through ${formatDate(plan.valid_until)}` : ''}`
+
+  // No-regenerate-within-window: only offer Generate once the plan has expired.
+  const generateLabel = isExpired ? "Generate this week's plan" : null
+
+  return (
+    <div>
+      <PlanHeader
+        kicker={kicker}
+        insight={plan.ai_insight ?? 'Your practice plan'}
+        generateLabel={generateLabel}
+        onGenerate={onGenerate}
+        isPending={generate.isPending}
+      />
+
+      {errorNotice}
+
+      {plan.coach_note ? <ReasoningPanel note={plan.coach_note} /> : null}
+
+      <FocusAreas areas={focusAreas} />
+
+      {drills.sessions.map((session, i) => (
+        <SessionSection
+          key={`session-${i}`}
+          session={session}
+          sessionNumber={i + 1}
+          drillsById={drillsById}
+        />
+      ))}
+
+      {plan.based_on_rounds ? (
+        <div
+          className="font-mono text-caddie-ink-mute"
+          style={{ fontSize: 10, letterSpacing: '0.04em', textTransform: 'uppercase', paddingTop: 4 }}
+        >
+          Based on your last {plan.based_on_rounds} round{plan.based_on_rounds === 1 ? '' : 's'}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -90,51 +90,52 @@ function normalizeCategoryProse(text: string): string {
 }
 
 // Tiny markdown-ish renderer scoped to the drill `instructions` format.
-// Segmentation: splits into paragraphs on either (a) a blank line or
-// (b) the boundary immediately before a **Header.** token — so the
-// continuous seed format `**Why.** … **Setup.** … **How.** …` produces
-// one paragraph per section rather than one wall of text.
-// Inline tokens: `**bold**` → <strong>, `*italic*` → <em>.
+// Tokenizes left-to-right into complete tokens (**bold** | *italic* | plain)
+// then groups: each **bold** header starts a new paragraph, following
+// plain/italic text belongs to that section.
+// The continuous seed format `**Why.** prose **Setup.** prose` produces one
+// paragraph per section. Complete-token matching (not a lookahead) avoids the
+// closing-**+body+opening-** ambiguity of the prior split approach.
 // No dangerouslySetInnerHTML — all text nodes + React elements only.
 function renderInstructions(text: string): React.ReactNode {
-  // Step 1: split on blank lines first, then within each chunk split
-  // before any **Header** token (lookahead keeps the token in the next segment).
-  const rawSegments = text
-    .split(/\n\s*\n/)
-    .flatMap((chunk) =>
-      chunk
-        .trim()
-        // Split at the position immediately before a **…** token that isn't
-        // at the very start of the chunk (so a leading header stays in chunk[0]).
-        .split(/(?=\*\*[^*]+\*\*)/)
-        .map((s) => s.trim())
-        .filter(Boolean),
-    )
-
-  // Inline tokenizer: handle both **bold** and *italic* (single asterisk).
-  function renderInline(para: string): React.ReactNode[] {
-    return para.split(/(\*\*[^*]+\*\*|\*[^*]+\*)/g).map((part, i) => {
-      if (/^\*\*[^*]+\*\*$/.test(part)) {
-        return (
-          <strong key={i} className="text-caddie-ink" style={{ fontWeight: 600 }}>
-            {part.slice(2, -2)}
-          </strong>
-        )
-      }
-      if (/^\*[^*]+\*$/.test(part)) {
-        return <em key={i}>{part.slice(1, -1)}</em>
-      }
-      return part
-    })
+  // Tokenize left-to-right into complete tokens: **bold** | *italic* | plain.
+  // Matching complete tokens (not a lookahead) avoids the closing-**+body+opening-**
+  // ambiguity. The seed uses **…** only for section headers and *…* for emphasis.
+  const tokens = text.match(/\*\*[^*]+\*\*|\*[^*]+\*|[^*]+/g) ?? []
+  // Group into paragraphs: each **bold** header starts a new paragraph; the
+  // following plain/italic text belongs to that section.
+  type Seg = { kind: 'b' | 'i' | 't'; text: string }
+  const paras: Seg[][] = []
+  let cur: Seg[] = []
+  for (const tok of tokens) {
+    if (tok.startsWith('**')) {
+      if (cur.length) paras.push(cur)
+      cur = [{ kind: 'b', text: tok.slice(2, -2) }]
+    } else if (tok.startsWith('*')) {
+      cur.push({ kind: 'i', text: tok.slice(1, -1) })
+    } else {
+      cur.push({ kind: 't', text: tok })
+    }
   }
+  if (cur.length) paras.push(cur)
 
-  return rawSegments.map((para, pi) => (
+  return paras.map((para, pi) => (
     <p
       key={pi}
       className="font-serif text-caddie-ink-dim"
       style={{ fontSize: 15, lineHeight: 1.6, marginTop: pi === 0 ? 0 : 12 }}
     >
-      {renderInline(para)}
+      {para.map((seg, si) =>
+        seg.kind === 'b' ? (
+          <strong key={si} className="text-caddie-ink" style={{ fontWeight: 600 }}>
+            {seg.text}
+          </strong>
+        ) : seg.kind === 'i' ? (
+          <em key={si}>{seg.text}</em>
+        ) : (
+          <span key={si}>{seg.text}</span>
+        ),
+      )}
     </p>
   ))
 }

--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -1,41 +1,17 @@
 import { Link } from 'react-router-dom'
+import type { PlanCategory, BlockType, StoredBlock, StoredSession, StoredFocusArea } from '@oga/core'
 import { useDrillsByIds, useGeneratePlan, useLatestPracticePlan } from '../../hooks/useDrills'
 import { toUserMessage } from '../../lib/errors'
 
 // ---------------------------------------------------------------------------
 // Stored-plan shapes. The generated Supabase types store `drills` and
 // `focus_areas` as `Json | null`; the engine writes the structured shapes
-// below (see the AI-plan engine spec). We narrow them here so the render
-// code is type-safe without trusting the loose Json type.
+// defined in `@oga/core` (StoredBlock, StoredSession, StoredFocusArea).
+// We narrow them here so the render code is type-safe without trusting the
+// loose Json type.
 // ---------------------------------------------------------------------------
 
-type PlanCategory = 'off_tee' | 'approach' | 'around_green' | 'putting'
-
-type BlockType = 'warmup' | 'technical' | 'skill_game' | 'pressure_game' | 'putting'
-
-type FocusArea = {
-  category: PlanCategory
-  reason: string
-  article?: { title: string; slug: string } | null
-}
-
-type PlanBlock = {
-  id: string
-  order: number
-  type: BlockType
-  drill_id: string
-  minutes: number
-  rationale: string
-  target: number | null
-}
-
-type PlanSession = {
-  title: string
-  total_minutes: number
-  blocks: PlanBlock[]
-}
-
-type PlanDrills = { sessions: PlanSession[] }
+type PlanDrills = { sessions: StoredSession[] }
 
 const CATEGORY_LABEL: Record<PlanCategory, string> = {
   off_tee: 'Off the tee',
@@ -59,7 +35,6 @@ const FACILITY_LABEL: Record<string, string> = {
   sim: 'Simulator',
 }
 
-const ACCENT = '#1F3D2C'
 const LINE = '#D9D2BF'
 
 // ---------------------------------------------------------------------------
@@ -91,8 +66,8 @@ function asDrills(value: unknown): PlanDrills {
   return { sessions: [] }
 }
 
-function asFocusAreas(value: unknown): FocusArea[] {
-  return Array.isArray(value) ? (value as FocusArea[]) : []
+function asFocusAreas(value: unknown): StoredFocusArea[] {
+  return Array.isArray(value) ? (value as StoredFocusArea[]) : []
 }
 
 // ---------------------------------------------------------------------------
@@ -329,7 +304,7 @@ function ReasoningPanel({ note }: { note: string }) {
   )
 }
 
-function FocusAreas({ areas }: { areas: FocusArea[] }) {
+function FocusAreas({ areas }: { areas: StoredFocusArea[] }) {
   if (areas.length === 0) return null
   return (
     <section style={{ borderTop: `1px solid ${LINE}`, paddingTop: 18, marginBottom: 32 }}>
@@ -377,7 +352,7 @@ function DrillCard({
   facilities,
 }: {
   index: number
-  block: PlanBlock
+  block: StoredBlock
   drillName: string
   facilities: string[]
 }) {
@@ -458,10 +433,10 @@ function DrillCard({
         </div>
         {block.target != null ? (
           <div
-            className="font-mono text-caddie-ink-mute"
-            style={{ fontSize: 10, letterSpacing: '0.04em', marginTop: 6 }}
+            className="font-mono text-caddie-ink-dim"
+            style={{ fontSize: 10, letterSpacing: '0.04em', marginTop: 10 }}
           >
-            target: {block.target}
+            Target: {block.target}
           </div>
         ) : null}
       </div>
@@ -474,7 +449,7 @@ function SessionSection({
   sessionNumber,
   drillsById,
 }: {
-  session: PlanSession
+  session: StoredSession
   sessionNumber: number
   drillsById: Record<string, { name: string; facility: string[] | null }>
 }) {
@@ -492,7 +467,7 @@ function SessionSection({
       </h2>
       <div>
         {blocks.map((block, i) => {
-          const drill = drillsById[block.drill_id]
+          const drill = block.drill_id ? drillsById[block.drill_id] : undefined
           return (
             <DrillCard
               key={block.id ?? `${block.drill_id}-${i}`}
@@ -520,8 +495,11 @@ export function PracticePlanPage() {
   const drills = asDrills(plan?.drills)
   const focusAreas = asFocusAreas(plan?.focus_areas)
 
-  // Resolve every block's drill UUID → row in one query.
-  const drillIds = drills.sessions.flatMap((s) => s.blocks.map((b) => b.drill_id))
+  // Resolve every block's drill UUID → row in one query. drill_id is string | undefined
+  // (StoredBlock shape); filter out any undefined before passing to useDrillsByIds.
+  const drillIds = drills.sessions.flatMap((s) =>
+    s.blocks.map((b) => b.drill_id).filter((id): id is string => id !== undefined),
+  )
   const drillsByIds = useDrillsByIds(drillIds)
   const drillsById = drillsByIds.data ?? {}
 

--- a/packages/supabase/src/queries/practice.ts
+++ b/packages/supabase/src/queries/practice.ts
@@ -46,3 +46,21 @@ export function updatePlanProgress(
     .select()
     .single()
 }
+
+export function getDrillsByIds(client: OgaSupabaseClient, ids: string[]) {
+  if (ids.length === 0) return Promise.resolve({ data: [] as DrillCard[], error: null })
+  return client
+    .from('drills')
+    .select('id, name, description, facility, duration_min, drill_type, category')
+    .in('id', ids)
+}
+
+type DrillCard = {
+  id: string
+  name: string
+  description: string | null
+  facility: string[] | null
+  duration_min: number | null
+  drill_type: string
+  category: string | null
+}

--- a/packages/supabase/src/queries/practice.ts
+++ b/packages/supabase/src/queries/practice.ts
@@ -51,7 +51,7 @@ export function getDrillsByIds(client: OgaSupabaseClient, ids: string[]) {
   if (ids.length === 0) return Promise.resolve({ data: [] as DrillCard[], error: null })
   return client
     .from('drills')
-    .select('id, name, description, facility, duration_min, drill_type, category')
+    .select('id, name, description, instructions, facility, duration_min, drill_type, category, source, source_url')
     .in('id', ids)
 }
 
@@ -59,8 +59,11 @@ type DrillCard = {
   id: string
   name: string
   description: string | null
+  instructions: string | null
   facility: string[] | null
   duration_min: number | null
   drill_type: string
   category: string | null
+  source: string | null
+  source_url: string | null
 }


### PR DESCRIPTION
Track 3 of the AI practice plan (#18): the web Practice page now **renders the plan the engine generates** and wires the **Generate** button — replacing the "Coming in phase 5" placeholder. Built to the `docs/design/future-features.html #practice` mockup, in the paper-editorial system (`DESIGN.md`).

## Scope (decided with the owner)
**Core render + Generate**, **faithful-sessions** layout. Per-block completion checkboxes and the feedback box are a deferred follow-up; mobile + the drill-library page are untouched.

## What's in here
- **Data layer:** `getDrillsByIds` (`@oga/supabase`), `useGeneratePlan()` (the first `supabase.functions.invoke` from web — invalidates the plan query), `useDrillsByIds()` to resolve block `drill_id`s → names. `useLatestPracticePlan` already existed.
- **`PracticePlanPage`:** renders the reasoning panel (`coach_note`), focus areas (with `/learn/:slug` citations), and the engine's sessions as numbered drill cards (name + why + facility pills + minutes + type tag + server-filled target). Six states: loading / no-plan (Generate CTA) / generating / live (no regen within the weekly window) / soft-expired ("last week's" + Generate) / error (`toUserMessage`). Reads the canonical `@oga/core` `StoredSession`/`StoredFocusArea`/`StoredBlock` types; degrades safely on null/empty/missing-drill data.

## Cross-check (multi-agent, as requested)
- **Spec + design:** ✅ no `DESIGN.md` violations, all 6 states correct, date/no-regen logic sound (no UTC off-by-one), faithful-sessions correctly implemented, scope held.
- **Code quality:** the one Important finding (local types duplicating + drifting from `@oga/core`'s canonical stored shapes) is **fixed** — the page now imports them; dead `ACCENT` const removed; `target` rendering polished for legibility.
- **Visual:** rendered via a throwaway harness with a representative plan + screenshotted — strong match to the mockup (warm paper, Fraunces headline, mono kickers, numbered drill cards, accent used sparingly, hairlines, no shadows).
- `pnpm typecheck` + `pnpm --filter web build` clean.

## Deferred follow-ups
- Per-block completion (`completed_drill_ids`) + the feedback box (needs `saveFeedback` in `@oga/supabase`) — fast next pass; the feedback box activates the loop the engine already reads.
- Mobile Practice screen; the drill-library page.
- Authoring drill `target_template`s so blocks show numeric targets (most are null today).

Part of #18 (Phase 3). No closing keyword — completion/feedback land in the follow-up.