### PR TITLE
chore(ios): declare App Privacy Manifest (#299)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -47,6 +47,63 @@ const config: ExpoConfig = {
       NSPhotoLibraryAddUsageDescription:
         'OGA may save round summary cards to your photo library.',
     },
+    // App Privacy Manifest (required for App Store uploads since May 2024).
+    // Expo SDK 51 reads this and emits PrivacyInfo.xcprivacy at prebuild —
+    // don't hand-place a file (CNG regenerates ios/). Declared at the app
+    // level because Apple doesn't reliably parse manifests bundled by static
+    // CocoaPod deps (per Expo's apple-privacy guide), so the Required Reason
+    // APIs our stack touches are redeclared here. Reason codes verified
+    // against deps actually present: expo-sqlite (FileTimestamp/DiskSpace),
+    // @react-native-async-storage (UserDefaults), react-native core
+    // (SystemBootTime). NSPrivacyTracking false — no IDFA, no ad SDKs.
+    privacyManifests: {
+      NSPrivacyTracking: false,
+      NSPrivacyTrackingDomains: [],
+      NSPrivacyCollectedDataTypes: [
+        {
+          NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeEmailAddress',
+          NSPrivacyCollectedDataTypeLinked: true,
+          NSPrivacyCollectedDataTypeTracking: false,
+          NSPrivacyCollectedDataTypePurposes: [
+            'NSPrivacyCollectedDataTypePurposeAppFunctionality',
+          ],
+        },
+        {
+          NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypePreciseLocation',
+          NSPrivacyCollectedDataTypeLinked: true,
+          NSPrivacyCollectedDataTypeTracking: false,
+          NSPrivacyCollectedDataTypePurposes: [
+            'NSPrivacyCollectedDataTypePurposeAppFunctionality',
+          ],
+        },
+        {
+          NSPrivacyCollectedDataType: 'NSPrivacyCollectedDataTypeOtherUserContent',
+          NSPrivacyCollectedDataTypeLinked: true,
+          NSPrivacyCollectedDataTypeTracking: false,
+          NSPrivacyCollectedDataTypePurposes: [
+            'NSPrivacyCollectedDataTypePurposeAppFunctionality',
+          ],
+        },
+      ],
+      NSPrivacyAccessedAPITypes: [
+        {
+          NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryFileTimestamp',
+          NSPrivacyAccessedAPITypeReasons: ['C617.1'],
+        },
+        {
+          NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryDiskSpace',
+          NSPrivacyAccessedAPITypeReasons: ['E174.1'],
+        },
+        {
+          NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategorySystemBootTime',
+          NSPrivacyAccessedAPITypeReasons: ['35F9.1'],
+        },
+        {
+          NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
+          NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
+        },
+      ],
+    },
   },
   android: {
     // Android package name stays as-is — already-shipped users have this

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -48,14 +48,13 @@ const config: ExpoConfig = {
         'OGA may save round summary cards to your photo library.',
     },
     // App Privacy Manifest (required for App Store uploads since May 2024).
-    // Expo SDK 51 reads this and emits PrivacyInfo.xcprivacy at prebuild —
-    // don't hand-place a file (CNG regenerates ios/). Declared at the app
-    // level because Apple doesn't reliably parse manifests bundled by static
-    // CocoaPod deps (per Expo's apple-privacy guide), so the Required Reason
-    // APIs our stack touches are redeclared here. Reason codes verified
-    // against deps actually present: expo-sqlite (FileTimestamp/DiskSpace),
-    // @react-native-async-storage (UserDefaults), react-native core
-    // (SystemBootTime). NSPrivacyTracking false — no IDFA, no ad SDKs.
+    // Hand-placing a PrivacyInfo.xcprivacy is futile here — CNG regenerates
+    // ios/. Declared at the app level because Apple doesn't reliably parse
+    // manifests bundled by static CocoaPod deps (per Expo's apple-privacy
+    // guide), so the Required Reason APIs our stack touches are redeclared
+    // here, verified against deps actually present: expo-sqlite (FileTimestamp/
+    // DiskSpace), @react-native-async-storage (UserDefaults), react-native
+    // core (SystemBootTime). NSPrivacyTracking false — no IDFA, no ad SDKs.
     privacyManifests: {
       NSPrivacyTracking: false,
       NSPrivacyTrackingDomains: [],


### PR DESCRIPTION
## Declare App Privacy Manifest (#299)

Apple has required a Privacy Manifest for all App Store uploads since **May 1, 2024** — App Store Connect rejects builds without one. Adds `ios.privacyManifests` to `app.config.ts`; Expo SDK 51 reads it and emits `PrivacyInfo.xcprivacy` at prebuild (mobile uses CNG — `ios/` is regenerated, so a hand-placed file would be wiped).

### Why declared at the app level
Per [Expo's apple-privacy guide](https://docs.expo.dev/guides/apple-privacy/), Apple doesn't reliably parse `PrivacyInfo.xcprivacy` files bundled by static CocoaPod dependencies, so the Required-Reason APIs our stack touches are redeclared in the app manifest.

### Contents — verified against the real dependency tree (not just the audit)
| Declaration | Basis |
|---|---|
| Collected: email / precise location / other user content | auth, shot tracking, rounds+shots — all linked, **none tracking**, app-functionality |
| `NSPrivacyTracking: false` | no IDFA, no ad/tracking SDKs |
| FileTimestamp `C617.1`, DiskSpace `E174.1` | expo-sqlite 14.0.6 |
| UserDefaults `CA92.1` | @react-native-async-storage (confirmed imported in 4 files) |
| SystemBootTime `35F9.1` | react-native 0.74.5 core |

Crash-data type **omitted** — no Sentry/crash SDK in the tree yet (don't declare what we don't collect).

### Verification
- ✅ Schema validated by `ExpoConfig` types (`pnpm`/`tsc` mobile typecheck clean).
- ✅ Reason-code schema + "redeclare at app level" cross-checked against Expo's live docs; `CA92.1`/UserDefaults confirmed there.
- ⏳ Final enforcement is at **upload time** (first iOS build/submission) — can't be exercised without a build.

Closes #299.
