### PR TITLE
chore(ios): remove unused Always location permission + refine usage string (#301)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -27,16 +27,15 @@ const config: ExpoConfig = {
     buildNumber: '1',
     supportsTablet: true,
     infoPlist: {
+      // Foreground-only: OGA calls requestForegroundPermissionsAsync during a
+      // round and never requests background/Always location. The expo-location
+      // plugin below explicitly disables the Always variants (#301) so its
+      // default usage strings can't re-add a permission we never use — Apple
+      // rejects declaring permissions you don't request.
       NSLocationWhenInUseUsageDescription:
-        'OGA uses your location during a round to track shots and yardages.',
-      // NSLocationAlwaysAndWhenInUseUsageDescription is injected by the
-      // expo-location plugin below (locationAlwaysAndWhenInUsePermission).
-      // Don't duplicate the key here — Info.plist with duplicate keys is
-      // undefined behavior. #301 tracks removing the Always permission
-      // entirely since OGA only uses requestForegroundPermissionsAsync().
-      // No proprietary encryption beyond standard TLS/Keychain.
-      // false skips Apple's export-compliance prompt on every
-      // TestFlight upload.
+        'OGA uses your location during active rounds to track shot locations on the course map.',
+      // No proprietary encryption beyond standard TLS/Keychain. false skips
+      // Apple's export-compliance prompt on every TestFlight upload.
       ITSAppUsesNonExemptEncryption: false,
       // Stubbed pre-emptively (#305). Not used at runtime today — Expo
       // adds these automatically once expo-image-picker / expo-camera is
@@ -68,8 +67,12 @@ const config: ExpoConfig = {
     [
       'expo-location',
       {
-        locationAlwaysAndWhenInUsePermission:
-          'Allow OGA to use your location to track shots.',
+        // false → the plugin DELETES these keys from Info.plist
+        // (@expo/config-plugins Permissions.js: `=== false` deletes). Omitting
+        // them instead would fall back to the plugin's default usage string and
+        // re-add the Always permission. OGA is foreground-only — see infoPlist.
+        locationAlwaysAndWhenInUsePermission: false,
+        locationAlwaysPermission: false,
       },
     ],
     [


### PR DESCRIPTION
## Remove unused Always location permission + refine usage string (#301)

OGA only ever calls `requestForegroundPermissionsAsync` (plus a foreground `watchPositionAsync`) — verified across the codebase, no background request anywhere. Apple rejects apps that **declare a permission they don't request**, and the generic usage string was also a soft rejection vector.

### Why `false`, not "just remove the option"
The Always string came from the `expo-location` plugin's **default**, not our config. `@expo/config-plugins` `Permissions.js` falls back to the plugin's default usage string for any key whose value is `undefined` — so dropping the option would leave the permission in place. Passing `false` is what deletes the key:

```js
// @expo/config-plugins/build/ios/Permissions.js
if (permissions[permission] === false) { delete infoPlist[permission]; }
```

So both `locationAlwaysAndWhenInUsePermission` and `locationAlwaysPermission` are explicitly set to `false` (the plugin's option type allows `string | false | undefined`).

### Foreground string refined
> "OGA uses your location during active rounds to track shot locations on the course map."

(names the actual feature, per the usage-string guidance.)

### Verification — resolved prebuild config, not just reasoning
`npx expo config --type prebuild` → final `Info.plist`:
```
NSLocationWhenInUseUsageDescription => "OGA uses your location during active rounds to track shot locations on the course map."
(no NSLocationAlways* keys)
```
✅ Mobile typecheck clean.

Note: lightly conflicts on `app.config.ts` with #487 (privacy manifest) — disjoint regions; I'll rebase whichever merges second.

Closes #301.
