### PR TITLE
fix(web): constrain Shot Patterns plot frame to the SVG footprint

### DIFF
--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -265,10 +265,8 @@ export function ShotPatternsPage() {
                 {lieSlopeSide ? ` (${lieSlopeSide.replace('_', ' ')})` : ''}.
               </div>
             ) : (
-              // Width-constrained wrapper so the legend wraps within the plot's
-              // footprint instead of growing the cream box wider than the SVG
-              // (the legend's natural width on wide viewports exceeds 420 px,
-              // which was leaving empty space to the right of the plot).
+              // Constrain the wrapper so the legend's flex-wrap row wraps
+              // within the plot footprint instead of stretching the parent.
               <div style={{ width: SVG_VIEW_WIDTH }}>
                 <DispersionPlot points={points} stats={stats} />
                 <PatternLegend hasEllipses={!!stats} />

--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -265,10 +265,14 @@ export function ShotPatternsPage() {
                 {lieSlopeSide ? ` (${lieSlopeSide.replace('_', ' ')})` : ''}.
               </div>
             ) : (
-              <>
+              // Width-constrained wrapper so the legend wraps within the plot's
+              // footprint instead of growing the cream box wider than the SVG
+              // (the legend's natural width on wide viewports exceeds 420 px,
+              // which was leaving empty space to the right of the plot).
+              <div style={{ width: SVG_VIEW_WIDTH }}>
                 <DispersionPlot points={points} stats={stats} />
                 <PatternLegend hasEllipses={!!stats} />
-              </>
+              </div>
             )}
           </div>
 


### PR DESCRIPTION
## What was wrong

On wide viewports, the "Pattern" cream box on \`/patterns\` was rendering visibly wider than the dispersion plot inside it — the SVG sat left-anchored with empty space to the right, and gridlines only filled the left ~60% of the cream area.

## Why

The cream box sizes to whichever child is widest:

- \`<DispersionPlot>\` SVG width: \`min(420px, 90vw)\` → capped at 420px
- \`<PatternLegend>\` (sibling): \`flex flex-wrap\` row with six items (SOLID, PUSH/PULL, MISS, UNSPECIFIED, 68%, 95%); natural width on wide viewports is **~600px**

When both children render, the legend's natural width forces the cream box wider than the SVG. The SVG renders at 420px and sits at the top-left of that wider box.

(Only reproduced when shots existed — the empty-shot placeholder and loading state already hardcode \`width: SVG_VIEW_WIDTH\`, so they didn't show the bug.)

## Fix

Wrap the \`<DispersionPlot>\` + \`<PatternLegend>\` pair in a \`<div style={{ width: SVG_VIEW_WIDTH }}>\` so the legend wraps within the plot's footprint and the cream box hugs that width.

\`\`\`diff
- ) : (
-   <>
-     <DispersionPlot points={points} stats={stats} />
-     <PatternLegend hasEllipses={!!stats} />
-   </>
- )}
+ ) : (
+   // Width-constrained wrapper so the legend wraps within the plot's
+   // footprint instead of growing the cream box wider than the SVG …
+   <div style={{ width: SVG_VIEW_WIDTH }}>
+     <DispersionPlot points={points} stats={stats} />
+     <PatternLegend hasEllipses={!!stats} />
+   </div>
+ )}
\`\`\`

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Design/UI change
- [ ] Refactor
- [ ] Docs

## Testing
- [x] pnpm typecheck — green (3/3)
- [ ] Visual verify on Vercel preview
- [ ] Verify the share-card export path still renders at fixed 1200×630 (unaffected — share card has its own component path that passes an explicit \`size\`, not the responsive \`SVG_VIEW_WIDTH\`)

## Notes for reviewer

- 6 lines changed (\`<>\` → \`<div style={{ width: SVG_VIEW_WIDTH }}>\`)
- No data, no contract, no schema changes
- Loading and empty-shot states unaffected (they already constrained their width)
- Share-card export (\`ShotPatternsShareCard.tsx\`) unaffected — it passes \`size={1200}\` explicitly and renders its own legend