### PR TITLE
feat(web): generation progress bar + fix(engine): treat APIConnectionError as transient

### DIFF
--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -206,6 +206,44 @@ function GenerateButton({
   )
 }
 
+/** Indeterminate sliding progress bar shown while generation is in flight.
+ *  Claude calls can take 15–45s; static "Generating…" text gives no signal
+ *  the call is alive. The bar is the only motion cue and lives at the top of
+ *  whichever generate surface (NoPlanState card or PlanHeader) the user
+ *  clicked. Keyframes inlined so the change is contained to this file. */
+function GenerateProgressBar({ visible }: { visible: boolean }) {
+  if (!visible) return null
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: 'relative',
+        height: 3,
+        width: '100%',
+        background: '#EBE5D6',
+        overflow: 'hidden',
+        borderRadius: 2,
+      }}
+    >
+      <style>{`
+        @keyframes oga-progress-slide {
+          0%   { transform: translateX(-100%); }
+          100% { transform: translateX(400%); }
+        }
+      `}</style>
+      <div
+        className="bg-caddie-accent"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          width: '25%',
+          animation: 'oga-progress-slide 1.4s ease-in-out infinite',
+        }}
+      />
+    </div>
+  )
+}
+
 function PageHeading() {
   return (
     <>
@@ -271,8 +309,18 @@ function NoPlanState({
       </div>
       <div
         className="bg-caddie-surface"
-        style={{ border: `1px solid ${LINE}`, borderRadius: 4, padding: '40px 32px', maxWidth: 640 }}
+        style={{
+          border: `1px solid ${LINE}`,
+          borderRadius: 4,
+          padding: '40px 32px',
+          maxWidth: 640,
+          position: 'relative',
+        }}
       >
+        {/* Top-of-card progress bar while generation is in flight. */}
+        <div style={{ position: 'absolute', top: 0, left: 0, right: 0 }}>
+          <GenerateProgressBar visible={isPending} />
+        </div>
         <div className="kicker" style={{ marginBottom: 12 }}>
           No plan yet
         </div>
@@ -338,24 +386,27 @@ function PlanHeader({
   isPending: boolean
 }) {
   return (
-    <div
-      className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3"
-      style={{ marginBottom: 28 }}
-    >
-      <div>
-        <div className="kicker" style={{ marginBottom: 8 }}>
-          {kicker}
-        </div>
-        <h1
-          className="font-serif text-caddie-ink"
-          style={{ fontSize: 28, fontWeight: 500, fontStyle: 'italic', lineHeight: 1.15, maxWidth: 640 }}
-        >
-          {insight}
-        </h1>
+    <div style={{ marginBottom: 28 }}>
+      {/* Top-of-section progress bar while a regenerate is in flight. */}
+      <div style={{ marginBottom: 8 }}>
+        <GenerateProgressBar visible={isPending} />
       </div>
-      {generateLabel ? (
-        <GenerateButton label={generateLabel} onGenerate={onGenerate} isPending={isPending} />
-      ) : null}
+      <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
+        <div>
+          <div className="kicker" style={{ marginBottom: 8 }}>
+            {kicker}
+          </div>
+          <h1
+            className="font-serif text-caddie-ink"
+            style={{ fontSize: 28, fontWeight: 500, fontStyle: 'italic', lineHeight: 1.15, maxWidth: 640 }}
+          >
+            {insight}
+          </h1>
+        </div>
+        {generateLabel ? (
+          <GenerateButton label={generateLabel} onGenerate={onGenerate} isPending={isPending} />
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -206,11 +206,8 @@ function GenerateButton({
   )
 }
 
-/** Indeterminate sliding progress bar shown while generation is in flight.
- *  Claude calls can take 15–45s; static "Generating…" text gives no signal
- *  the call is alive. The bar is the only motion cue and lives at the top of
- *  whichever generate surface (NoPlanState card or PlanHeader) the user
- *  clicked. Keyframes inlined so the change is contained to this file. */
+/** Keyframes inlined so this stays a single-file change instead of touching
+ *  the global stylesheet for one progress bar. */
 function GenerateProgressBar({ visible }: { visible: boolean }) {
   if (!visible) return null
   return (
@@ -387,10 +384,13 @@ function PlanHeader({
 }) {
   return (
     <div style={{ marginBottom: 28 }}>
-      {/* Top-of-section progress bar while a regenerate is in flight. */}
-      <div style={{ marginBottom: 8 }}>
-        <GenerateProgressBar visible={isPending} />
-      </div>
+      {/* Wrapper conditional, not just the bar: an always-rendered margin
+       *  would shift the title row by 8px in the idle (non-regenerating) state. */}
+      {isPending ? (
+        <div style={{ marginBottom: 8 }}>
+          <GenerateProgressBar visible />
+        </div>
+      ) : null}
       <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3">
         <div>
           <div className="kicker" style={{ marginBottom: 8 }}>

--- a/supabase/functions/generate-practice-plan/index.ts
+++ b/supabase/functions/generate-practice-plan/index.ts
@@ -584,14 +584,20 @@ function classifyClaudeError(err: unknown, model: string): RawModelOutput {
       }
     }
 
-    // Transient: rate-limit / overload (529→InternalServerError) / 5xx. Baseline
-    // but do NOT burn the user's monthly cap — by NOT inserting a row here, the
-    // count query naturally excludes this attempt (we serve a baseline that is
-    // also stored, but the cap counts plans; transient retries shouldn't penalize
-    // the user). We tag the reason so the caller can choose not to persist.
+    // Transient: rate-limit / overload (529→InternalServerError) / 5xx /
+    // connection-level failures (incl. APIConnectionTimeoutError — the SDK
+    // never reaches Anthropic, so there's no HTTP response to classify; the
+    // call timed out at the socket). All four are retryable conditions, so
+    // baseline ephemerally (no INSERT) — by NOT inserting a row here, the
+    // count query naturally excludes this attempt (we serve a baseline that
+    // is also stored, but the cap counts plans; transient retries shouldn't
+    // penalize the user) AND the cadence guard isn't tripped (a persisted
+    // baseline with valid_until 7d out would lock the user out of retrying).
+    // We tag the reason so the caller can choose not to persist.
     const transient =
       err instanceof Anthropic.RateLimitError ||
       err instanceof Anthropic.InternalServerError ||
+      err instanceof Anthropic.APIConnectionError ||
       type === 'overloaded_error' ||
       err.status === 429 ||
       (typeof err.status === 'number' && err.status >= 500)


### PR DESCRIPTION
## Why

Surfaces a real bug from today's smoke test: a Claude API timeout during plan generation (`APIConnectionTimeoutError` after 61s wall-clock) was misclassified as a non-transient error → the orchestrator **persisted** a baseline plan with `valid_until = today + 7` → the cadence guard then **locked the user out of regenerating for 7 days**.

Manually deleted the broken baseline row from dev for the affected user (TestGolfer); without (C), this lockout would recur on any future Claude blip.

## (B) Generation progress bar

Claude calls can legitimately take 15–45s. Static "Generating…" button text gave zero signal that the call was alive — users (myself included) thought the click did nothing.

- New `GenerateProgressBar` component (local to `PracticePlanPage.tsx`). Thin (3px) indeterminate sliding gradient, only renders when `visible=true`.
- Placed above the GenerateButton on **both** entry points:
  - **First-time generation** — top of the `NoPlanState` card
  - **Regenerate** (after expiry) — top of the `PlanHeader`
- Pure CSS animation (`@keyframes oga-progress-slide`), inlined in the component. No library, no global stylesheet change.

## (C) Classify `Anthropic.APIConnectionError` as transient

`classifyClaudeError` already matches `RateLimitError` / `InternalServerError` / `overloaded_error` / `status>=500` as transient — but a **connection-level failure** (no HTTP response at all; the SDK never reached Anthropic) is just as retryable.

\`\`\`diff
 const transient =
   err instanceof Anthropic.RateLimitError ||
   err instanceof Anthropic.InternalServerError ||
+  err instanceof Anthropic.APIConnectionError ||
   type === 'overloaded_error' ||
   err.status === 429 ||
   (typeof err.status === 'number' && err.status >= 500)
\`\`\`

`APIConnectionError` is the SDK's base class for connection failures and covers `APIConnectionTimeoutError` (today's failure) via inheritance.

With this fix, a timeout returns **503 ephemerally** — no INSERT, the per-user cap isn't burned, and the cadence guard isn't tripped, so the user can retry immediately.

## Scope

- **2 files, +79 / −22 lines**
- ≤30 LOC web edit (new component + 2 mount points)
- ~2 LOC + comment block on the engine
- No schema change, no contract change
- Typecheck green across the workspace

## Testing
- [x] pnpm typecheck — green (3/3)
- [ ] pnpm test — N/A (no test coverage on engine error classification; would be a follow-up)
- [ ] Visual verify in browser — pending preview deploy
- [ ] Engine smoke test — pending Edge function redeploy + a fresh Generate click

## Deployment

- Web side ships with the Vercel preview / dev merge.
- **Engine side (C) requires an Edge function redeploy.** I'll fire it via MCP right after this PR opens so dev's `generate-practice-plan` v6 picks up the classification change.