### PR TITLE
fix(mobile): Learn back button returns to the list, not Home

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -220,8 +220,10 @@ export default function AppLayout() {
           ),
         }}
       />
-      <Tabs.Screen name="learn/index" options={{ href: null }} />
-      <Tabs.Screen name="learn/[article]" options={{ href: null }} />
+      {/* Learn is a nested stack (learn/_layout.tsx owns index + [article]),
+          so it collapses to a single hidden tab route. This is what makes
+          "← Back" from an article pop to the list instead of the Home tab. */}
+      <Tabs.Screen name="learn" options={{ href: null }} />
       <Tabs.Screen name="bag" options={{ href: null }} />
       <Tabs.Screen name="rounds" options={{ href: null }} />
       <Tabs.Screen name="round/new" options={{ href: null }} />

--- a/apps/mobile/app/(app)/learn/_layout.tsx
+++ b/apps/mobile/app/(app)/learn/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router'
+
+// Learn is its own stack so index → [article] is a real push: pressing
+// "← Back" in an article pops to the list instead of falling through to
+// the Home tab (which is what happened when the two screens were flat
+// sibling routes of the Tabs navigator). Screens render their own AppBar,
+// so the stack header stays hidden.
+export default function LearnLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />
+}


### PR DESCRIPTION
Split from the original combined Learn-nav PR (#486) per one-concern — this is the **bug fix half**.

`learn/index` and `learn/[article]` were flat sibling `Tabs.Screen` routes. `@react-navigation/bottom-tabs` defaults to `backBehavior: 'firstRoute'`, and `href: null` only hides the tab button (routes still live in tab history), so `router.back()` from an article popped the **tab** history to the first route = Home, not the list.

**Fix:** `learn/_layout.tsx` (a `Stack`) collapses the folder to one `learn` tab route; `index → [article]` becomes a real stack push → Back pops to the list. Cross-checked against expo-router 3.5.24 / bottom-tabs 6.5.20 source.

✅ Mobile typecheck clean. The Home 'yardage book' preview ships separately (feature/learn-home-preview).