### PR TITLE
fix(mobile): iOS press feedback via PressableTouch (#303)

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -7,6 +7,7 @@ import {
   Text,
   View,
 } from 'react-native'
+import { PressableTouch } from '../../../../components/ui/PressableTouch'
 import { captureRef } from 'react-native-view-shot'
 import * as Sharing from 'expo-sharing'
 import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router'
@@ -555,7 +556,7 @@ export default function RoundIndex() {
             const d = score != null && score > 0 ? score - h.par : null
             const hasShots = hs ? holeScoreIdsWithShots.has(hs.id) : false
             return (
-              <Pressable
+              <PressableTouch
                 key={h.id}
                 accessibilityRole={hasShots ? 'button' : 'text'}
                 accessibilityLabel={
@@ -634,7 +635,7 @@ export default function RoundIndex() {
                 >
                   {hasShots ? '→' : ''}
                 </Text>
-              </Pressable>
+              </PressableTouch>
             )
           })}
         </View>

--- a/apps/mobile/components/round/HoleMapOverlays.tsx
+++ b/apps/mobile/components/round/HoleMapOverlays.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps } from 'react'
-import { Pressable, Text, View } from 'react-native'
+import { Text, View } from 'react-native'
+import { PressableTouch } from '../ui/PressableTouch'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 
 // Shared pill chrome — dark translucent card on satellite, per DESIGN.md
@@ -287,7 +288,7 @@ function ToolbarButton({
   disabled?: boolean
 }) {
   return (
-    <Pressable
+    <PressableTouch
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityState={{ disabled: !!disabled, selected: !!active }}
@@ -298,8 +299,8 @@ function ToolbarButton({
       // Static style object, NOT a `({ pressed }) => …` callback: under
       // NativeWind/css-interop a function `style` on a wrapped RN component is
       // never resolved, so the active cream fill silently never applied —
-      // that's why the selected toolbar/rail state never highlighted. Press
-      // feedback is android_ripple instead (Android-first; #303).
+      // that's why the selected toolbar/rail state never highlighted. Android
+      // press feedback is android_ripple; iOS dims via PressableTouch (#303).
       style={{
         width: 52,
         height: 52,
@@ -315,7 +316,7 @@ function ToolbarButton({
         size={24}
         color={active ? '#1C211C' : '#F2EEE5'}
       />
-    </Pressable>
+    </PressableTouch>
   )
 }
 
@@ -380,7 +381,7 @@ function RailPill({
   onPress: () => void
 }) {
   return (
-    <Pressable
+    <PressableTouch
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityState={{ selected: active }}
@@ -408,6 +409,6 @@ function RailPill({
       >
         {label}
       </Text>
-    </Pressable>
+    </PressableTouch>
   )
 }

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -5,6 +5,7 @@ import {
   Text,
   View,
 } from 'react-native'
+import { PressableTouch } from '../ui/PressableTouch'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { HoleMap, type LatLng } from './HoleMap'
@@ -412,7 +413,7 @@ export default function LiveRoundSession({
           <Text style={{ ...KICKER, color: 'rgba(242,238,229,0.45)' }}>
             Shot {data.shotNumber}
           </Text>
-          <Pressable
+          <PressableTouch
             accessibilityRole="button"
             accessibilityLabel="Round options"
             onPress={() => setMenuOpen(true)}
@@ -423,7 +424,7 @@ export default function LiveRoundSession({
             <Text style={{ color: '#F2EEE5', fontSize: 22, fontWeight: '600', lineHeight: 24 }}>
               ⋮
             </Text>
-          </Pressable>
+          </PressableTouch>
         </View>
       </View>
 
@@ -665,7 +666,7 @@ export default function LiveRoundSession({
               elevation: 8,
             }}
           >
-            <Pressable
+            <PressableTouch
               accessibilityRole="button"
               accessibilityLabel="End round early"
               onPress={() => {
@@ -678,7 +679,7 @@ export default function LiveRoundSession({
               <Text style={{ color: '#F2EEE5', fontSize: 15, fontWeight: '600' }}>
                 End round early
               </Text>
-            </Pressable>
+            </PressableTouch>
             <View
               style={{
                 height: 1,
@@ -686,7 +687,7 @@ export default function LiveRoundSession({
                 marginHorizontal: 8,
               }}
             />
-            <Pressable
+            <PressableTouch
               accessibilityRole="button"
               accessibilityLabel="Delete round"
               onPress={() => {
@@ -699,7 +700,7 @@ export default function LiveRoundSession({
               <Text style={{ color: '#E0796B', fontSize: 15, fontWeight: '600' }}>
                 Delete round
               </Text>
-            </Pressable>
+            </PressableTouch>
           </View>
         </>
       )}

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -1,4 +1,5 @@
 import { Pressable, Text, View } from 'react-native'
+import { PressableTouch } from '../ui/PressableTouch'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { KICKER, type RoundState } from './hole/types'
 
@@ -119,7 +120,7 @@ function PrimaryCta({
   onPress: () => void
 }) {
   return (
-    <Pressable
+    <PressableTouch
       accessibilityRole="button"
       accessibilityLabel={label}
       accessibilityState={{ disabled: !!disabled }}
@@ -129,8 +130,8 @@ function PrimaryCta({
       // Static style object, NOT a `({ pressed }) => …` callback: under
       // NativeWind/css-interop a function `style` on a wrapped RN component is
       // never resolved, so the backgroundColor it returns silently never lands
-      // — that was the "CTA has no background on the satellite" bug. Press
-      // feedback comes from android_ripple instead (Android-first; #303).
+      // — that was the "CTA has no background on the satellite" bug. Android
+      // press feedback is android_ripple; iOS dims via PressableTouch (#303).
       style={{
         // Cream fill + forest text reads on ANY satellite (the forest-on-trees
         // version blended into dark imagery). Disabled stays a dark pill.
@@ -158,7 +159,7 @@ function PrimaryCta({
       >
         {label}
       </Text>
-    </Pressable>
+    </PressableTouch>
   )
 }
 
@@ -172,7 +173,7 @@ function SecondaryPill({
   danger?: boolean
 }) {
   return (
-    <Pressable
+    <PressableTouch
       accessibilityRole="button"
       accessibilityLabel={label}
       onPress={onPress}
@@ -191,7 +192,7 @@ function SecondaryPill({
       <Text style={{ color: danger ? '#E6A99C' : CREAM, fontSize: 14, fontWeight: '600' }}>
         {label}
       </Text>
-    </Pressable>
+    </PressableTouch>
   )
 }
 
@@ -205,7 +206,7 @@ function TextChip({
   strong?: boolean
 }) {
   return (
-    <Pressable
+    <PressableTouch
       accessibilityRole="button"
       accessibilityLabel={label}
       onPress={onPress}
@@ -228,7 +229,7 @@ function TextChip({
       }}
     >
       <Text style={{ ...KICKER, color: strong ? CREAM : 'rgba(242,238,229,0.85)' }}>{label}</Text>
-    </Pressable>
+    </PressableTouch>
   )
 }
 
@@ -280,7 +281,7 @@ function NavChevron({
   onPress: () => void
 }) {
   return (
-    <Pressable
+    <PressableTouch
       accessibilityRole="button"
       accessibilityLabel={dir === 'prev' ? 'Previous hole' : 'Next hole'}
       accessibilityState={{ disabled }}
@@ -299,6 +300,6 @@ function NavChevron({
       <Text style={{ color: CREAM, fontSize: 20, fontWeight: '500' }}>
         {dir === 'prev' ? '‹' : '›'}
       </Text>
-    </Pressable>
+    </PressableTouch>
   )
 }

--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Modal, Pressable, ScrollView, Text, View } from 'react-native'
+import { PressableTouch } from '../ui/PressableTouch'
 import {
   DEFAULT_BAG,
   LIE_TYPE_LABELS,
@@ -199,7 +200,7 @@ function ShotRowView({
     shot.distance_to_target != null ? formatDistance(shot.distance_to_target, unit) : null
 
   return (
-    <Pressable
+    <PressableTouch
       android_ripple={{ color: '#EBE5D6' }}
       accessibilityRole="button"
       accessibilityLabel={`Edit shot ${shot.shot_number}: ${clubLabel}`}
@@ -227,7 +228,7 @@ function ShotRowView({
         )}
       </View>
       <Text style={{ color: '#8A8B7E', fontSize: 12 }}>Edit</Text>
-    </Pressable>
+    </PressableTouch>
   )
 }
 

--- a/apps/mobile/components/ui/PressableTouch.tsx
+++ b/apps/mobile/components/ui/PressableTouch.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react'
+import {
+  Platform,
+  Pressable,
+  type GestureResponderEvent,
+  type PressableProps,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native'
+
+// UIKit dims non-destructive controls to ~0.75 alpha on press; match that.
+const IOS_PRESSED_OPACITY = 0.75
+
+type Props = Omit<PressableProps, 'style'> & {
+  style?: StyleProp<ViewStyle>
+  pressedOpacity?: number
+}
+
+/**
+ * Pressable with an iOS press-down opacity dim. Android keeps its native
+ * `android_ripple`; iOS has no ripple, so we toggle opacity on
+ * onPressIn/onPressOut via a STATIC style array.
+ *
+ * Why not `style={({ pressed }) => …}`: NativeWind 4 css-interop silently
+ * drops a function `style` on wrapped RN components, so it never lands (#303).
+ * The `style` prop here is therefore typed as a non-function StyleProp.
+ *
+ * `ref` is not forwarded — no caller needs one yet. Add `forwardRef` when a
+ * tap target genuinely needs `measure()`/focus.
+ *
+ * Default tap target for the app; reach for this instead of a bare Pressable.
+ */
+export function PressableTouch({
+  style,
+  onPress,
+  onPressIn,
+  onPressOut,
+  disabled,
+  pressedOpacity = IOS_PRESSED_OPACITY,
+  ...rest
+}: Props) {
+  const [pressed, setPressed] = useState(false)
+  // Only dim genuinely-interactive presses: skip disabled and no-op rows (the
+  // scorecard renders non-played holes as a Pressable with no onPress).
+  const dim = Platform.OS === 'ios' && pressed && !disabled && onPress != null
+  return (
+    <Pressable
+      {...rest}
+      disabled={disabled}
+      onPress={onPress}
+      onPressIn={(e: GestureResponderEvent) => {
+        setPressed(true)
+        onPressIn?.(e)
+      }}
+      onPressOut={(e: GestureResponderEvent) => {
+        setPressed(false)
+        onPressOut?.(e)
+      }}
+      style={[style, dim ? { opacity: pressedOpacity } : null]}
+    />
+  )
+}

--- a/apps/mobile/components/ui/PressableTouch.tsx
+++ b/apps/mobile/components/ui/PressableTouch.tsx
@@ -13,7 +13,6 @@ const IOS_PRESSED_OPACITY = 0.75
 
 type Props = Omit<PressableProps, 'style'> & {
   style?: StyleProp<ViewStyle>
-  pressedOpacity?: number
 }
 
 /**
@@ -27,8 +26,6 @@ type Props = Omit<PressableProps, 'style'> & {
  *
  * `ref` is not forwarded — no caller needs one yet. Add `forwardRef` when a
  * tap target genuinely needs `measure()`/focus.
- *
- * Default tap target for the app; reach for this instead of a bare Pressable.
  */
 export function PressableTouch({
   style,
@@ -36,7 +33,6 @@ export function PressableTouch({
   onPressIn,
   onPressOut,
   disabled,
-  pressedOpacity = IOS_PRESSED_OPACITY,
   ...rest
 }: Props) {
   const [pressed, setPressed] = useState(false)
@@ -56,7 +52,7 @@ export function PressableTouch({
         setPressed(false)
         onPressOut?.(e)
       }}
-      style={[style, dim ? { opacity: pressedOpacity } : null]}
+      style={[style, dim ? { opacity: IOS_PRESSED_OPACITY } : null]}
     />
   )
 }


### PR DESCRIPTION
Closes #303.

`android_ripple` is silently ignored on iOS, so 11 `Pressable`s across 5 live-round files had **no press-down feedback** there (persistent active/selected fills still rendered; only the momentary press state was missing).

## Fix
New `apps/mobile/components/ui/PressableTouch.tsx` — a `Pressable` that keeps the native `android_ripple` on Android and dims opacity (0.75, UIKit's press alpha) on iOS via `onPressIn`/`onPressOut` + a **static style array**.

The textbook `style={({ pressed }) => …}` callback **cannot** be used here: NativeWind 4 css-interop silently drops function `style` on wrapped RN components ([nativewind #847](https://github.com/nativewind/nativewind/issues/847)) — the exact trap every one of these sites already dodged with static style objects. The dim is gated to genuinely-interactive presses (`!disabled && onPress != null`) so non-played scorecard rows and disabled buttons don't flash.

All 11 `android_ripple` sites swapped `Pressable`→`PressableTouch`; their static styles are unchanged. The `active:` className variant was rejected (open NativeWind bugs [#1583](https://github.com/nativewind/nativewind/issues/1583)/[#1678](https://github.com/nativewind/nativewind/issues/1678) + it would reintroduce css-interop on a surface deliberately kept on plain styles).

## Sites (5 files)
`round/[id]/index.tsx` scorecard row · `PastHoleShotsSheet` row · `HoleMapOverlays` ToolbarButton + RailPill · `LiveRoundSession` header ⋮ + End/Delete menu · `MapBottomChrome` PrimaryCta/SecondaryPill/TextChip/NavChevron.

## Review & verification
- Plan cross-checked by **two agents** (RN/NativeWind correctness + repo-fit/regression) — both signed off; their two refinements (0.75 default, ref-not-forwarded JSDoc note) are incorporated.
- `npm run typecheck` clean (validates every tag swap + that all props forward).
- No automated test: mobile has no RN component-test harness and this is presentational/framework behavior (repo norm).

## Manual QA (device/simulator)
- [ ] iOS: each touched control dims on press; **tap a non-played scorecard hole row → no opacity flash**.
- [ ] Android: ripple unchanged on every control.