### PR TITLE
fix(core): frame Patterns dispersion aim-relative, not compass N/E (#464)

### DIFF
--- a/packages/core/src/shot-patterns.test.ts
+++ b/packages/core/src/shot-patterns.test.ts
@@ -32,9 +32,11 @@ describe('computeDispersion', () => {
   })
 
   it('converts lat/lng deltas to yard offsets', () => {
-    // 0.001 deg lat ≈ 121 yards north → distanceOffset ~ +121
-    // 0.001 deg lng at lat 40 ≈ 121000 * cos(40°) ~ 92,690 yards/deg
+    // Aimed due north (start south of aim). End 0.001 deg lat ≈ 121 yds north
+    // of aim = straight down the line → distanceOffset ~ +121, lateral ~0.
     const s = shot({
+      startLat: AIM_LAT - 0.001,
+      startLng: AIM_LNG,
       aimLat: AIM_LAT,
       aimLng: AIM_LNG,
       endLat: AIM_LAT + 0.001,
@@ -45,22 +47,61 @@ describe('computeDispersion', () => {
     expect(p!.lateralOffsetYards).toBeCloseTo(0, 5)
   })
 
-  it('positive lateral when end is east of aim', () => {
+  it('frames offsets relative to the aim line, not compass N/E (regression #464)', () => {
+    // Shot aimed due EAST (start west of aim → bearing ~90°), landing
+    // straight down the line: purely east of aim = all distance, no
+    // perpendicular miss. Compass framing mislabels the eastward end as a
+    // huge LATERAL offset; aim-relative framing must read it as ~all distance.
     const s = shot({
+      id: 'east',
+      startLat: AIM_LAT,
+      startLng: AIM_LNG - 0.001,
       aimLat: AIM_LAT,
       aimLng: AIM_LNG,
       endLat: AIM_LAT,
-      endLng: AIM_LNG + 0.0001,
+      endLng: AIM_LNG + 0.001,
     })
     const [p] = computeDispersion([s])
-    expect(p!.lateralOffsetYards).toBeGreaterThan(0)
+    expect(p!.lateralOffsetYards).toBeCloseTo(0, 0) // no perpendicular miss
+    expect(p!.distanceOffsetYards).toBeGreaterThan(50) // it's all distance
+  })
+
+  it('reads identical perp misses identically regardless of aim bearing (regression #464)', () => {
+    // Same shot — 30 yds right of aim, dead on for distance — flown on two
+    // different compass bearings (north vs east). The compass frame smears
+    // these into different lateral/distance offsets; the aim-relative frame
+    // must report the same perpendicular miss for both.
+    const PERP = 30
+    const northAimedRight = shot({
+      id: 'n',
+      startLat: AIM_LAT - 0.001,
+      startLng: AIM_LNG,
+      aimLat: AIM_LAT,
+      aimLng: AIM_LNG,
+      endLat: AIM_LAT,
+      endLng: AIM_LNG + PERP / (Y_PER_DEG_LAT * Math.cos((AIM_LAT * Math.PI) / 180)),
+    })
+    const eastAimedRight = shot({
+      id: 'e',
+      startLat: AIM_LAT,
+      startLng: AIM_LNG - 0.001,
+      aimLat: AIM_LAT,
+      aimLng: AIM_LNG,
+      endLat: AIM_LAT - PERP / Y_PER_DEG_LAT, // south of an east aim = right
+      endLng: AIM_LNG,
+    })
+    const [pn] = computeDispersion([northAimedRight])
+    const [pe] = computeDispersion([eastAimedRight])
+    expect(pn!.lateralOffsetYards).toBeCloseTo(PERP, 0)
+    expect(pe!.lateralOffsetYards).toBeCloseTo(pn!.lateralOffsetYards, 0)
   })
 
   it('projects start distance into the aim-relative plane when present', () => {
     const s = shot({
+      startLat: AIM_LAT - 0.001, // ~121 yds short of aim, due south
+      startLng: AIM_LNG,
       aimLat: AIM_LAT,
       aimLng: AIM_LNG,
-      startLat: AIM_LAT - 0.001, // ~121 yds short of aim
       endLat: AIM_LAT,
       endLng: AIM_LNG,
     })
@@ -68,15 +109,14 @@ describe('computeDispersion', () => {
     expect(p!.startDistanceOffsetYards).toBeCloseTo(-121, 0)
   })
 
-  it('leaves start distance undefined when start coords are missing', () => {
+  it('skips shots without a start position (cannot derive the aim line)', () => {
     const s = shot({
       aimLat: AIM_LAT,
       aimLng: AIM_LNG,
       endLat: AIM_LAT + 0.001,
       endLng: AIM_LNG,
     })
-    const [p] = computeDispersion([s])
-    expect(p!.startDistanceOffsetYards).toBeUndefined()
+    expect(computeDispersion([s])).toHaveLength(0)
   })
 })
 

--- a/packages/core/src/shot-patterns.ts
+++ b/packages/core/src/shot-patterns.ts
@@ -173,10 +173,12 @@ export function computeDispersionStats(points: DispersionPoint[]): DispersionSta
 /**
  * One shot's end position expressed in the AIM-RELATIVE frame:
  * `alongYards` long of aim (+ = past the aim point), `perpYards` right of
- * the aim line (+ = right). Unlike `computeDispersion` (which is compass-
- * framed N/E), this rotates by the shot's intended line so spreads can be
- * drawn correctly on a hole at any bearing. Returns null unless start, aim,
- * AND end coords are all finite — start+aim are needed to derive the bearing.
+ * the aim line (+ = right). Rotates by the shot's intended (start→aim) line so
+ * spreads read correctly on a hole at any bearing. This is the lightweight
+ * along/perp pair (used by the live-round overlay); `computeDispersion` shares
+ * the same `rotateAroundAim` core but returns full DispersionPoints. Returns
+ * null unless start, aim, AND end coords are all finite — start+aim are needed
+ * to derive the bearing.
  */
 export function aimRelativeOffsets(
   shot: Shot,

--- a/packages/core/src/shot-patterns.ts
+++ b/packages/core/src/shot-patterns.ts
@@ -49,32 +49,61 @@ function isFiniteNumber(n: number | null | undefined): n is number {
   return n !== null && n !== undefined && Number.isFinite(n)
 }
 
+/** True only when start, aim, AND end coords are all finite — the minimum
+ *  needed to derive the intended (start→aim) line and frame the shot to it. */
+function hasAimGeometry(
+  s: Shot,
+): s is Shot &
+  Record<
+    'startLat' | 'startLng' | 'aimLat' | 'aimLng' | 'endLat' | 'endLng',
+    number
+  > {
+  return (
+    isFiniteNumber(s.startLat) &&
+    isFiniteNumber(s.startLng) &&
+    isFiniteNumber(s.aimLat) &&
+    isFiniteNumber(s.aimLng) &&
+    isFiniteNumber(s.endLat) &&
+    isFiniteNumber(s.endLng)
+  )
+}
+
+/**
+ * Rotate a (target − aim) displacement into the aim-relative frame given the
+ * intended-line bearing θ (radians, CW from N). `alongYards` = past the aim
+ * point along the line; `perpYards` = right of the line. Scale deg→yards
+ * BEFORE rotating — 1° lng ≠ 1° lat in distance.
+ */
+function rotateAroundAim(
+  targetLat: number,
+  targetLng: number,
+  aimLat: number,
+  aimLng: number,
+  θ: number,
+): { alongYards: number; perpYards: number } {
+  const north = (targetLat - aimLat) * YARDS_PER_DEG_LAT
+  const east = (targetLng - aimLng) * yardsPerDegLng(aimLat)
+  return {
+    alongYards: north * Math.cos(θ) + east * Math.sin(θ),
+    perpYards: -north * Math.sin(θ) + east * Math.cos(θ),
+  }
+}
+
 export function computeDispersion(shots: Shot[]): DispersionPoint[] {
   const points: DispersionPoint[] = []
   for (const s of shots) {
-    if (
-      !isFiniteNumber(s.aimLat) ||
-      !isFiniteNumber(s.aimLng) ||
-      !isFiniteNumber(s.endLat) ||
-      !isFiniteNumber(s.endLng)
-    ) {
-      continue
-    }
-    const aimLat = s.aimLat
-    const aimLng = s.aimLng
-    const endLat = s.endLat
-    const endLng = s.endLng
-    const latYards = (endLat - aimLat) * YARDS_PER_DEG_LAT
-    const lngYards = (endLng - aimLng) * yardsPerDegLng(aimLat)
-    let startDistanceOffsetYards: number | undefined
-    if (isFiniteNumber(s.startLat)) {
-      startDistanceOffsetYards = (s.startLat - aimLat) * YARDS_PER_DEG_LAT
-    }
+    // Aim-relative framing needs the start→aim line, so skip shots missing
+    // start (compass-framing them and mixing bearings smears the pattern — #464).
+    if (!hasAimGeometry(s)) continue
+    const θ = toRadians(bearingDegrees(s.startLat, s.startLng, s.aimLat, s.aimLng))
+    const end = rotateAroundAim(s.endLat, s.endLng, s.aimLat, s.aimLng, θ)
+    const start = rotateAroundAim(s.startLat, s.startLng, s.aimLat, s.aimLng, θ)
     points.push({
       id: s.id,
-      lateralOffsetYards: lngYards,
-      distanceOffsetYards: latYards,
-      startDistanceOffsetYards,
+      lateralOffsetYards: end.perpYards,
+      distanceOffsetYards: end.alongYards,
+      // Start projected onto the aim line (negative = behind aim = the carry).
+      startDistanceOffsetYards: start.alongYards,
       shotResult: s.shotResult,
       lieSlope: s.lieSlope,
       lieSlopeForward: s.lieSlopeForward,
@@ -152,26 +181,10 @@ export function computeDispersionStats(points: DispersionPoint[]): DispersionSta
 export function aimRelativeOffsets(
   shot: Shot,
 ): { alongYards: number; perpYards: number } | null {
-  if (
-    !isFiniteNumber(shot.startLat) ||
-    !isFiniteNumber(shot.startLng) ||
-    !isFiniteNumber(shot.aimLat) ||
-    !isFiniteNumber(shot.aimLng) ||
-    !isFiniteNumber(shot.endLat) ||
-    !isFiniteNumber(shot.endLng)
-  ) {
-    return null
-  }
+  if (!hasAimGeometry(shot)) return null
   // Bearing of the intended line (start → aim), compass degrees CW from N.
   const θ = toRadians(bearingDegrees(shot.startLat, shot.startLng, shot.aimLat, shot.aimLng))
-  // end − aim in a local yards ENU plane (rotate AFTER the deg→yard scaling,
-  // never on raw degrees — 1° lng ≠ 1° lat in distance).
-  const north = (shot.endLat - shot.aimLat) * YARDS_PER_DEG_LAT
-  const east = (shot.endLng - shot.aimLng) * yardsPerDegLng(shot.aimLat)
-  return {
-    alongYards: north * Math.cos(θ) + east * Math.sin(θ),
-    perpYards: -north * Math.sin(θ) + east * Math.cos(θ),
-  }
+  return rotateAroundAim(shot.endLat, shot.endLng, shot.aimLat, shot.aimLng, θ)
 }
 
 export interface AimRelativeDispersion {


### PR DESCRIPTION
Closes #464.

## The bug

`computeDispersion` measured each shot's end-vs-aim offset as raw **North/East** — `(endLat−aimLat)`, `(endLng−aimLng)` — so `lateralOffsetYards` was east-west spread, not perpendicular-to-the-shot. Aggregating shots aimed on different compass bearings smeared the ellipse and mislabeled lateral vs distance spread. Everything downstream that reads `avgLateralOffset` (dominant-miss, shot-shape, and the **aim-correction text**) was wrong too, not just the plot.

The correct rotation already existed in the same module — `aimRelativeOffsets()`, added for the live-round overlay (#474) — but the Patterns pages never adopted it.

## The fix

Rotate each shot's `(end−aim)` **and** `(start−aim)` vectors into the aim-relative frame by the `start→aim` bearing, via a shared `rotateAroundAim` core that `aimRelativeOffsets` now also uses (one bearing implementation, can't drift). `DispersionPoint`'s shape and field names are unchanged — `lateralOffsetYards` now correctly means perpendicular-to-aim (+ = right), `distanceOffsetYards` means along-aim (+ = long) — so **every consumer is corrected with zero consumer-side edits**: web + mobile dispersion plots, both 1200×630 share cards, the ball-flight chart, `getAimCorrection`, and `dispersionVerdict`.

Aim-relative framing requires a start position (to derive the line), so `computeDispersion` now skips start-less shots. **Data check: all 727 dev shots that have aim+end already have a start** — the post-round placement flow always writes it — so nothing drops in practice.

## Tests

TDD: added two `#464` regressions first (an east-aimed straight shot must read ~0 lateral; identical perpendicular misses flown on different bearings must read identically), watched them fail against the compass code, then fixed. Re-derived the existing `computeDispersion` assertions for the aim frame.

- `@oga/core`: **521 tests pass**
- web + mobile + supabase typecheck: clean

## Visual QA

Signed-in capture of `/patterns` (driver, 128 seeded shots) on the dev e2e user: 68/95 cones compute and center on AIM; summary reads Avg Lateral 0.2 yd / Straight / Straight / ±15.2/12.5 yd / "well centered on target." No regression; ball-flight chart renders.

Scope note: `computeAimRelativeDispersion` (live-round overlay) is left untouched — the web↔mobile dedup is already tracked in #475.