### PR TITLE
fix(mobile): Learn navigation — own stack + Home discoverability

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -220,8 +220,10 @@ export default function AppLayout() {
           ),
         }}
       />
-      <Tabs.Screen name="learn/index" options={{ href: null }} />
-      <Tabs.Screen name="learn/[article]" options={{ href: null }} />
+      {/* Learn is a nested stack (learn/_layout.tsx owns index + [article]),
+          so it collapses to a single hidden tab route. This is what makes
+          "← Back" from an article pop to the list instead of the Home tab. */}
+      <Tabs.Screen name="learn" options={{ href: null }} />
       <Tabs.Screen name="bag" options={{ href: null }} />
       <Tabs.Screen name="rounds" options={{ href: null }} />
       <Tabs.Screen name="round/new" options={{ href: null }} />

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ScrollView, Text, View } from 'react-native'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Pressable, ScrollView, Text, View } from 'react-native'
 import { formatSG } from '@oga/core'
 import { deleteRound, getProfile, getRecentSGData } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
@@ -21,6 +21,7 @@ import {
   RecentRoundsList,
   type RecentRoundRow,
 } from '../../components/home/RecentRoundsList'
+import { LearnPreview } from '../../components/home/LearnPreview'
 
 type Profile = Database['public']['Tables']['profiles']['Row']
 
@@ -58,6 +59,15 @@ export default function Home() {
     name: string
   } | null>(null)
   const [deleting, setDeleting] = useState(false)
+
+  // The "yardage book" preview lives at the bottom of the scroll; the hint
+  // up top scrolls to it (captured y is relative to the scroll content
+  // since the preview is a direct child of the contentContainer).
+  const scrollRef = useRef<ScrollView>(null)
+  const learnYRef = useRef(0)
+  const scrollToLearn = useCallback(() => {
+    scrollRef.current?.scrollTo({ y: learnYRef.current, animated: true })
+  }, [])
 
   const handleDelete = useCallback(
     async (id: string) => {
@@ -149,7 +159,7 @@ export default function Home() {
   return (
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
       <AppBar eyebrow={eyebrow} title={profile?.username ?? 'Home'} />
-      <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
+      <ScrollView ref={scrollRef} contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
         <Text
           style={{
             color: '#1C211C',
@@ -162,9 +172,14 @@ export default function Home() {
         >
           {firstName ? `Good round, ${firstName}.` : 'Good round.'}
         </Text>
-        <Text style={{ color: '#5C6356', fontSize: 14, marginBottom: 22 }}>
+        <Text style={{ color: '#5C6356', fontSize: 14, marginBottom: 10 }}>
           Last {rounds.length} round{rounds.length === 1 ? '' : 's'}
         </Text>
+        <Pressable onPress={scrollToLearn} hitSlop={6} style={{ marginBottom: 22 }}>
+          <Text style={{ color: '#8A8B7E', fontSize: 13, fontStyle: 'italic' }}>
+            ↓ New to a stat? The yardage book's at the bottom.
+          </Text>
+        </Pressable>
 
         {rounds.length > 0 && (
           <>
@@ -265,6 +280,14 @@ export default function Home() {
           rounds={rounds}
           onRequestDelete={(id, name) => setPendingDelete({ id, name })}
         />
+
+        <View
+          onLayout={(e) => {
+            learnYRef.current = e.nativeEvent.layout.y
+          }}
+        >
+          <LearnPreview />
+        </View>
       </ScrollView>
       <ConfirmDialog
         visible={!!pendingDelete}

--- a/apps/mobile/app/(app)/learn/_layout.tsx
+++ b/apps/mobile/app/(app)/learn/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router'
+
+// Learn is its own stack so index → [article] is a real push: pressing
+// "← Back" in an article pops to the list instead of falling through to
+// the Home tab (which is what happened when the two screens were flat
+// sibling routes of the Tabs navigator). Screens render their own AppBar,
+// so the stack header stays hidden.
+export default function LearnLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />
+}

--- a/apps/mobile/components/home/LearnPreview.tsx
+++ b/apps/mobile/components/home/LearnPreview.tsx
@@ -1,0 +1,102 @@
+import { Pressable, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import { LEARN_SECTIONS, readingTimeMinutes, type LearnArticle } from '@oga/core'
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+// First three readable pieces in catalog order. Section order already
+// encodes editorial priority (fundamentals first), so this surfaces the
+// two flagship published articles without needing a `featured` flag or
+// dates on the model. `soon` stubs aren't tappable, so they're excluded.
+const FEATURED: LearnArticle[] = LEARN_SECTIONS.flatMap((s) => s.articles)
+  .filter((a) => a.status !== 'soon')
+  .slice(0, 3)
+
+export function LearnPreview() {
+  const router = useRouter()
+
+  return (
+    <View style={{ borderTopWidth: 2, borderColor: '#9F9580', paddingTop: 18, marginTop: 8 }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'baseline',
+          justifyContent: 'space-between',
+          marginBottom: 12,
+        }}
+      >
+        <Text style={KICKER}>From the yardage book</Text>
+        <Pressable
+          accessibilityRole="link"
+          accessibilityLabel="See all Learn articles"
+          onPress={() => router.push('/(app)/learn')}
+          hitSlop={8}
+        >
+          <Text style={{ ...KICKER, color: '#1F3D2C' }}>See all →</Text>
+        </Pressable>
+      </View>
+
+      {FEATURED.map((article) => (
+        <PreviewRow
+          key={article.id}
+          article={article}
+          onSelect={() =>
+            router.push({
+              pathname: '/(app)/learn/[article]',
+              params: { article: article.id },
+            })
+          }
+        />
+      ))}
+    </View>
+  )
+}
+
+function PreviewRow({
+  article,
+  onSelect,
+}: {
+  article: LearnArticle
+  onSelect: () => void
+}) {
+  const reading = readingTimeMinutes(article)
+  return (
+    <Pressable
+      onPress={onSelect}
+      style={{
+        borderTopWidth: 1,
+        borderColor: '#D9D2BF',
+        paddingVertical: 14,
+        flexDirection: 'row',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+      }}
+    >
+      <View style={{ flex: 1, paddingRight: 12 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'baseline', flexWrap: 'wrap' }}>
+          <Text style={{ color: '#1C211C', fontSize: 16, fontStyle: 'italic', fontWeight: '500' }}>
+            {article.title}
+          </Text>
+          {article.status === 'draft' && (
+            <Text style={{ ...KICKER, color: '#A66A1F', marginLeft: 8 }}>Draft</Text>
+          )}
+        </View>
+        <Text style={{ color: '#5C6356', fontSize: 13, lineHeight: 18, marginTop: 4 }}>
+          {article.description}
+        </Text>
+      </View>
+      <View style={{ alignItems: 'flex-end' }}>
+        {reading != null && (
+          <Text style={{ ...KICKER, color: '#8A8B7E', marginBottom: 4 }}>{reading} min</Text>
+        )}
+        <Text style={{ color: '#8A8B7E', fontSize: 18, fontStyle: 'italic' }}>→</Text>
+      </View>
+    </Pressable>
+  )
+}


### PR DESCRIPTION
## Mobile Learn — fix Back + surface on Home

Two coupled problems, both rooted in how Learn was wired into the tab navigator. Cross-checked against expo-router 3.5.24 / @react-navigation/bottom-tabs 6.5.20 source before implementing.

### 1. Back bug (fix)
`learn/index` and `learn/[article]` were flat **sibling** `Tabs.Screen` routes. `@react-navigation/bottom-tabs` defaults to `backBehavior: 'firstRoute'`, and `href: null` only hides the tab button — the routes still participate in tab history. So `router.back()` from an article popped the **tab** history to the first route = **Home**, not the list.

**Fix:** add `learn/_layout.tsx` (a `Stack`) so the folder collapses to a single `learn` tab route and `index → [article]` is a real stack push. Back now pops to the **list**.

### 2. Discoverability (feature)
Learn was `href: null` with its only entry a link buried on the Practice screen — "can't find Learn at all."

- New **"From the yardage book"** preview at the bottom of Home: first 3 readable articles (catalog order → surfaces the two flagship published pieces) + a **"See all →"** into the full list.
- A muted top-of-Home **hint** (`↓ New to a stat? The yardage book's at the bottom.`) that smooth-scrolls down to the section.

### Notes
- Article selection computed inline — no new `@oga/core` field/helper (single caller).
- The Practice → Learn link still resolves to the list (verified).
- Edge case (cross-checked): opening an article straight from the Home preview → Back returns to Home in the common case; if the Learn stack was already visited that session it returns to the list. Both acceptable; inherent to tab+nested-stack.

### Verification
- ✅ Mobile typecheck clean.
- ⏳ **Device QA pending** (author at work, no device): Back-from-article → list, preview placement/spacing, scroll-to-hint feel.

Files: `learn/_layout.tsx` (new), `components/home/LearnPreview.tsx` (new), `(app)/_layout.tsx` (route collapse), `(app)/index.tsx` (hint + preview).
