### PR TITLE
fix(mobile): live-round map fixes — AimGhosts, first-ball, drag hit target

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -458,12 +458,30 @@ export function HoleMap({
     },
     [onSetAim],
   )
-  // Static child — memoized so the PureComponent never re-bitmaps it. 80pt
-  // transparent hit area around a small center grab-dot.
+  // Static child — memoized so the PureComponent never re-bitmaps it.
+  // @rnmapbox PointAnnotation hit-tests the OPAQUE pixels of the rendered
+  // bitmap, NOT the React View frame — so a fully transparent pad is not
+  // grabbable and only the tiny dot was draggable. A visible translucent 48pt
+  // disc gives a real ~48pt opaque touch target (and shows the grab zone). The
+  // outer 80pt box just centers it. Proper fix is a MarkerView + gesture-handler
+  // rewrite — see the tracking issue.
   const aimHandle = useMemo(
     () => (
       <View style={{ width: 80, height: 80, alignItems: 'center', justifyContent: 'center' }}>
-        <Marker color="#A66A1F" border="#FBF8F1" size={9} />
+        <View
+          style={{
+            width: 48,
+            height: 48,
+            borderRadius: 24,
+            backgroundColor: 'rgba(166,106,31,0.22)',
+            borderWidth: 1.5,
+            borderColor: 'rgba(166,106,31,0.6)',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Marker color="#A66A1F" border="#FBF8F1" size={9} />
+        </View>
       </View>
     ),
     [],
@@ -823,14 +841,17 @@ export function HoleMap({
                 onSetBall(c)
               }}
             >
-              {/* 44pt transparent hit area so the marker is comfortable
-                  to grab one-handed — Apple HIG minimum target size.
-                  The visual marker stays small; the touchable area
-                  extends well past it. */}
+              {/* Translucent 44pt grab disc. PointAnnotation hit-tests the
+                  opaque bitmap pixels, not the View frame, so a transparent
+                  pad isn't grabbable — the filled disc IS the touch target. */}
               <View
                 style={{
                   width: 44,
                   height: 44,
+                  borderRadius: 22,
+                  backgroundColor: 'rgba(31,61,44,0.20)',
+                  borderWidth: 1.5,
+                  borderColor: 'rgba(31,61,44,0.55)',
                   alignItems: 'center',
                   justifyContent: 'center',
                 }}

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -103,6 +103,14 @@ interface HoleMapProps {
    * The map itself stays mounted across the whole round — see #264.
    */
   holeNumber: number
+  /**
+   * True when the current SET_AIM exit is a real shot commit (raw
+   * roundState → SHOT_DETAIL / PUTTING) rather than a "Re-place ball"
+   * backout. The `phase` prop collapses both to PLACE_BALL, so the aim-ghost
+   * promotion needs this separate signal to record a ghost on commit without
+   * leaving a stray one on re-place. Defaults false.
+   */
+  aimCommitted?: boolean
   onSetAim: (loc: LatLng) => void
   onSetBall: (loc: LatLng) => void
   onPlacePin?: (loc: LatLng) => void
@@ -166,6 +174,7 @@ export function HoleMap({
   handicap,
   previousShots,
   phase = 'PLACE_BALL',
+  aimCommitted = false,
   missingHoleLayout = false,
   gpsPosition,
   courseCenter,
@@ -219,6 +228,7 @@ export function HoleMap({
     ball,
     aim,
     phase,
+    aimCommitted,
     holeNumber,
   })
 

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -128,6 +128,8 @@ export default function LiveRoundSession({
     isPastMode,
     storedPin: data.storedPin,
     roundPin: data.roundPin,
+    tee: data.tee,
+    hasPriorShots: data.remoteShotCount + data.localShotCount > 0,
   })
 
   // Camera anchors on the tee box — the player's starting point. Pin/green
@@ -448,6 +450,14 @@ export default function LiveRoundSession({
                 : finalState.roundState === 'SET_AIM'
                   ? 'SET_AIM'
                   : 'PLACE_BALL'
+          }
+          // A SET_AIM → SHOT_DETAIL/PUTTING transition is a real shot commit;
+          // SET_AIM → bare PLACE_BALL ("Re-place ball") is a backout. The
+          // collapsed `phase` above can't tell them apart, so the aim-ghost
+          // promotion reads this raw-roundState signal instead.
+          aimCommitted={
+            finalState.roundState === 'SHOT_DETAIL' ||
+            finalState.roundState === 'PUTTING'
           }
           showLocationPuck={
             finalState.roundState !== 'SHOT_DETAIL' &&

--- a/apps/mobile/components/round/hole/useHoleState.ts
+++ b/apps/mobile/components/round/hole/useHoleState.ts
@@ -19,6 +19,13 @@ interface UseHoleStateInput {
   isPastMode: boolean
   storedPin: LatLng | null
   roundPin: LatLng | null
+  /** Hole's tee-box coords, used to default shot 1's ball marker so the
+   *  player starts from the tee rather than an empty map. Null on holes
+   *  without layout. */
+  tee: LatLng | null
+  /** Whether any shot has been logged on this hole yet (remote + pending).
+   *  The tee default only applies on shot 1 (no prior shots). */
+  hasPriorShots: boolean
 }
 
 export interface UseHoleStateResult {
@@ -48,6 +55,8 @@ export function useHoleState({
   isPastMode,
   storedPin,
   roundPin,
+  tee,
+  hasPriorShots,
 }: UseHoleStateInput): UseHoleStateResult {
   const [aim, setAim] = useState<LatLng | null>(null)
   // Auto-spawned aims start untouched; flipped true by a user drag/long-press
@@ -317,6 +326,20 @@ export function useHoleState({
     setAim(null)
     setRoundState('PLACE_BALL')
   }, [currentHoleId])
+
+  // Default shot 1's ball marker to the tee box so the player starts from a
+  // sensible point instead of an empty map. This is only an INITIAL default:
+  // live GPS (PLACE_BALL effect above) and manual drag both overwrite it, and
+  // the `!ball` guard means it never clobbers a ball GPS/the player already
+  // placed. Gated to shot 1 (no prior shots), PLACE_BALL, live mode, and a
+  // known tee. Past mode places shots by hand, so it's excluded.
+  useEffect(() => {
+    if (isPastMode) return
+    if (hasPriorShots) return
+    if (roundState !== 'PLACE_BALL') return
+    if (ball || !tee) return
+    setBall({ lat: tee.lat, lng: tee.lng })
+  }, [isPastMode, hasPriorShots, roundState, ball, tee?.lat, tee?.lng])
 
   // Stop GPS when the app backgrounds. The native location callback
   // fires into a null JS module if the OS tears down the app while a

--- a/apps/mobile/components/round/markers/AimGhost.tsx
+++ b/apps/mobile/components/round/markers/AimGhost.tsx
@@ -12,6 +12,15 @@ interface AimGhostHookOpts {
   ball: LatLng | null | undefined
   aim: LatLng | null | undefined
   phase: HoleMapPhase
+  // Whether the SET_AIM exit is a real shot commit (roundState →
+  // SHOT_DETAIL / PUTTING) vs a "Re-place ball" backout (roundState →
+  // bare PLACE_BALL). The HoleMap `phase` collapses both to PLACE_BALL
+  // (HoleMapPhase has no SHOT_DETAIL/PUTTING), so the string alone can't
+  // tell a committed shot from an abandoned aim — promoting on every exit
+  // would re-introduce the duplicate-ghost bug (commit 4670661), dropping
+  // on every exit means no ghost ever records. This flag, derived from the
+  // raw roundState in LiveRoundSession, is the authoritative discriminator.
+  aimCommitted: boolean
   // Explicit hole-change signal. The prior "previousShotsLen === 0"
   // heuristic worked when HoleMap remounted per hole, but in the
   // resident-MapView world (post-#264) it fires during the gap between
@@ -34,6 +43,7 @@ export function useAimGhosts({
   ball,
   aim,
   phase,
+  aimCommitted,
   holeNumber,
 }: AimGhostHookOpts): AimGhostHookResult {
   const [aimGhosts, setAimGhosts] = useState<
@@ -50,22 +60,34 @@ export function useAimGhosts({
     }
   }, [isAimPhase, ball?.lat, ball?.lng, aim?.lat, aim?.lng])
 
+  // Mirror the latest commit signal + live aim into refs so the
+  // phase-gated effect below reads current values without re-running on
+  // every aim drag (which would fire mid-SET_AIM, before any exit).
+  const aimCommittedRef = useRef(aimCommitted)
+  aimCommittedRef.current = aimCommitted
+  const aimRef = useRef(aim)
+  aimRef.current = aim
+
   const ghostPhaseRef = useRef<HoleMapPhase>(phase)
   useEffect(() => {
-    // Promote only on a COMMITTED exit (→ SHOT_DETAIL / PUTTING). Backing out
-    // to PLACE_BALL via "Re-place ball" abandons the aim — promoting it there
-    // left a stray ghost from the discarded aim, so the player ended up with
-    // two aim points after re-aiming. Drop the snapshot instead.
+    // Promote only on a COMMITTED exit. Both a real shot commit and a
+    // "Re-place ball" backout leave SET_AIM for HoleMap-phase PLACE_BALL
+    // (the phase enum collapses SHOT_DETAIL/PUTTING into PLACE_BALL), so the
+    // phase string can't distinguish them — that collision is why promotion
+    // was dead. `aimCommitted` (from the raw roundState) does distinguish:
+    //   - commit (confirmAim / on-green) → aimCommitted true, aim still set
+    //   - skip aim                       → aimCommitted true, aim cleared (null)
+    //   - re-place ball                  → aimCommitted false
+    // Promote iff committed AND the aim survived the exit (excludes skip),
+    // else drop. Reading the live `aim` here — rather than aimTouched, whose
+    // reset is an async effect — avoids any cross-component effect-ordering
+    // race, so a re-place / skip can never wrongly promote a duplicate.
     if (ghostPhaseRef.current === 'SET_AIM' && phase !== 'SET_AIM') {
-      if (phase === 'PLACE_BALL') {
-        lastAimSnapshotRef.current = null
-      } else {
-        const snap = lastAimSnapshotRef.current
-        if (snap) {
-          setAimGhosts((prev) => [...prev, snap])
-          lastAimSnapshotRef.current = null
-        }
+      const snap = lastAimSnapshotRef.current
+      if (snap && aimCommittedRef.current && aimRef.current) {
+        setAimGhosts((prev) => [...prev, snap])
       }
+      lastAimSnapshotRef.current = null
     }
     ghostPhaseRef.current = phase
   }, [phase])

--- a/apps/mobile/components/round/markers/AimGhost.tsx
+++ b/apps/mobile/components/round/markers/AimGhost.tsx
@@ -12,14 +12,10 @@ interface AimGhostHookOpts {
   ball: LatLng | null | undefined
   aim: LatLng | null | undefined
   phase: HoleMapPhase
-  // Whether the SET_AIM exit is a real shot commit (roundState →
-  // SHOT_DETAIL / PUTTING) vs a "Re-place ball" backout (roundState →
-  // bare PLACE_BALL). The HoleMap `phase` collapses both to PLACE_BALL
-  // (HoleMapPhase has no SHOT_DETAIL/PUTTING), so the string alone can't
-  // tell a committed shot from an abandoned aim — promoting on every exit
-  // would re-introduce the duplicate-ghost bug (commit 4670661), dropping
-  // on every exit means no ghost ever records. This flag, derived from the
-  // raw roundState in LiveRoundSession, is the authoritative discriminator.
+  // Authoritative "was this a real shot commit?" flag, derived from the raw
+  // roundState in LiveRoundSession. HoleMap's `phase` collapses a commit and
+  // a "Re-place ball" backout into the same PLACE_BALL, so the phase string
+  // alone can't tell them apart. See the promote effect below for how it's used.
   aimCommitted: boolean
   // Explicit hole-change signal. The prior "previousShotsLen === 0"
   // heuristic worked when HoleMap remounted per hole, but in the


### PR DESCRIPTION
Three live-round map fixes (split out of #479 per "one concern per PR").

## 1. AimGhosts not rendering (regression)
`4670661` gated ghost promotion on the map phase, but committed shots and Re-place-ball both collapse to `PLACE_BALL`, so the promote branch was dead. Now keys off an explicit `aimCommitted` signal (`roundState` SHOT_DETAIL/PUTTING) AND the live aim surviving the transition — committed shot → one ghost, skip-aim / re-place → none (no duplicate).

## 2. First ball seeded on the tee box
Shot 1 with no ball yet defaults the ball marker to the hole's tee coords; GPS-follow still refines it.

## 3. Aim/ball drag hit target too small
`@rnmapbox` `PointAnnotation` hit-tests the **opaque pixels of the rendered bitmap**, not the View frame — so the 80pt transparent hit-pad did nothing and only the ~9px dot was grabbable (touches missed → map panned). Replaced with a visible translucent grab disc (aim 48pt, ball 44pt) so the hittable area is ~5× larger. Interim — proper rewrite tracked separately.

## QA
Mobile typecheck green; on-device validation in progress.
