### PR TITLE
chore(edge): explicit verify_jwt = true for round-summary-email (#450 review)

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -61,3 +61,11 @@ enabled = false
 # the dryRun service-role gate inside the function is only safe while this is on.
 [functions.generate-practice-plan]
 verify_jwt = true
+
+# round-summary-email is cron-only. Its `isServiceRole` decoder reads `role`
+# from the JWT payload without re-checking the signature — it trusts the
+# Supabase gateway has already validated it. Make that dependency explicit
+# (instead of relying on the platform default) so a future upstream change
+# can't silently let unsigned tokens reach the handler.
+[functions.round-summary-email]
+verify_jwt = true


### PR DESCRIPTION
PR #450 review follow-up.

## Why

`round-summary-email`'s [`isServiceRole`](supabase/functions/round-summary-email/index.ts) decoder reads `role` from the JWT payload **without re-checking the signature** — it trusts that the Supabase gateway has already validated it. The comment at `index.ts:40–46` explicitly acknowledges this.

That trust is sound while `verify_jwt = true`, but the function had no entry in `supabase/config.toml` — it relied on the platform default. A future upstream change to that default would silently let unsigned tokens reach the handler.

`generate-practice-plan` already declares `verify_jwt = true` explicitly (`config.toml:62–63`) with a comment explaining exactly why it matters. This PR mirrors that for `round-summary-email`.

## Change

Adds a new block to `supabase/config.toml`:

\`\`\`toml
[functions.round-summary-email]
verify_jwt = true
\`\`\`

Plus a 5-line comment explaining why the explicit declaration is load-bearing for the cron-only service-role guard.

## Behavior

**No-op today** — matches the current Supabase default. The value is making the dependency visible to maintainers and immune to platform defaults shifting.

## Once merged

PR #450 (dev → main release) picks this up via its `dev` head — nothing to re-trigger there manually.