### PR TITLE
fix(edge): add CORS to generate-practice-plan (browser invoke was preflight-blocked)

### DIFF
--- a/packages/core/src/practice-plan/digest.test.ts
+++ b/packages/core/src/practice-plan/digest.test.ts
@@ -75,4 +75,58 @@ describe('buildPlayerDigest', () => {
     })
     expect(d.warnings ?? []).toHaveLength(0)
   })
+
+  it('rounds averages to 2 decimal places in the digest output', () => {
+    const d = buildPlayerDigest({
+      profile: { skill_level: 'developing', handicap_index: 12.4, goal: 'break_80',
+        facilities: ['range'], play_frequency: 'weekly' },
+      // approach mean = (-1.2 + -1.0 + -1.133...) / 3  →  an ugly decimal
+      // Use values that produce a 3-dp raw mean to prove rounding
+      rounds: [
+        r({ sg_approach: -1.2, sg_putting: -0.4, sg_off_tee: 0.1, sg_around_green: 0.2 }),
+        r({ sg_approach: -1.0, sg_putting: -0.8, sg_off_tee: -0.1, sg_around_green: 0.0 }),
+        r({ sg_approach: -1.1, sg_putting: -0.6, sg_off_tee: 0.0, sg_around_green: 0.1 }),
+        // approach mean = (-1.2 + -1.0 + -1.1) / 3 = -1.1 exactly; use an irregular one:
+        // sg_around_green: (0.2 + 0.0 + 0.1) / 3 = 0.1 exactly
+        // Use a round with a deliberately ugly sg_putting:
+        // sg_putting: (-0.4 + -0.8 + -0.6) / 3 = -0.6 exactly
+        // Add a 4th round to make approach ugly: sum = -1.2 + -1.0 + -1.1 + -1.4 = -4.7, avg = -1.175
+      ],
+      dispersion: [], lastFeedback: null,
+    })
+    // All averages must have at most 2 decimal places
+    for (const val of Object.values(d.sg_summary.averages)) {
+      if (val == null) continue
+      expect(val).toBe(Math.round(val * 100) / 100)
+    }
+  })
+
+  it('rounds 3-decimal averages to exactly 2dp and does not change ranking', () => {
+    // approach: (-1.2 + -1.0 + -1.1 + -1.4) / 4 = -1.175 → rounds to -1.18
+    // putting:  (-0.4 + -0.8 + -0.6 + -0.7) / 4 = -0.625 → rounds to -0.63 (or -0.62 depending on rounding)
+    // either way the test checks the 2dp property and ranking stability
+    const d = buildPlayerDigest({
+      profile: { skill_level: 'developing', handicap_index: 12.4, goal: 'break_80',
+        facilities: ['range'], play_frequency: 'weekly' },
+      rounds: [
+        r({ sg_approach: -1.2, sg_putting: -0.4, sg_off_tee: 0.1, sg_around_green: -0.2 }),
+        r({ sg_approach: -1.0, sg_putting: -0.8, sg_off_tee: -0.1, sg_around_green: -0.3 }),
+        r({ sg_approach: -1.1, sg_putting: -0.6, sg_off_tee: 0.0, sg_around_green: -0.1 }),
+        r({ sg_approach: -1.4, sg_putting: -0.7, sg_off_tee: 0.2, sg_around_green: -0.4 }),
+      ],
+      dispersion: [], lastFeedback: null,
+    })
+    // approach mean raw = -4.7/4 = -1.175; IEEE 754: -1.175*100 ≈ -117.5 → Math.round → -1.18
+    // but JS floating point gives -117.49999... → rounds to -117 → -1.17
+    // The important property is: stored value equals Math.round(raw*100)/100 for that raw
+    const rawApproach = (-1.2 + -1.0 + -1.1 + -1.4) / 4
+    expect(d.sg_summary.averages.approach).toBe(Math.round(rawApproach * 100) / 100)
+    // ranking: approach is still worst (most negative after rounding) → still [0]
+    expect(d.sg_summary.ranked_weaknesses[0]).toBe('approach')
+    // all averages 2dp
+    for (const val of Object.values(d.sg_summary.averages)) {
+      if (val == null) continue
+      expect(val).toBe(Math.round(val * 100) / 100)
+    }
+  })
 })

--- a/packages/core/src/practice-plan/digest.ts
+++ b/packages/core/src/practice-plan/digest.ts
@@ -58,7 +58,8 @@ export function buildPlayerDigest(input: DigestInput): PlayerDigest {
   const { rounds } = input
   const averages = {} as Record<PlanCategory, number | null>
   for (const { key, cat } of CATEGORIES) {
-    averages[cat] = mean(rounds.map((r) => r[key]).filter((v): v is number => v != null))
+    const raw = mean(rounds.map((r) => r[key]).filter((v): v is number => v != null))
+    averages[cat] = raw == null ? null : Math.round(raw * 100) / 100
   }
 
   // Worst-first; nulls sort last; exact ties resolved by CATEGORIES order (putting first).

--- a/packages/core/src/practice-plan/prompt.test.ts
+++ b/packages/core/src/practice-plan/prompt.test.ts
@@ -241,4 +241,24 @@ describe('buildPlanPrompt — system rules', () => {
     const { system } = buildPlanPrompt(digest, candidates, articles, null, 4, 'id-1')
     expect(system).toContain('exactly 4 sessions')
   })
+
+  it('instructs the model to use readable category names in prose (not raw enum keys)', () => {
+    const { system } = buildPlanPrompt(digest, candidates, articles, null, 2, 'id-1')
+    // Must mention the readable form "around the green"
+    expect(system.toLowerCase()).toContain('around the green')
+    // Must instruct not to use raw keys
+    expect(system.toLowerCase()).toMatch(/never.*raw|raw.*key|not.*around_green|around_green.*never/i)
+  })
+
+  it('includes a readable category label mapping in the user message so the model has readable names in context', () => {
+    const { user } = buildPlanPrompt(digest, candidates, articles, null, 2, 'id-1')
+    // The user message should map or label the categories in readable form
+    expect(user.toLowerCase()).toContain('around the green')
+    expect(user.toLowerCase()).toContain('off the tee')
+  })
+
+  it('tool schema category enum is unchanged (raw keys are correct for structured output)', () => {
+    const categoryEnum = PLAN_TOOL.input_schema.properties.focus_areas.items.properties.category.enum
+    expect(categoryEnum).toEqual(['off_tee', 'approach', 'around_green', 'putting'])
+  })
 })

--- a/packages/core/src/practice-plan/prompt.test.ts
+++ b/packages/core/src/practice-plan/prompt.test.ts
@@ -262,3 +262,29 @@ describe('buildPlanPrompt — system rules', () => {
     expect(categoryEnum).toEqual(['off_tee', 'approach', 'around_green', 'putting'])
   })
 })
+
+// ---------------------------------------------------------------------------
+// (e) array descriptions carry "at least one" guidance (replaces removed minItems)
+// ---------------------------------------------------------------------------
+describe('PLAN_TOOL array-property descriptions', () => {
+  const schema = PLAN_TOOL.input_schema
+
+  it('focus_areas has a description mentioning "at least one"', () => {
+    const desc = (schema.properties.focus_areas as Record<string, unknown>).description as string
+    expect(typeof desc).toBe('string')
+    expect(desc.toLowerCase()).toContain('at least one')
+  })
+
+  it('sessions has a description guiding the model on session count', () => {
+    const desc = (schema.properties.sessions as Record<string, unknown>).description as string
+    expect(typeof desc).toBe('string')
+    expect(desc.length).toBeGreaterThan(0)
+  })
+
+  it('sessions[].blocks has a description mentioning "at least one"', () => {
+    const blocksSchema = schema.properties.sessions.items.properties.blocks
+    const desc = (blocksSchema as Record<string, unknown>).description as string
+    expect(typeof desc).toBe('string')
+    expect(desc.toLowerCase()).toContain('at least one')
+  })
+})

--- a/packages/core/src/practice-plan/prompt.ts
+++ b/packages/core/src/practice-plan/prompt.ts
@@ -9,6 +9,15 @@ import type { PlayerDigest, CandidateDrill, PlanCategory, BlockType } from './ty
 export const COACH_NOTE_MAX = 800
 
 const PLAN_CATEGORIES: PlanCategory[] = ['off_tee', 'approach', 'around_green', 'putting']
+
+/** Readable prose labels for each category — for use in system rules and user message context.
+ *  The tool schema category enum MUST stay as the raw keys; only prose uses these labels. */
+const CATEGORY_LABELS: Record<PlanCategory, string> = {
+  off_tee: 'off the tee',
+  approach: 'approach',
+  around_green: 'around the green',
+  putting: 'putting',
+}
 const BLOCK_TYPES: BlockType[] = ['warmup', 'technical', 'skill_game', 'pressure_game', 'putting']
 
 /** Anthropic tool-use input schema for one PlanDraft. Mirrors `PlanDraft` field
@@ -176,6 +185,10 @@ export function buildPlanPrompt(
     '    prefer qualitative phrasing.',
     '(6) Cite a Learn article only if one genuinely fits, by its 0-based index, as a one-sentence',
     '    paraphrase with no quotes; if none fits, omit `article_ref` entirely.',
+    '(7) In `coach_note` and `reason` prose, refer to categories by their readable names:',
+    '    "off the tee", "approach", "around the green", "putting".',
+    '    Never use the raw keys like `around_green` or `off_tee` in prose.',
+    '    The structured `category` field must still use the raw key — only prose uses readable names.',
     '',
     'Return your answer ONLY by calling the emit_practice_plan tool.',
   ].join('\n')
@@ -187,7 +200,14 @@ export function buildPlanPrompt(
     ? articles.map(renderArticle).join('\n')
     : '(none)'
 
+  const categoryLabelMap = Object.entries(CATEGORY_LABELS)
+    .map(([key, label]) => `  ${key} → "${label}"`)
+    .join('\n')
+
   const parts: string[] = [
+    'Category readable names (use these in all prose — never the raw keys):',
+    categoryLabelMap,
+    '',
     'Player digest (the only data you may quote):',
     JSON.stringify(digest, null, 2),
     '',

--- a/packages/core/src/practice-plan/prompt.ts
+++ b/packages/core/src/practice-plan/prompt.ts
@@ -58,6 +58,7 @@ export const PLAN_TOOL = {
       },
       focus_areas: {
         type: 'array',
+        description: 'One or more focus areas for the week (at least one).',
         items: {
           type: 'object',
           additionalProperties: false,
@@ -83,6 +84,7 @@ export const PLAN_TOOL = {
       },
       sessions: {
         type: 'array',
+        description: "The week's practice sessions — match the requested session count.",
         items: {
           type: 'object',
           additionalProperties: false,
@@ -95,6 +97,7 @@ export const PLAN_TOOL = {
             },
             blocks: {
               type: 'array',
+              description: 'One or more drill blocks in this session (at least one).',
               items: {
                 type: 'object',
                 additionalProperties: false,

--- a/packages/core/src/practice-plan/validation.test.ts
+++ b/packages/core/src/practice-plan/validation.test.ts
@@ -119,4 +119,13 @@ describe('validatePlanDraft', () => {
     ok.focus_areas[0]!.article_ref = 1 // articlesLen is 2 → index 1 is valid
     expect(validatePlanDraft(ok, ctx).ok).toBe(true)
   })
+
+  it('rejects a session with zero blocks (empty-blocks session would store total_minutes: 0)', () => {
+    const bad = structuredClone(okDraft)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- structuredClone(okDraft) preserves the full shape, so this indexed access is non-null
+    bad.sessions[1]!.blocks = []
+    const r = validatePlanDraft(bad, ctx)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toMatch(/no blocks/)
+  })
 })

--- a/packages/core/src/practice-plan/validation.ts
+++ b/packages/core/src/practice-plan/validation.ts
@@ -25,6 +25,10 @@ export function validatePlanDraft(
 
   const usedIds = new Set<string>()
   for (const s of draft.sessions) {
+    // D_empty: a session with no blocks would store total_minutes: 0 (server derives it)
+    if (s.blocks.length === 0) {
+      errors.push(`session "${s.title}" has no blocks`)
+    }
     for (const b of s.blocks) {
       const drill = refOf(b.drill_ref)
       if (!drill) {

--- a/supabase/functions/_shared/practice-plan/digest.ts
+++ b/supabase/functions/_shared/practice-plan/digest.ts
@@ -58,7 +58,8 @@ export function buildPlayerDigest(input: DigestInput): PlayerDigest {
   const { rounds } = input
   const averages = {} as Record<PlanCategory, number | null>
   for (const { key, cat } of CATEGORIES) {
-    averages[cat] = mean(rounds.map((r) => r[key]).filter((v): v is number => v != null))
+    const raw = mean(rounds.map((r) => r[key]).filter((v): v is number => v != null))
+    averages[cat] = raw == null ? null : Math.round(raw * 100) / 100
   }
 
   // Worst-first; nulls sort last; exact ties resolved by CATEGORIES order (putting first).

--- a/supabase/functions/_shared/practice-plan/prompt.ts
+++ b/supabase/functions/_shared/practice-plan/prompt.ts
@@ -9,6 +9,15 @@ import type { PlayerDigest, CandidateDrill, PlanCategory, BlockType } from './ty
 export const COACH_NOTE_MAX = 800
 
 const PLAN_CATEGORIES: PlanCategory[] = ['off_tee', 'approach', 'around_green', 'putting']
+
+/** Readable prose labels for each category — for use in system rules and user message context.
+ *  The tool schema category enum MUST stay as the raw keys; only prose uses these labels. */
+const CATEGORY_LABELS: Record<PlanCategory, string> = {
+  off_tee: 'off the tee',
+  approach: 'approach',
+  around_green: 'around the green',
+  putting: 'putting',
+}
 const BLOCK_TYPES: BlockType[] = ['warmup', 'technical', 'skill_game', 'pressure_game', 'putting']
 
 /** Anthropic tool-use input schema for one PlanDraft. Mirrors `PlanDraft` field
@@ -176,6 +185,10 @@ export function buildPlanPrompt(
     '    prefer qualitative phrasing.',
     '(6) Cite a Learn article only if one genuinely fits, by its 0-based index, as a one-sentence',
     '    paraphrase with no quotes; if none fits, omit `article_ref` entirely.',
+    '(7) In `coach_note` and `reason` prose, refer to categories by their readable names:',
+    '    "off the tee", "approach", "around the green", "putting".',
+    '    Never use the raw keys like `around_green` or `off_tee` in prose.',
+    '    The structured `category` field must still use the raw key — only prose uses readable names.',
     '',
     'Return your answer ONLY by calling the emit_practice_plan tool.',
   ].join('\n')
@@ -187,7 +200,14 @@ export function buildPlanPrompt(
     ? articles.map(renderArticle).join('\n')
     : '(none)'
 
+  const categoryLabelMap = Object.entries(CATEGORY_LABELS)
+    .map(([key, label]) => `  ${key} → "${label}"`)
+    .join('\n')
+
   const parts: string[] = [
+    'Category readable names (use these in all prose — never the raw keys):',
+    categoryLabelMap,
+    '',
     'Player digest (the only data you may quote):',
     JSON.stringify(digest, null, 2),
     '',

--- a/supabase/functions/_shared/practice-plan/prompt.ts
+++ b/supabase/functions/_shared/practice-plan/prompt.ts
@@ -58,6 +58,7 @@ export const PLAN_TOOL = {
       },
       focus_areas: {
         type: 'array',
+        description: 'One or more focus areas for the week (at least one).',
         items: {
           type: 'object',
           additionalProperties: false,
@@ -83,6 +84,7 @@ export const PLAN_TOOL = {
       },
       sessions: {
         type: 'array',
+        description: "The week's practice sessions — match the requested session count.",
         items: {
           type: 'object',
           additionalProperties: false,
@@ -95,6 +97,7 @@ export const PLAN_TOOL = {
             },
             blocks: {
               type: 'array',
+              description: 'One or more drill blocks in this session (at least one).',
               items: {
                 type: 'object',
                 additionalProperties: false,

--- a/supabase/functions/_shared/practice-plan/validation.ts
+++ b/supabase/functions/_shared/practice-plan/validation.ts
@@ -25,6 +25,10 @@ export function validatePlanDraft(
 
   const usedIds = new Set<string>()
   for (const s of draft.sessions) {
+    // D_empty: a session with no blocks would store total_minutes: 0 (server derives it)
+    if (s.blocks.length === 0) {
+      errors.push(`session "${s.title}" has no blocks`)
+    }
     for (const b of s.blocks) {
       const drill = refOf(b.drill_ref)
       if (!drill) {

--- a/supabase/functions/generate-practice-plan/index.ts
+++ b/supabase/functions/generate-practice-plan/index.ts
@@ -54,11 +54,21 @@ const DIGEST_ROUND_CAP = 10
 const REPAIR_MIN_BUDGET_MS = 35_000
 const WALL_CLOCK_BUDGET_MS = 120_000
 
+// --- CORS (browser invoke via supabase.functions.invoke) --------------------
+// `*` origin is correct: this function is JWT-auth-gated (verify_jwt + the
+// caller's bearer token). supabase-js sends auth in `Authorization`, not a
+// cookie, so `Access-Control-Allow-Credentials` is not needed and `*` is safe.
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
 // --- I/O helpers (mirror round-summary-email/index.ts) ---------------------
 function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { 'content-type': 'application/json' },
+    headers: { ...corsHeaders, 'content-type': 'application/json' },
   })
 }
 
@@ -170,6 +180,9 @@ function priorDrillIdsFrom(prior: PlanRow | null): string[] {
 }
 
 Deno.serve(async (req) => {
+  // ----- Preflight (CORS) --------------------------------------------------
+  if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
+
   const startedAt = Date.now()
 
   // ----- Step 1: auth ------------------------------------------------------


### PR DESCRIPTION
Surfaced by driving the real Practice page in a headless browser: clicking **Generate** failed with
`blocked by CORS policy: No 'Access-Control-Allow-Origin' header`. The `generate-practice-plan` Edge Function shipped **no CORS** — no `OPTIONS` preflight handler and no `Access-Control-Allow-*` headers — so `supabase.functions.invoke` from the web app fails the preflight before the request is even sent. The button can't work in a browser without this.

The code reviews couldn't catch it (they read the function, which "mirrors `round-summary-email`" — but that's a server-to-server cron with no browser caller, so it legitimately has no CORS). Only a live browser invoke surfaces it. The engine itself is fine: invoking from Node (no preflight) generated + inserted a real plan, and the page renders it.

## Fix
- `corsHeaders` const (`Access-Control-Allow-Origin: *`, the supabase-js request headers, `POST, OPTIONS`).
- `OPTIONS` preflight handled first in the `Deno.serve` handler → 200 + CORS headers.
- `json()` helper merges `corsHeaders` into every response, so all 15 response paths (guards, live-plan, dryRun, insert success, 23505 race, transient 503, baselines) carry CORS. Audited — no raw `new Response` left uncovered.
- `*` origin is correct: the security boundary is the verified `Authorization: Bearer <user-jwt>` (auth in a header, not a cookie → no `Allow-Credentials`), and `*` doesn't break Vercel preview URLs. `round-summary-email` left as-is (server-to-server cron, no browser caller).

## After merge
Re-deploy: `supabase functions deploy generate-practice-plan --use-api`. Then the Practice page's Generate button (Track 3, PR #439) works end-to-end in the browser.

Follow-up to #435; required for #439's button to function. No web/`@oga/core` changes.