### PR TITLE
fix(web): keep Shot Patterns plot inside the cream box on mobile-web

### DIFF
--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -17,7 +17,7 @@ import { useUnits } from '../../hooks/useUnits'
 import {
   DispersionPlot,
   pointColor,
-  SVG_VIEW_WIDTH,
+  SVG_SIZE,
 } from './components/DispersionPlot'
 import { ShotPatternsShareCard } from './components/ShotPatternsShareCard'
 
@@ -241,8 +241,9 @@ export function ShotPatternsPage() {
               <div
                 className="flex items-center justify-center text-caddie-ink-mute"
                 style={{
-                  width: SVG_VIEW_WIDTH,
-                  height: SVG_VIEW_WIDTH,
+                  width: SVG_SIZE,
+                  maxWidth: '100%',
+                  aspectRatio: '1 / 1',
                   fontSize: 13,
                 }}
               >
@@ -252,8 +253,9 @@ export function ShotPatternsPage() {
               <div
                 className="flex items-center justify-center text-caddie-ink-mute"
                 style={{
-                  width: SVG_VIEW_WIDTH,
-                  height: SVG_VIEW_WIDTH,
+                  width: SVG_SIZE,
+                  maxWidth: '100%',
+                  aspectRatio: '1 / 1',
                   fontSize: 13,
                   textAlign: 'center',
                   padding: 20,
@@ -267,7 +269,9 @@ export function ShotPatternsPage() {
             ) : (
               // Constrain the wrapper so the legend's flex-wrap row wraps
               // within the plot footprint instead of stretching the parent.
-              <div style={{ width: SVG_VIEW_WIDTH }}>
+              // `maxWidth: 100%` is parent-relative (not 90vw) so the cream
+              // box's own padding can't be overrun on narrow viewports.
+              <div style={{ width: SVG_SIZE, maxWidth: '100%' }}>
                 <DispersionPlot points={points} stats={stats} />
                 <PatternLegend hasEllipses={!!stats} />
               </div>

--- a/apps/web/src/pages/patterns/components/DispersionPlot.tsx
+++ b/apps/web/src/pages/patterns/components/DispersionPlot.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react'
 import type { DispersionPoint, DispersionStats } from '@oga/core'
 
 export const SVG_SIZE = 420
-export const SVG_VIEW_WIDTH = `min(${SVG_SIZE}px, 90vw)`
 
 // Pattern point colors. Solid = ink (neutral, the goal); push/pull = warn
 // amber; misses = neg brick. Stays inside the editorial palette.
@@ -24,7 +23,7 @@ export function DispersionPlot({
   points: DispersionPoint[]
   stats: DispersionStats | null
   // Fixed pixel size for the share card (viewport-independent capture).
-  // Omitted on the page → responsive `min(420px, 90vw)`.
+  // Omitted on the page → SVG fills its parent (page wrapper caps the width).
   size?: number
 }) {
   // Spread Math.max over every point ran on every render. Memoize the
@@ -55,7 +54,7 @@ export function DispersionPlot({
   const px = (lat: number) => cx + lat * scale
   const py = (dist: number) => cy - dist * scale
 
-  const renderDim = size ?? SVG_VIEW_WIDTH
+  const renderDim = size ?? '100%'
 
   return (
     <svg


### PR DESCRIPTION
## What

Follow-up to #447. That PR added a `width: SVG_VIEW_WIDTH` (`min(420px, 90vw)`) wrapper around the SVG + legend so the legend's flex-wrap row couldn't stretch the cream box past the plot on desktop. It worked on desktop but regressed mobile-web.

## Why mobile-web overflowed

`90vw` is viewport-relative — it doesn't shrink for ancestor paddings. On a 375 px viewport:

| Layer | Width |
|---|---|
| `<main>` content area | 375 − 32 = **343 px** (`paddingInline: clamp(16, 4vw, 32)`) |
| Cream box (grid-cols-1, full cell) | 343 px |
| Cream box content area | 343 − 28 (own padding 14×2) = **315 px** |
| Wrapper `width: 90vw` | **337.5 px** → overflows by ~22 px |

The dispersion box visibly poked past its container on mobile. The two empty/loading placeholders (`width: SVG_VIEW_WIDTH; height: SVG_VIEW_WIDTH`) had the same problem, just only visible in those branches.

## Fix

Switch to parent-relative sizing across all three render states:

- `DispersionPlot.renderDim`: `size ?? '100%'` — page render fills its parent; share-card path (passes fixed `size`) is unaffected.
- Page wrapper: `width: SVG_SIZE; maxWidth: 100%` — preferred 420 on desktop (cream box auto-sizes to it in the `minmax(0, auto)` grid column, same as #447), capped at parent width on mobile.
- Both placeholders: same pattern + `aspectRatio: 1 / 1` to stay square at any actual width.

Removed the now-unused `SVG_VIEW_WIDTH` export.

## Verification

Geometry check at 375 px viewport (via throwaway Playwright spec, since deleted): cream / wrapper / svg rects all fit — 16→359, 31→344, 31→344. Pre-fix the wrapper would have ended at 31 + 337.5 = 368.5, **9.5 px past the cream's right edge**.

Desktop at 1280 px: cream box renders at 420 px wide, hugging the SVG — #447's desktop fix preserved.

Typecheck green.

## QA

Real-iPhone Safari on the Vercel preview — load `/patterns`, pick a club with shots in the seed (7i has them), confirm the Pattern card no longer pokes past its cream container.