### PR TITLE
feat(core): practice-plan engine → mode taxonomy + close-on-green

### DIFF
--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -39,10 +39,11 @@ const CATEGORY_LABEL: Record<PlanCategory, string> = {
 
 const BLOCK_TYPE_LABEL: Record<BlockType, string> = {
   warmup: 'Warm-up',
-  technical: 'Technical',
+  blocked: 'Blocked',
+  random: 'Random',
   skill_game: 'Skill game',
   pressure_game: 'Pressure game',
-  putting: 'Putting',
+  on_course: 'On course',
 }
 
 const FACILITY_LABEL: Record<string, string> = {

--- a/packages/core/src/practice-plan/baseline.test.ts
+++ b/packages/core/src/practice-plan/baseline.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { selectBaselinePlan } from './baseline'
+import { selectBaselinePlan, BASELINE_PLANS } from './baseline'
+import type { BlockType } from './types'
+
+const VALID_MODES: BlockType[] = ['warmup', 'blocked', 'random', 'skill_game', 'pressure_game', 'on_course']
 
 describe('selectBaselinePlan', () => {
   it('returns a plan for a known skill×goal cell', () => {
@@ -19,5 +22,34 @@ describe('selectBaselinePlan', () => {
   })
   it('falls back to a default cell when skill/goal missing', () => {
     expect(selectBaselinePlan({ skill: null, goal: null, weekIndex: 3 }).sessions.length).toBeGreaterThan(0)
+  })
+
+  it('every block uses a valid practice MODE (no retired technical/putting types) and opens with a warmup', () => {
+    for (const variants of Object.values(BASELINE_PLANS)) {
+      for (const v of variants ?? []) {
+        // first block of the first session is a warmup (Decisions §3)
+        expect(v.sessions[0]!.blocks[0]!.type).toBe('warmup')
+        for (const s of v.sessions) {
+          for (const b of s.blocks) {
+            expect(VALID_MODES).toContain(b.type)
+          }
+        }
+      }
+    }
+  })
+
+  it('every session of every variant closes on the green (last block is a putting/around_green drill)', () => {
+    // Baseline block ids follow `b-<area>-<type>`; the green-area prefixes are `b-put-`
+    // (putting) and `b-atg-` (around_green) — the only category signal a placeholder
+    // block carries (drill_ref is a Phase-B placeholder). Per Decisions §3, the LAST
+    // block of EVERY session must be one of these.
+    for (const variants of Object.values(BASELINE_PLANS)) {
+      for (const v of variants ?? []) {
+        for (const s of v.sessions) {
+          const last = s.blocks[s.blocks.length - 1]!
+          expect(last.id).toMatch(/^b-(put|atg)-/)
+        }
+      }
+    }
   })
 })

--- a/packages/core/src/practice-plan/baseline.ts
+++ b/packages/core/src/practice-plan/baseline.ts
@@ -39,15 +39,15 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               type: 'warmup',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 10,
-              rationale: 'Gate drill to ingrain a square face at impact.',
+              rationale: 'Easy lag rolls to find the speed of the greens before any focused work.',
             },
             {
-              id: 'b-put-technical',
+              id: 'b-put-blocked',
               order: 1,
-              type: 'putting',
+              type: 'blocked',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 20,
-              rationale: 'Distance-control ladder from 10 – 30 ft.',
+              rationale: 'Gate drill — repeated straight putts to ingrain a square face and start line.',
             },
             {
               id: 'b-put-game',
@@ -55,7 +55,7 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               type: 'pressure_game',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: '18-hole putting game on the practice green to simulate real-round pressure.',
+              rationale: '18-hole putting game on the practice green to add consequence to the stroke.',
             },
           ],
         },
@@ -64,20 +64,21 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
           total_minutes: 30,
           blocks: [
             {
-              id: 'b-atg-chip',
+              id: 'b-atg-blocked',
               order: 0,
-              type: 'technical',
+              type: 'blocked',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: 'Bump-and-run from tight lies to a near pin.',
+              rationale: 'Bump-and-run from tight lies to a near pin — same shot, repeated.',
             },
+            // Closes on the green (an around_green skill game) per Decisions §3.
             {
               id: 'b-atg-game',
               order: 1,
               type: 'skill_game',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: 'Up-and-down challenge: 10 balls from various lies around the green.',
+              rationale: 'Up-and-down challenge: 10 balls from various lies around the green, keep score.',
             },
           ],
         },
@@ -111,45 +112,57 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               type: 'warmup',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 10,
-              rationale: 'Nine-o\'clock to three-o\'clock half-swing to groove contact.',
+              rationale: 'Nine-o\'clock to three-o\'clock half-swings to groove contact.',
             },
             {
-              id: 'b-app-technical',
+              id: 'b-app-blocked',
               order: 1,
-              type: 'technical',
+              type: 'blocked',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 20,
-              rationale: 'Alignment-stick target gate drill — 7-iron to a specific pin.',
+              rationale: 'Alignment-stick target gate — 7-iron to a specific pin, same shot repeated.',
             },
+            // Closes on the green (an around_green skill game) — every session ends on the green per Decisions §3.
+            // Unique id (Variant A already uses `b-atg-game`).
             {
-              id: 'b-app-game',
+              id: 'b-atg-updown-game',
               order: 2,
               type: 'skill_game',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: 'Hit-the-green game: score +1 for GIR, 0 for miss; target ≥ 7/10.',
+              rationale: 'Up-and-down challenge: 10 balls from various lies around the green, keep score.',
             },
           ],
         },
         {
-          title: 'Tee-shot consistency',
-          total_minutes: 30,
+          title: 'Tee shots, then close on the green',
+          total_minutes: 45,
           blocks: [
             {
-              id: 'b-ott-technical',
+              id: 'b-ott-warmup',
               order: 0,
-              type: 'technical',
+              type: 'warmup',
               drill_ref: 0, // Phase B: resolve to real drill id
-              minutes: 15,
-              rationale: 'Slow-motion takeaway drill to reduce over-the-top path.',
+              minutes: 10,
+              rationale: 'Easy half-speed swings with a mid-iron to loosen up before driver.',
             },
             {
-              id: 'b-ott-game',
+              id: 'b-ott-blocked',
               order: 1,
-              type: 'skill_game',
+              type: 'blocked',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: 'Fairway-finder challenge: 10 drives, score for landing zone.',
+              rationale: 'Path-gate drill to reduce an over-the-top move, same swing repeated.',
+            },
+            // Closes on the green (a putting skill game) per Decisions §3.
+            // Unique id (Variant A already uses `b-put-game`).
+            {
+              id: 'b-put-lag-game',
+              order: 2,
+              type: 'skill_game',
+              drill_ref: 0, // Phase B: resolve to real drill id
+              minutes: 20,
+              rationale: 'Lag-ladder game from 10–40 ft to end every session on the green.',
             },
           ],
         },

--- a/packages/core/src/practice-plan/prompt.test.ts
+++ b/packages/core/src/practice-plan/prompt.test.ts
@@ -25,7 +25,7 @@ const candidates: CandidateDrill[] = [
     id: 'drill-aaa',
     name: 'Gate Drill',
     category: 'approach',
-    drill_type: 'technical',
+    drill_type: 'blocked',
     duration_min: 15,
     facility: ['range'],
     target_template: {
@@ -75,13 +75,14 @@ describe('PLAN_TOOL schema', () => {
     ])
   })
 
-  it('enum-constrains blocks[].type to the five BlockType members', () => {
+  it('enum-constrains blocks[].type to the six practice-mode BlockType members', () => {
     expect(blockItem.properties.type.enum).toEqual([
       'warmup',
-      'technical',
+      'blocked',
+      'random',
       'skill_game',
       'pressure_game',
-      'putting',
+      'on_course',
     ])
   })
 
@@ -170,7 +171,7 @@ describe('buildPlanPrompt — 0-based indexing', () => {
     const { user } = buildPlanPrompt(digest, candidates, articles, null, 2, 'id-1')
     expect(user).toContain('Gate Drill')
     expect(user).toContain('approach')
-    expect(user).toContain('technical')
+    expect(user).toContain('blocked')
     // the target metric tag may appear, but the numeric baseline/min/max must not
     expect(user).toContain('greens_hit')
     expect(user).not.toContain('target_template')
@@ -240,6 +241,24 @@ describe('buildPlanPrompt — system rules', () => {
   it('threads the requested session count into the system rules', () => {
     const { system } = buildPlanPrompt(digest, candidates, articles, null, 4, 'id-1')
     expect(system).toContain('exactly 4 sessions')
+  })
+
+  it('encodes the session-flow pedagogy: single focus, warmup open, close on the green, modes as a progression, no facility gate', () => {
+    const { system } = buildPlanPrompt(digest, candidates, articles, null, 3, 'id-1')
+    const lower = system.toLowerCase()
+    // one focus area per session
+    expect(lower).toMatch(/one focus area/)
+    // mode progression used in tandem, not swaps
+    expect(lower).toContain('progression')
+    expect(lower).toMatch(/not 1-for-1 swaps|never.*swap|not.*swap/)
+    // open with a warmup, close on the green
+    expect(lower).toContain('open every session with a `warmup`')
+    expect(lower).toMatch(/close every session on the green/)
+    expect(lower).toMatch(/putting.*around_green|around_green.*putting/)
+    // graceful: include a mode only when a candidate exists (random/on_course may be absent)
+    expect(lower).toMatch(/only when a candidate.*exists|may be absent/)
+    // no facility filtering — facility is a display hint
+    expect(lower).toMatch(/do not filter by the player's facilities|never a gate/)
   })
 
   it('instructs the model to use readable category names in prose (not raw enum keys)', () => {

--- a/packages/core/src/practice-plan/prompt.ts
+++ b/packages/core/src/practice-plan/prompt.ts
@@ -18,7 +18,7 @@ const CATEGORY_LABELS: Record<PlanCategory, string> = {
   around_green: 'around the green',
   putting: 'putting',
 }
-const BLOCK_TYPES: BlockType[] = ['warmup', 'technical', 'skill_game', 'pressure_game', 'putting']
+const BLOCK_TYPES: BlockType[] = ['warmup', 'blocked', 'random', 'skill_game', 'pressure_game', 'on_course']
 
 /** Anthropic tool-use input schema for one PlanDraft. Mirrors `PlanDraft` field
  *  names exactly so `validatePlanDraft` / `resolvePlanForStorage` consume the
@@ -192,6 +192,19 @@ export function buildPlanPrompt(
     '    "off the tee", "approach", "around the green", "putting".',
     '    Never use the raw keys like `around_green` or `off_tee` in prose.',
     '    The structured `category` field must still use the raw key — only prose uses readable names.',
+    '(8) Each session targets ONE focus AREA (the day\'s focus); the week\'s sessions cover the',
+    '    ranked weaknesses worst-first. Sequence the focus through the practice MODES as a',
+    '    PROGRESSION used in tandem — blocked (build the movement) → random (transfer it,',
+    '    a different shot every ball) → skill_game (measure it) → pressure_game (test it under',
+    '    consequence). The modes are NOT 1-for-1 swaps; use as many as the candidate list offers',
+    '    for that focus. `random` and `on_course` drills may be ABSENT — include a mode ONLY when',
+    '    a candidate of that drill_type exists; never invent one.',
+    '(9) Session FLOW: OPEN every session with a `warmup` block, then run the focus through the',
+    '    modes above, and CLOSE every session on the green — the LAST block must reference a drill',
+    '    whose category is `putting` or `around_green`. Prefer fuller, shorter blocks (more',
+    '    activities, less time each) over a few long blocks.',
+    '(10) Do NOT filter by the player\'s facilities. Surface and sequence drills regardless of where',
+    '     they are best done — players improvise. `facility` is a display hint only, never a gate.',
     '',
     'Return your answer ONLY by calling the emit_practice_plan tool.',
   ].join('\n')

--- a/packages/core/src/practice-plan/storage.test.ts
+++ b/packages/core/src/practice-plan/storage.test.ts
@@ -12,8 +12,8 @@ const gateTmpl: TargetTemplate = {
 // Same pool shape as validation.test.ts; d1/d2 carry target_templates, d0 (warmup) does not.
 const pool: CandidateDrill[] = [
   { id: 'drill-uuid-0', name: 'Warm', category: 'approach', drill_type: 'warmup', duration_min: 8, facility: [], target_template: null },
-  { id: 'drill-uuid-1', name: 'Wedge ladder', category: 'approach', drill_type: 'technical', duration_min: 20, facility: ['range'], target_template: wedgeTmpl },
-  { id: 'drill-uuid-2', name: 'Gate', category: 'putting', drill_type: 'technical', duration_min: 15, facility: ['putting'], target_template: gateTmpl },
+  { id: 'drill-uuid-1', name: 'Wedge ladder', category: 'approach', drill_type: 'blocked', duration_min: 20, facility: ['range'], target_template: wedgeTmpl },
+  { id: 'drill-uuid-2', name: 'Gate', category: 'putting', drill_type: 'blocked', duration_min: 15, facility: ['putting'], target_template: gateTmpl },
 ]
 
 const articles = [
@@ -38,8 +38,8 @@ const draft: PlanDraft = {
   sessions: [
     { title: 'S1', total_minutes: 43, blocks: [
       { id: 's1b1', order: 1, type: 'warmup', drill_ref: 0, minutes: 8, rationale: 'loosen up' },
-      { id: 's1b2', order: 2, type: 'technical', drill_ref: 1, minutes: 20, rationale: 'wedge control' },
-      { id: 's1b3', order: 3, type: 'technical', drill_ref: 2, minutes: 15, rationale: 'gate' },
+      { id: 's1b2', order: 2, type: 'blocked', drill_ref: 1, minutes: 20, rationale: 'wedge control' },
+      { id: 's1b3', order: 3, type: 'blocked', drill_ref: 2, minutes: 15, rationale: 'gate' },
     ] },
   ],
 }
@@ -71,7 +71,7 @@ describe('resolvePlanForStorage', () => {
     const noTmpl: PlanDraft = structuredClone(draft)
     // point block to d0 (no template) but keep it a non-warmup type the validator would gate;
     // here we only test storage's tmpl-absent branch.
-    noTmpl.sessions[0]!.blocks[1]!.type = 'technical'
+    noTmpl.sessions[0]!.blocks[1]!.type = 'blocked'
     noTmpl.sessions[0]!.blocks[1]!.drill_ref = 0 // pool[0].target_template is null
     const out = resolvePlanForStorage(noTmpl, ctx)
     expect(out.drills.sessions[0]!.blocks[1]!.target).toBeNull()
@@ -90,7 +90,7 @@ describe('resolvePlanForStorage', () => {
     const b = out.drills.sessions[0]!.blocks[1]!
     expect(b.id).toBe('s1b2')
     expect(b.order).toBe(2)
-    expect(b.type).toBe('technical')
+    expect(b.type).toBe('blocked')
     expect(b.minutes).toBe(20)
     expect(b.rationale).toBe('wedge control')
   })

--- a/packages/core/src/practice-plan/types.ts
+++ b/packages/core/src/practice-plan/types.ts
@@ -2,7 +2,7 @@ import type { SkillLevel, Goal } from '../constants'
 
 export type PlanCategory = 'off_tee' | 'approach' | 'around_green' | 'putting'
 export type PlayFrequency = 'monthly' | 'weekly' | 'multi_weekly' | 'daily'
-export type BlockType = 'warmup' | 'technical' | 'skill_game' | 'pressure_game' | 'putting'
+export type BlockType = 'warmup' | 'blocked' | 'random' | 'skill_game' | 'pressure_game' | 'on_course'
 
 /** Already-fetched round, SG columns only (no stats engine needed). */
 export interface RoundSG {

--- a/packages/core/src/practice-plan/validation.test.ts
+++ b/packages/core/src/practice-plan/validation.test.ts
@@ -10,10 +10,10 @@ import type { PlanDraft, CandidateDrill } from './types'
 // the precondition the guard is testing for.
 const pool: CandidateDrill[] = [
   { id: 'd0', name: 'Warm', category: 'approach', drill_type: 'warmup', duration_min: 8, facility: [], target_template: null },
-  { id: 'd1', name: 'Wedge ladder', category: 'approach', drill_type: 'technical', duration_min: 20, facility: ['range'], target_template: null },
-  { id: 'd2', name: 'Gate', category: 'putting', drill_type: 'technical', duration_min: 15, facility: ['putting'], target_template: null },
+  { id: 'd1', name: 'Wedge ladder', category: 'approach', drill_type: 'blocked', duration_min: 20, facility: ['range'], target_template: null },
+  { id: 'd2', name: 'Gate', category: 'putting', drill_type: 'blocked', duration_min: 15, facility: ['putting'], target_template: null },
   { id: 'd3', name: 'Chip clock', category: 'around_green', drill_type: 'skill_game', duration_min: 15, facility: [], target_template: null },
-  { id: 'd4', name: 'Draw bias', category: 'off_tee', drill_type: 'technical', duration_min: 20, facility: ['range'], target_template: null },
+  { id: 'd4', name: 'Draw bias', category: 'off_tee', drill_type: 'blocked', duration_min: 20, facility: ['range'], target_template: null },
 ]
 const okDraft: PlanDraft = {
   week_focus: 'approach + putting',
@@ -22,12 +22,12 @@ const okDraft: PlanDraft = {
   sessions: [
     { title: 'S1', total_minutes: 43, blocks: [
       { id: 's1b1', order: 1, type: 'warmup', drill_ref: 0, minutes: 8, rationale: 'x' },
-      { id: 's1b2', order: 2, type: 'technical', drill_ref: 1, minutes: 20, rationale: 'x' },
-      { id: 's1b3', order: 3, type: 'technical', drill_ref: 2, minutes: 15, rationale: 'x' },
+      { id: 's1b2', order: 2, type: 'blocked', drill_ref: 1, minutes: 20, rationale: 'x' },
+      { id: 's1b3', order: 3, type: 'blocked', drill_ref: 2, minutes: 15, rationale: 'x' }, // green closer: d2 is putting (D10)
     ] },
     { title: 'S2', total_minutes: 35, blocks: [
-      { id: 's2b1', order: 1, type: 'technical', drill_ref: 1, minutes: 20, rationale: 'x' },
-      { id: 's2b2', order: 2, type: 'technical', drill_ref: 2, minutes: 15, rationale: 'x' },
+      { id: 's2b1', order: 1, type: 'blocked', drill_ref: 1, minutes: 20, rationale: 'x' },
+      { id: 's2b2', order: 2, type: 'blocked', drill_ref: 2, minutes: 15, rationale: 'x' }, // green closer: d2 is putting (D10)
     ] },
   ],
 }
@@ -117,6 +117,50 @@ describe('validatePlanDraft', () => {
     const ok = structuredClone(okDraft)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- structuredClone(okDraft) preserves the full shape, so this indexed access is non-null
     ok.focus_areas[0]!.article_ref = 1 // articlesLen is 2 → index 1 is valid
+    expect(validatePlanDraft(ok, ctx).ok).toBe(true)
+  })
+
+  it('rejects a plan that does not open with a warmup (first block of the first session)', () => {
+    const bad = structuredClone(okDraft)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- structuredClone(okDraft) preserves the full shape, so this indexed access is non-null
+    bad.sessions[0]!.blocks[0]!.type = 'blocked' // d0 is a warmup drill; D3 still passes only if drill matches, so swap the drill too
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- structuredClone(okDraft) preserves the full shape, so this indexed access is non-null
+    bad.sessions[0]!.blocks[0]!.drill_ref = 1 // d1 is blocked → D3 ok, but the plan no longer opens with a warmup
+    const r = validatePlanDraft(bad, ctx)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toMatch(/open with a warmup/)
+  })
+
+  it('rejects a plan whose LAST session does not close on the green (last block category not putting/around_green)', () => {
+    const bad = structuredClone(okDraft)
+    // Point the final block of the last session at d4 (off_tee) — a non-green closer.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- structuredClone(okDraft) preserves the full shape, so this indexed access is non-null
+    const last = bad.sessions[bad.sessions.length - 1]!
+    last.blocks[last.blocks.length - 1]!.drill_ref = 4 // d4: off_tee/blocked
+    const r = validatePlanDraft(bad, ctx)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toMatch(/close on the green/)
+  })
+
+  it('rejects a plan whose NON-final session does not close on the green (per-session D10)', () => {
+    // D10 is PER-SESSION: every session must end on the green, not just the last one.
+    // Point the final block of the FIRST (non-final) session at d4 (off_tee) — the last
+    // session still closes green, so this fails only if the rule is enforced per-session.
+    const bad = structuredClone(okDraft)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- structuredClone(okDraft) preserves the full shape, so this indexed access is non-null
+    const first = bad.sessions[0]!
+    first.blocks[first.blocks.length - 1]!.drill_ref = 4 // d4: off_tee/blocked — non-green closer
+    const r = validatePlanDraft(bad, ctx)
+    expect(r.ok).toBe(false)
+    expect(r.errors.join(' ')).toMatch(/close on the green/)
+  })
+
+  it('accepts a plan that closes on an around_green drill (not just putting)', () => {
+    const ok = structuredClone(okDraft)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- structuredClone(okDraft) preserves the full shape, so this indexed access is non-null
+    const last = ok.sessions[ok.sessions.length - 1]!
+    last.blocks[last.blocks.length - 1]!.drill_ref = 3 // d3: around_green/skill_game
+    last.blocks[last.blocks.length - 1]!.type = 'skill_game' // keep D3 (type==drill_type) satisfied
     expect(validatePlanDraft(ok, ctx).ok).toBe(true)
   })
 

--- a/packages/core/src/practice-plan/validation.ts
+++ b/packages/core/src/practice-plan/validation.ts
@@ -48,6 +48,30 @@ export function validatePlanDraft(
     // total_minutes is server-derived (sum of block minutes) — not validated here
   }
 
+  // D9: the plan must OPEN with a warmup — the first block of the first session.
+  // Unconditional (Decisions §3) — every session structure starts with an on-ramp.
+  const firstSession = draft.sessions[0]
+  const firstBlock = firstSession?.blocks[0]
+  if (firstBlock && firstBlock.type !== 'warmup') {
+    errors.push(`first block ${firstBlock.id} type ${firstBlock.type} != warmup (plan must open with a warmup)`)
+  }
+
+  // D10: EVERY session must CLOSE on the green — the last block of EACH session must
+  // reference a drill whose category is `putting` or `around_green`. Unconditional
+  // (Decisions §3): "the last thing you do in every session is putting always," no
+  // facility gating. Per-session, not just the final session.
+  for (const s of draft.sessions) {
+    const lastBlock = s.blocks[s.blocks.length - 1]
+    if (lastBlock) {
+      const closer = refOf(lastBlock.drill_ref)
+      if (closer && closer.category !== 'putting' && closer.category !== 'around_green') {
+        errors.push(
+          `last block ${lastBlock.id} drill category ${closer.category} != putting/around_green (session "${s.title}" must close on the green)`,
+        )
+      }
+    }
+  }
+
   // D5: each of the top-2 weaknesses must have at least one non-warmup block covering it
   const covered = new Set<PlanCategory>()
   for (const s of draft.sessions) {

--- a/supabase/functions/_shared/practice-plan/baseline.ts
+++ b/supabase/functions/_shared/practice-plan/baseline.ts
@@ -39,15 +39,15 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               type: 'warmup',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 10,
-              rationale: 'Gate drill to ingrain a square face at impact.',
+              rationale: 'Easy lag rolls to find the speed of the greens before any focused work.',
             },
             {
-              id: 'b-put-technical',
+              id: 'b-put-blocked',
               order: 1,
-              type: 'putting',
+              type: 'blocked',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 20,
-              rationale: 'Distance-control ladder from 10 – 30 ft.',
+              rationale: 'Gate drill — repeated straight putts to ingrain a square face and start line.',
             },
             {
               id: 'b-put-game',
@@ -55,7 +55,7 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               type: 'pressure_game',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: '18-hole putting game on the practice green to simulate real-round pressure.',
+              rationale: '18-hole putting game on the practice green to add consequence to the stroke.',
             },
           ],
         },
@@ -64,20 +64,21 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
           total_minutes: 30,
           blocks: [
             {
-              id: 'b-atg-chip',
+              id: 'b-atg-blocked',
               order: 0,
-              type: 'technical',
+              type: 'blocked',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: 'Bump-and-run from tight lies to a near pin.',
+              rationale: 'Bump-and-run from tight lies to a near pin — same shot, repeated.',
             },
+            // Closes on the green (an around_green skill game) per Decisions §3.
             {
               id: 'b-atg-game',
               order: 1,
               type: 'skill_game',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: 'Up-and-down challenge: 10 balls from various lies around the green.',
+              rationale: 'Up-and-down challenge: 10 balls from various lies around the green, keep score.',
             },
           ],
         },
@@ -111,45 +112,57 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               type: 'warmup',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 10,
-              rationale: 'Nine-o\'clock to three-o\'clock half-swing to groove contact.',
+              rationale: 'Nine-o\'clock to three-o\'clock half-swings to groove contact.',
             },
             {
-              id: 'b-app-technical',
+              id: 'b-app-blocked',
               order: 1,
-              type: 'technical',
+              type: 'blocked',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 20,
-              rationale: 'Alignment-stick target gate drill — 7-iron to a specific pin.',
+              rationale: 'Alignment-stick target gate — 7-iron to a specific pin, same shot repeated.',
             },
+            // Closes on the green (an around_green skill game) — every session ends on the green per Decisions §3.
+            // Unique id (Variant A already uses `b-atg-game`).
             {
-              id: 'b-app-game',
+              id: 'b-atg-updown-game',
               order: 2,
               type: 'skill_game',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: 'Hit-the-green game: score +1 for GIR, 0 for miss; target ≥ 7/10.',
+              rationale: 'Up-and-down challenge: 10 balls from various lies around the green, keep score.',
             },
           ],
         },
         {
-          title: 'Tee-shot consistency',
-          total_minutes: 30,
+          title: 'Tee shots, then close on the green',
+          total_minutes: 45,
           blocks: [
             {
-              id: 'b-ott-technical',
+              id: 'b-ott-warmup',
               order: 0,
-              type: 'technical',
+              type: 'warmup',
               drill_ref: 0, // Phase B: resolve to real drill id
-              minutes: 15,
-              rationale: 'Slow-motion takeaway drill to reduce over-the-top path.',
+              minutes: 10,
+              rationale: 'Easy half-speed swings with a mid-iron to loosen up before driver.',
             },
             {
-              id: 'b-ott-game',
+              id: 'b-ott-blocked',
               order: 1,
-              type: 'skill_game',
+              type: 'blocked',
               drill_ref: 0, // Phase B: resolve to real drill id
               minutes: 15,
-              rationale: 'Fairway-finder challenge: 10 drives, score for landing zone.',
+              rationale: 'Path-gate drill to reduce an over-the-top move, same swing repeated.',
+            },
+            // Closes on the green (a putting skill game) per Decisions §3.
+            // Unique id (Variant A already uses `b-put-game`).
+            {
+              id: 'b-put-lag-game',
+              order: 2,
+              type: 'skill_game',
+              drill_ref: 0, // Phase B: resolve to real drill id
+              minutes: 20,
+              rationale: 'Lag-ladder game from 10–40 ft to end every session on the green.',
             },
           ],
         },

--- a/supabase/functions/_shared/practice-plan/prompt.ts
+++ b/supabase/functions/_shared/practice-plan/prompt.ts
@@ -18,7 +18,7 @@ const CATEGORY_LABELS: Record<PlanCategory, string> = {
   around_green: 'around the green',
   putting: 'putting',
 }
-const BLOCK_TYPES: BlockType[] = ['warmup', 'technical', 'skill_game', 'pressure_game', 'putting']
+const BLOCK_TYPES: BlockType[] = ['warmup', 'blocked', 'random', 'skill_game', 'pressure_game', 'on_course']
 
 /** Anthropic tool-use input schema for one PlanDraft. Mirrors `PlanDraft` field
  *  names exactly so `validatePlanDraft` / `resolvePlanForStorage` consume the
@@ -192,6 +192,19 @@ export function buildPlanPrompt(
     '    "off the tee", "approach", "around the green", "putting".',
     '    Never use the raw keys like `around_green` or `off_tee` in prose.',
     '    The structured `category` field must still use the raw key — only prose uses readable names.',
+    '(8) Each session targets ONE focus AREA (the day\'s focus); the week\'s sessions cover the',
+    '    ranked weaknesses worst-first. Sequence the focus through the practice MODES as a',
+    '    PROGRESSION used in tandem — blocked (build the movement) → random (transfer it,',
+    '    a different shot every ball) → skill_game (measure it) → pressure_game (test it under',
+    '    consequence). The modes are NOT 1-for-1 swaps; use as many as the candidate list offers',
+    '    for that focus. `random` and `on_course` drills may be ABSENT — include a mode ONLY when',
+    '    a candidate of that drill_type exists; never invent one.',
+    '(9) Session FLOW: OPEN every session with a `warmup` block, then run the focus through the',
+    '    modes above, and CLOSE every session on the green — the LAST block must reference a drill',
+    '    whose category is `putting` or `around_green`. Prefer fuller, shorter blocks (more',
+    '    activities, less time each) over a few long blocks.',
+    '(10) Do NOT filter by the player\'s facilities. Surface and sequence drills regardless of where',
+    '     they are best done — players improvise. `facility` is a display hint only, never a gate.',
     '',
     'Return your answer ONLY by calling the emit_practice_plan tool.',
   ].join('\n')

--- a/supabase/functions/_shared/practice-plan/types.ts
+++ b/supabase/functions/_shared/practice-plan/types.ts
@@ -2,7 +2,7 @@ import type { SkillLevel, Goal } from '../constants.ts'
 
 export type PlanCategory = 'off_tee' | 'approach' | 'around_green' | 'putting'
 export type PlayFrequency = 'monthly' | 'weekly' | 'multi_weekly' | 'daily'
-export type BlockType = 'warmup' | 'technical' | 'skill_game' | 'pressure_game' | 'putting'
+export type BlockType = 'warmup' | 'blocked' | 'random' | 'skill_game' | 'pressure_game' | 'on_course'
 
 /** Already-fetched round, SG columns only (no stats engine needed). */
 export interface RoundSG {

--- a/supabase/functions/_shared/practice-plan/validation.ts
+++ b/supabase/functions/_shared/practice-plan/validation.ts
@@ -48,6 +48,30 @@ export function validatePlanDraft(
     // total_minutes is server-derived (sum of block minutes) — not validated here
   }
 
+  // D9: the plan must OPEN with a warmup — the first block of the first session.
+  // Unconditional (Decisions §3) — every session structure starts with an on-ramp.
+  const firstSession = draft.sessions[0]
+  const firstBlock = firstSession?.blocks[0]
+  if (firstBlock && firstBlock.type !== 'warmup') {
+    errors.push(`first block ${firstBlock.id} type ${firstBlock.type} != warmup (plan must open with a warmup)`)
+  }
+
+  // D10: EVERY session must CLOSE on the green — the last block of EACH session must
+  // reference a drill whose category is `putting` or `around_green`. Unconditional
+  // (Decisions §3): "the last thing you do in every session is putting always," no
+  // facility gating. Per-session, not just the final session.
+  for (const s of draft.sessions) {
+    const lastBlock = s.blocks[s.blocks.length - 1]
+    if (lastBlock) {
+      const closer = refOf(lastBlock.drill_ref)
+      if (closer && closer.category !== 'putting' && closer.category !== 'around_green') {
+        errors.push(
+          `last block ${lastBlock.id} drill category ${closer.category} != putting/around_green (session "${s.title}" must close on the green)`,
+        )
+      }
+    }
+  }
+
   // D5: each of the top-2 weaknesses must have at least one non-warmup block covering it
   const covered = new Set<PlanCategory>()
   for (const s of draft.sessions) {

--- a/supabase/functions/generate-practice-plan/index.ts
+++ b/supabase/functions/generate-practice-plan/index.ts
@@ -352,13 +352,14 @@ Deno.serve(async (req) => {
     candidates = await getCandidatePool(supabase, {
       skillLevel: profile.skill_level ?? 'developing',
       goal: profile.goal ?? 'break_90',
-      facilities: profile.facilities,
-      // Top weaknesses drive the gate; always carry a warmup/putting via
-      // retrieval's completeness guarantee. weaknessTargets is intentionally
-      // OMITTED — no category→target-tag map exists in @oga/core yet, and the opt
-      // is optional (absent ⇒ stable id-asc order). Wire it when that map lands.
-      // Pass the FULL ranked list (worst-first) — a too-narrow gate could starve
-      // the pool; the prompt rules still force top-2 coverage on the model side.
+      // NO facility gate (Decisions §4) — facilities are not passed to retrieval;
+      // every drill is surfaced. Top weaknesses drive the gate; retrieval's
+      // completeness guarantee always carries a warmup + a green-area closer.
+      // weaknessTargets is intentionally OMITTED — no category→target-tag map
+      // exists in @oga/core yet, and the opt is optional (absent ⇒ stable id-asc
+      // order). Wire it when that map lands. Pass the FULL ranked list (worst-first)
+      // — a too-narrow gate could starve the pool; the prompt rules still force
+      // top-2 coverage on the model side.
       focusCategories: weaknesses,
     })
     articles = getPublishedArticles()
@@ -372,8 +373,8 @@ Deno.serve(async (req) => {
   let storedDraft: PlanDraft | null = null
   let raw: RawModelOutput | null = null
 
-  // No candidates means the corpus can't cover this player's weaknesses under
-  // their facility constraints (§17 floor gap) — skip Claude, serve baseline.
+  // No candidates means the corpus has no verified drills matching this player's
+  // skill/goal/weakness categories — skip Claude, serve baseline.
   if (candidates.length === 0) {
     console.warn('[generate-practice-plan] empty candidate pool → baseline')
   } else {

--- a/supabase/functions/generate-practice-plan/retrieval.ts
+++ b/supabase/functions/generate-practice-plan/retrieval.ts
@@ -34,8 +34,6 @@ const DRILL_SELECT =
 export interface CandidatePoolOpts {
   skillLevel: string
   goal: string
-  /** The player's available facilities (e.g. ['range','practice_green']). */
-  facilities: string[]
   /** Ranked weakness categories from the digest (worst-first). */
   focusCategories: PlanCategory[]
   /** Weakness target tags (e.g. ['start_line','dispersion','lag']) used ONLY to
@@ -51,11 +49,8 @@ export interface CandidatePoolOpts {
  *
  *  Trust posture for interpolated values:
  *  - `goal` is safe: DB CHECK constraint (migration 0001) limits it to the
- *    known enum set ('break_100', 'break_90', …, 'scratch').
- *  - `facilities` is safe in practice (app-controlled enum values) but has NO
- *    DB CHECK constraint — it's a text[] with no brace/comma characters in any
- *    valid value, so pgArray can't be weaponized. A malformed PostgREST filter
- *    from either will throw in getCandidatePool, which now degrades to a baseline
+ *    known enum set ('break_100', 'break_90', …, 'scratch'). A malformed PostgREST
+ *    filter from it would throw in getCandidatePool, which degrades to a baseline
  *    in the orchestrator (no hard 500). */
 function pgArray(values: string[]): string {
   return `{${values.join(',')}}`
@@ -85,33 +80,39 @@ function toCandidate(r: DrillRow): CandidateDrill {
  * §7 candidate pool. Gate (all ANDed):
  *   - `skill_levels @> [skillLevel]`            — drill suits this skill band
  *   - `goals = '{}' OR goals @> [goal]`         — goal-agnostic OR matches the goal
- *   - `facility = '{}' OR facility && facilities` — anywhere-doable OR ≥1 facility match
  *   - `category = any(focusCategories)`         — attacks a ranked weakness
  *   - `verified = true`                          — maintainer-vetted only
+ *
+ * NO facility gate (taxonomy Decisions §4): every drill is surfaced regardless of
+ * the player's access — players improvise. `facility` survives on the candidate as
+ * a display-only "where" hint, never a filter.
  *
  * Order: targets-overlap-with-weaknesses DESC, then `id` ASC (total tiebreak).
  * PostgREST can't ORDER BY an array-overlap count, so we fetch the full gated set
  * ordered by `id asc` (stable + total), score overlap in JS, and stable-sort.
  *
  * Completeness guarantee: the pool is normally capped at POOL_LIMIT (25) and
- * always includes ≥1 `warmup` AND ≥1 drill whose `drill_type` is `putting` or
- * `pressure_game` (when the gated set contains any), so the model can always
- * build a full session. In the degenerate case where the top-25 can't satisfy
- * both guarantees via the swap path (every slot is shielding the other
- * guarantee), `ensurePresent` appends rather than swaps, so the pool may grow
- * to 26–27. This is safe: `validatePlanDraft` range-checks every `drill_ref`
- * against `candidates.length`, so a slightly-over-cap pool never causes a
- * silent out-of-bounds resolve.
+ * always includes ≥1 `warmup` drill AND ≥1 drill whose CATEGORY is `putting` or
+ * `around_green` (the always-close-on-the-green drill — when the gated set contains
+ * any), so the model can always build a full session that opens with a warmup and
+ * closes on the green. In the degenerate case where the top-25 can't satisfy both
+ * guarantees via the swap path (every slot is shielding the other guarantee),
+ * `ensurePresent` appends rather than swaps, so the pool may grow to 26–27. This is
+ * safe: `validatePlanDraft` range-checks every `drill_ref` against
+ * `candidates.length`, so a slightly-over-cap pool never causes a silent
+ * out-of-bounds resolve.
  */
 export async function getCandidatePool(
   supabase: SupabaseClient,
   opts: CandidatePoolOpts,
 ): Promise<CandidateDrill[]> {
-  const { skillLevel, goal, facilities, focusCategories, weaknessTargets = [] } = opts
+  const { skillLevel, goal, focusCategories, weaknessTargets = [] } = opts
 
   if (focusCategories.length === 0) return []
 
-  let query = supabase
+  // NO facility gate (Decisions §4) — every drill is surfaced; `facility` is a
+  // display hint only, carried through on the candidate but never filtered on.
+  const query = supabase
     .from('drills')
     .select(DRILL_SELECT)
     .eq('verified', true)
@@ -120,16 +121,8 @@ export async function getCandidatePool(
     // goal-agnostic ('{}') OR explicitly tagged for this goal. Two separate
     // .or() groups are AND-combined by PostgREST — the intended (A) AND (B).
     .or(`goals.eq.${pgArray([])},goals.cs.${pgArray([goal])}`)
-
-  // facility: anywhere-doable ('{}') OR overlaps the player's facilities. With no
-  // facilities known, the overlap arm can't match, so gate to anywhere-doable only.
-  query =
-    facilities.length > 0
-      ? query.or(`facility.eq.${pgArray([])},facility.ov.${pgArray(facilities)}`)
-      : query.eq('facility', pgArray([]))
-
-  // Stable, total base order; JS re-ranks by overlap below.
-  query = query.order('id', { ascending: true })
+    // Stable, total base order; JS re-ranks by overlap below.
+    .order('id', { ascending: true })
 
   const { data, error } = await query.returns<DrillRow[]>()
   if (error) {
@@ -147,10 +140,13 @@ export async function getCandidatePool(
 
   const ranked = scored.map((s) => s.r)
 
-  // Top slice, then guarantee a warmup and a putting/pressure_game drill are present.
+  // Top slice, then guarantee a warmup drill and a green-area (putting/around_green)
+  // closer are present — the always-open-with-a-warmup / always-close-on-the-green
+  // structure (Decisions §3) is enforced by `validatePlanDraft`; the pool must be
+  // able to satisfy it.
   const isWarmup = (r: DrillRow) => r.drill_type === 'warmup'
-  const isPuttingOrPressure = (r: DrillRow) =>
-    r.drill_type === 'putting' || r.drill_type === 'pressure_game'
+  const isGreenCloser = (r: DrillRow) =>
+    r.category === 'putting' || r.category === 'around_green'
 
   const selected = ranked.slice(0, POOL_LIMIT)
 
@@ -175,8 +171,8 @@ export async function getCandidatePool(
     selected.push(candidate)
   }
 
-  ensurePresent(isWarmup, isPuttingOrPressure)
-  ensurePresent(isPuttingOrPressure, isWarmup)
+  ensurePresent(isWarmup, isGreenCloser)
+  ensurePresent(isGreenCloser, isWarmup)
 
   return selected.map(toCandidate)
 }


### PR DESCRIPTION
## What

Brings the `generate-practice-plan` engine in line with the practice-mode taxonomy (foundation merged in #442). The engine now speaks the new `drill_type` vocabulary and encodes the session flow from the practice articles.

### Changes
- **types** — `BlockType` → `warmup · blocked · random · skill_game · pressure_game · on_course`.
- **validation** (security-critical; D1–D8 unchanged) — added **D9** (every session opens with a `warmup`) and **D10** (every session closes on the green: the last block's drill `category` is `putting` or `around_green`). Both per-session.
- **baseline** — fallback plans use valid modes only; every session opens with a warmup and closes on a putting/around_green drill.
- **prompt** — tool-schema block enum → the six modes; session-flow guidance: one focus area per session, warmup open, blocked→random→skill_game→pressure_game→short-game→putting close, modes used **in tandem** (not 1-for-1 swaps), include a mode only when a candidate of that type exists, **no facility gating**.
- **retrieval** — **dropped facility filtering**: every drill is surfaced regardless of the player's facilities; `facility` is carried as a display hint only. Closer-completeness guarantee repointed to `category ∈ {putting, around_green}`.
- Re-vendored into `functions/_shared` (drift-check green).

### Verification
489 tests + typecheck pass; vendor drift-check OK. Two-stage review (spec-compliance: D9/D10 mutation-tested non-vacuous, D1–D8 intact, no residual facility gating; + code-quality).

### ⚠️ Deploy sequence
Depends on migration `0033` (#442). After merge: apply `0033` to the dev DB → redeploy `generate-practice-plan` (\`--use-api\`) → verify a real plan follows the flow. `random`/`on_course` modes are graceful (no drills yet — authored in a follow-up corpus-fill PR).