### PR TITLE
fix(mobile): iOS safe-area insets, collapse double modal, gesture root

### DIFF
--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   View,
 } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { HoleMap, type LatLng } from './HoleMap'
 import type { ShotLoggerValue } from './ShotLogger'
@@ -63,6 +64,7 @@ export default function LiveRoundSession({
   const router = useRouter()
   const { user } = useAuth()
   const { toDisplay } = useUnits()
+  const insets = useSafeAreaInsets()
 
   const [holeNumber, setHoleNumber] = useState(initialHoleNumber)
 
@@ -363,7 +365,9 @@ export default function LiveRoundSession({
       <View
         style={{
           backgroundColor: '#1C211C',
-          paddingTop: 52,
+          // Was a hardcoded 52 (Android ~24dp status bar + 28 gap); use the
+          // real top inset so the header clears the Dynamic Island (#494).
+          paddingTop: insets.top + 28,
           paddingBottom: 14,
           paddingHorizontal: 18,
           flexDirection: 'row',
@@ -494,7 +498,9 @@ export default function LiveRoundSession({
             onPress={() => finalState.setAimHintVisible(false)}
             style={{
               position: 'absolute',
-              top: 48,
+              // Tracks the header offset (was 48 = ~24dp status bar + 24) so
+              // it shifts down with the header on notched devices (#494).
+              top: insets.top + 24,
               left: 12,
               right: 12,
               backgroundColor: 'rgba(28,33,28,0.92)',
@@ -640,7 +646,10 @@ export default function LiveRoundSession({
           <View
             style={{
               position: 'absolute',
-              top: 96,
+              // Drops just below the header; was 96 = ~24dp status bar + 72.
+              // Derive from the inset so it stays flush under the header
+              // when it grows on notched devices (#494).
+              top: insets.top + 72,
               right: 12,
               zIndex: 21,
               minWidth: 184,

--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -14,6 +14,7 @@ import {
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useUserBag } from '../../hooks/useUserBag'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 type ShotRow = Database['public']['Tables']['shots']['Row']
 
@@ -60,6 +61,7 @@ export function PastHoleShotsSheet({
   const clubs = bag.length > 0 ? bag : DEFAULT_BAG
   const [editingShot, setEditingShot] = useState<ShotRow | null>(null)
   const [saving, setSaving] = useState(false)
+  const insets = useSafeAreaInsets()
 
   const sortedShots = [...shots].sort((a, b) => a.shot_number - b.shot_number)
 
@@ -81,16 +83,31 @@ export function PastHoleShotsSheet({
     }
   }
 
+  // One <Modal> with discriminated content (list vs editor) — NOT two
+  // sibling Modals. iOS allows one presented modal per presenter, so the
+  // old stacked-Modal edit flow silently failed to present (#293/#495).
   return (
-    <>
     <Modal
       visible={visible}
       transparent
       animationType="slide"
-      onRequestClose={onClose}
+      onRequestClose={editingShot ? () => setEditingShot(null) : onClose}
     >
       <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' }}>
-        <Pressable style={{ flex: 1 }} onPress={onClose} />
+        <Pressable
+          style={{ flex: 1 }}
+          onPress={editingShot ? () => setEditingShot(null) : onClose}
+        />
+        {editingShot ? (
+          <EditShotSheet
+            shot={editingShot}
+            clubs={clubs}
+            unit={unit}
+            saving={saving}
+            onSave={(updates) => handleSave(editingShot.id, updates)}
+            onClose={() => setEditingShot(null)}
+          />
+        ) : (
         <View
           style={{
             backgroundColor: '#FBF8F1',
@@ -98,7 +115,7 @@ export function PastHoleShotsSheet({
             borderTopRightRadius: 12,
             paddingHorizontal: 18,
             paddingTop: 14,
-            paddingBottom: 28,
+            paddingBottom: insets.bottom + 28,
             maxHeight: '80%',
           }}
         >
@@ -161,31 +178,9 @@ export function PastHoleShotsSheet({
             <Text style={{ ...KICKER, color: '#5C6356' }}>Close</Text>
           </Pressable>
         </View>
-      </View>
-
-    </Modal>
-
-    <Modal
-      visible={visible && editingShot !== null}
-      transparent
-      animationType="slide"
-      onRequestClose={() => setEditingShot(null)}
-    >
-      <View style={{ flex: 1 }}>
-        <Pressable style={{ flex: 1 }} onPress={() => setEditingShot(null)} />
-        {editingShot && (
-          <EditShotSheet
-            shot={editingShot}
-            clubs={clubs}
-            unit={unit}
-            saving={saving}
-            onSave={(updates) => handleSave(editingShot.id, updates)}
-            onClose={() => setEditingShot(null)}
-          />
         )}
       </View>
     </Modal>
-    </>
   )
 }
 
@@ -246,6 +241,7 @@ interface EditShotSheetProps {
 }
 
 function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetProps) {
+  const insets = useSafeAreaInsets()
   const [club, setClub] = useState<string | null>(shot.club ?? null)
   const [lieType, setLieType] = useState<string | null>(shot.lie_type ?? null)
   const [shotResult, setShotResult] = useState<string | null>(shot.shot_result ?? null)
@@ -258,7 +254,7 @@ function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetPr
         borderTopRightRadius: 12,
         paddingHorizontal: 18,
         paddingTop: 14,
-        paddingBottom: 28,
+        paddingBottom: insets.bottom + 28,
         maxHeight: '90%',
       }}
     >

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -20,6 +20,7 @@ import {
 } from '@oga/core'
 import { GreenDiagram } from './GreenDiagram'
 import { useUnits } from '../../hooks/useUnits'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 export interface PuttingValue {
   puttDistanceFt?: number
@@ -186,6 +187,7 @@ export function PuttingSheet({
     })
   }
 
+  const insets = useSafeAreaInsets()
   const distance = value.puttDistanceFt ?? 0
 
   return (
@@ -197,7 +199,7 @@ export function PuttingSheet({
         borderTopRightRadius: 12,
         paddingHorizontal: 18,
         paddingTop: 10,
-        paddingBottom: 24,
+        paddingBottom: insets.bottom + 24,
         maxHeight: '90%',
       }}
     >

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import { Modal, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import Svg, { Circle, Line as SvgLine } from 'react-native-svg'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import {
   DEFAULT_BAG,
   LIE_TYPES,
@@ -125,6 +127,7 @@ export function ShotLogger({
     }))
   }, [bag])
 
+  const insets = useSafeAreaInsets()
   const isOnGreen = value.lieType === 'green'
 
   return (
@@ -134,6 +137,11 @@ export function ShotLogger({
       visible={visible}
       onRequestClose={onClose}
     >
+      {/* RN <Modal> opens a separate native window the app-root
+          GestureHandlerRootView doesn't reach — wrap the contents in
+          their own root so the on-green GreenDiagram aim-handle pan
+          gesture works (mirrors HoleModals; #496). */}
+      <GestureHandlerRootView style={{ flex: 1 }}>
       <View
         style={{
           flex: 1,
@@ -193,7 +201,7 @@ export function ShotLogger({
             borderTopRightRadius: 12,
             paddingHorizontal: 18,
             paddingTop: 10,
-            paddingBottom: 28,
+            paddingBottom: insets.bottom + 28,
           }}
         >
           <View
@@ -441,6 +449,7 @@ export function ShotLogger({
         </View>
         )}
       </View>
+      </GestureHandlerRootView>
     </Modal>
   )
 }


### PR DESCRIPTION
iOS pre-build fixes from the device-free Android→iOS portability audit (#308). Three confirmed issues, one branch.

Closes #494
Closes #495
Closes #496

## Changes
- **#494 safe-area insets** — the live-round header / aim-hint / overflow-menu derive from `insets.top` (were hardcoded `52`/`48`/`96`, tuned to Android's ~24dp status bar → tucked under the Dynamic Island on iPhone 14 Pro/15/16). They share the same inset so they shift together and stay flush. The ShotLogger, PuttingSheet and PastHoleShotsSheet bottom sheets add `insets.bottom` for home-indicator clearance. The inset math reproduces the old values on a 24dp Android device, so **Android layout is unchanged**.
- **#495 double-modal (#293)** — `PastHoleShotsSheet` presented two sibling `<Modal>`s at once (list + editor) by construction: tapping a shot set `editingShot` without closing the list Modal, so on iOS the editor silently never presents (one-presented-modal-per-presenter). Collapsed to **one `<Modal>` with discriminated `editingShot ? editor : list` content** — the repo's #293 convention, matching `HoleModals`. Backdrop / back / close behavior preserved.
- **#496 gesture root** — `ShotLogger` rendered `PuttingSheet` (the GreenDiagram pan gesture) inside a `<Modal>` with no local `GestureHandlerRootView`, so the aim handle wouldn't drag in the on-green-via-logger path. Wrapped it, mirroring `HoleModals.tsx:136`.

## Verification
- `npm run typecheck` green.
- **Not device-verified** — no iOS build exists yet. These are `defensive` fixes confirmed by code; real validation lands at the first iOS build (#376). Android behavior is preserved by construction (inset math = the old hardcodes at 24dp).

## Not included
- #303 (ripple → static press feedback) — separate batch; the fix must be static-style since NativeWind drops function-style callbacks.
- #309 (app icon) — needs the 1024×1024 asset + an `app.config.ts` `icon` key.
