### PR TITLE
feat(mobile): Learn parity — port all 20 articles to native

### DIFF
--- a/apps/mobile/app/(app)/learn/[article].tsx
+++ b/apps/mobile/app/(app)/learn/[article].tsx
@@ -2,37 +2,8 @@ import { Linking, Pressable, ScrollView, Text, View } from 'react-native'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { findLearnArticle } from '@oga/core'
 import { AppBar } from '../../../components/ui/AppBar'
-
-const KICKER: import('react-native').TextStyle = {
-  color: '#8A8B7E',
-  fontSize: 10,
-  fontWeight: '500',
-  letterSpacing: 1.4,
-  textTransform: 'uppercase',
-}
-
-const TITLE: import('react-native').TextStyle = {
-  color: '#1C211C',
-  fontSize: 26,
-  fontStyle: 'italic',
-  fontWeight: '500',
-  lineHeight: 32,
-  marginBottom: 14,
-}
-
-const BODY: import('react-native').TextStyle = {
-  color: '#1C211C',
-  fontSize: 15,
-  lineHeight: 22,
-  marginBottom: 14,
-}
-
-const SUBKICKER: import('react-native').TextStyle = {
-  ...KICKER,
-  color: '#5C6356',
-  marginTop: 14,
-  marginBottom: 10,
-}
+import { BODY, KICKER, SUBKICKER, TITLE } from '../../../components/learn/primitives'
+import { MOBILE_ARTICLES } from '../../../components/learn/articles'
 
 export default function ArticleScreen() {
   const router = useRouter()
@@ -136,9 +107,10 @@ function LiveArticle({ id }: { id: string }) {
       return <MentalGameArticle />
     case 'skill-games-pressure-games':
       return <SkillGamesArticle />
-    default:
-      return <StubBody title="Article" />
   }
+  const Ported = MOBILE_ARTICLES[id]
+  if (Ported) return <Ported />
+  return <StubBody title="Article" />
 }
 
 function StrokesGainedArticle() {

--- a/apps/mobile/components/learn/articles/BuildingYourBag.tsx
+++ b/apps/mobile/components/learn/articles/BuildingYourBag.tsx
@@ -1,0 +1,290 @@
+import { Text, View } from 'react-native'
+import Svg, { Circle, G, Line, Rect } from 'react-native-svg'
+import {
+  ArticleFooter,
+  ArticleHeader,
+  C,
+  DefRow,
+  Figure,
+  GlanceBox,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+} from '../primitives'
+
+export function BuildingYourBagArticle() {
+  return (
+    <View>
+      <ArticleHeader kicker="Your equipment · Draft" title="Building your bag." />
+
+      <H3>Fourteen clubs is a budget, not a checklist</H3>
+      <P>
+        The rules let you carry fourteen clubs — no more. Most golfers fill that
+        number out of habit: driver, 3-wood, irons down through the pitching
+        wedge, a sand wedge, a putter, and whatever was in the box. Almost nobody
+        asks the only question that matters — do these fourteen actually cover my
+        distances? Usually they don't. The goal was never to own fourteen clubs.
+        It's even gaps, top to bottom, with no dead zones.
+      </P>
+
+      <GlanceBox label="The two dead zones">
+        <DefRow term="Overlap" first>
+          Two clubs that carry the same distance. One of them is a wasted slot —
+          a club you could have spent covering a yardage you can't reach.
+        </DefRow>
+        <DefRow term="Hole">
+          A distance you can't cover with any full swing, so you're stuck
+          guessing at a three-quarter shot. Most often it sits just below the
+          pitching wedge.
+        </DefRow>
+      </GlanceBox>
+
+      <P>
+        Fix both and the bag fits you instead of the rack it came off. Everything
+        below is how to find and close those gaps.
+      </P>
+
+      <Hr />
+
+      <H3>Start from your distances, not the set</H3>
+      <Figure caption="Even gaps vs. an overlap and a hole">
+        <GapLadderDiagram />
+      </Figure>
+      <P style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>
+        Build the bag backwards from carry numbers, not forwards from a set you
+        bought. Hit five to ten balls with each club, average the carries — throw
+        out the obvious duffs — and list them top to bottom. The picture shows up
+        at once: where clubs bunch together, and where they spread.
+      </P>
+      <P style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>
+        Aim for even steps of roughly 10 to 15 yards between full clubs. Two
+        clubs landing within about 8 yards of each other is a wasted slot — one
+        of them is doing nothing. A gap wider than 15 leaves you stranded between
+        clubs, forced into a half-swing you'll never trust on the course.
+      </P>
+
+      <Hr />
+
+      <H3>The top of the bag: driver down to your longest club</H3>
+      <P>
+        This is where the most common dead zone hides. Modern lofts are strong,
+        and a lot of amateurs find their 3-, 4-, and 5-iron all carry within ten
+        yards of each other — three slots doing one club's job. The fix is to
+        replace the long irons you can't launch with hybrids or a higher-lofted
+        fairway wood: they get the ball up more easily and restore real
+        separation between clubs.
+      </P>
+      <P>
+        Keep long irons only if you have the speed to flight them and a reason to
+        hit it low. And check the very top: if your 3-wood off the deck goes
+        nearly as far as a driver you rarely trust, that's a slot you could spend
+        on a club you'll actually pull. Carry the longest club you can keep in
+        play, not the longest one you own.
+      </P>
+
+      <Hr />
+
+      <H3>The scoring clubs: wedges, where strokes are won and lost</H3>
+      <Figure caption="Wedges climbing in even loft steps">
+        <WedgeLoftDiagram />
+      </Figure>
+      <P style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>
+        The bottom of the bag is where most amateurs quietly leak strokes.
+        Pitching-wedge lofts have crept stronger over the years — a
+        game-improvement set may run 41–43°, where a traditional one sat at
+        45–46° — and that opens a big hole right below it, in the 30-to-50-yard
+        range where you score.
+      </P>
+      <P style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>
+        Space your wedges in even loft steps of about 4 to 6°. A common setup:
+        pitching wedge around 45°, gap wedge near 50°, sand wedge 54–56°, lob
+        wedge 58–60°. If your pitching wedge is 45° or stronger, a gap wedge
+        isn't optional — without it you've got a yawning hole exactly where touch
+        matters most. For most players, pitching, gap, and sand wedges cover it;
+        add a lob wedge only if you have the swing for it.
+      </P>
+      <P>
+        Which bounce and grind to put on those wedges is a fitting question, not
+        a gapping one — it's covered in the fittings guide. Here, the job is only
+        to make sure no two of them go the same distance and nothing's missing
+        below your pitching wedge.
+      </P>
+
+      <Hr />
+
+      <H3>The putter — the club you use most</H3>
+      <P>
+        Roughly 40% of the strokes in a round are putts, which makes the putter
+        the one slot you should never treat as an afterthought or a hand-me-down.
+        It doesn't need gapping, but it does need fitting — length, lie, and head
+        style matched to your stroke — and that's the cheapest set of strokes on
+        this page. One slot, used more than any other; spend it deliberately.
+      </P>
+
+      <Hr />
+
+      <H3>Where the fourteen go</H3>
+      <P>
+        There's no single correct bag, but a no-dead-zone build for most golfers
+        lands close to this. The exact count flexes — drop a wedge to add a
+        hybrid, or the reverse — as long as the gaps stay even.
+      </P>
+
+      <SampleBag />
+
+      <P>
+        Run the range test once a season and after any new club. A bag with even
+        gaps and nothing you can't hit beats a bag full of the newest models —
+        the fourteen slots are a budget, and the player who spends them on
+        coverage instead of habit shoots lower without buying a thing.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: "USGA · Rule 4, the player's equipment",
+            href: 'https://www.usga.org/content/usga/home-page/rules/rules-2019/rules-of-golf/rule-4.html',
+            note: "The fourteen-club limit — you may carry no more than fourteen clubs, but no minimum and no restriction on type.",
+          },
+          {
+            name: 'Bobby Walia Golf · club gapping guide',
+            href: 'https://www.bobbywaliagolf.com/club-gapping-guide/',
+            note: 'Distance gapping and finding the holes — aim for even 10–15 yard steps; long irons that bunch within ten yards are better replaced with hybrids.',
+          },
+          {
+            name: 'Hireko Golf · gapping your irons',
+            href: 'https://www.hirekogolf.com/blog/post/guide-to-gapping-your-irons-correctly-solving-iron-distance-gaps',
+            note: 'Companion gapping reference — even steps between full clubs, no bunched long irons.',
+          },
+          {
+            name: 'Golf Digest · everything to know about wedge lofts',
+            href: 'https://www.golfdigest.com/story/everything-you-need-to-know-about-wedge-lofts',
+            note: 'Wedge lofts and the gap below the pitching wedge — strong pitching-wedge lofts open a gap; space wedges about 4–6° apart to close it.',
+          },
+          {
+            name: 'MyGolfSpy · wedge gapping by handicap',
+            href: 'https://mygolfspy.com/news-opinion/instruction/wedge-gapping-chart-by-handicap-distance-lofts-and-trends/',
+            note: 'Wedge distances and lofts by handicap — even spacing keeps the scoring range covered.',
+          },
+        ]}
+      />
+
+      <ArticleFooter>Last reviewed May 2026 · Draft, needs fitter review</ArticleFooter>
+    </View>
+  )
+}
+
+// Top row: even gaps. Bottom row: a bunched overlap and an accent-marked hole.
+// Same viewBox + path data as the web GapLadderDiagram.
+function GapLadderDiagram() {
+  return (
+    <Svg width="100%" viewBox="0 0 160 110" style={{ aspectRatio: 160 / 110 }}>
+      {/* even-gap ladder */}
+      <Line x1={18} y1={34} x2={142} y2={34} stroke="#9F9580" strokeWidth={1.5} />
+      {[18, 43, 68, 93, 118, 142].map((x) => (
+        <G key={`top-${x}`}>
+          <Line x1={x} y1={28} x2={x} y2={40} stroke={C.ink} strokeWidth={1.5} />
+          <Circle cx={x} cy={34} r={2} fill={C.ink} />
+        </G>
+      ))}
+      {/* dead-zone ladder: two bunched, then a hole */}
+      <Line x1={18} y1={84} x2={142} y2={84} stroke="#9F9580" strokeWidth={1.5} />
+      {[18, 30, 92, 117, 142].map((x) => (
+        <G key={`bot-${x}`}>
+          <Line x1={x} y1={78} x2={x} y2={90} stroke={C.ink} strokeWidth={1.5} />
+          <Circle cx={x} cy={84} r={2} fill={C.ink} />
+        </G>
+      ))}
+      {/* the hole, marked in accent */}
+      <Line x1={34} y1={98} x2={88} y2={98} stroke={C.accent} strokeWidth={1.5} />
+      <Line x1={34} y1={95} x2={34} y2={101} stroke={C.accent} strokeWidth={1.5} />
+      <Line x1={88} y1={95} x2={88} y2={101} stroke={C.accent} strokeWidth={1.5} />
+    </Svg>
+  )
+}
+
+// Four wedges climbing in even loft steps. Same viewBox + data as web.
+function WedgeLoftDiagram() {
+  const bars = [
+    { x: 26, h: 30 },
+    { x: 58, h: 42 },
+    { x: 90, h: 54 },
+    { x: 122, h: 66 },
+  ]
+  return (
+    <Svg width="100%" viewBox="0 0 160 96" style={{ aspectRatio: 160 / 96 }}>
+      <Line x1={14} y1={82} x2={146} y2={82} stroke="#9F9580" strokeWidth={1.5} />
+      {bars.map((b) => (
+        <Rect
+          key={b.x}
+          x={b.x}
+          y={82 - b.h}
+          width={12}
+          height={b.h}
+          rx={2}
+          fill="none"
+          stroke={C.ink}
+          strokeWidth={1.5}
+        />
+      ))}
+    </Svg>
+  )
+}
+
+// Where a no-dead-zone build for most golfers spends its fourteen slots.
+// Web renders a 2-col table; on phone we stack role over its description.
+function SampleBag() {
+  const rows: { role: string; clubs: string }[] = [
+    {
+      role: 'Off the tee',
+      clubs: 'Driver — one slot, the longest club you can keep in play.',
+    },
+    {
+      role: 'Long approach',
+      clubs:
+        'A 3-wood, hybrids, or a high-lofted fairway — whatever you actually hit off the deck. Most amateurs gap better with hybrids than 3- and 4-irons.',
+    },
+    {
+      role: 'Mid & short irons',
+      clubs: 'Roughly 5-iron through pitching wedge, in even 10–15 yard steps.',
+    },
+    {
+      role: 'Scoring',
+      clubs:
+        'Pitching, gap, and sand wedge cover most players; add a lob wedge if you have the swing for it. Even 4–6° loft gaps.',
+    },
+    {
+      role: 'On the green',
+      clubs: "Putter — the club you use most. Fit it, don't default it.",
+    },
+  ]
+  return (
+    <View style={{ marginBottom: 18, borderTopWidth: 1, borderTopColor: C.line }}>
+      {rows.map((r) => (
+        <View
+          key={r.role}
+          style={{
+            paddingVertical: 12,
+            borderBottomWidth: 1,
+            borderBottomColor: C.line,
+          }}
+        >
+          <Text
+            style={{
+              color: C.ink,
+              fontSize: 15,
+              fontStyle: 'italic',
+              fontWeight: '500',
+              marginBottom: 4,
+            }}
+          >
+            {r.role}
+          </Text>
+          <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 20 }}>{r.clubs}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/FittingsWithCoaches.tsx
+++ b/apps/mobile/components/learn/articles/FittingsWithCoaches.tsx
@@ -1,0 +1,289 @@
+import { Text, View } from 'react-native'
+import {
+  ArticleHeader,
+  ArticleFooter,
+  BulletList,
+  Callout,
+  C,
+  Em,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+  Strong,
+} from '../primitives'
+
+export function FittingsWithCoachesArticle() {
+  return (
+    <View>
+      <ArticleHeader
+        kicker="Working with coaches · Draft"
+        title="A lesson changes the swing; a fitting fits it."
+      />
+
+      <P>
+        The equipment guide on <Em>golf fittings</Em> covers what each fitting
+        measures and changes — driver, irons, wedges, putter, shaft, and ball —
+        and when each one is worth the money. This is the companion question from
+        the coaching side: who should fit you, how a fitting fits into working
+        with a coach, and how to time it so you're not fitting expensive
+        equipment to a swing you're about to change. The two appointments are
+        easy to confuse, and treating them as one is how golfers waste both.
+      </P>
+
+      <FitterTable />
+
+      <Hr />
+
+      <H3>Two different appointments</H3>
+      <P>
+        A lesson tries to change your swing. A fitting fits clubs to the swing
+        you actually have today — not the one you're hoping to build. That's the
+        line that confuses people: they want to "fix the slice first, then get
+        fit," and end up playing ill-fitting clubs for a year while they chase a
+        swing change.
+      </P>
+      <P>
+        The better order is usually the opposite. Properly fit equipment fits the
+        swing you bring tomorrow, and when you stop compensating for the wrong
+        gear, a coach's changes often come <Em>faster</Em>. Unless you are a brand
+        new golfer with nothing stable to measure, "fix it first" is mostly
+        backward — get fit to your current swing, then let lessons move it, and
+        re-check the specs when the swing has genuinely changed.
+      </P>
+
+      <Hr />
+
+      <H3>Who's actually fitting you</H3>
+      <P>
+        Not all fittings come from the same chair, and the chair matters. Three
+        people might fit you, and their incentives are not identical:
+      </P>
+      <BulletList
+        items={[
+          <Text key="coach">
+            <Strong>Your coach or instructor.</Strong> Already knows your typical
+            miss, your goals, and the change you're in the middle of. A fitting
+            run by — or coordinated with — your coach starts with all of that
+            context instead of a blank sheet. The catch: not every teaching pro is
+            a trained fitter, so ask what tools and data they actually use.
+          </Text>,
+          <Text key="independent">
+            <Strong>An independent fitter.</Strong> Carries multiple brands and
+            gets paid for the fitting, not the badge on the head, so the
+            recommendation is brand-neutral. The catch: they meet you cold and only
+            see the swing you bring that hour — tell them what you're working on so
+            they don't fit you to a temporary flaw.
+          </Text>,
+          <Text key="oem">
+            <Strong>A brand (OEM) fitter.</Strong> Deep on one manufacturer's
+            lineup and often free, which is great if you already want that brand.
+            The catch: the answer will be that brand, so treat it as fitting{' '}
+            <Em>within</Em> a line you've chosen, not an open comparison.
+          </Text>,
+        ]}
+      />
+      <P>
+        The strongest setup is a team that talks. The Titleist Performance
+        Institute model makes this explicit — coach, fitness, and fitting aligned
+        on the same goals — and most club fitters, left alone, have no idea what
+        your instructor is trying to build. You are the one who has to connect
+        them.
+      </P>
+
+      <Hr />
+
+      <H3>Time it around your swing, not against it</H3>
+      <P>
+        The "fit the swing you have" rule has a wrinkle worth getting right.
+        Real swing changes are usually incremental and ongoing, not a single
+        overhaul on a Tuesday — so there is rarely a perfect "finished" moment to
+        fit. Waiting for one mostly means playing bad gear forever.
+      </P>
+      <P>
+        The actual danger is narrow: getting fit cold, in the middle of a major
+        rebuild, to a swing you're about to abandon. Avoid it with coordination,
+        not delay. Tell your coach before you book a fitting, and tell the fitter
+        what you're working on — a degree of lie or a shaft profile can either
+        support a change your coach is making or quietly fight it, and only the
+        two of them together can tell which.
+      </P>
+
+      <Hr />
+
+      <H3>The body comes first</H3>
+      <P>
+        Before the launch monitor, the right spec depends on what your body can
+        actually do. The textbook lie angle, shaft, and length assume a range of
+        motion you may or may not have; a mobility limit in the hips or shoulders
+        can make the "standard" recommendation wrong for you. This is the
+        body-swing connection the Titleist Performance Institute built its
+        certification around — a physical screen that correlates how you move
+        with how you should be fit and coached. A good coach-led fitting starts
+        there, not at the driver.
+      </P>
+
+      <Callout>
+        <P style={{ marginBottom: 0, fontSize: 14, lineHeight: 21 }}>
+          <Strong>The one move:</Strong> loop your coach in before you book the
+          fitting, and tell the fitter the exact change you're working on. A
+          fitting done in a vacuum optimizes launch and spin for one hour's swing;
+          a fitting that knows your coach's plan optimizes for the player you're
+          becoming.
+        </P>
+      </Callout>
+
+      <H3>Red flags</H3>
+      <P>
+        A coach-coordinated fitting should make your equipment quieter, not your
+        wallet lighter. Walk if you see these:
+      </P>
+      <BulletList
+        items={[
+          <Text key="onebrand">
+            <Strong>A "fitting" that only ever lands on one brand</Strong> — or one
+            that never asks what you currently play or what you're working on.
+          </Text>,
+          <Text key="midlesson">
+            <Strong>Gear pushed in the middle of a lesson.</Strong> A purchase is a
+            separate appointment; your most expensive coaching minutes shouldn't go
+            to a sales pitch.
+          </Text>,
+          <Text key="promise">
+            <Strong>"Buy these and your slice is gone."</Strong> Equipment can
+            remove a fight against your gear; it can't install a swing change. If
+            someone promises clubs will fix mechanics, they're selling, not
+            fitting.
+          </Text>,
+        ]}
+      />
+
+      <P>
+        Get the order and the team right — body first, fit the swing you have,
+        coach and fitter on the same page — and a fitting stops being a gamble on
+        gear and becomes part of the same plan as your lessons.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: "Fit the swing you have, don't wait to \"fix\" it",
+            note: (
+              <Text>
+                <Link href="https://golf.com/gear/fix-your-swing-club-fitting/">
+                  GOLF.com · why fixing your swing before a fitting is backward
+                </Link>{' '}
+                and{' '}
+                <Link href="https://scramble.golftec.com/blog/2015/06/fit-vs-fix-should-i-get-fit-for-clubs-or-fix-my-swing/">
+                  GolfTEC · fit vs fix
+                </Link>{' '}
+                — fit to your current swing; properly fit gear tends to speed a
+                change up, not wait on it.
+              </Text>
+            ),
+          },
+          {
+            name: 'Coach and fitter should be aligned',
+            note: (
+              <Text>
+                <Link href="https://www.mytpi.com/certification">
+                  Titleist Performance Institute · the team approach
+                </Link>{' '}
+                and{' '}
+                <Link href="https://www.dennissalesgolf.com/golf-drills-and-practice-blogs/2025/3/18/why-you-should-get-fit-by-your-instructor-not-just-a-club-fitter">
+                  why getting fit by your instructor matters
+                </Link>{' '}
+                — most fitters, left alone, don't know your coach's plan; the player
+                has to connect them.
+              </Text>
+            ),
+          },
+          {
+            name: 'Your body shapes the right spec',
+            note: (
+              <Text>
+                <Link href="https://www.titleist.com/fitting/golf-club-fitting/titleist-performance-institute">
+                  Titleist Performance Institute · the body-swing connection
+                </Link>{' '}
+                — a physical screen correlates how you move with how you should be fit
+                and coached, so the fitting starts with the body, not the driver.
+              </Text>
+            ),
+          },
+        ]}
+      />
+
+      <ArticleFooter>Last reviewed May 2026 · Draft, needs coaching review</ArticleFooter>
+    </View>
+  )
+}
+
+// The three people who might fit you, set against the two things that actually
+// distinguish them — context and brand-neutrality — plus when each is the right
+// chair. Leads the article because the choice of fitter frames everything after.
+// Stacked single-column per row for phone width.
+function FitterTable() {
+  const rows: { who: string; knows: string; neutral: string; best: string }[] = [
+    {
+      who: 'Your coach',
+      knows: 'Knows your swing & plan',
+      neutral: 'Depends on their tools',
+      best: "When you're mid-change",
+    },
+    {
+      who: 'Independent',
+      knows: 'Meets you cold',
+      neutral: 'Brand-neutral',
+      best: 'For an open comparison',
+    },
+    {
+      who: 'Brand (OEM)',
+      knows: 'Meets you cold',
+      neutral: 'One brand only',
+      best: "Once you've picked a brand",
+    },
+  ]
+  return (
+    <View
+      style={{
+        backgroundColor: C.boxBg,
+        borderWidth: 1,
+        borderColor: C.line,
+        borderRadius: 2,
+        paddingVertical: 14,
+        paddingHorizontal: 18,
+        marginBottom: 18,
+      }}
+    >
+      {rows.map((r, i) => (
+        <View
+          key={r.who}
+          style={{
+            paddingTop: i === 0 ? 0 : 10,
+            marginTop: i === 0 ? 0 : 10,
+            borderTopWidth: i === 0 ? 0 : 1,
+            borderTopColor: C.line,
+          }}
+        >
+          <Text
+            style={{
+              color: C.ink,
+              fontSize: 15,
+              fontStyle: 'italic',
+              marginBottom: 2,
+            }}
+          >
+            {r.who}
+          </Text>
+          <Text style={{ color: C.ink, fontSize: 14, lineHeight: 20 }}>
+            {r.knows} · {r.neutral}
+          </Text>
+          <Text style={{ color: C.inkDim, fontSize: 13, lineHeight: 19, marginTop: 2 }}>
+            Best: {r.best}
+          </Text>
+        </View>
+      ))}
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/GuideToFittings.tsx
+++ b/apps/mobile/components/learn/articles/GuideToFittings.tsx
@@ -1,0 +1,431 @@
+/**
+ * Mobile port of the web Learn article
+ * (apps/web/src/pages/learn/articles/GuideToFittingsArticle.tsx).
+ *
+ * Faithful transcription — prose is verbatim. Web one-off components (Fit, QA,
+ * FitByHandicap) are rebuilt as local RN components; shared block/inline pieces
+ * come from ../primitives. Sources map to the shared <Sources /> primitive.
+ */
+import type { ReactNode } from 'react'
+import { Text, View } from 'react-native'
+import {
+  ArticleFooter,
+  ArticleHeader,
+  BulletList,
+  C,
+  H3,
+  Hr,
+  KICKER,
+  Link,
+  P,
+  Sources,
+  Strong,
+  Subhead,
+} from '../primitives'
+
+export function GuideToFittingsArticle() {
+  return (
+    <View>
+      <ArticleHeader kicker="Your equipment · Draft" title="Golf fittings." />
+
+      <H3>There is no such thing as "getting fit"</H3>
+      <P>
+        Most golfers picture a fitting as one appointment that sorts out their
+        clubs. It isn't. Driver, irons, wedges, putter, shaft, and ball are six
+        different fittings measuring six different things, and being dialed in
+        with one tells you nothing about the others.
+      </P>
+      <P>
+        Knowing what each one actually changes is how you spend fitting money
+        where it returns strokes instead of where it sells clubs. So before you
+        book anything, here is what is on the table.
+      </P>
+
+      <Hr />
+
+      <H3>The six fittings, and what each one changes</H3>
+
+      <Fit
+        name="Driver"
+        measures="launch angle, spin rate, club path, face angle, ball speed"
+        adjusts="loft, shaft, and — on most modern heads — movable weights and an adjustable hosel. The goal is a launch-and-spin pairing that carries: too much spin balloons it, too little drops it out of the sky early."
+      />
+      <Fit
+        name="Irons"
+        measures="lie angle, length, shaft weight and flex, grip size"
+        adjusts="mostly lie and length. Lie angle is the one that quietly costs accuracy — and most players are off. Across more than 100,000 fittings, Ping finds the majority of golfers don't match the standard lie, and a single degree off can push a wedge five to six yards offline."
+      />
+      <Fit
+        name="Wedges"
+        measures="bounce, grind, and the loft gaps between your wedges"
+        adjusts="which bounce and grind suit your turf and swing. Bounce is the angle that keeps the sole from digging: high bounce (over 10°) suits soft turf, fluffy lies, and steep digger swings; low bounce (4–6°) suits firm turf and shallow, sweeping contact; mid bounce (7–10°) is the versatile middle. Grind is the shape of the sole around that bounce."
+      />
+      <Fit
+        name="Putter"
+        measures="length, lie, loft, and your stroke shape — how much it arcs"
+        adjusts="length, lie, head style, and grip. A strong-arc stroke and a straight-back-straight-through stroke want different head designs. It is the club you use most and the one amateurs fit least."
+      />
+      <Fit
+        name="Shaft"
+        measures="how the shaft loads and delivers the head for your speed and tempo"
+        adjusts="flex, weight, and bend profile. Flex is how much the shaft bends through the swing; too soft for your speed and the head lags behind your hands and the face arrives pointing offline. Flex is not standardized — one brand's stiff can play like another's regular."
+      />
+      <Fit
+        name="Ball"
+        measures="how compression and cover suit your speed and short game"
+        adjusts="which ball you play. Compression is matched to swing speed; the cover — soft urethane versus a firmer ionomer — trades greenside spin and feel against durability and distance. The ball is a fitting too, and the cheapest one to test."
+      />
+
+      <Hr />
+
+      <H3>When to get fitted — start where it pays</H3>
+      <P>
+        You don't need every fitting at once, and a brand-new golfer doesn't
+        need any yet — the swing has to repeat before there is anything stable
+        to measure. After that, fit in the order that returns the most strokes
+        for the money.
+      </P>
+
+      <FitByHandicap />
+
+      <P>
+        The through-line: fit the club you use most and the swing you actually
+        have, not the one you are hoping to build.
+      </P>
+
+      <Hr />
+
+      <H3>Get the most out of the day</H3>
+      <P>
+        A fitting is only as good as the swing you bring to it. A few habits
+        separate data you can trust from a wasted hour:
+      </P>
+      <BulletList
+        items={[
+          <Text key="0">
+            <Strong>Bring the clubs you actually play.</Strong> The fitter needs
+            a baseline — every recommendation should be measured against your
+            current gamer, not against nothing.
+          </Text>,
+          <Text key="1">
+            <Strong>Warm up like a round, not a long-drive contest.</Strong> Fit
+            the swing you play with, not the one that shows up for three perfect
+            balls.
+          </Text>,
+          <Text key="2">
+            <Strong>Come with a goal and your typical miss.</Strong> "I lose it
+            right off the tee" or "my wedges are gapping badly" focuses the hour.
+          </Text>,
+          <Text key="3">
+            <Strong>Hit enough balls per option.</Strong> One good shot is luck;
+            a fitter should be reading a cluster, not a highlight.
+          </Text>,
+          <Text key="4">
+            <Strong>Be honest about how often you play.</Strong> The best club
+            for a range hero who plays twice a year is not the best club for you.
+          </Text>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>A real fitting vs a sales pitch</H3>
+      <P>
+        A fitting and a sale can look identical from the outside. The difference
+        is whether the session is about your numbers or about the rack.
+      </P>
+
+      <Subhead>Signs it's a real fitting</Subhead>
+      <BulletList
+        items={[
+          'A launch monitor is running and you are shown your numbers',
+          'Several heads and shafts are tested back-to-back, not just one',
+          'The fitter explains what each change did to the ball flight',
+          "You are sometimes told a change isn't worth the money",
+        ]}
+      />
+
+      <Subhead>Signs it's a sales pitch</Subhead>
+      <BulletList
+        items={[
+          'One option is pushed hard from the start',
+          "No data is shown, or the numbers are kept on the fitter's side",
+          '"This is what everyone\'s playing" stands in for your results',
+          'Every session somehow ends in exactly one thing to buy',
+        ]}
+      />
+
+      <P>
+        Indoor fitting gives controlled launch-monitor data; outdoor lets you
+        see real flight and roll. Both are valid — but either way the numbers
+        should be explained to you, not just sold.
+      </P>
+
+      <Hr />
+
+      <H3>Questions worth asking</H3>
+      <P>
+        The fitter works for you for that hour, even when the bay is inside a
+        shop. These turn a transaction back into a fitting — each one, and what
+        you're listening for in the answer:
+      </P>
+      <QA lead="&ldquo;What are we optimizing for?&rdquo;">
+        You want a clear target before the first ball — carry distance, tighter
+        dispersion, better gapping. "Let's just hit some and see" is not a plan.
+      </QA>
+      <QA lead="&ldquo;Can I see the numbers for every option?&rdquo;">
+        A real fitting shows you the data for each club, not just announces a
+        winner. If the screen only faces the fitter, ask them to turn it around.
+      </QA>
+      <QA lead="&ldquo;How does this compare to what I'm playing now?&rdquo;">
+        Every change should beat your current gamer by enough to matter — and
+        "better" should be a number, not a feeling.
+      </QA>
+      <QA lead="&ldquo;Is this difference real, or is it inside my scatter?&rdquo;">
+        If an option averages five yards longer but your shots vary by twenty,
+        that five yards is noise. A good fitter talks in averages and spread,
+        not single shots.
+      </QA>
+      <QA lead="&ldquo;What would you change first — and what isn't worth it?&rdquo;">
+        A fitter willing to tell you something doesn't matter is one you can
+        trust on the things that do.
+      </QA>
+      <QA lead="&ldquo;What are my yardage gaps?&rdquo;">
+        You want even gaps between clubs — no two going the same distance, and
+        no big holes where you're stranded between clubs.
+      </QA>
+
+      <Hr />
+
+      <H3>Decoding what the fitter says</H3>
+      <P>
+        Fitters talk in launch-monitor shorthand. Here is what the common
+        phrases actually mean — and when one is a real signal versus a way to
+        wave a weak number past you.
+      </P>
+      <QA lead="&ldquo;You need more launch / less spin.&rdquo;">
+        Your carry isn't matching your speed. With the driver, too much spin
+        balloons the ball and costs distance; too little and it drops out of the
+        sky early. The fix is launch and spin working together, usually through
+        loft and shaft.
+      </QA>
+      <QA lead="&ldquo;Your smash factor is 1.4-something.&rdquo;">
+        How much ball speed you got for your clubhead speed — basically, how
+        flush you struck it. Around 1.50 with a driver is efficient; a low
+        number usually means off-center contact, which can be the club or your
+        strike, so make sure it's the club before you pay for it.
+      </QA>
+      <QA lead="&ldquo;Your dispersion tightened up.&rdquo;">
+        Your shots are landing in a smaller area. This matters more than one
+        extra-long drive — the tighter pattern is the one that keeps you in
+        play. Reward dispersion over the occasional bomb.
+      </QA>
+      <QA lead="&ldquo;Your spin axis is tilted.&rdquo;">
+        That's your curve: the ball fades or draws because the face and the path
+        don't match. Same mechanism as a slice in any ball-flight explainer —
+        the fitter is just reading it off the monitor.
+      </QA>
+      <QA lead="&ldquo;This shaft loads better for you.&rdquo;">
+        A feel-and-timing claim. It can be real, but it should still show up in
+        the data — better contact, tighter dispersion, more speed. If it only
+        feels better and the numbers are flat, that's preference, not
+        performance.
+      </QA>
+      <QA lead="&ldquo;Your attack angle is up / down.&rdquo;">
+        Whether you're hitting up or down on the ball at impact. The driver
+        likes a slightly upward strike for carry; irons want a downward strike
+        that bottoms out just after the ball.
+      </QA>
+      <QA lead="&ldquo;The numbers don't tell the whole story.&rdquo;">
+        Sometimes true for feel — but it's also the line used to sell you past
+        data that doesn't support the upgrade. Make them tell you exactly what
+        the numbers are missing.
+      </QA>
+
+      <Hr />
+
+      <H3>When you're ready, and how often</H3>
+      <P>
+        You are ready when your contact is consistent enough that the fitter is
+        measuring your swing and not your mishits — roughly, when most shots
+        find the middle of the face. Get re-fit after a swing change, a real
+        change in speed, or every few years as your body and the equipment move
+        on. You don't need the newest model. You need clubs that match you.
+      </P>
+
+      <Hr />
+
+      <H3>What it costs</H3>
+      <P>
+        Big retailers often fit for free when you buy. Independent fittings run
+        roughly $75–150 for a single club up to $300 and more for a full bag,
+        sometimes credited back toward a purchase, with building the clubs
+        billed separately. The fitting itself is cheap next to a set of irons —
+        and a putter fitting is the cheapest stroke-saver on this page.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'Understanding the PING fitting charts',
+            href: 'https://www.globalgolf.com/articles/pro-tip-110/',
+            note: (
+              <Text>
+                <Text style={{ ...KICKER, color: C.inkDim }}>
+                  Lie angle and iron fitting
+                </Text>
+                {'  '}
+                Paired with{' '}
+                <Link href="https://mygolfspy.com/news-opinion/historys-mysteries-the-birth-of-pings-color-code-system/">
+                  MyGolfSpy on PING's color-code system
+                </Link>{' '}
+                — over 100,000 fittings show most golfers don't match the
+                standard lie; a degree off moves a wedge several yards offline.
+              </Text>
+            ),
+          },
+          {
+            name: 'Titleist Vokey · Wedge Bounce',
+            href: 'https://www.vokey.com/explained/wedge-bounce',
+            note: (
+              <Text>
+                <Text style={{ ...KICKER, color: C.inkDim }}>
+                  Wedge bounce and grind
+                </Text>
+                {'  '}
+                Paired with{' '}
+                <Link href="https://www.golfdigest.com/story/wedge-bounce-versus-wedge-grind-explained">
+                  Golf Digest · bounce vs grind
+                </Link>{' '}
+                — high, mid, and low bounce, and which turf and swing each
+                suits.
+              </Text>
+            ),
+          },
+          {
+            name: 'MyGolfSpy · shaft flex by swing speed',
+            href: 'https://mygolfspy.com/news-opinion/instruction/golf-driver-shaft-flex-chart-find-the-right-flex-for-your-swing-speed/',
+            note: (
+              <Text>
+                <Text style={{ ...KICKER, color: C.inkDim }}>
+                  Shaft flex and ball, matched to swing speed
+                </Text>
+                {'  '}
+                Paired with{' '}
+                <Link href="https://www.pgatoursuperstore.com/learning-center/ultimate-golf-club-shaft-flex-guide.html">
+                  PGA Tour Superstore · shaft flex guide
+                </Link>{' '}
+                — flex changes where the face points at impact, and isn't
+                standard across brands; compression pairs to the same
+                swing-speed logic.
+              </Text>
+            ),
+          },
+          {
+            name: 'TrackMan · 6 numbers every amateur should know',
+            href: 'https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know',
+            note: (
+              <Text>
+                <Text style={{ ...KICKER, color: C.inkDim }}>
+                  What the fitter's numbers mean
+                </Text>
+                {'  '}
+                Paired with{' '}
+                <Link href="https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman">
+                  the ultimate guide to TrackMan data
+                </Link>{' '}
+                — launch, spin, smash factor, attack angle, and dispersion, in
+                plain terms.
+              </Text>
+            ),
+          },
+        ]}
+      />
+
+      <ArticleFooter>Last reviewed May 2026 · Draft, needs fitter review</ArticleFooter>
+    </View>
+  )
+}
+
+// ── local one-off components (web Fit / QA / FitByHandicap) ──────────────────
+
+/** One fitting type: what it measures vs what it actually adjusts. */
+function Fit({
+  name,
+  measures,
+  adjusts,
+}: {
+  name: string
+  measures: string
+  adjusts: string
+}) {
+  return (
+    <View style={{ borderTopWidth: 1, borderTopColor: C.line, paddingTop: 12, marginBottom: 12 }}>
+      <Text style={{ color: C.ink, fontSize: 18, fontStyle: 'italic', marginBottom: 6 }}>
+        {name}
+      </Text>
+      <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>
+        <FitTag>Measures</FitTag> {measures}
+      </Text>
+      <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 22, marginTop: 4 }}>
+        <FitTag>Adjusts</FitTag> {adjusts}
+      </Text>
+    </View>
+  )
+}
+
+/** Inline small-caps label prefix used inside <Fit>. */
+function FitTag({ children }: { children: ReactNode }) {
+  return (
+    <Text style={{ ...KICKER, color: C.mute }}>{children}</Text>
+  )
+}
+
+/** A question to ask (or a phrase the fitter uses) and what it actually means. */
+function QA({ lead, children }: { lead: string; children: ReactNode }) {
+  return (
+    <View style={{ borderTopWidth: 1, borderTopColor: C.line, paddingTop: 10, marginBottom: 10 }}>
+      <Text style={{ color: C.ink, fontSize: 15, fontStyle: 'italic', marginBottom: 4 }}>
+        {lead}
+      </Text>
+      <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>{children}</Text>
+    </View>
+  )
+}
+
+/** Fitting priority by handicap — fit the highest-return club for where you are. */
+function FitByHandicap() {
+  const rows: { stage: string; advice: string }[] = [
+    {
+      stage: 'New golfer',
+      advice: 'Not yet. Get contact repeatable first — there is nothing stable to fit.',
+    },
+    {
+      stage: '20+ handicap',
+      advice: 'Putter first. The club you use most, and the cheapest to fit.',
+    },
+    {
+      stage: '10–20',
+      advice: 'Irons and wedges — lie angle, length, and the loft gaps between wedges.',
+    },
+    {
+      stage: 'Under 10',
+      advice: 'Everything, ball included — small gains are worth chasing now.',
+    },
+  ]
+  return (
+    <View style={{ marginBottom: 18, borderTopWidth: 1, borderTopColor: C.line }}>
+      {rows.map((r) => (
+        <View
+          key={r.stage}
+          style={{ paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: C.line }}
+        >
+          <Text style={{ color: C.ink, fontSize: 15, fontStyle: 'italic', marginBottom: 4 }}>
+            {r.stage}
+          </Text>
+          <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 21 }}>{r.advice}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/LessonsAndCoaching.tsx
+++ b/apps/mobile/components/learn/articles/LessonsAndCoaching.tsx
@@ -1,0 +1,372 @@
+import { Text, View } from 'react-native'
+import {
+  ArticleHeader,
+  ArticleFooter,
+  BulletList,
+  Callout,
+  Em,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+  Strong,
+  C,
+  KICKER,
+  BODY,
+} from '../primitives'
+
+export function LessonsAndCoachingArticle() {
+  return (
+    <View>
+      <ArticleHeader
+        kicker="Working with coaches · Draft"
+        title="Lessons and coaching."
+      />
+
+      <H3>Most golfers waste the lesson hour</H3>
+      <P>
+        A golf lesson is one of the highest-leverage hours you can spend on your
+        game — and most golfers either never book one or get almost nothing out
+        of the ones they do. They show up cold, collect a tip, never practice
+        it, slide back to their old swing within a week, and conclude that
+        "lessons don't work for me." The lesson worked fine. The hour around it
+        didn't. This guide is about both halves: choosing a teacher worth your
+        money, and setting yourself up to actually keep what they give you.
+      </P>
+
+      <Hr />
+
+      <H3>What the letters after a name mean — and don't</H3>
+      <P>
+        Certifications tell you someone cleared a bar. They don't tell you
+        whether that person is the right teacher for <Em>you</Em>.
+      </P>
+      <BulletList
+        items={[
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>PGA / LPGA.</Strong> A PGA of America or LPGA teaching
+            professional has completed a long training and testing program and
+            knows the game deeply. It's a real credential — and a broad one. It
+            certifies competence and seriousness, not that this particular coach
+            communicates in a way that clicks for you.
+          </Text>,
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>TPI (Titleist Performance Institute).</Strong> A
+            TPI-certified instructor is trained in the "body-swing connection" —
+            they screen your physical mobility and limitations first, so they're
+            less likely to prescribe a position your body literally cannot reach.
+            Useful if you've got an injury history or wonder why a textbook move
+            feels impossible.
+          </Text>,
+        ]}
+      />
+      <P>
+        Treat any certification as a floor, not a ceiling. The best teacher you
+        ever have might have a wall of letters or just a long line of students
+        who got better. The credential gets them on your shortlist; the next few
+        questions decide whether they make the cut.
+      </P>
+
+      <Hr />
+
+      <H3>Questions worth asking before you book</H3>
+      <P>
+        You're hiring someone. It's fair — and smart — to interview them first.
+        A quick email or phone call answers most of this:
+      </P>
+      <BulletList
+        items={[
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>What's your teaching philosophy?</Strong> A good teacher can
+            answer in a sentence or two. Vagueness here is a warning.
+          </Text>,
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>Do you use video and a launch monitor?</Strong> You want
+            someone who measures, not just eyeballs and guesses.
+          </Text>,
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>How do you structure things — one-offs or a series?</Strong>{' '}
+            The honest answer is almost always a series, and you want a coach who
+            says so.
+          </Text>,
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>Who do you mostly teach?</Strong> A coach who lives with
+            competitive players may not be the right fit for a nervous beginner,
+            and vice versa.
+          </Text>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>Green flags and red flags</H3>
+      <P>
+        Once you're in front of someone — or watching a few minutes of how they
+        teach online — the difference between a teacher who'll help you and one
+        who won't is usually obvious within a lesson:
+      </P>
+
+      <FlagColumns />
+
+      <Hr />
+
+      <H3>Online or in person?</H3>
+      <P>
+        In-person lessons give a coach hands-on feedback in real time — they can
+        feel your grip, move you into a position, and react to a shot the second
+        it happens. That's hard to beat for first-time fundamentals and anything
+        kinesthetic. Online coaching — you send swing videos, they send back a
+        breakdown — is cheaper, fits any schedule, and lets you work with a
+        specialist who isn't within driving distance. It leans on you to film
+        well and to self-apply between notes.
+      </P>
+      <P>
+        For a lot of golfers the best answer is both: in person to set the
+        direction and learn the feel, online to maintain it and stay
+        accountable between range trips.
+      </P>
+
+      <Hr />
+
+      <H3>Show up ready</H3>
+      <P>
+        How much you get out of an hour is mostly decided before it starts.
+      </P>
+      <BulletList
+        items={[
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>Bring your own clubs.</Strong> They're what you actually
+            play, fitted (or mis-fitted) to you. A coach learns a lot from them.
+          </Text>,
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>Bring your phone.</Strong> You'll want video to review later,
+            and your own footage of the feels they give you.
+          </Text>,
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>Tell them the truth up front:</Strong> your goals, your
+            typical miss, what's been bothering you, and what you actually shoot.
+            The more specific, the faster they can help.
+          </Text>,
+          <Text style={{ ...BODY, marginBottom: 0 }}>
+            <Strong>Take notes</Strong> — during the lesson or the moment it
+            ends. The clarity you feel walking off the range fades startlingly
+            fast by the next day.
+          </Text>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>Feel isn't real</H3>
+      <P>
+        This is the single most useful thing to understand about taking
+        instruction: what a change <Em>feels</Em> like and what the camera
+        actually shows are almost never the same. When a coach asks you to feel
+        something that seems wildly exaggerated, they're usually using that gap
+        on purpose — the feeling that produces the correct position often feels
+        like a gross overcorrection. Don't argue with the feel and don't trust
+        it either. Trust the checkpoint — the video, the launch-monitor number,
+        the ball flight — and let the feel be whatever gets you there.
+      </P>
+
+      <Hr />
+
+      <H3>Why you might get worse before you get better</H3>
+      <P>
+        A genuine swing change means overwriting a motor pattern your brain has
+        grooved over years. For a while the old pattern is fading and the new
+        one hasn't taken hold, so you're caught in between — contact gets clumsy,
+        the odd shot flies sideways, and your scores can dip. This is a normal,
+        predictable stage of learning a new movement, not a sign the lesson
+        failed or the teacher was wrong.
+      </P>
+      <Callout>
+        <Text style={{ color: C.ink, fontSize: 14, lineHeight: 22 }}>
+          <Strong>So plan for the dip.</Strong> Commit to a set number of
+          practice sessions on the change before you judge it, expect a rough
+          patch in the middle, and don't carry a half-built swing into a round
+          that matters. The most common way golfers waste a good lesson is
+          bailing on the change the first time it costs them a few shots.
+        </Text>
+      </Callout>
+
+      <Hr />
+
+      <H3>One lesson rarely fixes anything</H3>
+      <P>
+        Skill change comes from reps and feedback loops, not a single
+        revelation on a Tuesday. Going in expecting to be "fixed" in an hour is
+        the surest way to be disappointed. Commit to a block instead — say three
+        to five lessons over a couple of months — and judge the teacher on the
+        block, not the first session.
+      </P>
+      <P>
+        Between lessons, practice exactly what they gave you, not the new tip
+        you stumbled onto on YouTube that week — mixing coaches mid-change is how
+        you end up with no swing at all. At the end of the block, take stock: is
+        my miss smaller, are my numbers or scores trending the right way, do I
+        understand what I'm doing and why? If the answer is yes, keep going. If
+        there's no plan, no progress after honest effort, or you simply never
+        understand the language they teach in, it's fair to move on.
+      </P>
+
+      <Hr />
+
+      <H3>Coaching yourself between lessons</H3>
+      <P>
+        You can do a surprising amount of your own checking with a phone and a
+        little honesty. Film two angles: <Strong>down the line</Strong> (camera
+        directly behind you, on the target line) and <Strong>face on</Strong>{' '}
+        (straight in front). They show different things — the down-the-line view
+        reveals swing plane and path, the face-on view shows sway, weight, and
+        ball position. Compare yourself to the checkpoints your coach gave you,
+        not to a tour pro built nothing like you.
+      </P>
+      <P>
+        Data does the same job for the parts you can't see. A launch monitor —
+        Trackman, a Garmin unit, whatever you can borrow — or your own
+        round-tracking turns "I think I'm better" into evidence you can act on.
+        And the most useful thing you can carry into a lesson is a clear read on
+        where you're actually losing shots.
+      </P>
+      <Callout>
+        <Text style={{ color: C.ink, fontSize: 14, lineHeight: 22 }}>
+          <Strong>Walk in with a diagnosis, not a complaint.</Strong> "I'm
+          hitting it bad" burns the first ten minutes of the hour. "My strokes
+          gained data says I lose about 1.2 shots a round on approach, and my
+          miss is right" points the lesson straight at the leak. If you track
+          your rounds in OGA, you arrive with that read already done — and the
+          coach spends the hour fixing instead of interviewing.
+        </Text>
+      </Callout>
+
+      <Hr />
+
+      <H3>The bottom line</H3>
+      <P>
+        Pick a teacher who measures, explains the why, and sends you away with a
+        plan. Show up with your clubs, your numbers, and the truth about your
+        miss. Expect to get a little worse before you get better, and don't quit
+        the change in the dip. Do that and a lesson stops being a tip you forget
+        by Saturday and becomes the fastest way there is to actually get better.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'Titleist Performance Institute · About Certification',
+            href: 'https://www.mytpi.com/certification/about',
+            note: (
+              <Text>
+                on the body-swing-connection approach and physical screening;{' '}
+                <Link href="https://www.pga.com/things-to-do/coaches">
+                  PGA of America · Coaches
+                </Link>{' '}
+                for what a PGA teaching professional is and how to find one.
+              </Text>
+            ),
+          },
+          {
+            name: 'HackMotion · Worse After Golf Lessons?',
+            href: 'https://hackmotion.com/worse-after-golf-lessons/',
+            note: '— the temporary performance dip is a normal stage of overwriting a grooved motor pattern: the old swing fades before the new one takes hold, so contact gets clumsy in the middle. Expected, not a failure.',
+          },
+        ]}
+      />
+
+      <ArticleFooter>Last reviewed May 2026 · Draft, needs review</ArticleFooter>
+    </View>
+  )
+}
+
+// Side-by-side "look for / walk away from" cards. Single-column stacked on
+// phone. Palette stays in the house earth tones — the accent green marks the
+// column you want, a muted ink marks the one you don't. No red; the labels
+// carry the meaning. Keeps the ✓ / · glyphs and the green/amber accent split.
+function FlagColumns() {
+  return (
+    <View style={{ marginBottom: 14, gap: 12 }}>
+      <FlagCard
+        label="Look for"
+        accent
+        items={[
+          'Ties every change to ball flight — what it does, not just how it looks',
+          'Gives you a feel AND a checkpoint you can verify on your own',
+          'Sends you off with a clear practice plan',
+          'Explains the why, so you could re-teach it to a friend',
+          'Asks about your goals and your typical miss before touching your swing',
+        ]}
+      />
+      <FlagCard
+        label="Walk away from"
+        items={[
+          'Only tells you what’s wrong, never how to fix it',
+          'One identical swing prescribed to every student',
+          'No video, no launch monitor — all eyeball and opinion',
+          'Jargon with no translation into something you can do',
+          'Promises a quick, one-lesson fix',
+        ]}
+      />
+    </View>
+  )
+}
+
+function FlagCard({
+  label,
+  items,
+  accent,
+}: {
+  label: string
+  items: string[]
+  accent?: boolean
+}) {
+  const edge = accent ? C.accent : C.line
+  return (
+    <View
+      style={{
+        borderWidth: 1,
+        borderColor: edge,
+        backgroundColor: C.boxBg,
+        borderRadius: 2,
+        padding: 14,
+      }}
+    >
+      <Text
+        style={{
+          ...KICKER,
+          color: accent ? C.accent : C.inkDim,
+          marginBottom: 10,
+          paddingBottom: 8,
+          borderBottomWidth: 1,
+          borderBottomColor: edge,
+        }}
+      >
+        {label}
+      </Text>
+      <View>
+        {items.map((item) => (
+          <View
+            key={item}
+            style={{ flexDirection: 'row', gap: 8, marginBottom: 8 }}
+          >
+            <Text
+              style={{
+                color: accent ? C.accent : C.mute,
+                fontSize: 13.5,
+                lineHeight: 20,
+              }}
+            >
+              {accent ? '✓' : '·'}
+            </Text>
+            <Text
+              style={{ color: C.ink, fontSize: 13.5, lineHeight: 20, flex: 1 }}
+            >
+              {item}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/MeasurableGoals.tsx
+++ b/apps/mobile/components/learn/articles/MeasurableGoals.tsx
@@ -1,0 +1,208 @@
+import { Text, View } from 'react-native'
+import Svg, { Line, Rect, Text as SvgText } from 'react-native-svg'
+import {
+  ArticleFooter,
+  ArticleHeader,
+  C,
+  DefRow,
+  Em,
+  Figure,
+  GlanceBox,
+  H3,
+  Hr,
+  P,
+  Sources,
+} from '../primitives'
+
+export function MeasurableGoalsArticle() {
+  return (
+    <View>
+      <ArticleHeader kicker="Improving your game · Draft" title="A goal you can pass or fail." />
+
+      <P>
+        Most practice goals are wishes wearing a goal's clothes — work on my
+        irons, get more consistent, fix the slice. None of them can be passed or
+        failed, so none of them can tell you whether the session worked. A real
+        goal has a number and a verdict: when you're done you either hit it or
+        you didn't. This is how to build one.
+      </P>
+      <P>
+        It starts with picking the right <Em>kind</Em> of goal — because not all
+        of them are yours to control.
+      </P>
+
+      <H3>Three kinds of goal</H3>
+      <GlanceBox label="From least to most controllable">
+        <DefRow term="Outcome — Win the match. Beat Dave." first>
+          Depends on other people — you can play your best and still lose.
+        </DefRow>
+        <DefRow term="Performance — Break 85. Hit 7 of 10 greens.">
+          Your own number, measured against yourself, not the field.
+        </DefRow>
+        <DefRow term="Process — Commit to the routine. Finish the swing.">
+          The action itself — entirely under your control, every shot.
+        </DefRow>
+      </GlanceBox>
+      <P>
+        The trouble with outcome goals is that you don't fully own them: a clean
+        round can still lose to someone putting out of their mind. Hang your sense
+        of a good day on the outcome and you've imported anxiety you can't do
+        anything about. Performance and process goals are the ones worth setting
+        in practice — and of the two, process goals travel best under pressure. In
+        a study of club golfers, the players trained to set process goals
+        controlled their competitive anxiety and held their concentration better
+        than players given no goals at all. Keep the outcome as the direction
+        you're heading; score yourself on the performance and process steps that
+        get you there.
+      </P>
+
+      <Hr />
+
+      <H3>Start with a baseline</H3>
+      <P>
+        You can't make a goal measurable until you know your current number.
+        Before you set a target, measure where you stand: hit ten wedges from 60
+        yards, count how many finish within a flagstick's length — say four. Now
+        the goal isn't a figure you invented out of optimism; it's "beat four." A
+        baseline turns every later session into a comparison instead of a guess,
+        and it keeps the target honest — pinned to your actual game rather than to
+        what you wish your game looked like.
+      </P>
+
+      <Hr />
+
+      <H3>Calibrate the difficulty</H3>
+      <P>
+        Goal-setting research is consistent on one point: specific, hard goals
+        beat vague or easy ones — but only up to the edge of what you can actually
+        do. A goal you clear every single time just confirms what you already had.
+        A goal you never reach only tells you, again, that you failed. Aim for the
+        band in between — the target you make roughly half the time. That's the
+        version that pulls your skill forward without snapping your commitment to
+        chasing it, the same "harder on purpose" principle behind random and
+        pressure practice.
+      </P>
+      <Figure caption="Success rate on the goal. Clear it every time and it teaches nothing; never clear it and it only demoralizes. The target you make about half the time is the one that moves your skill.">
+        <DifficultyBand />
+      </Figure>
+
+      <Hr />
+
+      <H3>The anatomy of a testable goal</H3>
+      <P>
+        Whatever the skill, a goal you can score has the same four parts. Leave
+        any one of them vague and the verdict goes fuzzy with it.
+      </P>
+      <AnatomyTable />
+
+      <Hr />
+
+      <H3>Then move it</H3>
+      <P>
+        The whole point of a baseline is that you re-set it. Clear your target a
+        few sessions running and it has gone too easy — raise it. A measurable
+        goal isn't a finish line you cross once; it's a number you keep nudging
+        upward as the skill comes in. What never changes is the test itself: at
+        the end of every session you can say plainly whether you passed. A goal you
+        can't score isn't a goal. It's a hope.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'Locke & Latham, American Psychologist (2002) · goal-setting theory, a 35-year review',
+            href: 'https://doi.org/10.1037/0003-066X.57.9.705',
+            note: 'Specific and difficult goals consistently produce higher performance than vague or easy ones, up to the limit of ability.',
+          },
+          {
+            name: 'Kingston & Hardy, The Sport Psychologist (1997)',
+            href: 'https://journals.humankinetics.com/view/journals/tsp/11/3/article-p277.xml',
+            note: 'Club golfers trained on process goals controlled competitive anxiety and held concentration better than a no-goal group.',
+          },
+          {
+            name: 'International Review of Sport & Exercise Psychology (2022) · systematic review and meta-analysis of goal setting in sport',
+            href: 'https://www.tandfonline.com/doi/full/10.1080/1750984X.2022.2116723',
+            note: 'Pooled evidence that goal setting improves performance, with process and performance goals carrying the effect.',
+          },
+          {
+            name: 'Psychology of Sport & Exercise (2015) · holistic process goals for learning and performance under pressure',
+            href: 'https://www.sciencedirect.com/science/article/abs/pii/S1469029214001800',
+            note: 'A process focus helps skills hold up when the pressure is on.',
+          },
+        ]}
+      />
+
+      <ArticleFooter>Last reviewed May 2026 · Draft, needs coaching review</ArticleFooter>
+    </View>
+  )
+}
+
+// Editorial line-art: the success-rate band, productive middle in accent.
+// Same viewBox + coordinate/path data as the web DifficultyBand.
+function DifficultyBand() {
+  return (
+    <Svg width="100%" height={76} viewBox="0 0 220 76">
+      {/* full success-rate track */}
+      <Rect x={14} y={26} width={192} height={14} fill="none" stroke="#9F9580" strokeWidth={1.5} />
+      {/* the productive middle band, ~40–70%, in accent */}
+      <Rect x={90} y={26} width={58} height={14} fill={C.accent} opacity={0.16} />
+      <Line x1={90} y1={22} x2={90} y2={44} stroke={C.accent} strokeWidth={1.5} />
+      <Line x1={148} y1={22} x2={148} y2={44} stroke={C.accent} strokeWidth={1.5} />
+      <SvgText x={14} y={58} fontSize={7} fontFamily="monospace" letterSpacing={1} fill={C.mute}>
+        TOO EASY
+      </SvgText>
+      <SvgText x={98} y={58} fontSize={7} fontFamily="monospace" letterSpacing={1} fill={C.accent}>
+        THE ZONE
+      </SvgText>
+      <SvgText x={168} y={58} fontSize={7} fontFamily="monospace" letterSpacing={1} fill={C.mute}>
+        TOO HARD
+      </SvgText>
+      <SvgText x={10} y={20} fontSize={7} fontFamily="monospace" fill={C.mute}>
+        0%
+      </SvgText>
+      <SvgText x={196} y={20} fontSize={7} fontFamily="monospace" fill={C.mute}>
+        100%
+      </SvgText>
+    </Svg>
+  )
+}
+
+// The four parts every scoreable goal shares. Web renders a 2-col table;
+// mobile stacks each row as italic term + dim detail (single column).
+function AnatomyTable() {
+  const rows: { part: string; detail: string }[] = [
+    {
+      part: 'The shot',
+      detail: 'Exactly what you’re hitting — 7-iron, 60-yard wedge, 6-foot putt. Not “irons.”',
+    },
+    {
+      part: 'The standard',
+      detail: 'What counts as a success — inside 20 feet, on the green, holed.',
+    },
+    {
+      part: 'The sample',
+      detail: 'How many attempts — ten balls, so one lucky or unlucky swing can’t decide it.',
+    },
+    {
+      part: 'The verdict',
+      detail: 'The number to beat — 6 of 10, up from last week’s 4.',
+    },
+  ]
+  return (
+    <View style={{ marginBottom: 14, borderTopWidth: 1, borderTopColor: C.line }}>
+      {rows.map((r) => (
+        <View
+          key={r.part}
+          style={{ paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: C.line }}
+        >
+          <Text
+            style={{ color: C.ink, fontSize: 15, fontStyle: 'italic', fontWeight: '500', marginBottom: 4 }}
+          >
+            {r.part}
+          </Text>
+          <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 20 }}>{r.detail}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/Operation36.tsx
+++ b/apps/mobile/components/learn/articles/Operation36.tsx
@@ -1,0 +1,377 @@
+import { Text, View } from 'react-native'
+import {
+  ArticleHeader,
+  ArticleFooter,
+  BulletList,
+  Callout,
+  Em,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+  Strong,
+  C,
+} from '../primitives'
+
+export function Operation36Article() {
+  return (
+    <View>
+      <ArticleHeader
+        kicker="Improving your game · Draft"
+        title="The Operation 36 philosophy."
+      />
+
+      <H3>Most golfers learn in the wrong order</H3>
+      <P>
+        The traditional path into golf goes like this: stand on a mat at the
+        range, hit a full swing a few hundred times, chase a textbook position,
+        and someday — once the swing "looks right" — take it to the course. The
+        short game and the business of actually scoring get filed under{' '}
+        <Em>later</Em>. The trouble is that the first real round usually arrives
+        long before the swing does, and a beginner who can't yet finish a hole
+        spends four hours confirming they're bad at golf. A lot of people quit
+        right there.
+      </P>
+      <P>
+        Operation 36 — a long-term development program created in 2010 by the
+        PGA coaches Matthew Reagan and Ryan Dailey — inverts the order. Instead
+        of building a swing and hoping a game shows up, you start on the course,
+        25 yards from the hole, and you earn the right to move back only once
+        you can post a score from where you stand. You learn to play golf by
+        playing golf, at a distance where playing it is actually possible.
+      </P>
+
+      <Hr />
+
+      <H3>How the progression works</H3>
+      <P>
+        The whole system runs on one number you can pass or fail:{' '}
+        <Strong>shoot 36 — par for nine holes — from your current distance.</Strong>{' '}
+        Clear it and you move back a stage; until then, you stay where you are.
+        You begin in Division 1, playing nine holes from 25 yards out, where
+        every hole is reachable and every score you write down is a real score.
+        Break 36 and you step back to 50 yards, then 75, and onward in stages
+        until, eventually, you're shooting par from the full tees — the same
+        game the rest of the course is playing.
+      </P>
+
+      <ProgressionLadder />
+
+      <P>
+        Notice what the structure does: it never lets the challenge run too far
+        ahead of the skill. You don't get launched to the back tees and told to
+        survive. You face a version of golf you can complete today, and the
+        course only grows when you've proven you've outgrown it. Moving back is
+        something you <Em>earn</Em>, which makes each step feel like a promotion
+        instead of a punishment.
+      </P>
+
+      <Hr />
+
+      <H3>What "36" actually means</H3>
+      <P>
+        The 36 is simply par for nine holes — four strokes a hole, nine holes,
+        thirty-six. What makes it clever is that you're chasing that par on a
+        course scaled to your ability instead of from the back tees. From 25
+        yards, giving yourself four shots to hole out is a target almost anyone
+        can reach with a little practice. So par stops being the intimidating
+        standard printed on the scorecard and becomes a personal, rolling
+        benchmark: par for <Em>your</Em> distance, today.
+      </P>
+      <P>
+        The number never changes — it's always 36 — but what it asks of you
+        grows as you move back. Par from 25 yards and par from 150 are the same
+        score and wildly different feats, and the gap between them is exactly
+        the ground you've earned your way across. That's the quiet trick of it:
+        a raw beginner and a single-digit handicap can both be "shooting par,"
+        each from the course that fits them, each with a real reason to be proud
+        of the number they wrote down.
+      </P>
+
+      <Hr />
+
+      <H3>Why starting near the hole works</H3>
+      <P>
+        The instinct to "master the swing first" feels responsible, but it puts
+        the hardest, least rewarding part of golf at the very front, before any
+        sense of competence has had a chance to form. Starting near the hole
+        flips the experience on its head:
+      </P>
+      <BulletList
+        items={[
+          <Text key="a">
+            <Strong>You learn to score, not just to swing.</Strong> From 25 yards
+            the job is to get the ball in the hole, which is the actual game.
+            Range golf measures whether a shot looked good; on-course golf
+            measures whether it counted.
+          </Text>,
+          <Text key="b">
+            <Strong>Confidence comes from finishing holes.</Strong> Completing a
+            nine and writing down a number you're proud of builds belief in a way
+            that striping range balls never quite does.
+          </Text>,
+          <Text key="c">
+            <Strong>The short game is honest.</Strong> Did it go in or didn't it?
+            A chip and a putt give instant, unambiguous feedback — far easier to
+            judge than whether a full swing was "on plane."
+          </Text>,
+          <Text key="d">
+            <Strong>It defuses the frustration spiral.</Strong> The beginner who
+            tops three off the tee and triple-bogeys the first hole learns to
+            dread the course. The one shooting 36 from 25 yards learns to look
+            forward to it.
+          </Text>,
+        ]}
+      />
+      <P>
+        There's a sound learning principle underneath all of this. Skills are
+        built fastest when the challenge sits just at the edge of current
+        ability — hard enough to demand effort, easy enough to succeed at often.
+        Coaches call it the optimal challenge point, and it's why you don't
+        start a basketball beginner at the three-point line. Operation 36 is
+        that idea wearing golf shoes: calibrate the distance to the player, then
+        ratchet it up only as fast as they can handle.
+      </P>
+
+      <Hr />
+
+      <H3>What it actually teaches</H3>
+      <P>
+        Beyond getting beginners hooked, the inside-out order quietly teaches a
+        few things the range-first path tends to leave out:
+      </P>
+      <BulletList
+        items={[
+          <Text key="a">
+            <Strong>Putting and chipping are the foundation, not an afterthought.</Strong>{' '}
+            They're the first thing you practice and the last thing every hole
+            comes down to.
+          </Text>,
+          <Text key="b">
+            <Strong>Scoring is its own skill.</Strong> Hitting it well and
+            shooting a number are related but not the same — and the program
+            trains the second one directly, from day one.
+          </Text>,
+          <Text key="c">
+            <Strong>Course management arrives naturally.</Strong> Playing real
+            holes, even short ones, forces real decisions: where to leave the
+            ball, when to play safe, how to think a hole backward from the pin.
+          </Text>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>What the program actually sells</H3>
+      <P>
+        The distance ladder is the part that's easy to describe, but it isn't
+        really what you pay for. Operation 36 is built around coaching: a
+        structured curriculum that introduces a set of skills at each level,
+        live group classes with a PGA coach, drills to work on between sessions,
+        and an app that tracks where you sit in the progression. The "shoot 36
+        to move back" framework is the scaffold — the teaching, the drills, and
+        the feedback are what actually carry you up it.
+      </P>
+      <P>
+        That's a fair trade, and for a lot of people — especially kids in a
+        junior program — it's some of the best money in golf. But it does mean
+        the full experience comes with a price tag and a place you have to show
+        up to. The framework rewards you for scoring; the coaching tells you{' '}
+        <Em>how</Em> to score better. The two are worth separating, because the
+        second part is the expensive part — and it's the part you can assemble
+        in other ways.
+      </P>
+
+      <Hr />
+
+      <H3>Borrowing the idea without joining the program</H3>
+      <P>
+        You don't need to enroll anywhere to use the thinking. The philosophy
+        survives perfectly well on its own, and any golfer — beginner or not —
+        can fold it into how they practice and play:
+      </P>
+      <Callout>
+        <Text style={{ color: C.ink, fontSize: 14, lineHeight: 22 }}>
+          <Strong>Start your sessions close and work outward.</Strong> Open with
+          wedges and chips from 25–50 yards before you ever pull the driver. When
+          you're learning a new club, begin with partial swings at a short target
+          and lengthen only once contact is repeatable.
+        </Text>
+      </Callout>
+      <Callout>
+        <Text style={{ color: C.ink, fontSize: 14, lineHeight: 22 }}>
+          <Strong>Measure practice by "did I score," not "did I hit it well."</Strong>{' '}
+          Give yourself a pass/fail target — up-and-down from 30 yards, two-putt
+          from 20 feet — instead of grading the look of the swing. Build the
+          distance or the difficulty back only when you're clearing the bar
+          consistently.
+        </Text>
+      </Callout>
+
+      <Hr />
+
+      <H3>A guided version you can build for free</H3>
+      <P>
+        On the course, the same logic argues for playing the tees that fit your
+        game today rather than the ones ego or habit picks for you. Move up,
+        give yourself reachable holes, and make the round about completing it
+        well instead of grinding through a course built for someone who hits it
+        forty yards past you. As your scoring holds up, move back — the same
+        earned progression, on a real card.
+      </P>
+      <P>
+        The harder thing to replicate on your own is the guidance — the part
+        that tells you what to work on and shows you you're improving. That's a
+        lot of what OGA is built to do. Strokes gained analysis runs the
+        diagnosis a coach would, pointing at the one part of your game quietly
+        costing you the most shots; a practice plan turns that into specific
+        things to go work on; and tracking your rounds gives you the rising line
+        that tells you when you've earned the next step back. It's the same
+        loop — diagnose, practice, prove it, move back — without a membership.
+      </P>
+      <P>
+        None of that asks you to be a junior, to have grown up at a country
+        club, or to pay for a coach you can't reach. An app doesn't replace a
+        good teacher — the Operation 36 coaches are excellent at theirs — but
+        the <Em>shape</Em> of the journey, start where you can win and earn your
+        way back, is something any golfer can follow with honest tracking and
+        practice that has a point to it.
+      </P>
+
+      <Hr />
+
+      <H3>Credit where it's due</H3>
+      <P>
+        The structured, distance-based progression described here was developed
+        and popularized by{' '}
+        <Link href="https://operation36.golf/">Operation 36 Golf</Link>
+        , and the "shoot 36 to move back" framework is theirs. What's general —
+        and free for anyone to borrow — is the underlying idea: start where you
+        can succeed, measure by scoring, and earn your way back. You can apply
+        that on any course, with any bag, without signing up for anything.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'Operation 36 Golf · How It Works',
+            href: 'https://operation36.golf/how-it-works/',
+            note: (
+              <Text>
+                The program — distance progression and the "shoot 36" rule:
+                start at 25 yards, shoot 36 or better for nine holes to level up,
+                and work back through stages to the full tees.{' '}
+                <Link href="https://www.pga.com/story/operation-36-helping-golfers-find-a-love-for-the-game-for-life">
+                  PGA of America
+                </Link>{' '}
+                on the program's founding (2010, Matthew Reagan and Ryan Dailey)
+                and why achievable milestones keep beginners connected to the
+                game.
+              </Text>
+            ),
+          },
+          {
+            name: 'Keiser University College of Golf · Developing Confidence in Beginner Golfers',
+            href: 'https://collegeofgolf.keiseruniversity.edu/developing-confidence-in-beginner-golfers-thoughts-and-recommendations/',
+            note: 'Why achievable challenges build skill and confidence — on the optimal challenge point: learning is fastest when a task is neither too easy nor too hard, so difficulty should rise step by step as competence does.',
+          },
+        ]}
+      />
+
+      <ArticleFooter>Last reviewed May 2026 · Draft, needs review</ArticleFooter>
+    </View>
+  )
+}
+
+// The distance ladder: the reader climbs from 25 yards to the full tees, with a
+// "shoot 36" gate between each rung. Read top-to-bottom it shows the whole
+// earned progression at a glance. The final rung is the accent — the goal.
+function ProgressionLadder() {
+  return (
+    <View style={{ marginTop: 4, marginBottom: 22 }}>
+      <Rung distance="25 yd" caption="Division 1 · where you start" />
+      <Gate />
+      <Rung distance="50 yd" caption="Division 2" />
+      <Gate />
+      <Rung distance="75 yd" caption="and back a stage at a time" />
+      <Gate />
+      <Rung distance="100 yd" caption="" />
+      <Gate />
+      <Rung distance="150 yd" caption="" />
+      <Gate />
+      <Rung distance="Full tees" caption="par from the back — the goal" goal />
+    </View>
+  )
+}
+
+function Rung({
+  distance,
+  caption,
+  goal,
+}: {
+  distance: string
+  caption: string
+  goal?: boolean
+}) {
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 12,
+        borderWidth: 1,
+        borderColor: goal ? C.accent : C.line,
+        backgroundColor: goal ? C.accent : C.boxBg,
+        borderRadius: 2,
+        paddingVertical: 10,
+        paddingHorizontal: 16,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: 18,
+          fontStyle: 'italic',
+          color: goal ? '#F2EEE5' : C.ink,
+          minWidth: 78,
+        }}
+      >
+        {distance}
+      </Text>
+      {caption ? (
+        <Text
+          style={{
+            fontSize: 12,
+            flex: 1,
+            color: goal ? 'rgba(242,238,229,0.78)' : C.mute,
+          }}
+        >
+          {caption}
+        </Text>
+      ) : null}
+    </View>
+  )
+}
+
+// The gate between rungs: a connector carrying the single rule that moves you
+// back a stage. The chevron is a simple text glyph instead of the web's svg.
+function Gate() {
+  return (
+    <View style={{ alignItems: 'center', paddingVertical: 6 }}>
+      <Text
+        style={{
+          ...{
+            fontSize: 9,
+            letterSpacing: 1.3,
+            textTransform: 'uppercase' as const,
+            color: C.inkDim,
+            paddingVertical: 2,
+          },
+        }}
+      >
+        Shoot 36 to advance
+      </Text>
+      <Text style={{ fontSize: 13, lineHeight: 13, color: '#9F9580' }}>⌄</Text>
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/PracticeModes.tsx
+++ b/apps/mobile/components/learn/articles/PracticeModes.tsx
@@ -1,0 +1,347 @@
+import { Text, View } from 'react-native'
+import Svg, { Circle, Line, Polygon, Polyline, Rect, Text as SvgText } from 'react-native-svg'
+import {
+  ArticleHeader,
+  ArticleFooter,
+  DefRow,
+  Em,
+  Figure,
+  GlanceBox,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+  C,
+} from '../primitives'
+
+export function PracticeModesArticle() {
+  return (
+    <View>
+      <ArticleHeader
+        kicker="Improving your game · Draft"
+        title="Block, random, and pressure."
+      />
+
+      <H3>The practice that feels best teaches least</H3>
+      <P>
+        The most satisfying practice — same club, same target, ball after ball
+        until it grooves — is also the least durable. Half a century of
+        motor-learning research keeps landing on the same uncomfortable result:
+        how well you hit it on the range is a poor predictor of how well you'll
+        learn. The practice that improves your score often feels worse while
+        you're doing it.
+      </P>
+      <P>
+        There are three modes worth understanding — blocked, random, and
+        pressure. Each does a different job, and the mistake nearly every golfer
+        makes is living entirely in the first one. This is what each mode is for,
+        and how to put them together.
+      </P>
+
+      <GlanceBox label="The three modes at a glance">
+        <DefRow term="Blocked" first>
+          Same shot, repeated. Installs a new movement — fast gains, fragile.
+        </DefRow>
+        <DefRow term="Random">
+          A different shot every ball. Builds durable, transferable skill.
+        </DefRow>
+        <DefRow term="Pressure">
+          Consequence on the shot. Carries the skill to the first tee.
+        </DefRow>
+      </GlanceBox>
+
+      <Hr />
+
+      <H3>Blocked — building the movement</H3>
+      <P>
+        Blocked practice is one shot repeated: the same club to the same target,
+        over and over. It's the right tool for installing a brand-new movement or
+        working through a swing change — repetition lets you feel the new pattern
+        without anything else competing for attention, and you improve fast
+        inside the session. That fast improvement is exactly the trap. The gains
+        are fragile, and they tend not to follow you to the course. Use blocks to
+        install a feel, not to finish it: a short blocked warm-up, then move on.
+      </P>
+
+      <Hr />
+
+      <H3>Random — the mode that actually transfers</H3>
+
+      <Figure caption="Top row: blocked practice groups the same shot together. Bottom row: random practice interleaves club and target every ball.">
+        <ScheduleDiagram />
+      </Figure>
+
+      <P>
+        Random practice mixes it up every ball — different club, different
+        target, never the same shot twice in a row. It produces a strange,
+        well-documented pattern called the contextual interference effect:
+        random practice makes you <Em>worse</Em> during the session but{' '}
+        <Em>better</Em> days later, on the tests that measure real learning —
+        retention and transfer to new situations.
+      </P>
+      <P>
+        The reason is that each ball forces you to build the shot from scratch,
+        the way the course always will — you never hit the same putt twice in a
+        round. Studies of golf putting and chipping show it directly: random
+        groups putt worse in practice, then more accurately on a delayed
+        retention test, and build a mental model of the stroke closer to a
+        skilled player's.
+      </P>
+      <P>
+        This is what the psychologist Robert Bjork named a{' '}
+        <Em>desirable difficulty</Em> — a condition that slows you down now and
+        pays off later. It feels like you're practicing badly, which is precisely
+        why most people avoid it. Once a movement is roughly in place, the bulk of
+        your practice should live here.
+      </P>
+
+      <Figure caption="Skill over time. Blocked practice (grey) looks better on the range; random practice (green) wins where it counts — days later, on the course.">
+        <RetentionDiagram />
+      </Figure>
+
+      <Hr />
+
+      <H3>Pressure — closing the gap to the first tee</H3>
+      <P>
+        The range swing that abandons you on the first tee is a transfer failure:
+        you rehearsed the skill in a calm state you never actually compete in.
+        Pressure practice fixes the mismatch by adding consequence — a putt you
+        have to hole, a number to beat, one ball and one attempt — so the skill
+        is trained alongside the nerves it will meet. Sport-psychology research on
+        acclimatization shows that practicing under mild, manufactured pressure
+        helps performance hold up when the real thing arrives, and is one of the
+        better-supported defenses against choking.
+      </P>
+      <P>
+        The companion article on skill games and pressure games is the how — the
+        specific games that manufacture that consequence. The point here is only
+        the why: a skill you've never tested under pressure is a skill you don't
+        yet own on the course.
+      </P>
+
+      <Hr />
+
+      <H3>How to combine them</H3>
+      <P>
+        The modes aren't a menu to pick from; they're a progression. Match the
+        mix to what you're trying to do, and shift it as a movement stabilizes.
+      </P>
+
+      <CombineTable />
+
+      <P>
+        Within a single session, the same shape works: a few minutes of blocks to
+        find the feel, the bulk of the time in random practice with the club and
+        target changing every ball, and a pressure game to finish. Across months,
+        a new change starts blocked-heavy and tilts toward random and pressure as
+        it holds up.
+      </P>
+
+      <Hr />
+
+      <H3>Why it has to feel worse</H3>
+      <P>
+        The through-line under all three modes is the same: performance during
+        practice is a poor guide to learning, and the conditions that build
+        durable, transferable skill are the ones that feel harder while you're in
+        them. If your range sessions feel smooth and your scores aren't moving,
+        that gap is the signal — not to practice more, but to practice in a way
+        that makes the work harder in the right places.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'The contextual interference effect (blocked vs random)',
+            note: (
+              <Text>
+                <Link href="https://www.nature.com/articles/s41598-024-65753-3">
+                  Scientific Reports (2024) · meta-analysis
+                </Link>{' '}
+                confirms high contextual interference improves retention, and{' '}
+                <Link href="https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285">
+                  Magill & Hall, Quest (1998)
+                </Link>{' '}
+                reviews the effect first shown by Shea & Morgan (1979): random
+                order hurts practice, helps learning.
+              </Text>
+            ),
+          },
+          {
+            name: 'Random practice in golf specifically',
+            note: (
+              <Text>
+                <Link href="https://www.frontiersin.org/journals/sports-and-active-living/articles/10.3389/fspor.2024.1324615/full">
+                  Frontiers · motor learning in golf, a systematic review
+                </Link>{' '}
+                and{' '}
+                <Link href="https://pubmed.ncbi.nlm.nih.gov/28449601/">
+                  Fazeli et al. (2017) · random vs blocked in golf putting
+                </Link>{' '}
+                — random groups putt worse in practice, better in retention, with a
+                more skilled mental model.
+              </Text>
+            ),
+          },
+          {
+            name: 'Why harder practice helps — variability and desirable difficulty',
+            note: (
+              <Text>
+                <Link href="https://link.springer.com/article/10.3758/s13421-021-01168-z">
+                  Memory & Cognition (2021) · interleaving and transfer
+                </Link>{' '}
+                and{' '}
+                <Link href="https://pubmed.ncbi.nlm.nih.gov/14768838/">
+                  Sherwood & Lee (2003) · schema theory review
+                </Link>{' '}
+                — variable, interleaved practice is a "desirable difficulty" that
+                builds more general, robust skill.
+              </Text>
+            ),
+          },
+          {
+            name: 'Practicing under pressure',
+            note: (
+              <Text>
+                <Link href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
+                  International Review of Sport & Exercise Psychology (2018) ·
+                  choking interventions, a systematic review
+                </Link>{' '}
+                and{' '}
+                <Link href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2025.1435374/full">
+                  Frontiers in Psychology (2025) · performance under pressure
+                </Link>{' '}
+                — acclimatization and pre-performance routines help skills survive
+                competitive anxiety.
+              </Text>
+            ),
+          },
+          {
+            name: 'Deliberate practice, and its limits',
+            note: (
+              <Text>
+                <Link href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6731745/">
+                  Macnamara & Hambrick, revisiting Ericsson, Krampe &
+                  Tesch-Römer (1993)
+                </Link>{' '}
+                — practice quality matters enormously, though the strong claim that
+                hours alone explain expertise has not fully replicated.
+              </Text>
+            ),
+          },
+        ]}
+      />
+
+      <ArticleFooter>
+        Last reviewed May 2026 · Draft, needs coaching review
+      </ArticleFooter>
+    </View>
+  )
+}
+
+// Three shot types as shapes: top row grouped (blocked), bottom interleaved
+// (random). Same viewBox + coordinate data as the web inline svg, re-authored
+// in react-native-svg.
+function Shape({ type, x, y }: { type: 'c' | 's' | 't'; x: number; y: number }) {
+  if (type === 'c') {
+    return <Circle cx={x} cy={y} r={3.5} fill="none" stroke={C.ink} strokeWidth={1.5} />
+  }
+  if (type === 's') {
+    return (
+      <Rect x={x - 3.3} y={y - 3.3} width={6.6} height={6.6} fill="none" stroke={C.ink} strokeWidth={1.5} />
+    )
+  }
+  return (
+    <Polygon
+      points={`${x},${y - 4.2} ${x + 4},${y + 3.4} ${x - 4},${y + 3.4}`}
+      fill="none"
+      stroke={C.ink}
+      strokeWidth={1.5}
+    />
+  )
+}
+
+function ScheduleDiagram() {
+  type Mark = { t: 'c' | 's' | 't'; x: number }
+  const xs = [20, 35, 50, 65, 80, 95, 110, 125, 140]
+  const order = (seq: ('c' | 's' | 't')[]): Mark[] =>
+    seq.map((t, i) => ({ t, x: xs[i] ?? 0 }))
+  const blocked = order(['c', 'c', 'c', 's', 's', 's', 't', 't', 't'])
+  const random = order(['c', 's', 't', 's', 'c', 't', 't', 'c', 's'])
+  return (
+    <Svg width="100%" height={90} viewBox="0 0 160 90">
+      {blocked.map((m, i) => (
+        <Shape key={`b-${i}`} type={m.t} x={m.x} y={28} />
+      ))}
+      {random.map((m, i) => (
+        <Shape key={`r-${i}`} type={m.t} x={m.x} y={64} />
+      ))}
+    </Svg>
+  )
+}
+
+// Contextual interference: blocked wins in practice, random wins later. Same
+// viewBox + coordinate data as the web inline svg, re-authored in
+// react-native-svg.
+function RetentionDiagram() {
+  return (
+    <Svg width="100%" height={110} viewBox="0 0 200 110">
+      <Line x1={24} y1={86} x2={188} y2={86} stroke={C.mute} strokeWidth={1.5} />
+      <Line x1={24} y1={14} x2={24} y2={86} stroke={C.mute} strokeWidth={1.5} />
+      <Line x1={106} y1={18} x2={106} y2={86} stroke={C.line} strokeWidth={1} strokeDasharray="3 3" />
+      {/* blocked: high in practice, drops later */}
+      <Polyline points="30,44 106,30 182,68" fill="none" stroke={C.mute} strokeWidth={2} />
+      {/* random: low in practice, best later (accent) */}
+      <Polyline points="30,74 106,60 182,30" fill="none" stroke={C.accent} strokeWidth={2} />
+      <SvgText x={54} y={100} fontSize={7} fontFamily="monospace" letterSpacing={1} fill={C.mute}>
+        PRACTICE
+      </SvgText>
+      <SvgText x={136} y={100} fontSize={7} fontFamily="monospace" letterSpacing={1} fill={C.mute}>
+        LATER
+      </SvgText>
+    </Svg>
+  )
+}
+
+// Match the mode mix to the goal, and shift it as the movement stabilizes.
+// Web's 2-col CombineTable rendered stacked: italic goal + dim body per row.
+function CombineTable() {
+  const rows: { goal: string; mix: string }[] = [
+    {
+      goal: 'Installing a new move',
+      mix: 'Mostly blocked. Repeat the shot until the new feel is reliable before adding any variety.',
+    },
+    {
+      goal: 'Building durable skill',
+      mix: 'Mostly random. A different club and target every ball — this is where most practice should live.',
+    },
+    {
+      goal: 'Getting ready to compete',
+      mix: 'Add pressure. Put consequence on the shot, woven into random practice rather than tacked on at the end.',
+    },
+  ]
+  return (
+    <View style={{ marginBottom: 14, borderTopWidth: 1, borderTopColor: C.line }}>
+      {rows.map((r) => (
+        <View
+          key={r.goal}
+          style={{ paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: C.line }}
+        >
+          <Text
+            style={{
+              color: C.ink,
+              fontSize: 15,
+              fontStyle: 'italic',
+              fontWeight: '500',
+              marginBottom: 4,
+            }}
+          >
+            {r.goal}
+          </Text>
+          <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 20 }}>{r.mix}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/PracticeVsScoringRound.tsx
+++ b/apps/mobile/components/learn/articles/PracticeVsScoringRound.tsx
@@ -1,0 +1,414 @@
+import { Text, View } from 'react-native'
+import {
+  ArticleHeader,
+  ArticleFooter,
+  BulletList,
+  Callout,
+  Em,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+  Strong,
+  C,
+  KICKER,
+} from '../primitives'
+
+export function PracticeVsScoringRoundArticle() {
+  return (
+    <View>
+      <ArticleHeader
+        kicker="On the course · Draft"
+        title="Decide which round you're playing."
+      />
+
+      <P>
+        A practice round and a scoring round use the same eighteen holes, but
+        they are two different jobs — and trying to do both at once does neither
+        well. The guide on <Em>how to practice effectively</Em> makes the
+        distinction in a sentence: one is for information, the other is for
+        performance. This is the on-course version — what each round is actually
+        for, how to run a real practice round instead of just a casual one, and
+        why the rounds that blur the line teach you the least.
+      </P>
+
+      <ModeTable />
+
+      <Hr />
+
+      <H3>What a practice round is actually for</H3>
+      <P>
+        A practice round is reconnaissance. You are not trying to shoot a number
+        — you are gathering the information that lets you commit on the day it
+        counts. It's what tour players spend the days before a tournament doing
+        — more on their method below — and you can get most of the value in a
+        single honest loop.
+      </P>
+      <BulletList
+        items={[
+          <Text>
+            <Strong>Hit driver off the tees you're unsure about.</Strong> You
+            learn whether your driver actually reaches the fairway bunker or the
+            dogleg trouble. You can always dial back to a 3-wood in competition —
+            but only if you know what driver does first.
+          </Text>,
+          <Text>
+            <Strong>Find where you can't miss.</Strong> On every approach, note
+            the side that leaves a dead chip or a ball in the water. Course
+            management is mostly knowing the one place the ball can't go; the
+            practice round is where you find it.
+          </Text>,
+          <Text>
+            <Strong>Putt from the spots you'll actually face.</Strong> Roll a few
+            from each likely pin area to learn the speed and the big breaks. The
+            green is where rounds are won, and it reads differently than it
+            looks.
+          </Text>,
+          <Text>
+            <Strong>Play a ball from the rough and a bunker.</Strong> A shot or
+            two from the conditions you'll meet tells you how this course's turf
+            and sand behave before they surprise you under pressure.
+          </Text>,
+          <Text>
+            <Strong>Don't keep score.</Strong> A score on a practice round sets
+            an expectation you'll carry to the first tee for no reason. Drop a
+            second ball, try the riskier line, hole out for the read — the round
+            is for learning, not for a number.
+          </Text>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>How the pros do it</H3>
+      <P>
+        The gold standard for this lives on tour, and the logic scales down to
+        any golfer. Pros don't see a tournament course cold on Thursday — they
+        arrive days early and play practice rounds Monday and Tuesday, with
+        Wednesday's pro-am often serving as one last relaxed look. By the time
+        the first round counts, they've already made every decision the course
+        is going to ask of them.
+      </P>
+      <P>
+        Most of that work is reconnaissance, not swing practice. The caddie
+        scouts the course — sometimes separately from the player — pacing off
+        yardages to landing zones and to each pin area, logging the wind, and
+        recording the club, speed, and spin from shots hit along the way. All of
+        it goes into a yardage book built on top of the detailed base book the
+        event supplies, until the player has a hole-by-hole plan: the club off
+        each tee, the number to leave on each approach, and the side that can't
+        be short-sided. Crucially, they practice approaches to the actual hole
+        locations planned for the four tournament days — not to wherever the
+        flag happens to sit that morning.
+      </P>
+      <P>
+        Greens are the one place the rules recently pushed pros back toward
+        doing their own homework. Since 2022, golf's governing bodies have let
+        tournaments require an approved yardage book whose green diagrams show
+        only minimal detail — major slopes and tiers, not a full contour map —
+        and the only extra notes allowed are ones the player or caddie made from
+        watching a ball actually roll. Even the best players in the world now
+        have to earn their green reads in the practice round, which is exactly
+        what you should be doing anyway.
+      </P>
+
+      <Hr />
+
+      <H3>Borrow the method, skip the budget</H3>
+      <P>
+        You don't have a caddie, four days, or a closed golf course — but the
+        method shrinks to fit an ordinary tee time. The goal is unchanged: walk
+        off knowing the course so that nothing in your next scoring round is a
+        first-time surprise.
+      </P>
+      <BulletList
+        items={[
+          <Text>
+            <Strong>Go when it's quiet.</Strong> An early or twilight tee time,
+            or a slow midweek afternoon, lets you drop a second ball and
+            experiment without a group breathing down your neck. Reconnaissance
+            needs room to fail.
+          </Text>,
+          <Text>
+            <Strong>Keep a notebook.</Strong> A phone note or a cheap yardage
+            book is plenty. One line per hole: a stock layup number and the one
+            place the ball can't go — "7th: lay back to 110, water long-right,
+            bail short-left." You'll have forgotten it by next week otherwise.
+          </Text>,
+          <Text>
+            <Strong>Rehearse the in-between yardages.</Strong> Every course keeps
+            handing you the same awkward numbers — a 40-yard pitch, a 215-yard
+            par 3, a layup that leaves three-quarter wedge. Hit those on purpose
+            so they're rehearsed instead of improvised under pressure.
+          </Text>,
+          <Text>
+            <Strong>Learn the big greens from every side.</Strong> Lag a putt
+            from the front, the back, and each edge of the largest greens to feel
+            the speed and the two or three breaks that actually matter. Speed
+            surprises cost more strokes than misread line.
+          </Text>,
+          <Text>
+            <Strong>Practice the misses, not the makes.</Strong> Chip and play
+            bunker shots from the spots you tend to short-side yourself, not the
+            comfortable ones — those are the shots that wreck a scoring round, so
+            meet them here first.
+          </Text>,
+          <Text>
+            <Strong>No time for a full loop? Do it in reverse.</Strong> After an
+            ordinary round, jot three notes per nine while the holes are fresh. A
+            handful of rounds like that builds the same course knowledge a
+            dedicated practice round would, just spread out over time.
+          </Text>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>What a scoring round demands</H3>
+      <P>
+        A scoring round is performance. One ball, every shot counts, and the
+        only job is to post the lowest number you can with the game you brought.
+        That means the opposite of the practice round on almost every count.
+      </P>
+      <BulletList
+        items={[
+          <Text>
+            <Strong>Full routine on every shot.</Strong> The same pre-shot
+            sequence, even on the throwaway ones. A consistent pre-shot routine
+            is one of the most reliably effective mental tools in the game — a
+            meta-analysis across sports found routines measurably improve
+            performance, and they help most precisely when the pressure is on and
+            the mind wants to wander.
+          </Text>,
+          <Text>
+            <Strong>Commit, then accept.</Strong> Pick the shot, commit to it,
+            and take the result without relitigating it. The experimenting was
+            supposed to happen in the practice round; here, a half-committed
+            swing is the worst of both worlds.
+          </Text>,
+          <Text>
+            <Strong>One ball, no mulligans.</Strong> The score only means
+            something if it's the score you actually made. Play it down, count
+            everything, move on.
+          </Text>,
+          <Text>
+            <Strong>Manage, don't experiment.</Strong> Aim at the fat of the
+            green, favor the safe miss, and save the new shot you've been working
+            on for the range. Even tour players aim at the center, not the pin,
+            for anything longer than a short iron.
+          </Text>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>Why mixing them costs you both</H3>
+      <P>
+        The common mistake isn't choosing the wrong mode — it's failing to
+        choose, and drifting through the round half in each. You take the round
+        seriously enough to feel the nerves, but loosely enough to drop a second
+        ball when one goes sideways. The result is the worst of both: the
+        anxiety of performance without a real score to show for it, and the
+        freedom of practice without any of the information.
+      </P>
+      <P>
+        It also quietly ruins your data. If you track rounds to find where your
+        game leaks strokes, a dropped second ball or a "let me just try the cut
+        here" poisons the signal — the round no longer reflects the decisions and
+        misses you'd actually make. A round is only worth measuring if it was
+        played honestly: one ball, full commitment, every stroke counted.
+      </P>
+
+      <Hr />
+
+      <H3>The casual round is neither — and that's the trap</H3>
+      <P>
+        Most weekend rounds are neither a true practice round nor a true scoring
+        round. That's completely fine — golf is supposed to be fun, and most of
+        the time the goal is a good walk with friends. The trap is mistaking a
+        steady diet of casual rounds for improvement work. A casual round gives
+        you neither clean recon nor a trustworthy score; it just gives you a
+        pleasant afternoon, which is its own reward but not a feedback loop.
+      </P>
+      <P>
+        If you actually want to get better, some of your rounds have to be
+        honestly one or the other: a recon loop where you experiment freely and
+        keep notes, or a committed scoring round you track without fudging. The
+        line between them is the whole point.
+      </P>
+
+      <Callout>
+        <Text style={{ color: C.ink, fontSize: 14, lineHeight: 22 }}>
+          <Strong>The one habit:</Strong> before you hit the first tee shot,
+          decide out loud which round this is. "This is a practice round" or
+          "I'm playing this one for score" — said before you start — is what
+          keeps you from drifting into the half-committed middle where neither
+          version pays off.
+        </Text>
+      </Callout>
+
+      <P>
+        The skill in golf isn't only swinging the club; it's knowing which game
+        you're playing on any given day and committing to it fully. Pick one
+        before you tee off, and both your scores and your practice get sharper
+        for it.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'A practice round is recon, not a score',
+            note: (
+              <Text>
+                <Link href="https://www.pga.com/story/prioritize-your-practice-sessions-to-prepare-for-a-big-golf-tournament">
+                  PGA of America · preparing for a tournament
+                </Link>{' '}
+                and{' '}
+                <Link href="https://golfstateofmind.com/course-management-lessons-from-the-pga-tour/">
+                  Golf State of Mind · course-management lessons from the PGA
+                  Tour
+                </Link>{' '}
+                — hit driver to learn the trouble, find the no-go side, default
+                to the center of the green, and keep score out of it.
+              </Text>
+            ),
+          },
+          {
+            name: 'Pre-shot routines help most under pressure',
+            note: (
+              <Text>
+                <Link href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2021.1944271">
+                  International Review of Sport & Exercise Psychology (2021) ·
+                  meta-analysis of pre-performance routines
+                </Link>{' '}
+                — a consistent routine produces a measurable performance benefit,
+                and it matters most when the pressure invites distraction.
+              </Text>
+            ),
+          },
+          {
+            name: 'Why the practice mindset is a separate gear',
+            note: (
+              <Text>
+                <Link href="https://www.sportspsychologygolf.com/how-to-think-about-practice-rounds-in-golf/">
+                  Golf Psychology (Dr. Patrick Cohn) · how to think about
+                  practice rounds
+                </Link>{' '}
+                — treating a practice round as a performance is how golfers carry
+                scoring anxiety into a day that was supposed to lower it.
+              </Text>
+            ),
+          },
+          {
+            name: 'How tour players turn recon into a plan',
+            note: (
+              <Text>
+                <Link href="https://www.golfmonthly.com/features/5-secrets-of-the-players-open-yardage-book">
+                  Golf Monthly · inside a tour player's yardage book
+                </Link>{' '}
+                and{' '}
+                <Link href="https://golfingfocus.com/what-do-pros-have-in-their-yardage-books-things-have-changed/">
+                  Golfing Focus · what pros carry in their yardage books
+                </Link>{' '}
+                — caddies pace off pin-zone yardages and log wind, club, and spin
+                in practice rounds, building a hole-by-hole game plan before
+                round one.
+              </Text>
+            ),
+          },
+          {
+            name: 'Even the pros earn their green reads in practice',
+            note: (
+              <Text>
+                <Link href="https://www.pgatour.com/article/news/ground-rules/2021/11/02/new-rule-will-limit-information-players-can-use-for-reading-greens-yardage-book-pga-tour">
+                  PGA TOUR · the green-reading-materials rule (Model Local Rule
+                  G-11, effective 2022)
+                </Link>{' '}
+                and{' '}
+                <Link href="https://www.golfdigest.com/story/usga-randa-approve-model-local-rule-to-limit-use-of-green-reading-materials">
+                  Golf Digest · USGA and R&A on the limit
+                </Link>{' '}
+                — approved books now show only minimal green detail, and any
+                extra notes must come from a player or caddie watching a ball
+                roll.
+              </Text>
+            ),
+          },
+        ]}
+      />
+
+      <ArticleFooter>Last reviewed May 2026 · Draft, needs review</ArticleFooter>
+    </View>
+  )
+}
+
+// The two rounds set side by side across the dimensions that actually differ —
+// the comparison is the article's thesis, so it leads before the prose. On
+// phone the web 3-column grid is rebuilt as stacked dimension blocks, each with
+// its practice / scoring values labeled.
+function ModeTable() {
+  const rows: { dim: string; practice: string; scoring: string }[] = [
+    { dim: 'The job', practice: 'Gather information', scoring: 'Post a number' },
+    { dim: 'Balls', practice: 'Drop extras, experiment', scoring: 'One ball, no mulligans' },
+    { dim: 'Routine', practice: 'Loose', scoring: 'Full, every shot' },
+    { dim: 'Risk', practice: 'Try the dangerous line', scoring: 'Favor the safe miss' },
+    { dim: 'Score', practice: "Don't keep it", scoring: 'Count everything' },
+    {
+      dim: 'Success is',
+      practice: 'Walking off knowing the course',
+      scoring: 'The lowest number you can',
+    },
+  ]
+  return (
+    <View
+      style={{
+        backgroundColor: C.boxBg,
+        borderWidth: 1,
+        borderColor: C.line,
+        borderRadius: 2,
+        paddingVertical: 14,
+        paddingHorizontal: 16,
+        marginBottom: 18,
+      }}
+    >
+      {rows.map((r, i) => (
+        <View
+          key={r.dim}
+          style={{
+            paddingTop: i === 0 ? 0 : 12,
+            marginTop: i === 0 ? 0 : 12,
+            borderTopWidth: i === 0 ? 0 : 1,
+            borderTopColor: C.line,
+          }}
+        >
+          <Text
+            style={{
+              color: C.ink,
+              fontSize: 14,
+              fontStyle: 'italic',
+              fontWeight: '500',
+              marginBottom: 6,
+            }}
+          >
+            {r.dim}
+          </Text>
+          <View style={{ flexDirection: 'row', gap: 12 }}>
+            <View style={{ flex: 1 }}>
+              <Text style={{ ...KICKER, color: C.inkDim, marginBottom: 3 }}>
+                Practice round
+              </Text>
+              <Text style={{ color: C.ink, fontSize: 13, lineHeight: 19 }}>{r.practice}</Text>
+            </View>
+            <View style={{ flex: 1 }}>
+              <Text style={{ ...KICKER, color: C.inkDim, marginBottom: 3 }}>
+                Scoring round
+              </Text>
+              <Text style={{ color: C.ink, fontSize: 13, lineHeight: 19 }}>{r.scoring}</Text>
+            </View>
+          </View>
+        </View>
+      ))}
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/QuestionsForCoach.tsx
+++ b/apps/mobile/components/learn/articles/QuestionsForCoach.tsx
@@ -1,0 +1,208 @@
+import { View } from 'react-native'
+import {
+  ArticleHeader,
+  P,
+  H3,
+  Hr,
+  BulletList,
+  Callout,
+  GlanceBox,
+  DefRow,
+  Sources,
+  ArticleFooter,
+  Strong,
+  Em,
+  Link,
+} from '../primitives'
+
+export function QuestionsForCoachArticle() {
+  return (
+    <View>
+      <ArticleHeader
+        kicker="Working with coaches · Draft"
+        title="A lesson is a conversation."
+      />
+
+      <P>
+        Most golfers treat a lesson as a download: stand there, collect the tip,
+        nod, drive home. The ones who actually improve treat it as a conversation
+        — and the questions they ask are what turn a good feeling on the range
+        into a change they can still find next week. The companion guide on{' '}
+        <Em>lessons and coaching</Em> covers choosing a teacher and the questions
+        to ask <Em>before</Em> you book. This is the conversation once you're in
+        the bay, and the handful of questions at the end that decide whether any
+        of it survives the drive home.
+      </P>
+
+      <GlanceBox label="When to ask what">
+        <DefRow term="Before booking" first>
+          Who to hire — philosophy, video, series. Covered in the
+          lessons-and-coaching guide.
+        </DefRow>
+        <DefRow term="While teaching">
+          What the change is for, the feel and its checkpoint, and how the miss
+          shows up.
+        </DefRow>
+        <DefRow term="Before you leave">
+          The exact drill and dose, what to ignore, the dip to expect, and when
+          to check back.
+        </DefRow>
+      </GlanceBox>
+
+      <Hr />
+
+      <H3>While they're teaching</H3>
+      <P>
+        A tip you can't reproduce on your own is worthless by Tuesday. These
+        three turn a position into something portable.
+      </P>
+      <BulletList
+        items={[
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"What is this doing to my ball flight?"</Strong> You want the
+            change tied to an outcome you can see, not just a body position.
+            Research on where golfers aim their attention is unusually consistent:
+            focusing on the <Em>effect</Em> of a movement — what the ball does —
+            produces better and more durable results than focusing on the body
+            part making it. If the answer is only "get your hands here," ask what
+            "here" is supposed to <Em>produce</Em>.
+          </P>,
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"What's the feel, and what's the checkpoint?"</Strong> Feel
+            and reality rarely match, so you want both — a feel to chase in the
+            moment, and an external checkpoint you can verify alone: a video
+            angle, a ball-flight window, a launch number. The feel gets you
+            moving; the checkpoint keeps you honest when the coach isn't standing
+            there.
+          </P>,
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"How will I know when I'm doing it wrong?"</Strong> Every new
+            move has a characteristic miss. Knowing the failure mode in advance
+            lets you catch yourself drifting, instead of grooving the error for
+            three weeks until the next lesson.
+          </P>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>Before you leave</H3>
+      <P>
+        The clarity you feel walking off the range fades startlingly fast. Pin it
+        down before you go.
+      </P>
+      <BulletList
+        items={[
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"What exactly do I practice, and how much?"</Strong> A change
+            without a dose is a wish. Get the specific drill and a number — reps,
+            minutes, or sessions — so "practice this" becomes something you can
+            schedule. Then spread it across days rather than cramming it into one
+            marathon; practice spaced over time sticks far better than the same
+            reps in a single grind.
+          </P>,
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"What do I ignore until next time?"</Strong> Permission to
+            work on one thing is the most underrated gift a coach can give. Ask
+            what to leave alone — including the new tip you'll inevitably trip
+            over online this week. Mixing sources mid-change is how you end up
+            with no swing at all.
+          </P>,
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"What should get worse first?"</Strong> A real swing change
+            usually dips before it climbs. Ask how rough the middle gets and how
+            long it lasts, so you don't abandon a good change the first time it
+            costs you a few shots.
+          </P>,
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"When should we check this?"</Strong> Set the next checkpoint
+            before you leave — a date, or a milestone like "once I can hit it 7 of
+            10." That's what turns a one-off tip into a plan.
+          </P>,
+        ]}
+      />
+
+      <Callout>
+        <P style={{ marginBottom: 0, fontSize: 14, lineHeight: 21 }}>
+          <Strong>If you ask one question, ask this:</Strong> "If I could only
+          practice one thing this week, what would it be?" It forces your coach to
+          prioritize out loud and hands you the single highest-leverage rep to
+          take home — the antidote to leaving with a list of six things and doing
+          none of them well.
+        </P>
+      </Callout>
+
+      <Hr />
+
+      <H3>Questions that waste the hour</H3>
+      <P>A few questions feel productive and aren't. Skip them.</P>
+      <BulletList
+        items={[
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"What does [tour player] do here?"</Strong> Their body, speed,
+            and tens of thousands of reps aren't yours. The right model is the
+            checkpoint your coach set for <Em>you</Em>, not a swing built for
+            someone else.
+          </P>,
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"Should I buy this club or gadget?"</Strong> A purchase or a
+            fitting is a different appointment. Don't spend your most expensive
+            coaching minutes on gear questions.
+          </P>,
+          <P style={{ marginBottom: 0 }}>
+            <Strong>"Is my swing fixed now?"</Strong> One lesson rarely fixes
+            anything — skill comes from reps and feedback loops, not a single
+            revelation on a Tuesday. Judge the coach over a block of lessons, not
+            the first hour.
+          </P>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>The thread under all of it</H3>
+      <P>
+        A lesson isn't something done to you — it's something you steer. Ask what
+        the change is <Em>for</Em>, how to verify it alone, what to ignore, and
+        when to check back, and you walk out with a plan instead of a feeling.
+        That's the whole difference between a tip you've forgotten by Saturday and
+        a change that's still with you next season.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'Focus on the ball, not the body part',
+            href: 'https://gwulf.faculty.unlv.edu/wp-content/uploads/2018/11/Wulf_AF_review_2013.pdf',
+            note: (
+              <P style={{ marginBottom: 0, fontSize: 13, lineHeight: 19 }}>
+                Wulf, International Review of Sport & Exercise Psychology (2013) ·
+                attentional focus, a 15-year review, and a golf-specific test in{' '}
+                <Link href="https://journals.humankinetics.com/view/journals/jmld/1/1/article-p2.xml">
+                  Journal of Motor Learning & Development (2013) · external focus,
+                  X-factor and carry distance
+                </Link>{' '}
+                — focusing on the movement's effect (the ball) beats focusing on
+                the body part making it.
+              </P>
+            ),
+          },
+          {
+            name: 'And it holds up over days',
+            href: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC11246618/',
+            note: 'Internal vs external focus on golf putting accuracy over multiple days (2024) — the external-focus advantage persists on delayed retention, not just in the moment.',
+          },
+          {
+            name: 'Space the practice you’re given',
+            href: 'https://www.sciencedirect.com/science/article/abs/pii/S016794570000021X',
+            note: 'Shea et al., Human Movement Science (2000) · spacing practice across days — the same reps spread over several days produce far better retention than the same total packed into one session.',
+          },
+        ]}
+      />
+
+      <ArticleFooter>
+        Last reviewed May 2026 · Draft, needs coaching review
+      </ArticleFooter>
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/SelfDiagnosis.tsx
+++ b/apps/mobile/components/learn/articles/SelfDiagnosis.tsx
@@ -1,0 +1,492 @@
+import type { ReactNode } from 'react'
+import { Text, View } from 'react-native'
+import Svg, { Path } from 'react-native-svg'
+import {
+  ArticleHeader,
+  ArticleFooter,
+  BulletList,
+  Em,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+  Strong,
+  Subhead,
+  C,
+} from '../primitives'
+
+export function SelfDiagnosisArticle() {
+  return (
+    <View>
+      <ArticleHeader kicker="On the course · Draft" title="Self-diagnosis." />
+
+      <H3>You know something is off</H3>
+      <P>
+        Most golfers can feel that a part of their game is leaking shots. Far
+        fewer can say what is actually happening — and that gap is the
+        difference between fixing a problem and flailing at it. "I'm playing
+        bad" is not a diagnosis. "I lose most of my strokes on approach, my miss
+        is a push to the right with the mid-irons, and it gets worse when I bear
+        down" is a diagnosis. A diagnosis points at a fix.
+      </P>
+      <P>
+        This guide hands you the vocabulary and the framework to read your own
+        game. You don't need a coach behind you and you don't need a launch
+        monitor. You need to watch where your ball actually goes, round after
+        round, and be honest and specific about the pattern. The work here is
+        noticing — not judging.
+      </P>
+
+      <Hr />
+
+      <H3>Start where the strokes leak</H3>
+      <P>
+        Golf hands you four bills to pay every round: the tee shot, the
+        approach, the short game, and the putter. Before you diagnose a swing,
+        find out which bill is bleeding you. Spending an afternoon fixing your
+        driver when you three-putt six times a round is solving a problem you
+        don't have.
+      </P>
+      <P>
+        If you track strokes gained, this is already answered for you — whichever
+        category is most negative is where to look first. If you don't track
+        anything, you can still eyeball it over three or four rounds:
+      </P>
+      <BulletList
+        items={[
+          <Text>
+            <Strong>Off the tee</Strong> — how often does a tee shot cost you a
+            penalty stroke or a chip-out sideways?
+          </Text>,
+          <Text>
+            <Strong>Approach</Strong> — how often do you miss the green, and when
+            you miss, is it by a little or by a lot?
+          </Text>,
+          <Text>
+            <Strong>Short game</Strong> — when you miss a green, how often do you
+            get up and down in two?
+          </Text>,
+          <Text>
+            <Strong>Putting</Strong> — how many putts a round, and how many of
+            those are three-putts?
+          </Text>,
+        ]}
+      />
+      <P>
+        Whichever answer makes you wince is your starting point. Diagnose that
+        area first and ignore the rest for now. You can only rebuild one wall at
+        a time.
+      </P>
+
+      <Hr />
+
+      <H3>Four questions for any miss</H3>
+      <P>
+        Once you know the area, the same four questions crack open almost any
+        ball-flight problem. Ask them in order. Each answer narrows the field.
+      </P>
+
+      <DiagnosticFlow />
+
+      <Subhead>1. What is your typical miss?</Subhead>
+      <P>
+        Name it precisely. Direction misses — <Em>push, pull, slice, hook</Em> —
+        are mostly a story about your clubface and your swing path at impact.
+        Contact misses — <Em>fat, thin, toe, heel</Em> — are mostly a story about
+        where the bottom of your swing arc lives. A "bad shot" is useless
+        information. "A pull that starts left and stays left" tells you the face
+        was closed to your target. Specificity is the whole game here.
+      </P>
+
+      <Subhead>2. Is it consistent or random?</Subhead>
+      <P>
+        This is the most important question and the most encouraging one. A{' '}
+        <Strong>consistent</Strong> miss — the same shape almost every time — is
+        a pattern, and a pattern can be aimed around or adjusted out. That is
+        good news. A <Strong>random</Strong> miss — left, then right, then fat,
+        with no rhyme — usually points further back, at contact and fundamentals:
+        grip, posture, alignment, or balance changing from swing to swing.
+        Consistency is a sign you are closer to fixed than you feel.
+      </P>
+
+      <Subhead>3. Does it get worse under pressure?</Subhead>
+      <P>
+        If a miss only shows up on the first tee, over water, or when you are
+        trying to protect a good score, the cause is often tension and tempo, not
+        technique. Pressure speeds people up and tightens the hands. A swing that
+        works on the range and falls apart on the card is rarely a mechanical
+        problem — it is a rhythm-and-grip-pressure problem wearing a mechanical
+        costume.
+      </P>
+
+      <Subhead>4. All clubs, or specific ones?</Subhead>
+      <P>
+        A miss that shows up with <Strong>every club</Strong> is systemic —
+        something in your setup or motion that travels with you: grip, posture,
+        alignment, ball position. A miss isolated to <Strong>one club</Strong> is
+        usually about that club specifically — the driver's length and low loft
+        exaggerate whatever your hands do, a particular wedge you don't trust, a
+        long iron most amateurs simply shouldn't be carrying.
+      </P>
+
+      <Hr />
+
+      <H3>Off the tee</H3>
+      <P>
+        The expensive tee misses are the ones that find penalty areas: the big
+        slice and the snap hook. Run the four questions. A consistent curve in
+        one direction is a face-to-path relationship you can work on or simply
+        aim for in the meantime. A two-way miss — slice one hole, hook the next —
+        is harder to live with and usually traces to alignment and tempo rather
+        than one fixable flaw.
+      </P>
+      <Example
+        flight="Consistent slice with the driver, but straight with the irons"
+        read="The face is open to a path that's swinging across the ball, left of target — and the driver's length and low loft magnify the side-spin the irons hide. Because the irons are fine, this is rarely a whole-swing rebuild."
+        focus="Check alignment first (slicers often aim further left to compensate, which steepens the across-the-ball path and feeds the slice), then check grip strength. A grip rotated too far toward the target leaves the face open at speed."
+      />
+
+      <Hr />
+
+      <H3>Approach</H3>
+      <P>
+        Approach misses come in two flavors: <Em>direction</Em> (push/pull, or a
+        curve) and <Em>contact</Em> (fat/thin). Direction misses behave like the
+        tee — read the curve and the start line. Contact misses are about your
+        low point: fat means the arc bottoms out behind the ball, thin means you
+        caught it on the way up or pulled out of the shot.
+      </P>
+      <Example
+        flight="Fat shots with the irons, especially under pressure"
+        read="Catching it heavy means the low point of your swing fell behind the ball. Under pressure this is commonly weight hanging on the back foot or the hips thrusting toward the ball through impact (early extension) — both move the bottom of the arc backward."
+        focus="An impact-bag drill teaches the hands and body where solid contact lives; a slow, balance-focused drill — hold your finish for three seconds on every range ball — retrains weight moving forward. Confirm with a coach if it persists, because fat contact has more than one cause."
+      />
+
+      <Hr />
+
+      <H3>Short game</H3>
+      <P>
+        Around the green, the two killers are the chunk and the skull — and they
+        are often the same fault from opposite directions: a low point that
+        wanders because the hands try to lift the ball into the air instead of
+        letting the loft do it. The fix lives in setup and a quieter, descending
+        strike, not in a different club.
+      </P>
+      <P>
+        Distance control is the other half. If your chips finish reliably short
+        or reliably long, that is a consistent, fixable pattern — adjust your
+        default and re-calibrate. If they scatter with no pattern, the contact is
+        the problem, not the green-reading or the touch.
+      </P>
+
+      <Hr />
+
+      <H3>Putting</H3>
+      <P>
+        Putting misses are easy to mislabel. Most golfers blame their read when
+        the real culprit is speed. Read errors and pace errors look different on
+        the green: a read error leaves you a tester on the same side most of the
+        time; a pace error leaves you long and short, and it is what turns a
+        routine two-putt into a three.
+      </P>
+      <Example
+        flight="Three-putts from inside 20 feet"
+        read="From that range you almost never misread the line badly enough to three-putt — the cause is pace. The first putt finishes too far past or too far short, leaving a knee-knocker you then miss."
+        focus="Train speed, not line. Hit putts with your eyes closed and guess where each finished before you look; you'll sharpen the feel for distance fast. Lag drills to a tee or a coin — not a hole — keep your focus on the speed instead of the make."
+      />
+
+      <Hr />
+
+      <H3>Consistent is fixable; random is fundamentals</H3>
+      <P>
+        If you take one thing from this guide, take the second question. A
+        consistent miss is a friend — it is repeatable, which means it is
+        understandable, which means it is fixable, and in the meantime it is
+        aimable. A random miss is telling you to go back to the boring basics:
+        grip, posture, alignment, ball position, balance. Nobody wants the answer
+        to be "check your setup," but it usually is.
+      </P>
+
+      <Hr />
+
+      <H3>When to bring this to a coach</H3>
+      <P>
+        Self-diagnosis tells you <Em>what</Em> is happening and points you at the
+        likely <Em>why</Em>. It does not replace a trained eye and a camera for
+        the things you cannot see in your own swing. Bring a coach a diagnosis,
+        not a vague complaint — "consistent push with the mid-irons, worse under
+        pressure, fine with the wedges" gets you a productive lesson far faster
+        than "I'm hitting it bad." You will have done half their work for them,
+        and you will know whether the fix they give you actually addresses the
+        pattern you walked in with.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'Ball flight — start line, curve, and why the driver curves more',
+            note: (
+              <Text>
+                <Link href="https://www.trackman.com/blog/golf/face-to-path">
+                  TrackMan · Face to Path
+                </Link>{' '}
+                and{' '}
+                <Link href="https://www.trackman.com/blog/golf/club-path">
+                  Club Path
+                </Link>{' '}
+                — the clubface sets roughly 85% of the start line; the
+                face-to-path gap sets the curve. The driver's lower loft means a
+                smaller{' '}
+                <Link href="https://www.trackman.com/blog/golf/spin-loft">
+                  spin loft
+                </Link>
+                , so the spin axis tilts more easily — which is why it curves
+                more than the irons.
+              </Text>
+            ),
+          },
+          {
+            name: 'Low point and fat contact',
+            note: (
+              <Text>
+                <Link href="https://www.mytpi.com/articles/swing/why-early-extension-causes-a-reduction-of-power-in-the-golf-swing">
+                  Titleist Performance Institute · Early Extension
+                </Link>
+                ;{' '}
+                <Link href="https://golf.com/instruction/biggest-swing-mistake-amateurs-make/">
+                  Golf.com on GolfTEC swing data
+                </Link>
+                .
+              </Text>
+            ),
+          },
+          {
+            name: 'Putting — pace over read from range',
+            note: (
+              <Text>
+                Mark Broadie, <Em>Every Shot Counts</Em> (2014);{' '}
+                <Link href="https://www.pga.info/discover/latest/news/why-setting-realistic-expectations-lag-putting-key-shooting-lower-scores/">
+                  PGA · lag-putting expectations
+                </Link>
+                .
+              </Text>
+            ),
+          },
+          {
+            name: 'Pressure — why a range swing breaks on the card',
+            note: (
+              <Text>
+                <Link href="https://www.peaksports.com/sports-psychology-blog/choking-under-pressure-in-golf/">
+                  Peak Performance Sport Psychology (Dr. Patrick Cohn)
+                </Link>{' '}
+                and{' '}
+                <Link href="https://www.trine.edu/academics/centers/center-for-sports-studies/blog/2022/choking_in_sports.aspx">
+                  Trine University · choking in sport
+                </Link>{' '}
+                — under pressure the automatic motion is disrupted, the hands
+                tighten and tempo goes; the reset is feel and rhythm, not
+                mechanics.
+              </Text>
+            ),
+          },
+        ]}
+      />
+
+      <ArticleFooter>
+        Last reviewed May 2026 · Draft, needs instructor review
+      </ArticleFooter>
+    </View>
+  )
+}
+
+// Worked example: a real-world miss, what it tells you, and where to focus.
+// Local one-off (single article) — accent-bordered card, palette C.
+function Example({
+  flight,
+  read,
+  focus,
+}: {
+  flight: string
+  read: string
+  focus: string
+}) {
+  return (
+    <View
+      style={{
+        backgroundColor: C.boxBg,
+        borderLeftWidth: 3,
+        borderLeftColor: C.accent,
+        padding: 14,
+        marginBottom: 14,
+        borderRadius: 2,
+      }}
+    >
+      <Text
+        style={{
+          color: C.ink,
+          fontSize: 16,
+          fontStyle: 'italic',
+          marginBottom: 8,
+        }}
+      >
+        “{flight}”
+      </Text>
+      <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 22, marginBottom: 8 }}>
+        <Strong>What it reads as:</Strong> {read}
+      </Text>
+      <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>
+        <Strong>Where to focus:</Strong> {focus}
+      </Text>
+    </View>
+  )
+}
+
+// A compact top-down flowchart of the four questions, so a reader can scan the
+// decision path even if they skip the prose that expands each one below. Short
+// labels only here — the detail lives in the prose, not duplicated in the chart.
+// Local one-off (single article) — RN View/Text + palette C.
+function DiagnosticFlow() {
+  return (
+    <View style={{ marginTop: 4, marginBottom: 22 }}>
+      <FlowQ n="01" q="What is your miss?" />
+      <Arrow />
+      <FlowRow>
+        <Chip label="Direction" sub="face & path" hint="push · pull · slice · hook" />
+        <Chip label="Contact" sub="low point" hint="fat · thin · toe · heel" />
+      </FlowRow>
+      <Arrow />
+      <FlowQ n="02" q="Same shape every time?" />
+      <Arrow />
+      <FlowRow>
+        <Chip accent label="Consistent" sub="a fixable pattern" />
+        <Chip label="Random" sub="check fundamentals" />
+      </FlowRow>
+      <Arrow />
+      <FlowQ n="03" q="Only under pressure?" />
+      <Arrow />
+      <FlowRow>
+        <Chip label="Yes" sub="tempo, not technique" />
+      </FlowRow>
+      <Arrow />
+      <FlowQ n="04" q="One club, or all of them?" />
+      <Arrow />
+      <FlowRow>
+        <Chip label="One club" sub="that club's setup" />
+        <Chip label="All clubs" sub="something systemic" />
+      </FlowRow>
+    </View>
+  )
+}
+
+function FlowQ({ n, q }: { n: string; q: string }) {
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'baseline',
+          gap: 10,
+          borderWidth: 1,
+          borderColor: '#9F9580',
+          borderRadius: 2,
+          backgroundColor: C.surface,
+          paddingVertical: 10,
+          paddingHorizontal: 16,
+        }}
+      >
+        <Text style={{ fontSize: 10, letterSpacing: 1.4, color: C.mute }}>{n}</Text>
+        <Text style={{ color: C.ink, fontSize: 17, fontStyle: 'italic' }}>{q}</Text>
+      </View>
+    </View>
+  )
+}
+
+// Vertical connector with a chevron — the visual "flow" between steps.
+function Arrow() {
+  return (
+    <View style={{ alignItems: 'center', marginVertical: 7 }}>
+      <View style={{ width: 2, height: 12, backgroundColor: '#9F9580' }} />
+      <Svg width={11} height={7} viewBox="0 0 11 7">
+        <Path d="M1 1 L5.5 6 L10 1" fill="none" stroke="#9F9580" strokeWidth={1.5} />
+      </Svg>
+    </View>
+  )
+}
+
+function FlowRow({ children }: { children: ReactNode }) {
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        gap: 10,
+        justifyContent: 'center',
+        flexWrap: 'wrap',
+      }}
+    >
+      {children}
+    </View>
+  )
+}
+
+// One branch of a question. The accent variant is a filled green chip used once,
+// on the "Consistent" answer — the outcome the reader is hoping for.
+function Chip({
+  label,
+  sub,
+  hint,
+  accent,
+}: {
+  label: string
+  sub: string
+  hint?: string
+  accent?: boolean
+}) {
+  return (
+    <View
+      style={{
+        flex: 1,
+        minWidth: 140,
+        maxWidth: 210,
+        borderWidth: 1,
+        borderColor: accent ? C.accent : C.line,
+        backgroundColor: accent ? C.accent : C.boxBg,
+        borderRadius: 2,
+        paddingVertical: 9,
+        paddingHorizontal: 12,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: 10,
+          letterSpacing: 1.4,
+          textTransform: 'uppercase',
+          color: accent ? '#F2EEE5' : C.inkDim,
+          marginBottom: 3,
+        }}
+      >
+        {label}
+      </Text>
+      <Text
+        style={{
+          fontSize: 14,
+          fontStyle: 'italic',
+          color: accent ? '#F2EEE5' : C.ink,
+        }}
+      >
+        {sub}
+      </Text>
+      {hint ? (
+        <Text
+          style={{
+            fontSize: 11,
+            color: accent ? 'rgba(242,238,229,0.72)' : C.mute,
+            marginTop: 3,
+          }}
+        >
+          {hint}
+        </Text>
+      ) : null}
+    </View>
+  )
+}

--- a/apps/mobile/components/learn/articles/SwingVariations.tsx
+++ b/apps/mobile/components/learn/articles/SwingVariations.tsx
@@ -1,0 +1,649 @@
+import { Text, View } from 'react-native'
+import Svg, { Circle, Line, Text as SvgText } from 'react-native-svg'
+import {
+  ArticleHeader,
+  ArticleFooter,
+  BulletList,
+  Callout,
+  Em,
+  Figure,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+  Strong,
+  KICKER,
+  C,
+} from '../primitives'
+
+export function SwingVariationsArticle() {
+  return (
+    <View>
+      <ArticleHeader
+        kicker="Improving your game · Draft"
+        title="Swing your swing."
+      />
+
+      <P>
+        Almost all golf instruction quietly assumes one student: a flexible,
+        able-bodied, average-height, right-handed player with a full, painless
+        turn. If that's not you — and for most golfers it isn't — a tip built for
+        that body can be useless or worse. The evidence for this is sitting in the
+        Hall of Fame, where some of the best players who ever lived swung in ways
+        a textbook would red-pen. There is no single correct golf swing. There is,
+        however, an <Em>easier</Em> swing for your body — one that's more
+        repeatable and less likely to hurt you — and a well-trained coach is the
+        fastest way to find it.
+      </P>
+
+      <Hr />
+
+      <H3>Before you take advice from anyone</H3>
+      <P>
+        Generic tips are optimized for the average golfer. Before you take one
+        from a video or an article, run it through a few honest questions:
+      </P>
+      <Checklist
+        items={[
+          'Am I as flexible as this instructor assumes?',
+          'Do I have an injury or limitation that affects how far I can rotate?',
+          'Is this person built like me — similar height, age, mobility?',
+          'Is this tip aimed at my actual miss, or is it generic?',
+          'Is it written for my handedness?',
+          'What is it quietly assuming about my swing that may not be true of mine?',
+        ]}
+      />
+      <P>
+        None of this means ignore instruction. It means apply it critically — a
+        tip that transformed someone built nothing like you is a hypothesis for
+        your swing, not a prescription.
+      </P>
+
+      <Hr />
+
+      <H3>The proof: great swings that broke the rules</H3>
+      <P>
+        If there were one correct swing, the best players in the world would all
+        own it. They emphatically don't. A short, non-exhaustive list of
+        "incorrect" swings that won at the highest level:
+      </P>
+      <HallOfFame />
+      <P>
+        The pattern isn't that technique doesn't matter — it matters enormously.
+        It's that each of these players found a motion that was repeatable for{' '}
+        <Em>their</Em> body and then owned it, instead of grinding toward a
+        position someone else's body was built for.
+      </P>
+
+      <Hr />
+
+      <H3>Every striking sport finds the same thing</H3>
+      <P>
+        Golf isn't special here. Sports science has spent decades studying how
+        athletes swing implements and throw objects — baseball pitches and swings,
+        the tennis serve, the javelin and hammer, cricket, hockey — and two
+        findings keep surfacing that map straight onto the golf swing.
+      </P>
+      <P>
+        The first: there is no single optimal movement. The motor-control pioneer
+        Nikolai Bernstein described skilled action as{' '}
+        <Em>"repetition without repetition"</Em> — even an expert never repeats a
+        motion exactly, and, counterintuitively, experts vary <Em>more</Em> than
+        beginners, because many different movement solutions reach the same
+        result. Studies of elite throwers land in the same place, calling for
+        individualized technical profiling rather than one template for everyone.
+      </P>
+      <P>
+        The second: what good technique shares isn't a position, it's a sequence.
+        Across pitching, the tennis serve, the javelin and the rest, power comes
+        from a kinetic chain that fires from the ground up — legs and trunk first,
+        then out to the fast, distal end: the hand, the racquet head, the
+        clubface. The shape of the motion varies from athlete to athlete; the
+        order doesn't. It's why a shorter, well-sequenced backswing so often beats
+        a long one that loses its timing — the same thing a pitching coach drills.
+      </P>
+      <P>
+        Together they're just "swing your swing" in lab form: build a motion your
+        body can sequence and repeat, rather than chasing a specific position
+        borrowed from a body unlike yours. The Hall of Fame and the biomechanics
+        literature agree.
+      </P>
+
+      <Hr />
+
+      <H3>Your body shapes your swing</H3>
+      <P>
+        Height, build, mobility, and handedness all change what a sound setup and
+        swing look like for you. These are tendencies, not rules — but they're a
+        better starting point than a one-size template.
+      </P>
+      <BodyTypeTable />
+      <P>
+        Notice how much of this is about equipment as well as motion. A swing and
+        the clubs that swing it are one system; fitting one to your body without
+        the other leaves performance on the table.
+      </P>
+
+      <Hr />
+
+      <H3>Schools of thought</H3>
+      <P>
+        "Swing plane" — roughly, how upright or flat the club travels — is where
+        much of the genuine expert disagreement lives. These are perspectives with
+        serious adherents, not a ranking. Most of the debate runs along a line
+        from steep and upright to flat and rotary, with single-plane methods at
+        one end.
+      </P>
+      <PlaneSpectrum />
+      <BulletList
+        items={[
+          <Text>
+            <Strong>The modern tour swing.</Strong> Big separation between the
+            shoulders and hips at the top — what Jim McLean popularized in 1992 as
+            the <Em>X-Factor</Em> — plus heavy use of the ground for speed. It's
+            what most online instruction assumes, and it produces enormous power.
+            It also asks for real flexibility, and its importance is genuinely
+            disputed: a number of teachers argue that chasing maximum X-Factor adds
+            lower-back stress for modest gain. Powerful, but not free, and not for
+            every body.
+          </Text>,
+          <Text>
+            <Strong>The classic flatter plane (Hogan).</Strong> Ben Hogan's{' '}
+            <Em>Five Lessons</Em> and its famous "pane of glass" image describe a
+            flatter, on-plane move that's still hugely influential. Tellingly, even
+            Hogan's plane isn't universal: as instructors have long noted, shorter
+            players tend to work above that pane and taller players below it — proof
+            that the most famous swing model in print still has to bend to the body
+            using it.
+          </Text>,
+          <Text>
+            <Strong>The single-plane swing (Moe Norman / Graves).</Strong> Club,
+            arms, and body set on essentially one plane at address and impact,
+            stripping out moving parts. Moe Norman — whom Sam Snead and others
+            called the greatest ball-striker who ever lived — built it intuitively;
+            Todd Graves, taught directly by Norman, now teaches it through the
+            Graves Golf Academy. Fewer moving parts and low spinal stress make it
+            worth a look for players who fight conventional complexity or have back
+            limitations.
+          </Text>,
+          <Text>
+            <Strong>Stack and Tilt.</Strong> Created by instructors Mike Bennett and
+            Andy Plummer, it keeps the weight forward over the lead side throughout
+            the swing to kill lateral sway. Controversial, but with real tour
+            adherents over the years (Aaron Baddeley and Mike Weir among them), and
+            potentially friendlier to limited hip mobility.
+          </Text>,
+          <Text>
+            <Strong>Rotary, body-driven methods.</Strong> A family of approaches
+            that lead with body rotation over hand and arm manipulation, on the
+            argument that fewer timing-dependent parts make the swing more
+            repeatable and easier on the body.
+          </Text>,
+        ]}
+      />
+
+      <P>
+        Other respected methods aren't really about plane at all — they're about
+        making the motion simpler, more repeatable, or kinder to the body, which
+        is the same goal reached through a different door.
+      </P>
+      <BulletList
+        items={[
+          <Text>
+            <Strong>Peak Performance (Don Trahan).</Strong> A short, vertical,
+            limited-turn backswing — "a little turn, a lot of lift" — that Trahan
+            built with orthopedic input to be easy on the back and friendly to
+            players who've lost flexibility, while arguing it gives up little or no
+            clubhead speed.
+          </Text>,
+          <Text>
+            <Strong>The A Swing (David Leadbetter).</Strong> An "alternative" that
+            rebuilds the backswing to be simpler and more repeatable, so the
+            downswing becomes mostly a reaction — aimed squarely at golfers who
+            can't groove the conventional move.
+          </Text>,
+          <Text>
+            <Strong>Swing the clubhead (Manuel de la Torre).</Strong> A feel-first
+            school in the Ernest Jones tradition: focus on swinging the club itself
+            rather than choreographing body positions, trusting the body to follow a
+            correct clubhead motion. De la Torre was the PGA's first National
+            Teacher of the Year, in 1986.
+          </Text>,
+        ]}
+      />
+
+      <P>
+        The honest takeaway is not "pick the right one." It's that a method which
+        transforms one golfer can fight another's body outright — so the question
+        is never "which swing is correct," but "which of these fits the body I
+        actually have."
+      </P>
+
+      <Hr />
+
+      <H3>Physical conditions and adaptations</H3>
+      <Callout>
+        <Text style={{ color: C.ink, fontSize: 14, lineHeight: 22 }}>
+          <Strong>This is general information, not medical advice.</Strong> If you
+          have any of the conditions below, get cleared by a medical professional
+          and work with a TPI-certified instructor <Em>before</Em> changing your
+          swing or starting intensive practice. The notes here are starting points
+          for that conversation, not prescriptions.
+        </Text>
+      </Callout>
+      <BulletList
+        items={[
+          <Text>
+            <Strong>Scoliosis.</Strong> Spinal curvature can make a high-torque
+            rotational swing a poor fit; a flatter, more arms-based or single-plane
+            motion may put less stress on the spine. This is exactly the case for a
+            physical screening before any intensive change.
+          </Text>,
+          <Text>
+            <Strong>Hip replacement or hip limitations.</Strong> Weight shift and
+            hip clearance are affected. Methods that reduce lateral movement (such
+            as single-plane or weight-forward styles) and a wider, more stable
+            stance can lower the demand on the hip.
+          </Text>,
+          <Text>
+            <Strong>Shoulder injury or limited shoulder mobility.</Strong> Backswing
+            length and follow-through are the first things to give. A shorter, more
+            controlled backswing that prioritizes solid contact usually beats
+            forcing a full turn you don't have.
+          </Text>,
+          <Text>
+            <Strong>Back injury or fused vertebrae.</Strong> When rotation is
+            restricted or gone, arms-dominant, minimal-rotation swings are the
+            adaptation, and Moe Norman's low-stress single-plane motion is worth
+            studying. Medical clearance first, always.
+          </Text>,
+          <Text>
+            <Strong>One-arm and adaptive golfers.</Strong> Competitive one-arm and
+            adaptive players exist and thrive. The mechanics are genuinely different,
+            not a tweak of the standard swing, and specialized adaptive instruction
+            exists to teach them.
+          </Text>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>How a good coach finds your swing</H3>
+      <P>
+        This is where a well-trained teacher earns their fee. The Titleist
+        Performance Institute (TPI) has done the most rigorous work on what it
+        calls the <Em>body-swing connection</Em> — mapping specific physical
+        limitations to the swing characteristics they tend to produce. A TPI
+        screening identifies what your body can and can't do <Em>before</Em> you
+        try to change anything, which is often more valuable than any single swing
+        tip.
+      </P>
+      <P>
+        That's the practical core of "swing your swing." A good coach assesses
+        your body first and prescribes to it; a good fitter measures your impact
+        and ball flight rather than textbook numbers; and the right equipment is
+        built to fit the swing your body actually makes. As the companion guides on
+        lessons and on the questions to ask your coach put it — the teacher worth
+        hiring is the one who looks at you before they look at a model.
+      </P>
+
+      <Hr />
+
+      <H3>The bottom line</H3>
+      <P>
+        "Swing your swing" isn't lazy advice. It's the most sophisticated advice
+        in golf. There is no one correct swing — the Hall of Fame settles that —
+        but there is a swing that's easier, more repeatable, and safer for your
+        particular body. Find your constraints honestly, build a motion that works
+        within them, fit your equipment to that motion, and work with a coach who
+        starts from your body and not a textbook. That, not copying a position
+        built for someone else, is the actual path to better golf.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'The body-swing connection',
+            note: (
+              <Text>
+                <Link href="https://www.mytpi.com/certification/about">
+                  Titleist Performance Institute · About Certification
+                </Link>{' '}
+                and{' '}
+                <Link href="https://mytpi.com/articles/fitness/x-factor_essentials_what_it_is_and_how_to_train_it">
+                  TPI · X-Factor essentials
+                </Link>{' '}
+                — screening the body first, and mapping physical limits to swing
+                characteristics.
+              </Text>
+            ),
+          },
+          {
+            name: 'What other striking and throwing sports show',
+            note: (
+              <Text>
+                <Link href="https://pmc.ncbi.nlm.nih.gov/articles/PMC7438768/">
+                  Bernstein's "repetition without repetition" (motor-control review)
+                </Link>{' '}
+                — skilled movement is variable, with many solutions to one task;{' '}
+                <Link href="https://pmc.ncbi.nlm.nih.gov/articles/PMC3445080/">
+                  the kinetic chain in overhand pitching
+                </Link>{' '}
+                and{' '}
+                <Link href="https://www.sciencedirect.com/science/article/pii/S002192902300235X">
+                  fifty years of performance-related sports biomechanics
+                </Link>{' '}
+                — power runs proximal-to-distal across throwing and striking sports,
+                and elite technique calls for individual profiling, not one template.
+              </Text>
+            ),
+          },
+          {
+            name: 'The modern swing and the X-Factor — and the dispute',
+            note: (
+              <Text>
+                <Link href="https://www.golfdigest.com/story/jim-mcleans-new-x-factor">
+                  Golf Digest · Jim McLean on the X-Factor
+                </Link>{' '}
+                (popularized 1992) and a critical view in{' '}
+                <Link href="https://www.perfectgolfswingreview.net/xfactor.htm">
+                  a review of the X-Factor evidence
+                </Link>{' '}
+                — power gains are real but contested, and high separation can add
+                lower-back stress.
+              </Text>
+            ),
+          },
+          {
+            name: 'The modern swing and lower-back load',
+            note: (
+              <Text>
+                <Link href="https://thejns.org/spine/view/journals/j-neurosurg-spine/31/6/article-p914.xml">
+                  Journal of Neurosurgery: Spine (2019) · lumbar degeneration in
+                  modern-era golfers
+                </Link>{' '}
+                links the repetitive modern swing to early disc wear, while a{' '}
+                <Link href="https://www.tandfonline.com/doi/full/10.1080/02640414.2024.2319443">
+                  2024 systematic review (Journal of Sports Sciences)
+                </Link>{' '}
+                cautions that the biomechanics-to-back-pain evidence is still limited
+                and conflicting — a real concern, not settled science.
+              </Text>
+            ),
+          },
+          {
+            name: 'The classic flatter plane (Hogan)',
+            note: (
+              <Text>
+                <Link href="https://www.usgtf.com/hogans-five-lessons-in-our-modern-game/">
+                  USGTF · Hogan's Five Lessons in the modern game
+                </Link>{' '}
+                and{' '}
+                <Link href="https://mygolfspy.com/news-opinion/ben-hogans-swing/">
+                  MyGolfSpy · Ben Hogan's swing
+                </Link>{' '}
+                — the "pane of glass" plane, and why it doesn't fit every height.
+              </Text>
+            ),
+          },
+          {
+            name: 'The single-plane swing (Moe Norman / Graves)',
+            note: (
+              <Text>
+                <Link href="https://gravesgolf.com/about-moe-norman/">
+                  Graves Golf · About Moe Norman
+                </Link>{' '}
+                and{' '}
+                <Link href="https://moenorman.org/">Todd Graves · Moe Norman</Link> — the
+                single-plane method, and the ball-striking reputation behind it.
+              </Text>
+            ),
+          },
+          {
+            name: 'Stack and Tilt',
+            note: (
+              <Text>
+                <Link href="https://en.wikipedia.org/wiki/Mike_Bennett_and_Andy_Plummer">
+                  Bennett & Plummer (Stack and Tilt)
+                </Link>{' '}
+                — weight-forward method and its tour adherents.
+              </Text>
+            ),
+          },
+          {
+            name: 'Simpler and body-friendly methods',
+            note: (
+              <Text>
+                <Link href="https://www.swingsurgeon.com/learn-the-swing">
+                  Don Trahan · Peak Performance Golf Swing
+                </Link>{' '}
+                (vertical, limited-turn, body-friendly),{' '}
+                <Link href="https://www.golfdigest.com/story/david-leadbetter-a-swing-starter-kit">
+                  David Leadbetter · the A Swing
+                </Link>{' '}
+                (a simpler, repeatable backswing), and{' '}
+                <Link href="https://www.wisconsin.golf/19th_hole/gary_d_amato/manuel-de-la-torres-former-students-committed-to-keeping-alive-his-simple-concepts-of-the/article_58cb7714-9baa-11ea-b99c-c79f89a574d7.html">
+                  Manuel de la Torre
+                </Link>{' '}
+                (Ernest Jones's "swing the clubhead," 1986 PGA Teacher of the Year).
+              </Text>
+            ),
+          },
+          {
+            name: 'Fitting clubs to your body',
+            note: (
+              <Text>
+                <Link href="https://pluggedingolf.com/much-lie-angle-matter-golf-myths-unplugged/">
+                  Plugged In Golf · lie-angle testing
+                </Link>{' '}
+                (a correct lie tightens left-right dispersion) and{' '}
+                <Link href="https://www.pga.info/discover/latest/news/pings-ultimate-guide-better-custom-fitting/">
+                  PING's custom-fitting guide
+                </Link>{' '}
+                — most golfers don't fit the standard off-the-rack build.
+              </Text>
+            ),
+          },
+          {
+            name: 'Great "incorrect" swings',
+            note: (
+              <Text>
+                <Link href="https://en.wikipedia.org/wiki/Jim_Furyk">Jim Furyk</Link>{' '}
+                (2003 U.S. Open;{' '}
+                <Link href="https://en.wikipedia.org/wiki/Jim_Furyk's_round_of_58">
+                  the 58
+                </Link>
+                ),{' '}
+                <Link href="https://en.wikipedia.org/wiki/Lee_Trevino">Lee Trevino</Link>{' '}
+                (six majors, self-taught fade),{' '}
+                <Link href="https://en.wikipedia.org/wiki/Nancy_Lopez">Nancy Lopez</Link>{' '}
+                (48 LPGA wins),{' '}
+                <Link href="https://en.wikipedia.org/wiki/John_Daly_(golfer)">
+                  John Daly
+                </Link>{' '}
+                (two majors), and{' '}
+                <Link href="https://en.wikipedia.org/wiki/Gary_Player">Gary Player</Link>{' '}
+                (nine majors, competitive into his 70s).
+              </Text>
+            ),
+          },
+        ]}
+      />
+
+      <ArticleFooter>
+        Last reviewed May 2026 · Draft, needs line-by-line accuracy review
+      </ArticleFooter>
+    </View>
+  )
+}
+
+// The self-awareness questions to run before taking a generic tip. A tinted
+// card with a "?"-glyph before each item, mirroring the web Checklist.
+function Checklist({ items }: { items: string[] }) {
+  return (
+    <View
+      style={{
+        backgroundColor: C.boxBg,
+        borderWidth: 1,
+        borderColor: C.line,
+        borderRadius: 2,
+        paddingVertical: 14,
+        paddingHorizontal: 18,
+        marginBottom: 18,
+      }}
+    >
+      <Text style={{ ...KICKER, color: C.inkDim, marginBottom: 12 }}>
+        Run this before you copy a tip
+      </Text>
+      {items.map((item) => (
+        <View key={item} style={{ flexDirection: 'row', gap: 8, marginBottom: 9 }}>
+          <Text style={{ color: C.accent, fontSize: 14, lineHeight: 21 }}>?</Text>
+          <Text style={{ color: C.ink, fontSize: 14, lineHeight: 21, flex: 1 }}>
+            {item}
+          </Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+// Cards: unconventional swings that won at the top. Single-column stack on
+// mobile (web uses an auto-fit grid).
+function HallOfFame() {
+  const players: { name: string; quirk: string; result: string }[] = [
+    {
+      name: 'Jim Furyk',
+      quirk: 'A double-loop swing no coach would teach from scratch.',
+      result: 'Won the 2003 U.S. Open; shot 58, the lowest round in PGA Tour history.',
+    },
+    {
+      name: 'Lee Trevino',
+      quirk: 'Open stance, a deliberate fade, self-taught — told for years to change it.',
+      result: 'Six major championships. Hall of Fame.',
+    },
+    {
+      name: 'Nancy Lopez',
+      quirk: 'A pronounced "flying" right elbow every textbook warns against.',
+      result: '48 LPGA Tour wins and a Hall of Fame career.',
+    },
+    {
+      name: 'Moe Norman',
+      quirk: 'A single-plane swing dismissed for decades as eccentric.',
+      result: 'Sam Snead and others called him the greatest ball-striker who ever lived.',
+    },
+    {
+      name: 'John Daly',
+      quirk: '"Grip it and rip it" — a backswing well past parallel.',
+      result: 'Two major championships: the 1991 PGA and the 1995 Open.',
+    },
+    {
+      name: 'Gary Player',
+      quirk: 'Smaller stature; a swing he kept reshaping as he aged.',
+      result: 'Nine majors, and competitive into his 70s.',
+    },
+  ]
+  return (
+    <View style={{ gap: 12, marginBottom: 16 }}>
+      {players.map((p) => (
+        <View
+          key={p.name}
+          style={{
+            borderWidth: 1,
+            borderColor: C.line,
+            backgroundColor: C.boxBg,
+            borderRadius: 2,
+            paddingVertical: 12,
+            paddingHorizontal: 14,
+          }}
+        >
+          <Text
+            style={{ color: C.ink, fontSize: 16, fontStyle: 'italic', marginBottom: 6 }}
+          >
+            {p.name}
+          </Text>
+          <Text style={{ color: C.inkDim, fontSize: 13, lineHeight: 20, marginBottom: 6 }}>
+            {p.quirk}
+          </Text>
+          <Text style={{ color: C.accent, fontSize: 13, lineHeight: 20, fontWeight: '500' }}>
+            {p.result}
+          </Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+// Body type → swing/equipment tendency. Tendencies, not rules. Stacked
+// single-column rows on mobile (web uses a 2-col flex row).
+function BodyTypeTable() {
+  const rows: { type: string; note: string }[] = [
+    {
+      type: 'Taller (6′2″+)',
+      note: 'Tend to stand more upright, with a flatter natural plane. Usually need longer clubs and flatter lie angles — off-the-rack clubs are built to a standard, not to you.',
+    },
+    {
+      type: 'Shorter',
+      note: 'Stand closer to the ball with a more upright shaft angle; an upright plane is natural and correct here. Shorter clubs and more upright lie angles often fit better.',
+    },
+    {
+      type: 'Limited flexibility / older',
+      note: 'A restricted turn changes everything. A shorter backswing with good sequencing beats a long one that collapses; force the “modern” power move and you risk injury. Gary Player’s swing evolved with his body for a reason.',
+    },
+    {
+      type: 'Heavier build',
+      note: 'A restricted hip turn is common, and compensating with more arm swing is adaptive, not wrong. Grip size and shaft flex fitting matter more, not less; standing a touch further from the ball can help.',
+    },
+    {
+      type: 'Left-handed',
+      note: 'Most instruction is written for righties — mirror the cues. Left-handed equipment is more limited, so custom fitting matters even more.',
+    },
+  ]
+  return (
+    <View style={{ marginBottom: 16, borderTopWidth: 1, borderTopColor: C.line }}>
+      {rows.map((r) => (
+        <View
+          key={r.type}
+          style={{ paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: C.line }}
+        >
+          <Text
+            style={{ color: C.ink, fontSize: 15, fontStyle: 'italic', marginBottom: 4 }}
+          >
+            {r.type}
+          </Text>
+          <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 21 }}>{r.note}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+// Editorial line-art: the shaft plane from upright to flat, with single-plane
+// shown as arms-and-shaft aligned. Same viewBox + coordinate data as the web
+// inline svg, re-authored in react-native-svg. Single plane in accent.
+function PlaneSpectrum() {
+  return (
+    <Figure caption='Roughly how the club travels — steep and upright through flat and rotary to a single plane. None is "correct"; each fits a different body.'>
+      <Svg width="100%" height={120} viewBox="0 0 240 120">
+        {/* ground + ball, shared origin at lower right */}
+        <Line x1={20} y1={100} x2={220} y2={100} stroke={C.mute} strokeWidth={1.5} />
+        <Circle cx={190} cy={100} r={3} fill={C.ink} />
+        {/* upright (steep) plane */}
+        <Line x1={190} y1={100} x2={150} y2={14} stroke={C.mute} strokeWidth={2} />
+        {/* flat (Hogan) plane */}
+        <Line x1={190} y1={100} x2={78} y2={36} stroke={C.mute} strokeWidth={2} />
+        {/* single plane (accent) */}
+        <Line x1={190} y1={100} x2={40} y2={64} stroke={C.accent} strokeWidth={2.5} />
+        <SvgText x={138} y={12} fontSize={7} fontFamily="monospace" letterSpacing={0.5} fill={C.mute}>
+          UPRIGHT
+        </SvgText>
+        <SvgText x={62} y={32} fontSize={7} fontFamily="monospace" letterSpacing={0.5} fill={C.mute}>
+          FLAT
+        </SvgText>
+        <SvgText x={20} y={60} fontSize={7} fontFamily="monospace" letterSpacing={0.5} fill={C.accent}>
+          SINGLE PLANE
+        </SvgText>
+      </Svg>
+    </Figure>
+  )
+}

--- a/apps/mobile/components/learn/articles/TrainingAids.tsx
+++ b/apps/mobile/components/learn/articles/TrainingAids.tsx
@@ -1,0 +1,535 @@
+import type { ReactNode } from 'react'
+import { Text, View } from 'react-native'
+import Svg, { Circle, Line, Rect } from 'react-native-svg'
+import {
+  ArticleHeader,
+  ArticleFooter,
+  BulletList,
+  DefRow,
+  Figure,
+  GlanceBox,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+  Subhead,
+  Strong,
+  Tag,
+  C,
+} from '../primitives'
+
+export function TrainingAidsArticle() {
+  return (
+    <View>
+      <ArticleHeader kicker="Your equipment · Draft" title="Training aids." />
+
+      <H3>Feeling productive isn't the same as getting better</H3>
+      <P>
+        The training-aid aisle sells a feeling: that buying the device is the
+        same as building the skill. Most of it isn't. A few aids genuinely teach
+        — they show you something you can't see on your own and let you fix it.
+        The rest just make practice feel like work without changing what your
+        ball does on Saturday.
+      </P>
+      <P>
+        This isn't a list of brands to buy. It's the categories — what problem
+        each kind of aid solves, how it works, who actually needs it, and when
+        in your development it earns a place in the bag. Before any of that, one
+        test sorts the coaches from the crutches.
+      </P>
+
+      <GlanceBox label="The test for any aid">
+        <DefRow term={'“Does it show me something I can’t see myself?”'} first>
+          If you can already feel it, you don’t need a device to tell you.
+        </DefRow>
+        <DefRow term={'“Can I trust the feedback on every rep?”'}>
+          A gate that lies or a number that bounces around trains nothing.
+        </DefRow>
+        <DefRow term={'“Does the skill survive when I put it down?”'}>
+          An aid you can’t wean off is a crutch, not a coach.
+        </DefRow>
+      </GlanceBox>
+
+      <Hr />
+
+      <H3>The seven kinds, and what each one trains</H3>
+      <P>
+        Six aids you can rehearse with, then the one that measures — the launch
+        monitor — which gets its own section because the numbers need
+        explaining.
+      </P>
+
+      <Aid
+        name="Alignment aids"
+        trains="Where you're actually aimed"
+        svg={<AlignmentDiagram />}
+        caption="Railroad tracks: body parallel-left, clubface on the target line."
+      >
+        <AidBody>
+          Standing beside the ball, your eyes lie. Most golfers aim well off the
+          target without feeling it, then build a compensation into the swing to
+          pull the ball back — baking in a fault to fix a setup error. Sticks on
+          the ground make the invisible error visible: one along your toes, one
+          on the ball-to-target line, body parallel-left like railroad tracks
+          while the clubface points at the target.
+        </AidBody>
+        <AidBody>
+          Everyone, from the first lesson on. Alignment is the cheapest
+          fundamental in the game and the one most quietly broken — even four
+          degrees off misses a 150-yard target by more than ten yards with a
+          perfect swing.
+        </AidBody>
+        <LookFor>
+          Two sticks, or two clubs from your bag. A laser adds precision you
+          don't need yet.
+        </LookFor>
+      </Aid>
+
+      <Aid
+        name="Putting aids"
+        trains="A square face and a repeating stroke"
+        svg={<PuttingGateDiagram />}
+        caption="Two tees form a gate the putt must roll through, on line to the hole."
+      >
+        <AidBody>
+          At putting distance the face angle decides almost everything about
+          where the ball starts — a couple of degrees open and you've missed —
+          and you can't watch your own eyes or face at address. A mirror shows
+          eye position and shoulder line; gates (two tees just wider than the
+          ball) force a square strike on an on-line start, or the ball clips a
+          tee; an arc trainer guides the stroke shape.
+        </AidBody>
+        <AidBody>
+          Anyone who three-putts or misses the short ones, which is nearly
+          everyone — putting is roughly 40% of the strokes in a round, and the
+          cheapest skill to train at home.
+        </AidBody>
+        <LookFor>
+          A mirror plus two tees covers it. Save the arc trainer for when you're
+          chasing a specific stroke shape.
+        </LookFor>
+      </Aid>
+
+      <Aid
+        name="Impact aids"
+        trains="What actually happens at the ball"
+        svg={<ImpactFaceDiagram />}
+        caption="Clubface grid; the accent dot is where you actually struck it."
+      >
+        <AidBody>
+          Impact lasts under half a thousandth of a second — you cannot feel
+          where on the face you caught it, yet strike location quietly drives
+          both distance and curve. Dry-erase or foot spray on the face leaves a
+          mark showing exactly where contact was: toe, heel, high, low. An impact
+          bag trains a hands-forward, flat-lead-wrist delivery with no ball to
+          chase.
+        </AidBody>
+        <AidBody>
+          The player who strikes it “fine sometimes” and loses distance for no
+          obvious reason. Off-center contact is usually the answer, and you can't
+          fix a pattern you can't see.
+        </AidBody>
+        <LookFor>
+          A can of spray costs a couple of dollars and is the highest-feedback
+          aid on this page.
+        </LookFor>
+      </Aid>
+
+      <Aid
+        name="Swing plane aids"
+        trains="The path the club travels"
+        svg={<SwingPlaneDiagram />}
+        caption="The inclined plane; the dashed line is an over-the-top, off-plane move."
+      >
+        <AidBody>
+          Swing plane is the tilted circle the club swings around your body. Get
+          steep or over the top of it and you fight strike and start direction
+          all day. It's hard to feel and easy to misjudge alone. A plane board or
+          an angled rod gives the club something to stay under or trace, so an
+          over-the-top move turns from a mystery into something obvious.
+        </AidBody>
+        <AidBody>
+          A player with one stubborn miss — a pull or a slice — once contact is
+          already repeatable. Not for a brand-new swing still hunting for the
+          center of the face; there's nothing stable yet to shape.
+        </AidBody>
+        <LookFor>
+          Simplicity. An alignment stick angled into the ground does most of
+          what an expensive plane board does.
+        </LookFor>
+      </Aid>
+
+      <Aid
+        name="Tempo aids"
+        trains="The rhythm that holds the swing together"
+        svg={<TempoDiagram />}
+        caption="The backswing runs roughly three times as long as the downswing."
+      >
+        <AidBody>
+          Tempo is the first thing to leave under pressure — a rushed transition
+          wrecks an otherwise sound swing. Tour players hold a remarkably steady
+          ratio, the backswing taking roughly three times as long as the
+          downswing, while amateurs often drift to four-to-one or worse and
+          snatch the club from the top. A metronome or a tones app trains that
+          three-to-one feel; a weighted club exaggerates the load so you stop
+          rushing.
+        </AidBody>
+        <AidBody>
+          The player whose range swing deserts them on the first tee. Tempo is a
+          finishing skill, not a beginner one — there has to be a swing before
+          there's a rhythm to smooth.
+        </AidBody>
+        <LookFor>
+          A free metronome app does the job. Don't swing a weighted club
+          full-speed cold.
+        </LookFor>
+      </Aid>
+
+      <Aid
+        name="Chipping & pitching aids"
+        trains="Landing spot and clean contact near the green"
+      >
+        <AidBody>
+          Short game is feel, and feel needs reps with feedback — but most
+          backyard chipping is aimless and trains nothing. A landing target — a
+          towel, a hoop, a small net — gives the one thing that actually matters
+          in a chip, where it lands, a clear bullseye, so you're rehearsing a
+          number instead of just making contact. Impact tape catches the thin and
+          fat patterns that wreck short shots.
+        </AidBody>
+        <AidBody>
+          Anyone leaking strokes inside 40 yards, which strokes-gained data says
+          is most amateurs.
+        </AidBody>
+        <LookFor>
+          A towel on the ground is a landing target. You don't need a branded
+          net.
+        </LookFor>
+      </Aid>
+
+      <Hr />
+
+      <H3>Launch monitors — the numbers, and which ones are yours</H3>
+      <P>
+        A launch monitor is the one aid that measures rather than guides. Point
+        it at your swing and it reports ball speed, club speed, launch angle,
+        spin, carry, total distance, and smash factor — and on better units, club
+        path and face angle. The trap is drowning in numbers that aren't yours to
+        worry about yet. Here is which is which.
+      </P>
+
+      <NumbersTable />
+
+      <Subhead>Free vs paid</Subhead>
+      <P>
+        Phone apps and sub-$500 units give reliable ball speed, club speed, and
+        carry with no subscription — and ball speed is the most stable reading
+        even on cheap hardware. Spin and launch get less precise as the price
+        drops; the $15,000-and-up commercial units (TrackMan, Foresight) earn
+        their cost in spin accuracy and indoor club data, which is why fitters
+        and tour players use them. For an amateur, a budget unit that nails carry
+        and smash factor measures everything you'd actually act on.
+      </P>
+
+      <Subhead>What to do with the data</Subhead>
+      <P>
+        Build a real yardage chart — most golfers overstate every club by a full
+        club, and the monitor settles it honestly. Watch your dispersion, not
+        your one longest carry. Use smash factor to tell a club problem from a
+        strike problem before you spend money on either. And leave alone the
+        numbers you can't change yet: chasing spin optimization before your
+        contact repeats is measuring mishits with a very expensive ruler.
+      </P>
+
+      <Hr />
+
+      <H3>What most golfers actually need</H3>
+      <P>
+        Set against the thesis, the honest shortlist is short and cheap. The aids
+        worth owning give you feedback you can't get on your own; the rest mostly
+        sell the feeling of practice.
+      </P>
+
+      <Subhead>Worth owning</Subhead>
+      <BulletList
+        items={[
+          <Text>
+            <Strong>Two alignment sticks</Strong> — or two clubs. Aim, ball
+            position, and a rough swing plane, all from one cheap pair.
+          </Text>,
+          <Text>
+            <Strong>A mirror</Strong> — putting setup and a square face, the
+            cheapest strokes to find at home.
+          </Text>,
+          <Text>
+            <Strong>Impact spray or tape</Strong> — the unvarnished truth about
+            where you strike it.
+          </Text>,
+          <Text>
+            <Strong>A landing towel</Strong> — turns aimless chipping into reps at
+            a real target.
+          </Text>,
+          <Text>
+            <Strong>A free metronome app</Strong> — tempo, for nothing.
+          </Text>,
+        ]}
+      />
+
+      <Subhead>Skip, or wait</Subhead>
+      <BulletList
+        items={[
+          <Text>
+            Anything promising speed or distance from swinging it through the air
+            alone.
+          </Text>,
+          <Text>
+            Single-purpose gadgets that just duplicate a three-dollar stick.
+          </Text>,
+          <Text>
+            A premium launch monitor before your carry and contact repeat — you'll
+            only be measuring mishits.
+          </Text>,
+          <Text>
+            Aids that work in the yard but never make it to the course, where the
+            skill has to show up.
+          </Text>,
+        ]}
+      />
+
+      <P>
+        The pattern holds across all of it: a real training aid shows you
+        something you can't see, then gets out of the way. If the skill vanishes
+        the moment you set the gadget down, it was a feeling — not a habit you
+        built.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'Why alignment is foundational',
+            note: (
+              <Text>
+                <Link href="https://www.pga.com/story/4-alignment-mistakes-killing-your-golf-game-and-how-to-fix-them">
+                  PGA of America · 4 alignment mistakes
+                </Link>{' '}
+                and{' '}
+                <Link href="https://golf.com/instruction/why-aim-alignment-poor-how-fix/">
+                  Golf.com · why your aim is poor
+                </Link>{' '}
+                — most golfers aim off the target without feeling it, and small
+                errors miss by yards over distance.
+              </Text>
+            ),
+          },
+          {
+            name: 'Face angle sets the start line',
+            note: (
+              <Text>
+                <Link href="https://www.trackman.com/blog/golf/what-is-face-angle">
+                  TrackMan · what is face angle
+                </Link>{' '}
+                and{' '}
+                <Link href="https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know">
+                  6 numbers every amateur should know
+                </Link>{' '}
+                — the clubface controls roughly 85% of where the ball starts, which
+                is why putting and impact aids train a square strike.
+              </Text>
+            ),
+          },
+          {
+            name: 'Tempo — the three-to-one ratio',
+            note: (
+              <Text>
+                <Link href="https://tourtempo.com/pages/tour-tempo-app">
+                  Tour Tempo
+                </Link>{' '}
+                on the 3:1 backswing-to-downswing finding, and{' '}
+                <Link href="https://www.pga.com/story/find-a-rhythm-and-tempo-that-fits-your-game">
+                  PGA of America · rhythm and tempo
+                </Link>{' '}
+                — tour players hold a steady ratio; amateurs often rush the
+                transition.
+              </Text>
+            ),
+          },
+          {
+            name: 'Launch monitors — which numbers, and what they cost',
+            note: (
+              <Text>
+                <Link href="https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman">
+                  TrackMan · the ultimate guide to the data
+                </Link>{' '}
+                and{' '}
+                <Link href="https://mygolfspy.com/buyers-guide/we-tested-12-launch-monitors-ranging-from-500-to-5000-whats-the-real-difference/">
+                  MyGolfSpy · $500 to $5,000 tested
+                </Link>{' '}
+                — ball speed and carry are reliable on budget units; spin and launch
+                precision are what the expensive ones buy.
+              </Text>
+            ),
+          },
+        ]}
+      />
+
+      <ArticleFooter>
+        Last reviewed May 2026 · Draft, needs coaching review
+      </ArticleFooter>
+    </View>
+  )
+}
+
+// ── local helpers (article-specific, co-located) ────────────────────────────
+
+// One aid category: an optional editorial diagram stacked above the prose.
+function Aid({
+  name,
+  trains,
+  svg,
+  caption,
+  children,
+}: {
+  name: string
+  trains: string
+  svg?: ReactNode
+  caption?: string
+  children: ReactNode
+}) {
+  return (
+    <View style={{ borderTopWidth: 1, borderTopColor: C.line, paddingTop: 14, marginBottom: 14 }}>
+      {svg ? <Figure caption={caption}>{svg}</Figure> : null}
+      <Text style={{ color: C.ink, fontSize: 18, fontStyle: 'italic', fontWeight: '500', marginBottom: 6 }}>
+        {name}
+      </Text>
+      <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 22, marginBottom: 8 }}>
+        <Tag>Trains</Tag> {trains}
+      </Text>
+      {children}
+    </View>
+  )
+}
+
+function AidBody({ children }: { children: ReactNode }) {
+  return (
+    <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 22, marginBottom: 8 }}>
+      {children}
+    </Text>
+  )
+}
+
+function LookFor({ children }: { children: ReactNode }) {
+  return (
+    <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>
+      <Tag>Look for</Tag> {children}
+    </Text>
+  )
+}
+
+// Which launch-monitor numbers are an amateur's, and which can wait.
+// Web's 2-col table → stacked term/description rows on phone.
+function NumbersTable() {
+  const rows: { num: string; who: string }[] = [
+    {
+      num: 'Carry distance',
+      who: 'Everyone. Your real number, not the one good swing — build your gapping from it.',
+    },
+    {
+      num: 'Smash factor',
+      who: 'Everyone. Ball speed over club speed: how flush you caught it. Separates a club problem from a strike problem.',
+    },
+    {
+      num: 'Dispersion',
+      who: 'Everyone. How tight your pattern is. Reward this over the occasional long bomb.',
+    },
+    {
+      num: 'Ball speed',
+      who: 'Everyone. The most reliable number on a budget unit, and the engine behind distance.',
+    },
+    {
+      num: 'Spin rate',
+      who: 'Better players and fittings. Dials in flight once contact repeats — and the least accurate reading on cheap units.',
+    },
+    {
+      num: 'Path & face angle',
+      who: 'Coaches and better players. Face angle alone sets about 85% of your start line — worth knowing, hard to change without help.',
+    },
+  ]
+  return (
+    <View style={{ marginBottom: 18 }}>
+      {rows.map((r, i) => (
+        <DefRow key={r.num} term={r.num} first={i === 0}>
+          {r.who}
+        </DefRow>
+      ))}
+    </View>
+  )
+}
+
+// ── editorial line-art diagrams (re-authored in react-native-svg) ────────────
+// Each keeps the web inline svg's viewBox "0 0 160 96" + exact coordinate /
+// path data. Palette via C; full-width to fit the phone Figure box.
+
+// Railroad tracks: body parallel-left, clubface on the target line.
+function AlignmentDiagram() {
+  return (
+    <Svg width="100%" height={96} viewBox="0 0 160 96">
+      <Line x1={36} y1={68} x2={140} y2={30} stroke="#9F9580" strokeWidth={1.5} />
+      <Line x1={26} y1={84} x2={130} y2={46} stroke="#9F9580" strokeWidth={1.5} />
+      <Circle cx={36} cy={68} r={4} fill={C.ink} />
+      <Circle cx={140} cy={30} r={5} fill="none" stroke={C.ink} strokeWidth={1.5} />
+      <Circle cx={140} cy={30} r={1.5} fill={C.ink} />
+    </Svg>
+  )
+}
+
+// Two tees form a gate the putt must roll through, on line to the hole.
+function PuttingGateDiagram() {
+  return (
+    <Svg width="100%" height={96} viewBox="0 0 160 96">
+      <Line x1={28} y1={50} x2={134} y2={50} stroke="#9F9580" strokeWidth={1.5} />
+      <Line x1={74} y1={36} x2={74} y2={44} stroke={C.ink} strokeWidth={1.5} />
+      <Line x1={74} y1={56} x2={74} y2={64} stroke={C.ink} strokeWidth={1.5} />
+      <Circle cx={28} cy={50} r={4} fill={C.ink} />
+      <Circle cx={144} cy={50} r={6} fill="none" stroke={C.ink} strokeWidth={1.5} />
+    </Svg>
+  )
+}
+
+// Clubface grid; the accent dot is where you actually struck it.
+function ImpactFaceDiagram() {
+  return (
+    <Svg width="100%" height={96} viewBox="0 0 160 96">
+      <Rect x={56} y={16} width={48} height={64} rx={3} fill={C.bg} stroke={C.ink} strokeWidth={1.5} />
+      <Line x1={72} y1={16} x2={72} y2={80} stroke={C.line} strokeWidth={1} />
+      <Line x1={88} y1={16} x2={88} y2={80} stroke={C.line} strokeWidth={1} />
+      <Line x1={56} y1={37} x2={104} y2={37} stroke={C.line} strokeWidth={1} />
+      <Line x1={56} y1={59} x2={104} y2={59} stroke={C.line} strokeWidth={1} />
+      <Circle cx={80} cy={48} r={4} fill="none" stroke="#9F9580" strokeWidth={1} />
+      <Circle cx={92} cy={34} r={3.5} fill={C.accent} />
+    </Svg>
+  )
+}
+
+// The inclined plane; the dashed line is an over-the-top, off-plane move.
+function SwingPlaneDiagram() {
+  return (
+    <Svg width="100%" height={96} viewBox="0 0 160 96">
+      <Line x1={18} y1={80} x2={144} y2={80} stroke={C.line} strokeWidth={1.5} />
+      <Line x1={42} y1={80} x2={138} y2={24} stroke="#9F9580" strokeWidth={1.5} />
+      <Line x1={42} y1={80} x2={96} y2={18} stroke="#9F9580" strokeWidth={1.5} strokeDasharray="3 3" />
+      <Line x1={42} y1={80} x2={80} y2={58} stroke={C.ink} strokeWidth={2.5} />
+      <Circle cx={42} cy={80} r={4} fill={C.ink} />
+    </Svg>
+  )
+}
+
+// The backswing runs roughly three times as long as the downswing.
+function TempoDiagram() {
+  return (
+    <Svg width="100%" height={96} viewBox="0 0 160 96">
+      <Rect x={20} y={32} width={120} height={14} rx={2} fill="#9F9580" />
+      <Rect x={20} y={56} width={40} height={14} rx={2} fill={C.ink} />
+    </Svg>
+  )
+}

--- a/apps/mobile/components/learn/articles/UnderstandingYourSwing.tsx
+++ b/apps/mobile/components/learn/articles/UnderstandingYourSwing.tsx
@@ -1,0 +1,207 @@
+import { Text, View } from 'react-native'
+import Svg, { Circle, Line, Path, Text as SvgText } from 'react-native-svg'
+import {
+  ArticleHeader,
+  ArticleFooter,
+  BulletList,
+  DefRow,
+  Em,
+  Figure,
+  GlanceBox,
+  H3,
+  Hr,
+  Link,
+  P,
+  Sources,
+  Strong,
+  C,
+} from '../primitives'
+
+export function UnderstandingYourSwingArticle() {
+  return (
+    <View>
+      <ArticleHeader
+        kicker="Improving your game · Draft"
+        title="The ball doesn't lie."
+      />
+
+      <P>
+        You don't need a coach behind you or a launch monitor in front of you to
+        know what your swing just did. Every shot leaves evidence — the line the
+        ball starts on, the way it curves, the divot in front of it, the mark on
+        the face — and that evidence is a readout of what the club was doing at
+        impact. Learn to read it and you can diagnose your own swing on any range
+        in the world. The companion <Em>self-diagnosis</Em> guide helps you find{' '}
+        <Em>which</Em> part of your game is leaking strokes; this one is about
+        reading <Em>what</Em> your swing is actually doing once you're there.
+      </P>
+
+      <Hr />
+
+      <H3>Start line and curve: the two-number readout</H3>
+      <P>
+        Modern launch-monitor data overturned what most of us were taught. Two
+        things at impact write the whole shot:
+      </P>
+      <GlanceBox label="What writes the shot">
+        <DefRow term="Face angle" first>
+          Where the ball starts. At impact the face sets roughly three-quarters
+          of the start line — more at slower speeds.
+        </DefRow>
+        <DefRow term="Face vs. path">
+          How the ball curves. The gap between where the face points and where
+          the club is travelling tilts the spin: open to the path curves away,
+          closed to it draws back.
+        </DefRow>
+      </GlanceBox>
+      <P>
+        So read every ball as two separate facts. <Strong>Where it starts</Strong>{' '}
+        is mostly your face. <Strong>How it curves</Strong> is the gap between
+        face and path. A shot that starts left and slices back right, for
+        instance, means the face was pointed left of the target but still open
+        relative to an even-more-leftward path — the classic out-to-in pull-slice.
+        The ball just told you both numbers; you only had to listen.
+      </P>
+
+      <Figure caption="The ball starts where the face points, then bends by the gap between face and path. Two facts, read off one shot.">
+        <BallFlightDiagram />
+      </Figure>
+
+      <Hr />
+
+      <H3>The divot tells you the rest</H3>
+      <P>
+        With an iron, the turf is a second instrument. On solid contact the divot
+        begins <Em>after</Em> the ball, not under it — proof you struck the ball
+        first and the low point of your arc was ahead of it. Beyond that, the
+        divot's shape and direction fill in the path your ball flight implied:
+      </P>
+      <BulletList
+        items={[
+          <Text>
+            <Strong>Direction.</Strong> A divot pointing left of target is the
+            fingerprint of an out-to-in (over-the-top) path; one pointing right
+            signals in-to-out. It should roughly agree with the curve you read off
+            the ball.
+          </Text>,
+          <Text>
+            <Strong>Depth and evenness.</Strong> A deep, gouged divot says your low
+            point is too far forward or your attack too steep; no divot at all
+            usually means you're bottoming out behind the ball. A divot deeper on
+            the toe or heel side points at how the club is delivered, not just where
+            it lands.
+          </Text>,
+          <Text>
+            <Strong>Where it starts.</Strong> A divot that begins well behind the
+            ball is the turf-side version of fat contact — the arc bottomed out
+            early.
+          </Text>,
+        ]}
+      />
+
+      <Hr />
+
+      <H3>The strike fills in the blanks</H3>
+      <P>
+        Where on the face you make contact is the cheapest data in golf to
+        collect: a dusting of foot spray, face tape, or even the wear pattern on a
+        dirty clubface shows it. Toward the toe or heel explains distance you
+        can't account for and a surprising amount of curve; high or low on the
+        face explains a shot that flew or ballooned for no obvious reason. A
+        scattered strike pattern, like a scattered ball flight, points back at the
+        fundamentals — setup, posture, balance — rather than any one swing move.
+      </P>
+
+      <Hr />
+
+      <H3>Three reads, one cause</H3>
+      <P>
+        The skill isn't any single read — it's that the ball, the divot, and the
+        strike almost always converge on the same story. A pull that curves right,
+        a divot aimed left, and a strike toward the heel are three witnesses to
+        one out-to-in delivery, not three separate problems. Find where they agree
+        and you've found the cause worth working on. And as the self-diagnosis
+        guide stresses: chase the <Em>pattern</Em>, not the one ugly shot. A miss
+        that repeats is a swing trait you can read and fix; a miss that's different
+        every time is a fundamentals problem hiding upstream.
+      </P>
+
+      <Hr />
+
+      <H3>When the read runs out</H3>
+      <P>
+        Reading your swing and <Em>changing</Em> it are different skills. You can
+        often diagnose the cause — an open face, a steep path — long before you
+        can reliably fix it, and that's exactly the moment a good coach earns
+        their fee. Walk in able to say "I start it left and it slices, my divots
+        point left" and you've handed them the diagnosis and bought yourself a far
+        more useful hour. The companion guides on lessons and on the questions to
+        ask your coach pick up from there. Until then: the ball doesn't lie. Learn
+        its language and you're never completely in the dark about your own swing.
+      </P>
+
+      <Sources
+        items={[
+          {
+            name: 'The modern ball-flight laws',
+            note: (
+              <Text>
+                <Link href="https://support.trackmangolf.com/hc/en-us/articles/5089892383515-Practice-Trackman-Data-Parameter-Definitions">
+                  TrackMan · data parameter definitions (face angle, club path)
+                </Link>{' '}
+                and{' '}
+                <Link href="https://theleftrough.com/new-ball-flight-laws/">
+                  a plain-English explainer of the new ball-flight laws
+                </Link>{' '}
+                — the face sets the start line; the face-to-path gap sets the
+                curve.
+              </Text>
+            ),
+          },
+          {
+            name: 'Reading path from the ball and the divot',
+            note: (
+              <Text>
+                <Link href="https://www.golfwrx.com/251459/use-the-new-ball-flight-laws-to-understand-your-tendencies/">
+                  GolfWRX · using the ball-flight laws to read your own tendencies
+                </Link>{' '}
+                — translating start line, curve, and divot direction back into
+                face and path.
+              </Text>
+            ),
+          },
+        ]}
+      />
+
+      <ArticleFooter>
+        Last reviewed May 2026 · Draft, needs coaching review
+      </ArticleFooter>
+    </View>
+  )
+}
+
+// Editorial line-art: the ball starts on the face line, then curves as the
+// face-to-path gap tilts the spin. Accent on the curving flight. Same viewBox
+// and coordinate data as the web inline svg, re-authored in react-native-svg.
+function BallFlightDiagram() {
+  return (
+    <Svg width="100%" height={120} viewBox="0 0 220 120">
+      {/* target line (dashed) */}
+      <Line x1={40} y1={108} x2={40} y2={14} stroke={C.mute} strokeWidth={1} strokeDasharray="3 3" />
+      <Circle cx={40} cy={108} r={3} fill={C.ink} />
+      {/* start line — straight, along the face direction */}
+      <Line x1={40} y1={108} x2={92} y2={20} stroke={C.mute} strokeWidth={1.5} />
+      {/* actual curving flight (accent) — starts on the face line then bends */}
+      <Path d="M40 108 Q 84 40 150 44" fill="none" stroke={C.accent} strokeWidth={2.5} />
+      <SvgText x={58} y={100} fontSize={7} fontFamily="monospace" letterSpacing={0.5} fill={C.mute}>
+        TARGET
+      </SvgText>
+      <SvgText x={86} y={16} fontSize={7} fontFamily="monospace" letterSpacing={0.5} fill={C.mute}>
+        START = FACE
+      </SvgText>
+      <SvgText x={120} y={58} fontSize={7} fontFamily="monospace" letterSpacing={0.5} fill={C.accent}>
+        CURVE = FACE vs PATH
+      </SvgText>
+    </Svg>
+  )
+}

--- a/apps/mobile/components/learn/articles/index.ts
+++ b/apps/mobile/components/learn/articles/index.ts
@@ -1,0 +1,32 @@
+import type { ComponentType } from 'react'
+import { BuildingYourBagArticle } from './BuildingYourBag'
+import { FittingsWithCoachesArticle } from './FittingsWithCoaches'
+import { GuideToFittingsArticle } from './GuideToFittings'
+import { LessonsAndCoachingArticle } from './LessonsAndCoaching'
+import { MeasurableGoalsArticle } from './MeasurableGoals'
+import { Operation36Article } from './Operation36'
+import { PracticeModesArticle } from './PracticeModes'
+import { PracticeVsScoringRoundArticle } from './PracticeVsScoringRound'
+import { QuestionsForCoachArticle } from './QuestionsForCoach'
+import { SelfDiagnosisArticle } from './SelfDiagnosis'
+import { SwingVariationsArticle } from './SwingVariations'
+import { TrainingAidsArticle } from './TrainingAids'
+import { UnderstandingYourSwingArticle } from './UnderstandingYourSwing'
+
+// Learn articles ported into their own files (the original 7 stay inline in
+// the [article].tsx screen). Keyed by the catalog id in @oga/core/learn.ts.
+export const MOBILE_ARTICLES: Record<string, ComponentType> = {
+  'building-your-bag': BuildingYourBagArticle,
+  'fittings-with-coaches': FittingsWithCoachesArticle,
+  'guide-to-fittings': GuideToFittingsArticle,
+  'lessons-and-coaching': LessonsAndCoachingArticle,
+  'measurable-goals': MeasurableGoalsArticle,
+  'operation-36': Operation36Article,
+  'practice-modes': PracticeModesArticle,
+  'practice-vs-scoring-round': PracticeVsScoringRoundArticle,
+  'questions-for-coach': QuestionsForCoachArticle,
+  'self-diagnosis': SelfDiagnosisArticle,
+  'swing-variations': SwingVariationsArticle,
+  'training-aids': TrainingAidsArticle,
+  'understanding-your-swing': UnderstandingYourSwingArticle,
+}

--- a/apps/mobile/components/learn/primitives.tsx
+++ b/apps/mobile/components/learn/primitives.tsx
@@ -1,0 +1,349 @@
+/**
+ * Shared rendering primitives for mobile Learn articles.
+ *
+ * Mobile mirrors the web Learn articles (apps/web/src/pages/learn/articles/*),
+ * which hand-roll near-identical H3/P/Hr/Callout/Sources/Footer components in
+ * every file. Rather than re-duplicate that boilerplate across 20 RN article
+ * files, the repeating pieces live here once (well over the 3-caller bar) and
+ * each article file composes them. Article-specific one-offs (a card grid only
+ * one article uses) stay co-located in that article's file.
+ *
+ * Inline emphasis uses nested <Text>: write `<P>plain <Strong>bold</Strong></P>`
+ * — RN flows nested Text inline just like the web <strong>/<em> spans.
+ */
+import type { ReactNode } from 'react'
+import { Linking, Text, View } from 'react-native'
+import type { TextStyle, ViewStyle } from 'react-native'
+
+// ── palette (matches web tokens + the existing mobile [article].tsx) ──────────
+export const C = {
+  ink: '#1C211C',
+  inkDim: '#5C6356',
+  mute: '#8A8B7E',
+  line: '#D9D2BF',
+  boxBg: '#EBE5D6',
+  surface: '#FBF8F1',
+  accent: '#1F3D2C',
+  amber: '#A66A1F',
+  bg: '#F2EEE5',
+} as const
+
+// ── text styles ───────────────────────────────────────────────────────────
+export const KICKER: TextStyle = {
+  color: C.mute,
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+export const TITLE: TextStyle = {
+  color: C.ink,
+  fontSize: 26,
+  fontStyle: 'italic',
+  fontWeight: '500',
+  lineHeight: 32,
+  marginBottom: 14,
+}
+
+export const BODY: TextStyle = {
+  color: C.ink,
+  fontSize: 15,
+  lineHeight: 22,
+  marginBottom: 14,
+}
+
+export const SUBKICKER: TextStyle = {
+  ...KICKER,
+  color: C.inkDim,
+  marginTop: 14,
+  marginBottom: 10,
+}
+
+const H3_STYLE: TextStyle = {
+  color: C.ink,
+  fontSize: 19,
+  fontStyle: 'italic',
+  fontWeight: '500',
+  lineHeight: 25,
+  marginTop: 22,
+  marginBottom: 12,
+}
+
+const H4_STYLE: TextStyle = {
+  color: C.ink,
+  fontSize: 16,
+  fontStyle: 'italic',
+  fontWeight: '500',
+  lineHeight: 22,
+  marginTop: 16,
+  marginBottom: 8,
+}
+
+// ── inline spans (nest inside <P>, <H3>, list items, etc.) ──────────────────
+export function Strong({ children }: { children: ReactNode }) {
+  return <Text style={{ fontWeight: '700' }}>{children}</Text>
+}
+
+export function Em({ children }: { children: ReactNode }) {
+  return <Text style={{ fontStyle: 'italic' }}>{children}</Text>
+}
+
+export function Link({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <Text
+      style={{ color: C.accent, textDecorationLine: 'underline' }}
+      onPress={() => Linking.openURL(href)}
+    >
+      {children}
+    </Text>
+  )
+}
+
+// ── block primitives ────────────────────────────────────────────────────────
+export function ArticleHeader({ kicker, title }: { kicker: string; title: string }) {
+  return (
+    <View>
+      <Text style={{ ...KICKER, marginBottom: 10 }}>{kicker}</Text>
+      <Text style={TITLE}>{title}</Text>
+    </View>
+  )
+}
+
+export function P({ children, style }: { children: ReactNode; style?: TextStyle }) {
+  return <Text style={[BODY, style]}>{children}</Text>
+}
+
+export function H3({ children }: { children: ReactNode }) {
+  return <Text style={H3_STYLE}>{children}</Text>
+}
+
+export function H4({ children }: { children: ReactNode }) {
+  return <Text style={H4_STYLE}>{children}</Text>
+}
+
+export function Subhead({ children }: { children: ReactNode }) {
+  return <Text style={SUBKICKER}>{children}</Text>
+}
+
+export function Hr() {
+  return (
+    <View style={{ borderTopWidth: 1, borderTopColor: C.line, marginVertical: 18 }} />
+  )
+}
+
+/** Plain disc bullet list. Each item may contain inline spans. */
+export function BulletList({ items }: { items: ReactNode[] }) {
+  return (
+    <View style={{ marginBottom: 14, marginTop: 2 }}>
+      {items.map((item, i) => (
+        <View key={i} style={{ flexDirection: 'row', gap: 8, marginBottom: 6 }}>
+          <Text style={{ ...BODY, marginBottom: 0 }}>{'•'}</Text>
+          <Text style={{ ...BODY, marginBottom: 0, flex: 1 }}>{item}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+/** Numbered (ordered) list. */
+export function NumberList({ items }: { items: ReactNode[] }) {
+  return (
+    <View style={{ marginBottom: 14, marginTop: 2 }}>
+      {items.map((item, i) => (
+        <View key={i} style={{ flexDirection: 'row', gap: 8, marginBottom: 6 }}>
+          <Text style={{ ...BODY, marginBottom: 0, fontWeight: '600' }}>{i + 1}.</Text>
+          <Text style={{ ...BODY, marginBottom: 0, flex: 1 }}>{item}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+/** Left-accent callout box. tone: 'accent' (green) | 'amber'. */
+export function Callout({
+  children,
+  tone = 'accent',
+}: {
+  children: ReactNode
+  tone?: 'accent' | 'amber'
+}) {
+  return (
+    <View
+      style={{
+        borderLeftWidth: 3,
+        borderLeftColor: tone === 'amber' ? C.amber : C.accent,
+        backgroundColor: C.boxBg,
+        padding: 14,
+        marginBottom: 14,
+        borderRadius: 2,
+      }}
+    >
+      {children}
+    </View>
+  )
+}
+
+/** Tinted "glance" box: optional small-caps label + arbitrary rows/content. */
+export function GlanceBox({
+  label,
+  children,
+  style,
+}: {
+  label?: string
+  children: ReactNode
+  style?: ViewStyle
+}) {
+  return (
+    <View
+      style={[
+        { backgroundColor: C.boxBg, padding: 14, marginBottom: 14, borderRadius: 2 },
+        style,
+      ]}
+    >
+      {label ? <Text style={{ ...KICKER, color: C.inkDim, marginBottom: 8 }}>{label}</Text> : null}
+      {children}
+    </View>
+  )
+}
+
+/** Definition-style row: italic term + description. Used in glance boxes,
+ *  glossary terms, the Bullet primitive, etc. `first` drops the top border. */
+export function DefRow({
+  term,
+  children,
+  first,
+}: {
+  term: ReactNode
+  children: ReactNode
+  first?: boolean
+}) {
+  return (
+    <View
+      style={{
+        paddingVertical: 12,
+        borderTopWidth: first ? 0 : 1,
+        borderTopColor: C.line,
+      }}
+    >
+      <Text style={{ color: C.ink, fontSize: 15, fontStyle: 'italic', fontWeight: '500', marginBottom: 4 }}>
+        {term}
+      </Text>
+      <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 20 }}>{children}</Text>
+    </View>
+  )
+}
+
+/** Inline label + body paragraph (web "Kv"). */
+export function Kv({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Text style={BODY}>
+      <Text style={{ fontWeight: '700' }}>{label} </Text>
+      {children}
+    </Text>
+  )
+}
+
+/** Small-caps pill tag. */
+export function Tag({ children }: { children: ReactNode }) {
+  return (
+    <Text
+      style={{
+        ...KICKER,
+        color: C.accent,
+        backgroundColor: C.boxBg,
+        paddingHorizontal: 8,
+        paddingVertical: 3,
+        borderRadius: 2,
+        overflow: 'hidden',
+      }}
+    >
+      {children}
+    </Text>
+  )
+}
+
+/** Figure wrapper — centers an svg/diagram with an optional caption. */
+export function Figure({ caption, children }: { caption?: string; children: ReactNode }) {
+  return (
+    <View style={{ marginBottom: 16, marginTop: 4 }}>
+      <View
+        style={{
+          backgroundColor: C.boxBg,
+          borderRadius: 2,
+          paddingVertical: 18,
+          paddingHorizontal: 14,
+          alignItems: 'center',
+        }}
+      >
+        {children}
+      </View>
+      {caption ? (
+        <Text style={{ ...KICKER, color: C.mute, marginTop: 8, textAlign: 'center' }}>
+          {caption}
+        </Text>
+      ) : null}
+    </View>
+  )
+}
+
+/** External-source list (web "Sources"): each item a name + note, optional link. */
+export function Sources({
+  items,
+}: {
+  items: { name: string; note: ReactNode; href?: string }[]
+}) {
+  return (
+    <View style={{ marginTop: 6 }}>
+      <Text style={{ ...KICKER, marginBottom: 4 }}>Sources</Text>
+      {items.map((s, i) => (
+        <View key={i} style={{ paddingVertical: 10, borderTopWidth: 1, borderTopColor: C.line }}>
+          <Text style={{ color: C.ink, fontSize: 14, fontStyle: 'italic', fontWeight: '500', marginBottom: 3 }}>
+            {s.href ? <Link href={s.href}>{s.name}</Link> : s.name}
+          </Text>
+          <Text style={{ color: C.inkDim, fontSize: 13, lineHeight: 19 }}>{s.note}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+/** Resource list (web "ResourceList"): {title, by?, note} entries. */
+export function ResourceList({
+  items,
+}: {
+  items: { title: string; by?: string; note: ReactNode }[]
+}) {
+  return (
+    <View style={{ marginVertical: 6 }}>
+      {items.map((r, i) => (
+        <View key={i} style={{ paddingVertical: 12, borderTopWidth: 1, borderTopColor: C.line }}>
+          <Text style={{ color: C.ink, fontSize: 15, fontStyle: 'italic', fontWeight: '500' }}>
+            {r.title}
+            {r.by ? <Text style={{ color: C.inkDim, fontStyle: 'normal', fontWeight: '400' }}> — {r.by}</Text> : null}
+          </Text>
+          <Text style={{ color: C.inkDim, fontSize: 14, lineHeight: 20, marginTop: 4 }}>{r.note}</Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+/** Article footer ("Last reviewed … · Draft …"). */
+export function ArticleFooter({ children }: { children: ReactNode }) {
+  return (
+    <Text
+      style={{
+        ...KICKER,
+        color: C.mute,
+        borderTopWidth: 1,
+        borderTopColor: C.line,
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 16,
+      }}
+    >
+      {children}
+    </Text>
+  )
+}


### PR DESCRIPTION
Ports the 13 missing Learn articles to mobile so **all 20 render** (was 7). Per-article RN components under `apps/mobile/components/learn/articles/` dispatched by id via a registry; shared primitives in `components/learn/primitives.tsx` replace the per-article boilerplate the web articles hand-roll; inline web `<svg>` figures re-authored in `react-native-svg` with matching viewBoxes. `[article].tsx` imports the shared styles and routes registry articles after the existing inline 7. Addresses #469.

_Split from the original combined PR per CONTRIBUTING "one concern per PR" — the crawler work is now #480, the live-round map fixes #481._

## On the flagged "unused" primitives
`H4` / `NumberList` / `Kv` / `ResourceList` are exported but not yet consumed by the 13 ported articles. **Kept intentionally:** the planned article unification (migrate the inline 7 → these primitives) will use them, so removing now would just be churn re-adding identical code shortly.

## QA
Mobile typecheck green; on-device render QA of the 20 articles pending.
