### PR TITLE
fix(mobile): play the brand splash on every login (#500)

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -9,7 +9,6 @@ import {
   View,
 } from 'react-native'
 import { Link, useRouter } from 'expo-router'
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { WebView } from 'react-native-webview'
 import { supabase } from '../../lib/supabase'
 
@@ -42,8 +41,9 @@ export default function Login() {
       setCaptchaToken(null)
       return
     }
-    await AsyncStorage.setItem('oga.pending-splash', '1').catch(() => {})
-    router.replace('/(app)')
+    // Route through the brand splash (plays on every login), which then
+    // forwards into the app. See app/(auth)/welcome.tsx (#500).
+    router.replace('/(auth)/welcome')
   }
 
   return (

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -9,7 +9,6 @@ import {
   View,
 } from 'react-native'
 import { Link, useRouter } from 'expo-router'
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import { WebView } from 'react-native-webview'
 import { supabase } from '../../lib/supabase'
 
@@ -44,8 +43,9 @@ export default function Signup() {
       setCaptchaToken(null)
       return
     }
-    await AsyncStorage.setItem('oga.pending-splash', '1').catch(() => {})
-    router.replace('/(app)')
+    // Route through the brand splash (plays on every login), which then
+    // forwards into the app. See app/(auth)/welcome.tsx (#500).
+    router.replace('/(auth)/welcome')
   }
 
   return (

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useRef } from 'react'
+import { Pressable, StyleSheet } from 'react-native'
+import { useRouter } from 'expo-router'
+import { StatusBar } from 'expo-status-bar'
+import Animated, {
+  Easing,
+  cancelAnimation,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from 'react-native-reanimated'
+
+// Post-login brand splash. login/signup `router.replace` here (not straight
+// to /(app)) so the staged-fade brand moment plays after EVERY login — the
+// root layout doesn't remount on in-session navigation, so a root-level
+// overlay could never fire post-login (#500). Forwards into the app when the
+// hold completes, or immediately on tap.
+const FADE_DURATION = 500
+const LOGO_DELAY = 500
+const TAGLINE_DELAY = 1200
+const SUPPORT_DELAY = 2000
+const HOLD_BEFORE_DISMISS = 3500
+const REDUCED_MOTION_HOLD = 1000
+
+export default function Welcome() {
+  const router = useRouter()
+  const reducedMotion = useReducedMotion()
+
+  const logoOpacity = useSharedValue(0)
+  const taglineOpacity = useSharedValue(0)
+  const supportOpacity = useSharedValue(0)
+  // Guards against a double-arm if the screen re-renders mid-fade.
+  const started = useRef(false)
+
+  useEffect(() => {
+    if (started.current) return
+    started.current = true
+    const enter = () => router.replace('/(app)')
+
+    if (reducedMotion) {
+      logoOpacity.value = 1
+      taglineOpacity.value = 1
+      supportOpacity.value = 1
+      const t = setTimeout(enter, REDUCED_MOTION_HOLD)
+      return () => clearTimeout(t)
+    }
+    logoOpacity.value = withDelay(
+      LOGO_DELAY,
+      withTiming(1, { duration: FADE_DURATION, easing: Easing.out(Easing.cubic) }),
+    )
+    taglineOpacity.value = withDelay(
+      TAGLINE_DELAY,
+      withTiming(1, { duration: FADE_DURATION, easing: Easing.out(Easing.cubic) }),
+    )
+    supportOpacity.value = withDelay(
+      SUPPORT_DELAY,
+      withTiming(1, { duration: FADE_DURATION, easing: Easing.out(Easing.cubic) }),
+    )
+    const t = setTimeout(enter, HOLD_BEFORE_DISMISS)
+    return () => clearTimeout(t)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Tap to skip — snap the text visible, then forward.
+  const handleSkip = () => {
+    cancelAnimation(logoOpacity)
+    cancelAnimation(taglineOpacity)
+    cancelAnimation(supportOpacity)
+    router.replace('/(app)')
+  }
+
+  const logoStyle = useAnimatedStyle(() => ({ opacity: logoOpacity.value }))
+  const taglineStyle = useAnimatedStyle(() => ({ opacity: taglineOpacity.value }))
+  const supportStyle = useAnimatedStyle(() => ({ opacity: supportOpacity.value }))
+
+  return (
+    <>
+      <StatusBar style="light" animated />
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Skip splash"
+        onPress={handleSkip}
+        style={styles.screen}
+      >
+        <Animated.Text style={[styles.wordmark, logoStyle]}>OGA</Animated.Text>
+        <Animated.Text style={[styles.tagline, taglineStyle]}>Track every shot.</Animated.Text>
+        <Animated.Text style={[styles.support, supportStyle]}>
+          Free and open source · Ko-fi support appreciated
+        </Animated.Text>
+      </Pressable>
+    </>
+  )
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#1C211C',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  wordmark: {
+    color: '#FBF8F1',
+    fontFamily: 'Fraunces-MediumItalic',
+    fontSize: 96,
+    fontStyle: 'italic',
+    letterSpacing: -2,
+    lineHeight: 100,
+  },
+  tagline: {
+    color: 'rgba(242,238,229,0.85)',
+    fontFamily: 'Fraunces-MediumItalic',
+    fontSize: 18,
+    fontStyle: 'italic',
+    marginTop: 18,
+  },
+  support: {
+    color: 'rgba(242,238,229,0.45)',
+    fontSize: 11,
+    letterSpacing: 1,
+    marginTop: 28,
+    textAlign: 'center',
+  },
+})

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Pressable, StyleSheet } from 'react-native'
+import { BackHandler, Pressable, StyleSheet } from 'react-native'
 import { useRouter } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import Animated, {
@@ -62,6 +62,16 @@ export default function Welcome() {
     return () => clearTimeout(t)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Android hardware back during the splash forwards into the app rather than
+  // popping to the (already-passed, now-authenticated) login screen.
+  useEffect(() => {
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      router.replace('/(app)')
+      return true
+    })
+    return () => sub.remove()
+  }, [router])
 
   // Tap to skip — snap the text visible, then forward.
   const handleSkip = () => {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,19 +1,15 @@
-import { useEffect, useRef, useState } from 'react'
-import { Pressable, StyleSheet, Text } from 'react-native'
+import { useEffect, useState } from 'react'
+import { StyleSheet } from 'react-native'
 import { Stack } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import * as SplashScreen from 'expo-splash-screen'
 import { useFonts } from 'expo-font'
-import AsyncStorage from '@react-native-async-storage/async-storage'
 import Animated, {
   Easing,
-  cancelAnimation,
   runOnJS,
   useAnimatedStyle,
-  useReducedMotion,
   useSharedValue,
-  withDelay,
   withTiming,
 } from 'react-native-reanimated'
 import { AuthProvider } from '../contexts/AuthContext'
@@ -21,23 +17,15 @@ import { useAuth } from '../hooks/useAuth'
 import { ErrorBoundary } from '../components/errors/ErrorBoundary'
 import '../global.css'
 
-// Native splash stays up until our JS-side font load + auth resolve
-// finish, so the brand mark never renders in a fallback serif. Without
-// preventAutoHide here, Expo would dismiss the splash the instant the
-// JS bundle finishes loading and the player would see a beat of system
-// serif before Fraunces becomes available.
+// Native splash stays up until our JS-side font load finishes so the brand
+// mark never renders in a fallback serif. The animated brand splash now lives
+// in app/(auth)/welcome.tsx (shown after every login); this layout keeps only
+// a brief loading gate over the cold-start auth-resolve window.
 void SplashScreen.preventAutoHideAsync().catch(() => {
-  // No-op: another path may have already hidden it (HMR reload, fast
-  // refresh after a crash). Nothing to do.
+  // No-op: another path may have already hidden it (HMR reload, fast refresh).
 })
 
-const FADE_DURATION = 500
-const LOGO_DELAY = 500
-const TAGLINE_DELAY = 1200
-const SUPPORT_DELAY = 2000
-const HOLD_BEFORE_DISMISS = 3500
 const FADE_OUT_DURATION = 350
-const REDUCED_MOTION_HOLD = 1000
 
 export default function RootLayout() {
   return (
@@ -53,210 +41,55 @@ function RootLayoutContent() {
     'Fraunces-MediumItalic': require('../assets/fonts/Fraunces-MediumItalic.ttf'),
   })
   const { loading: authLoading } = useAuth()
-  const reducedMotion = useReducedMotion()
 
-  const overlayOpacity = useSharedValue(1)
-  const logoOpacity = useSharedValue(0)
-  const taglineOpacity = useSharedValue(0)
-  const supportOpacity = useSharedValue(0)
-  const [overlayMounted, setOverlayMounted] = useState(true)
-  const [readyToDismiss, setReadyToDismiss] = useState(false)
-  // null = still checking storage, true = animate, false = skip
-  const [shouldAnimate, setShouldAnimate] = useState<boolean | null>(null)
-  // Guards the staged-fade effect against double-animation if the
-  // component re-renders mid-fade (font reload, fast refresh). Without
-  // this the withDelay timings would re-arm and stutter.
-  const animationStarted = useRef(false)
+  const gateOpacity = useSharedValue(1)
+  const [gateMounted, setGateMounted] = useState(true)
 
-  // Check whether a fresh login set the pending-splash flag. If not set,
-  // the user is resuming an existing session — skip the animation and
-  // dismiss the loading overlay as soon as fonts + auth are ready.
-  useEffect(() => {
-    AsyncStorage.getItem('oga.pending-splash')
-      .then((v) => {
-        if (v === '1') {
-          AsyncStorage.removeItem('oga.pending-splash').catch(() => {})
-          setShouldAnimate(true)
-        } else {
-          setShouldAnimate(false)
-        }
-      })
-      .catch(() => setShouldAnimate(false))
-  }, [])
-
-  // Hide native splash whenever fonts are loaded; idempotent.
+  // Hide the native splash once fonts are ready (idempotent).
   useEffect(() => {
     if (!fontsLoaded) return
     SplashScreen.hideAsync().catch(() => {})
   }, [fontsLoaded])
 
-  // Arm the staged fade choreography exactly once. animationStarted
-  // gates double-arms on re-render; reducedMotion is snapshotted at
-  // first-run time. A mid-fade toggle of reducedMotion is handled by
-  // the second effect below — this one never re-runs once started.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // Fade the loading gate out once fonts + auth both resolve — it bridges the
+  // gap between native-splash dismissal and the first real frame so the app
+  // never flashes a half-resolved screen on cold start.
   useEffect(() => {
-    if (!fontsLoaded || shouldAnimate !== true || animationStarted.current) return
-    animationStarted.current = true
-    if (reducedMotion) {
-      // Skip the staged choreography but still hold briefly so the
-      // brand registers as more than a single frame on slower devices.
-      logoOpacity.value = 1
-      taglineOpacity.value = 1
-      supportOpacity.value = 1
-      return
-    }
-    logoOpacity.value = withDelay(
-      LOGO_DELAY,
-      withTiming(1, { duration: FADE_DURATION, easing: Easing.out(Easing.cubic) }),
-    )
-    taglineOpacity.value = withDelay(
-      TAGLINE_DELAY,
-      withTiming(1, { duration: FADE_DURATION, easing: Easing.out(Easing.cubic) }),
-    )
-    supportOpacity.value = withDelay(
-      SUPPORT_DELAY,
-      withTiming(1, { duration: FADE_DURATION, easing: Easing.out(Easing.cubic) }),
-    )
-  }, [fontsLoaded])
-
-  // If the user toggles reduced-motion mid-fade, honor it: cancel any
-  // in-flight withDelay/withTiming and snap all text to visible. The
-  // first effect's animationStarted ref keeps it from re-arming.
-  useEffect(() => {
-    if (!reducedMotion) return
-    cancelAnimation(logoOpacity)
-    cancelAnimation(taglineOpacity)
-    cancelAnimation(supportOpacity)
-    logoOpacity.value = 1
-    taglineOpacity.value = 1
-    supportOpacity.value = 1
-  }, [reducedMotion, logoOpacity, taglineOpacity, supportOpacity])
-
-  // Mark the overlay as ready to dismiss. Two paths:
-  // - No animation (resuming session): ready immediately once flag check resolves.
-  // - Animation: ready after the staged hold completes.
-  useEffect(() => {
-    if (!fontsLoaded || shouldAnimate === null) return
-    if (!shouldAnimate) {
-      setReadyToDismiss(true)
-      return
-    }
-    const hold = reducedMotion ? REDUCED_MOTION_HOLD : HOLD_BEFORE_DISMISS
-    const t = setTimeout(() => setReadyToDismiss(true), hold)
-    return () => clearTimeout(t)
-  }, [fontsLoaded, shouldAnimate, reducedMotion])
-
-  useEffect(() => {
-    if (!fontsLoaded || authLoading || !readyToDismiss || shouldAnimate === null) return
-    overlayOpacity.value = withTiming(
+    if (!fontsLoaded || authLoading) return
+    gateOpacity.value = withTiming(
       0,
       { duration: FADE_OUT_DURATION, easing: Easing.out(Easing.cubic) },
       (finished) => {
-        if (finished) runOnJS(setOverlayMounted)(false)
+        if (finished) runOnJS(setGateMounted)(false)
       },
     )
-  }, [fontsLoaded, authLoading, readyToDismiss, overlayOpacity])
+  }, [fontsLoaded, authLoading, gateOpacity])
 
-  const overlayStyle = useAnimatedStyle(() => ({
-    opacity: overlayOpacity.value,
-  }))
-  const logoStyle = useAnimatedStyle(() => ({
-    opacity: logoOpacity.value,
-  }))
-  const taglineStyle = useAnimatedStyle(() => ({
-    opacity: taglineOpacity.value,
-  }))
-  const supportStyle = useAnimatedStyle(() => ({
-    opacity: supportOpacity.value,
-  }))
-
-  // Tap-to-skip: cancel any in-flight fade timings, snap all text to
-  // visible, and start the dismiss path. Auth still gates the actual
-  // unmount inside the effect above so we don't tear the overlay down
-  // before the profile fetch resolves.
-  const handleSkip = () => {
-    if (!fontsLoaded) return
-    cancelAnimation(logoOpacity)
-    cancelAnimation(taglineOpacity)
-    cancelAnimation(supportOpacity)
-    logoOpacity.value = 1
-    taglineOpacity.value = 1
-    supportOpacity.value = 1
-    setReadyToDismiss(true)
-  }
+  const gateStyle = useAnimatedStyle(() => ({ opacity: gateOpacity.value }))
 
   if (!fontsLoaded) return null
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      {/* Splash overlay has a near-black background (#1C211C). Force light
-          icons while it's mounted; auto-resolve takes over for the rest of
-          the app where backgrounds are light. */}
-      <StatusBar style={overlayMounted ? 'light' : 'auto'} animated />
+      {/* The loading gate is near-black (#1C211C); force light icons while it
+          covers the screen, then auto-resolve takes over. */}
+      <StatusBar style={gateMounted ? 'light' : 'auto'} animated />
       <ErrorBoundary>
         <Stack screenOptions={{ headerShown: false }} />
       </ErrorBoundary>
-      {overlayMounted && (
+      {gateMounted && (
         <Animated.View
-          pointerEvents={authLoading || !readyToDismiss ? 'auto' : 'none'}
-          style={[StyleSheet.absoluteFill, styles.overlay, overlayStyle]}
-        >
-          {shouldAnimate && (
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Skip splash"
-              onPress={handleSkip}
-              style={styles.skipHit}
-            >
-              <Animated.Text style={[styles.wordmark, logoStyle]}>
-                OGA
-              </Animated.Text>
-              <Animated.Text style={[styles.tagline, taglineStyle]}>
-                Track every shot.
-              </Animated.Text>
-              <Animated.Text style={[styles.support, supportStyle]}>
-                Free and open source · Ko-fi support appreciated
-              </Animated.Text>
-            </Pressable>
-          )}
-        </Animated.View>
+          pointerEvents={authLoading ? 'auto' : 'none'}
+          style={[StyleSheet.absoluteFill, styles.gate, gateStyle]}
+        />
       )}
     </GestureHandlerRootView>
   )
 }
 
 const styles = StyleSheet.create({
-  overlay: {
+  gate: {
     backgroundColor: '#1C211C',
     zIndex: 9999,
-  },
-  skipHit: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingHorizontal: 32,
-  },
-  wordmark: {
-    color: '#FBF8F1',
-    fontFamily: 'Fraunces-MediumItalic',
-    fontSize: 96,
-    fontStyle: 'italic',
-    letterSpacing: -2,
-    lineHeight: 100,
-  },
-  tagline: {
-    color: 'rgba(242,238,229,0.85)',
-    fontFamily: 'Fraunces-MediumItalic',
-    fontSize: 18,
-    fontStyle: 'italic',
-    marginTop: 18,
-  },
-  support: {
-    color: 'rgba(242,238,229,0.45)',
-    fontSize: 11,
-    letterSpacing: 1,
-    marginTop: 28,
-    textAlign: 'center',
   },
 })


### PR DESCRIPTION
Closes #500

## The bug
The animated brand splash ("OGA / Track every shot." on ink) was supposed to play after every login but only appeared on a later cold launch.

**Root cause (code-confirmed):** the splash was an overlay in the **root layout** (`app/_layout.tsx`); whether it animates was decided **once** in a mount-time `useEffect([])` reading the AsyncStorage flag `oga.pending-splash`. login/signup set the flag then `router.replace('/(app)')` — but in-session navigation **doesn't remount the root layout**, so the flag was never re-read and the splash deferred to the next cold start. AsyncStorage isn't reactive, so a mid-session write is invisible to the mounted layout.

## The fix (Option B — splash as its own route)
- **New `app/(auth)/welcome.tsx`** — the staged-fade brand splash (logo → tagline → support), tap-to-skip, reduced-motion aware, then `router.replace('/(app)')`. The `(auth)` group has no auth guard, so it renders fine post-login.
- **`login.tsx` / `signup.tsx`** — `router.replace('/(auth)/welcome')` instead of `/(app)`; removed the now-dead `AsyncStorage` flag (+ its import).
- **`_layout.tsx`** — stripped the overlay + flag + animation (now in the route); keeps only the native-splash-for-fonts gate and a brief loading gate over the cold-start auth-resolve window.

Now the splash plays after **every** login by construction (you pass through the route). A resumed session (cold-reopen while already logged in) shows just the native "o." splash, not the full animation — matching "after every login."

## Verification
- `tsc --noEmit` green under CI conditions (`.expo/types` absent → expo-router's permissive `Href`; the new `/(auth)/welcome` route resolves). The local-only error was a stale generated `router.d.ts`, regenerated on next `expo start`.
- **Not device-verified** — the on-device animation/timing is QA on the next build. Logic is a faithful port of the previous overlay choreography.
