### PR TITLE
feat(plan): resolve baseline drill_id by corpus name (#18 Track D)

### DIFF
--- a/packages/core/src/practice-plan/baseline.test.ts
+++ b/packages/core/src/practice-plan/baseline.test.ts
@@ -64,7 +64,6 @@ describe('selectBaselinePlan', () => {
           for (const b of s.blocks) {
             expect(b.drill_name, `block ${b.id} has no drill_name`).toBeTruthy()
             expect(typeof b.drill_name).toBe('string')
-            expect(b.drill_name!.length).toBeGreaterThan(0)
           }
         }
       }

--- a/packages/core/src/practice-plan/baseline.test.ts
+++ b/packages/core/src/practice-plan/baseline.test.ts
@@ -52,4 +52,22 @@ describe('selectBaselinePlan', () => {
       }
     }
   })
+
+  it('every block carries a drill_name that serveBaseline can resolve', () => {
+    // Each baseline block names a real corpus drill by name; the Edge fn
+    // queries `drills.name in (…)` and fills `drill_id` before INSERT.
+    // A missing/empty hint means the UI would show "Drill" and `canExpand`
+    // would be false — the regression D fixes.
+    for (const variants of Object.values(BASELINE_PLANS)) {
+      for (const v of variants ?? []) {
+        for (const s of v.sessions) {
+          for (const b of s.blocks) {
+            expect(b.drill_name, `block ${b.id} has no drill_name`).toBeTruthy()
+            expect(typeof b.drill_name).toBe('string')
+            expect(b.drill_name!.length).toBeGreaterThan(0)
+          }
+        }
+      }
+    }
+  })
 })

--- a/packages/core/src/practice-plan/baseline.ts
+++ b/packages/core/src/practice-plan/baseline.ts
@@ -2,8 +2,10 @@ import type { SkillLevel, Goal } from '../constants'
 import type { PlanDraft, PlanCategory } from './types'
 
 // Baseline plans are static content (same `PlanDraft` shape the UI renders).
-// NOTE: block `drill_ref` is a placeholder here — baseline drill references are
-// resolved to real drill ids when the baseline content is authored (Phase B).
+// Block `drill_name` is the canonical corpus name; `serveBaseline` resolves
+// each one to a real `drill_id` at storage time and strips the hint before
+// INSERT. `drill_ref` stays 0 (placeholder — baselines don't go through the
+// retrieval/Claude path that consumes it).
 type BaselineVariant = Omit<PlanDraft, 'sessions'> & {
   primaryCategory: PlanCategory
   sessions: PlanDraft['sessions']
@@ -37,7 +39,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-put-warmup',
               order: 0,
               type: 'warmup',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Speed Station (15-Inches-Past Lag Primer)',
               minutes: 10,
               rationale: 'Easy lag rolls to find the speed of the greens before any focused work.',
             },
@@ -45,7 +48,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-put-blocked',
               order: 1,
               type: 'blocked',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Gate Drill',
               minutes: 20,
               rationale: 'Gate drill — repeated straight putts to ingrain a square face and start line.',
             },
@@ -53,7 +57,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-put-game',
               order: 2,
               type: 'pressure_game',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Golden Eight (Walters)',
               minutes: 15,
               rationale: '18-hole putting game on the practice green to add consequence to the stroke.',
             },
@@ -67,7 +72,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-atg-blocked',
               order: 0,
               type: 'blocked',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Bump-and-Run',
               minutes: 15,
               rationale: 'Bump-and-run from tight lies to a near pin — same shot, repeated.',
             },
@@ -76,7 +82,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-atg-game',
               order: 1,
               type: 'skill_game',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Up-and-Down Scoring Game',
               minutes: 15,
               rationale: 'Up-and-down challenge: 10 balls from various lies around the green, keep score.',
             },
@@ -110,7 +117,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-app-warmup',
               order: 0,
               type: 'warmup',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: '7-Iron Calibration Warm-Up',
               minutes: 10,
               rationale: 'Nine-o\'clock to three-o\'clock half-swings to groove contact.',
             },
@@ -118,17 +126,19 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-app-blocked',
               order: 1,
               type: 'blocked',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Tee-Gate Center-Face',
               minutes: 20,
               rationale: 'Alignment-stick target gate — 7-iron to a specific pin, same shot repeated.',
             },
             // Closes on the green (an around_green skill game) — every session ends on the green per Decisions §3.
-            // Unique id (Variant A already uses `b-atg-game`).
+            // Unique id (Variant A already uses `b-atg-game`); intentionally reuses the same drill name.
             {
               id: 'b-atg-updown-game',
               order: 2,
               type: 'skill_game',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Up-and-Down Scoring Game',
               minutes: 15,
               rationale: 'Up-and-down challenge: 10 balls from various lies around the green, keep score.',
             },
@@ -142,7 +152,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-ott-warmup',
               order: 0,
               type: 'warmup',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Rhythm/Tempo Warm-Up',
               minutes: 10,
               rationale: 'Easy half-speed swings with a mid-iron to loosen up before driver.',
             },
@@ -150,7 +161,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-ott-blocked',
               order: 1,
               type: 'blocked',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Path Gate',
               minutes: 15,
               rationale: 'Path-gate drill to reduce an over-the-top move, same swing repeated.',
             },
@@ -160,7 +172,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-put-lag-game',
               order: 2,
               type: 'skill_game',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Distance Ladder',
               minutes: 20,
               rationale: 'Lag-ladder game from 10–40 ft to end every session on the green.',
             },

--- a/packages/core/src/practice-plan/types.ts
+++ b/packages/core/src/practice-plan/types.ts
@@ -56,6 +56,10 @@ export interface PlanBlock {
   drill_ref: number // index into the candidate pool
   minutes: number
   rationale: string
+  // Baseline-only hint: the canonical drill name in the corpus. `serveBaseline`
+  // resolves it to a real `drill_id` at storage time and strips this field
+  // before INSERT. Never emitted by Claude tool calls.
+  drill_name?: string
 }
 export interface PlanSession {
   title: string

--- a/supabase/functions/_shared/practice-plan/baseline.ts
+++ b/supabase/functions/_shared/practice-plan/baseline.ts
@@ -2,8 +2,10 @@ import type { SkillLevel, Goal } from '../constants.ts'
 import type { PlanDraft, PlanCategory } from './types.ts'
 
 // Baseline plans are static content (same `PlanDraft` shape the UI renders).
-// NOTE: block `drill_ref` is a placeholder here — baseline drill references are
-// resolved to real drill ids when the baseline content is authored (Phase B).
+// Block `drill_name` is the canonical corpus name; `serveBaseline` resolves
+// each one to a real `drill_id` at storage time and strips the hint before
+// INSERT. `drill_ref` stays 0 (placeholder — baselines don't go through the
+// retrieval/Claude path that consumes it).
 type BaselineVariant = Omit<PlanDraft, 'sessions'> & {
   primaryCategory: PlanCategory
   sessions: PlanDraft['sessions']
@@ -37,7 +39,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-put-warmup',
               order: 0,
               type: 'warmup',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Speed Station (15-Inches-Past Lag Primer)',
               minutes: 10,
               rationale: 'Easy lag rolls to find the speed of the greens before any focused work.',
             },
@@ -45,7 +48,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-put-blocked',
               order: 1,
               type: 'blocked',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Gate Drill',
               minutes: 20,
               rationale: 'Gate drill — repeated straight putts to ingrain a square face and start line.',
             },
@@ -53,7 +57,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-put-game',
               order: 2,
               type: 'pressure_game',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Golden Eight (Walters)',
               minutes: 15,
               rationale: '18-hole putting game on the practice green to add consequence to the stroke.',
             },
@@ -67,7 +72,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-atg-blocked',
               order: 0,
               type: 'blocked',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Bump-and-Run',
               minutes: 15,
               rationale: 'Bump-and-run from tight lies to a near pin — same shot, repeated.',
             },
@@ -76,7 +82,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-atg-game',
               order: 1,
               type: 'skill_game',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Up-and-Down Scoring Game',
               minutes: 15,
               rationale: 'Up-and-down challenge: 10 balls from various lies around the green, keep score.',
             },
@@ -110,7 +117,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-app-warmup',
               order: 0,
               type: 'warmup',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: '7-Iron Calibration Warm-Up',
               minutes: 10,
               rationale: 'Nine-o\'clock to three-o\'clock half-swings to groove contact.',
             },
@@ -118,17 +126,19 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-app-blocked',
               order: 1,
               type: 'blocked',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Tee-Gate Center-Face',
               minutes: 20,
               rationale: 'Alignment-stick target gate — 7-iron to a specific pin, same shot repeated.',
             },
             // Closes on the green (an around_green skill game) — every session ends on the green per Decisions §3.
-            // Unique id (Variant A already uses `b-atg-game`).
+            // Unique id (Variant A already uses `b-atg-game`); intentionally reuses the same drill name.
             {
               id: 'b-atg-updown-game',
               order: 2,
               type: 'skill_game',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Up-and-Down Scoring Game',
               minutes: 15,
               rationale: 'Up-and-down challenge: 10 balls from various lies around the green, keep score.',
             },
@@ -142,7 +152,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-ott-warmup',
               order: 0,
               type: 'warmup',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Rhythm/Tempo Warm-Up',
               minutes: 10,
               rationale: 'Easy half-speed swings with a mid-iron to loosen up before driver.',
             },
@@ -150,7 +161,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-ott-blocked',
               order: 1,
               type: 'blocked',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Path Gate',
               minutes: 15,
               rationale: 'Path-gate drill to reduce an over-the-top move, same swing repeated.',
             },
@@ -160,7 +172,8 @@ export const BASELINE_PLANS: Partial<Record<Cell | 'default', BaselineVariant[]>
               id: 'b-put-lag-game',
               order: 2,
               type: 'skill_game',
-              drill_ref: 0, // Phase B: resolve to real drill id
+              drill_ref: 0,
+              drill_name: 'Distance Ladder',
               minutes: 20,
               rationale: 'Lag-ladder game from 10–40 ft to end every session on the green.',
             },

--- a/supabase/functions/_shared/practice-plan/types.ts
+++ b/supabase/functions/_shared/practice-plan/types.ts
@@ -56,6 +56,10 @@ export interface PlanBlock {
   drill_ref: number // index into the candidate pool
   minutes: number
   rationale: string
+  // Baseline-only hint: the canonical drill name in the corpus. `serveBaseline`
+  // resolves it to a real `drill_id` at storage time and strips this field
+  // before INSERT. Never emitted by Claude tool calls.
+  drill_name?: string
 }
 export interface PlanSession {
   title: string

--- a/supabase/functions/generate-practice-plan/index.ts
+++ b/supabase/functions/generate-practice-plan/index.ts
@@ -673,9 +673,44 @@ async function serveBaseline(
   const weekIndex = Math.floor(Date.now() / (7 * 24 * 60 * 60 * 1000))
   const draft = selectBaselinePlan({ skill, goal, weekIndex, worstCategory })
 
-  // Baselines carry placeholder drill_refs (no resolved drill ids) — store the
-  // draft sessions as-is (UI renders the same PlanDraft shape). No pool to
-  // resolve against, so we map the draft directly.
+  // Resolve each baseline block's `drill_name` hint to a real `drill_id`
+  // against the corpus (one query, one map). Without this, the UI fallback
+  // shows the literal string "Drill" with no expand for every baseline block.
+  // Unresolved names (e.g., a prod project without migration 0034 applied)
+  // pass through with `drill_id` undefined — same as the pre-D behavior, so
+  // we never block a baseline on a name lookup miss.
+  const distinctNames = Array.from(
+    new Set(
+      draft.sessions.flatMap((s) =>
+        s.blocks.map((b) => b.drill_name).filter((n): n is string => !!n),
+      ),
+    ),
+  )
+  const nameToId = new Map<string, string>()
+  if (distinctNames.length > 0) {
+    const { data: drills, error: drillsErr } = await supabase
+      .from('drills')
+      .select('id, name')
+      .in('name', distinctNames)
+    if (drillsErr) {
+      console.error('[generate-practice-plan] baseline drills lookup failed', drillsErr.message)
+      // fall through with empty map — same as a corpus-less environment
+    } else {
+      for (const d of (drills ?? []) as { id: string; name: string }[]) {
+        nameToId.set(d.name, d.id)
+      }
+    }
+  }
+  const resolvedSessions = draft.sessions.map((s) => ({
+    ...s,
+    blocks: s.blocks.map((b) => {
+      const { drill_name, ...rest } = b
+      const drill_id = drill_name ? nameToId.get(drill_name) : undefined
+      // Strip the hint regardless; only attach drill_id when resolved.
+      return drill_id ? { ...rest, drill_id } : rest
+    }),
+  }))
+
   const days = validityDays ?? 7
   const validUntil = new Date()
   validUntil.setUTCDate(validUntil.getUTCDate() + days)
@@ -685,7 +720,7 @@ async function serveBaseline(
     ai_insight: draft.week_focus,
     coach_note: draft.coach_note,
     focus_areas: draft.focus_areas,
-    drills: { sessions: draft.sessions },
+    drills: { sessions: resolvedSessions },
     based_on_rounds: digest?.sg_summary.based_on_rounds ?? 0,
     valid_until: validUntil.toISOString().slice(0, 10),
     raw_model_output: raw ?? ({ status: 'baseline', reason } satisfies RawModelOutput),


### PR DESCRIPTION
## What

When the orchestrator falls back to a baseline plan (insufficient SG rounds, transient Claude error, generation failure), the persisted `drills.sessions[*].blocks[*].drill_id` was undefined — the UI fallback name was the literal string "Drill" with `canExpand = false`. Deferred Phase B work from the engine ship.

## Approach (locked plan, Approach A)

Hardcode a specific corpus drill **name** per baseline block. At `serveBaseline` time do ONE query `select id, name from drills where name in (...)`, build a name→id map, fill `drill_id` on each stored block, drop the `drill_name` hint from the persisted shape.

Editorial control + deterministic + obvious in source.

## Changes

- `PlanBlock` (`packages/core/src/practice-plan/types.ts`): adds optional `drill_name?: string` — baseline-only hint, never emitted by Claude tool calls.
- `baseline.ts`: sets `drill_name` on each of the 11 blocks across the two default variants (putting-focus + approach-focus). All 11 picks come from the v2 corpus seed (migration 0034). Names verified verbatim against `supabase/seed.sql`.
- `baseline.test.ts`: asserts every baseline block carries a non-empty `drill_name`.
- `_shared/practice-plan/{types,baseline}.ts`: vendor copies via `scripts/vendor-practice-plan.mjs`; drift-check OK (9 files).
- `generate-practice-plan/index.ts` `serveBaseline()`: collects distinct names, queries `drills`, builds a name→id map, produces `resolvedSessions` carrying `drill_id` with `drill_name` stripped. **Graceful fallback:** unresolved name (e.g., a prod project without migration 0034 applied yet) passes through with `drill_id` undefined — same as the pre-D behavior, so a missing corpus never blocks a baseline. The lookup error logs but doesn't fail.

All three `serveBaseline` exit paths (dryRun, transient-ephemeral, INSERT) carry the resolved sessions because resolution happens before the branch.

## Picks

Variant A (putting focus):
| Block | Drill |
|---|---|
| `b-put-warmup` | Speed Station (15-Inches-Past Lag Primer) |
| `b-put-blocked` | Gate Drill |
| `b-put-game` | Golden Eight (Walters) |
| `b-atg-blocked` | Bump-and-Run |
| `b-atg-game` | Up-and-Down Scoring Game |

Variant B (approach focus):
| Block | Drill |
|---|---|
| `b-app-warmup` | 7-Iron Calibration Warm-Up |
| `b-app-blocked` | Tee-Gate Center-Face |
| `b-atg-updown-game` | Up-and-Down Scoring Game *(intentional reuse)* |
| `b-ott-warmup` | Rhythm/Tempo Warm-Up |
| `b-ott-blocked` | Path Gate |
| `b-put-lag-game` | Distance Ladder |

## Tests / typecheck / drift

- `pnpm --filter @oga/core test` — 490 pass (was 489, +1 for the drill_name assertion).
- `pnpm typecheck` — green across `@oga/core`, `@oga/supabase`, `@oga/web`.
- `node scripts/check-shared-vendor.mjs` — OK (9 files).

## Deploy

After merge (or immediately for dev validation):
```
npx supabase functions deploy generate-practice-plan --use-api \
  --project-ref txquvfeyvkaetqlamqlz
```

## QA

On dev, force a baseline fallback (temporarily set `MIN_SG_ROUNDS=999` or use a fresh user with <5 SG rounds) → generate a plan → confirm every block has a real drill name + the expand toggle works.