### PR TITLE
feat(mobile): in-app account deletion (#306, #314)

### DIFF
--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -78,9 +78,20 @@ export default function ProfileTab() {
       Alert.alert('Could not delete account', error.message)
       return
     }
-    // Deleting the auth row leaves the current JWT valid until sign-out, so
-    // clear the session explicitly; the auth listener then redirects to login.
-    await supabase.auth.signOut()
+    // The account row is already gone; the JWT just stays valid until
+    // sign-out, so clear the session. If signOut itself errors we must STILL
+    // release the modal — otherwise the user is stranded in a disabled
+    // "Deleting…" dialog after an irreversible delete. On success the auth
+    // listener unmounts this screen and redirects to login.
+    const { error: signOutError } = await supabase.auth.signOut()
+    if (signOutError) {
+      setDeleting(false)
+      setDeleteOpen(false)
+      Alert.alert(
+        'Account deleted',
+        'Your account has been deleted. Restart the app to finish signing out.',
+      )
+    }
   }
 
   const trimmedUsername = username.trim()

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import {
   Alert,
   Linking,
+  Modal,
   Pressable,
   ScrollView,
   Text,
@@ -15,7 +16,6 @@ import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { AppBar } from '../../components/ui/AppBar'
-import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 
 type Profile = Database['public']['Tables']['profiles']['Row']
 type SkillLevel = Profile['skill_level']
@@ -467,12 +467,8 @@ export default function ProfileTab() {
         </Pressable>
       </ScrollView>
 
-      <ConfirmDialog
+      <DeleteAccountModal
         visible={deleteOpen}
-        title="Delete your OGA account?"
-        message="This will permanently delete your account and all rounds, shots, and saved data. This cannot be undone."
-        confirmLabel="Delete account"
-        destructive
         busy={deleting}
         onConfirm={deleteAccount}
         onCancel={() => setDeleteOpen(false)}
@@ -491,6 +487,158 @@ const inputStyle = {
   fontSize: 15,
   color: '#1C211C',
 } as const
+
+// Two-phase confirmation for the irreversible account delete, in a SINGLE
+// Modal (never two stacked — iOS allows one presented modal per presenter,
+// #293). Phase 1 is the "are you sure" warning; phase 2 requires typing the
+// exact phrase, so the delete can't be triggered by a stray tap.
+const DELETE_PHRASE = 'delete my account'
+
+function DeleteAccountModal({
+  visible,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  visible: boolean
+  busy: boolean
+  onConfirm: () => void | Promise<void>
+  onCancel: () => void
+}) {
+  const [phase, setPhase] = useState<'confirm' | 'type'>('confirm')
+  const [text, setText] = useState('')
+  const matches = text.trim().toLowerCase() === DELETE_PHRASE
+
+  // Reset to phase one whenever the modal (re)opens, so a reopened dialog
+  // never starts on the typed step with stale text.
+  useEffect(() => {
+    if (visible) {
+      setPhase('confirm')
+      setText('')
+    }
+  }, [visible])
+
+  return (
+    <Modal transparent animationType="fade" visible={visible} onRequestClose={onCancel}>
+      <View
+        style={{
+          flex: 1,
+          backgroundColor: 'rgba(28,33,28,0.55)',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: 18,
+        }}
+      >
+        <View
+          style={{
+            backgroundColor: '#FBF8F1',
+            borderColor: '#9F9580',
+            borderWidth: 1,
+            borderRadius: 4,
+            padding: 22,
+            width: '100%',
+            maxWidth: 360,
+          }}
+        >
+          <Text style={{ ...KICKER, marginBottom: 8 }}>Confirm delete</Text>
+          <Text
+            style={{
+              color: '#1C211C',
+              fontSize: 22,
+              fontStyle: 'italic',
+              fontWeight: '500',
+              lineHeight: 28,
+              marginBottom: 10,
+            }}
+          >
+            {phase === 'confirm' ? 'Delete your OGA account?' : 'Type to confirm'}
+          </Text>
+
+          {phase === 'confirm' ? (
+            <Text style={{ color: '#5C6356', fontSize: 14, lineHeight: 20, marginBottom: 22 }}>
+              This will permanently delete your account and all rounds, shots,
+              and saved data. This cannot be undone.
+            </Text>
+          ) : (
+            <>
+              <Text style={{ color: '#5C6356', fontSize: 14, lineHeight: 20, marginBottom: 14 }}>
+                Type{' '}
+                <Text style={{ fontWeight: '700', color: '#1C211C' }}>{DELETE_PHRASE}</Text>{' '}
+                below to permanently delete your account.
+              </Text>
+              <TextInput
+                value={text}
+                onChangeText={setText}
+                editable={!busy}
+                autoCapitalize="none"
+                autoCorrect={false}
+                placeholder={DELETE_PHRASE}
+                placeholderTextColor="#8A8B7E"
+                style={{ ...inputStyle, marginBottom: 22 }}
+                accessibilityLabel="Type delete my account to confirm"
+              />
+            </>
+          )}
+
+          <View style={{ flexDirection: 'row', justifyContent: 'flex-end', gap: 10 }}>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Cancel"
+              onPress={onCancel}
+              disabled={busy}
+              style={{
+                borderWidth: 1,
+                borderColor: '#D9D2BF',
+                borderRadius: 2,
+                paddingHorizontal: 14,
+                paddingVertical: 10,
+                opacity: busy ? 0.5 : 1,
+              }}
+            >
+              <Text style={{ color: '#5C6356', fontSize: 13, fontWeight: '500' }}>Cancel</Text>
+            </Pressable>
+
+            {phase === 'confirm' ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Continue to type-to-confirm step"
+                onPress={() => setPhase('type')}
+                style={{
+                  backgroundColor: '#A33A2A',
+                  borderRadius: 2,
+                  paddingHorizontal: 16,
+                  paddingVertical: 10,
+                }}
+              >
+                <Text style={{ color: '#F2EEE5', fontSize: 14, fontWeight: '600', letterSpacing: 0.3 }}>
+                  Continue
+                </Text>
+              </Pressable>
+            ) : (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Delete account"
+                onPress={onConfirm}
+                disabled={busy || !matches}
+                style={{
+                  backgroundColor: '#A33A2A',
+                  borderRadius: 2,
+                  paddingHorizontal: 16,
+                  paddingVertical: 10,
+                  opacity: busy || !matches ? 0.5 : 1,
+                }}
+              >
+                <Text style={{ color: '#F2EEE5', fontSize: 14, fontWeight: '600', letterSpacing: 0.3 }}>
+                  {busy ? 'Deleting…' : 'Delete account'}
+                </Text>
+              </Pressable>
+            )}
+          </View>
+        </View>
+      </View>
+    </Modal>
+  )
+}
 
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -15,6 +15,7 @@ import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { AppBar } from '../../components/ui/AppBar'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 
 type Profile = Database['public']['Tables']['profiles']['Row']
 type SkillLevel = Profile['skill_level']
@@ -65,6 +66,22 @@ export default function ProfileTab() {
   const [emailSummaries, setEmailSummaries] = useState(true)
   const [saving, setSaving] = useState(false)
   const [usernameTouched, setUsernameTouched] = useState(false)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  async function deleteAccount() {
+    setDeleting(true)
+    const { error } = await supabase.rpc('delete_my_account')
+    if (error) {
+      setDeleting(false)
+      setDeleteOpen(false)
+      Alert.alert('Could not delete account', error.message)
+      return
+    }
+    // Deleting the auth row leaves the current JWT valid until sign-out, so
+    // clear the session explicitly; the auth listener then redirects to login.
+    await supabase.auth.signOut()
+  }
 
   const trimmedUsername = username.trim()
   const usernameInvalid =
@@ -439,7 +456,27 @@ export default function ProfileTab() {
             Sign out
           </Text>
         </Pressable>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Delete account"
+          onPress={() => setDeleteOpen(true)}
+          style={{ paddingVertical: 12, alignItems: 'center' }}
+        >
+          <Text style={{ ...KICKER, color: '#A33A2A' }}>Delete account</Text>
+        </Pressable>
       </ScrollView>
+
+      <ConfirmDialog
+        visible={deleteOpen}
+        title="Delete your OGA account?"
+        message="This will permanently delete your account and all rounds, shots, and saved data. This cannot be undone."
+        confirmLabel="Delete account"
+        destructive
+        busy={deleting}
+        onConfirm={deleteAccount}
+        onCancel={() => setDeleteOpen(false)}
+      />
     </View>
   )
 }

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -695,6 +695,10 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      delete_my_account: {
+        Args: never
+        Returns: undefined
+      }
       insert_synthetic_hole: {
         Args: {
           p_course_id: string

--- a/supabase/migrations/0036_account_deletion_rpc.sql
+++ b/supabase/migrations/0036_account_deletion_rpc.sql
@@ -1,0 +1,50 @@
+-- 0036_account_deletion_rpc.sql
+-- Self-service account deletion (App Store Guideline 5.1.1(v): apps that
+-- support account creation must allow account deletion from inside the app).
+--
+-- Every user-owned table cascades off auth.users, so deleting the caller's
+-- auth row wipes ALL of their data with no per-table DELETEs:
+--
+--   auth.users ─cascade→ profiles ─cascade→ rounds ─cascade→ hole_scores
+--                                                   └cascade→ shots
+--                                  profiles ─cascade→ shots, practice_plans
+--   auth.users ─cascade→ user_clubs
+--
+-- We do NOT call auth.admin.delete_user — that is the service-role GoTrue
+-- API and is not callable from SQL. A direct DELETE on auth.users is the
+-- supported SQL path (Supabase "User Management" docs). The auth sub-tables
+-- (sessions, identities, refresh_tokens) also cascade off auth.users(id),
+-- so the auth side is cleaned too.
+--
+-- SECURITY DEFINER so the function runs as its owner (which can delete from
+-- auth.users); the auth.uid() guard ensures a caller can only ever delete
+-- its own account. search_path pinned to '' per house convention (0032) —
+-- every reference is fully schema-qualified, so no search_path injection.
+--
+-- Caveat handled by the client: deleting the auth row does not invalidate an
+-- already-issued JWT, so the mobile flow calls supabase.auth.signOut()
+-- immediately after this returns. (OGA uses no Supabase Storage, so the
+-- "can't delete a user who owns Storage objects" caveat does not apply.)
+create or replace function public.delete_my_account()
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  uid uuid := auth.uid();
+begin
+  if uid is null then
+    raise exception 'not authenticated';
+  end if;
+  delete from auth.users where id = uid;
+end;
+$$;
+
+-- Destructive + irreversible: only signed-in users may call it, never anon.
+-- Supabase's default privileges auto-grant EXECUTE on new functions to anon
+-- too, so revoke anon explicitly (revoking from `public` alone leaves the
+-- per-role grant in place). The auth.uid() guard already blocks an anon call,
+-- but anon should not hold the grant at all.
+revoke execute on function public.delete_my_account() from public, anon;
+grant execute on function public.delete_my_account() to authenticated;


### PR DESCRIPTION
## In-app account deletion (#306 + #314)

App Store Guideline 5.1.1(v) (mandatory since June 2022) requires apps that support account creation to allow account deletion inside the app. OGA had Sign Out but no delete flow. Decisions: SQL RPC, immediate hard delete, mobile now (web fast-follow).

### Key simplification
Every user-owned table cascades off auth.users:
```
auth.users -> profiles -> rounds -> hole_scores -> shots
              profiles -> shots, practice_plans
auth.users -> user_clubs
```
So removing the single auth row wipes all data with no per-table DELETEs. The audit's auth.admin.delete_user() SQL call was dropped (that's the service-role GoTrue API, not SQL-callable); a direct DELETE FROM auth.users is the supported path.

### Backend — 0036_account_deletion_rpc.sql
SECURITY DEFINER public.delete_my_account(), search_path='', auth.uid() guard. anon EXECUTE explicitly revoked (Supabase default privileges auto-grant it; revoking from public alone leaves the per-role grant).

### Mobile — Profile screen
"Delete account" (destructive) -> ConfirmDialog -> supabase.rpc('delete_my_account') -> supabase.auth.signOut() (JWT stays valid after the row removal, so the session is cleared; the auth listener redirects to login).

### Verified on a local Postgres
- Migration applies; function is SECURITY DEFINER (owner postgres).
- Grants after migration: authenticated only — anon removed (caught + fixed an over-broad default grant during testing).
- Seeded user + round + clubs, called the RPC with that user's JWT claim: BEFORE users=1 profiles=1 rounds=1 clubs=1 -> AFTER all 0 (txn rolled back). No Supabase Storage in OGA, so the Storage-owner caveat doesn't apply.

### Status
- Mobile + workspace typecheck clean.
- Migration + RPC + cascade proven on local Postgres.
- Device tap-through QA pending; migration applied to dev/prod on the normal deploy.

Web Settings parity (same shared RPC) is a fast-follow.

Closes #306
Closes #314
