### PR TITLE
docs(ios): first iOS build + on-device smoke runbook (#376)

### DIFF
--- a/docs/ios-submission.md
+++ b/docs/ios-submission.md
@@ -41,3 +41,77 @@ A reviewer could question WebView use under Guideline 4.2.7 (HTML5 wrappers) or
 **If rejected anyway:** escalate to the App Review Board with the response
 above — high probability of acceptance. Budget one round trip in the submission
 timeline.
+
+---
+
+## First iOS build & on-device smoke (#376)
+
+OGA has never been built for iOS. This is the runbook to get a signed IPA onto
+the test iPhone. Build host is Linux + a physical iPhone (no Mac) → builds run
+on EAS Cloud and install on the device via **internal (ad-hoc) distribution**; a
+simulator build is not useful here (it only runs in the macOS Simulator).
+
+### Config status (already in place — #298/#304/#305 satisfied)
+- `eas.json` — all three profiles carry iOS keys. `development`/`preview` use
+  `ios.simulator: false` (device builds); `production` omits a platform key so
+  it builds both OSes. **No eas.json change needed.**
+- `app.config.ts` `ios` — bundle id `golf.oga.app`, `buildNumber: '1'` (seed for
+  `autoIncrement` with `appVersionSource: 'remote'`), `supportsTablet`,
+  `ITSAppUsesNonExemptEncryption: false` (#304), `NSLocationWhenInUseUsage…`,
+  `NSCameraUsageDescription` + `NSPhotoLibraryAddUsageDescription` stubs (#305),
+  full Privacy Manifest (#299), `extra.eas.projectId`.
+- (The #376 issue body is stale: it cites a deleted `app.json` and bundle id
+  `app.opengolf.oga` — that string is the *Android* package; iOS is `golf.oga.app`.)
+
+### Prerequisites — needs your Apple/Expo/Mapbox accounts (cannot be done here)
+1. **#297** Apple Developer Program active + App Store Connect reachable. (Issue
+   still open; memory says the account went active ~2026-05-21 — confirm + close.)
+2. `eas login` as the Expo account that owns project
+   `f852bb53-02fc-46a1-b509-4b2170cb6d84`.
+3. **Two Mapbox tokens must reach the EAS build** (verify, set if missing):
+   - `MAPBOX_DOWNLOADS_TOKEN` — *secret* `sk.…` token, scoped with
+     `DOWNLOADS:READ`, for the iOS Mapbox CocoaPod at prebuild. The
+     `@rnmapbox/maps` plugin reads it from env.
+     `eas secret:create --scope project --name MAPBOX_DOWNLOADS_TOKEN --value sk.…`
+   - `EXPO_PUBLIC_MAPBOX_TOKEN` — *public* `pk.…` runtime token. `lib/maps.ts`
+     reads it via `process.env.EXPO_PUBLIC_MAPBOX_TOKEN`; `EXPO_PUBLIC_*` is
+     inlined at build time, so it must be an EAS env var (Android already needs
+     it — confirm it's an EAS env, not just a local `.env`).
+   - Check both: `eas env:list` / `eas secret:list`.
+
+### Build steps (run from `apps/mobile/`)
+1. Register the test iPhone for ad-hoc distribution:
+   `eas device:create` → choose "register a new device" → open the URL on the
+   iPhone, install the provisioning profile.
+2. Kick the first build (standalone, internal — simplest first smoke; the
+   `development` dev-client profile is for later JS iteration):
+   `eas build --platform ios --profile preview`
+   - First run is **interactive**: log into the Apple team, let EAS create the
+     Distribution cert + ad-hoc provisioning profile (it includes the device
+     from step 1) and register the App Store Connect app from the bundle id.
+3. When the build finishes, open the EAS build URL / QR on the iPhone and
+   install the IPA.
+
+### On-device smoke checklist (#376 acceptance)
+- [ ] App opens, brand splash → login screen, no cold-start crash.
+- [ ] Mapbox tiles render on a live-round map (validates BOTH tokens +
+      `@rnmapbox/maps` iOS config).
+- [ ] Fonts: Fraunces headings render. **Known gap:** `JetBrainsMono-Medium`
+      is referenced in 2 places but is **not bundled** (no font file, not in
+      `useFonts` in `app/_layout.tsx`) — those mono labels fall back to the
+      system font on iOS *and* Android. Cosmetic, pre-existing, not a crash.
+      Decide before launch: bundle the font (OFL, add to `assets/fonts/` +
+      `useFonts`) or drop the 2 `fontFamily: 'JetBrainsMono-Medium'` refs.
+- [ ] VoiceOver on → navigate the rounds list, hear structured labels
+      (cross-platform check of the merged a11y work).
+- [ ] iOS press feedback (#303) — controls dim on press; a non-played
+      scorecard hole row does NOT flash.
+- [ ] Safe-area: live-round header clears the Dynamic Island; bottom sheets
+      clear the home indicator (#494, merged).
+
+### After this lands
+Unblocks the rest of the device-dependent chain: #309 (store assets), #310
+(listing metadata), #312 (App Review demo account), #313 (TestFlight tracks —
+`eas submit` needs `submit.production` filled with Apple ID / ASC app id / team
+id), #315 (@oga.golf email). `eas.json` `submit.production` is an empty stub
+today; fill it at #313 with real Apple values.

--- a/docs/ios-submission.md
+++ b/docs/ios-submission.md
@@ -64,8 +64,8 @@ simulator build is not useful here (it only runs in the macOS Simulator).
   `app.opengolf.oga` — that string is the *Android* package; iOS is `golf.oga.app`.)
 
 ### Prerequisites — needs your Apple/Expo/Mapbox accounts (cannot be done here)
-1. **#297** Apple Developer Program active + App Store Connect reachable. (Issue
-   still open; memory says the account went active ~2026-05-21 — confirm + close.)
+1. **#297** Apple Developer Program active + App Store Connect reachable.
+   (TODO: confirm #297 is closed before proceeding.)
 2. `eas login` as the Expo account that owns project
    `f852bb53-02fc-46a1-b509-4b2170cb6d84`.
 3. **Two Mapbox tokens must reach the EAS build** (verify, set if missing):


### PR DESCRIPTION
Tees up the iOS build chain. Adds a "First iOS build & on-device smoke (#376)" section to `docs/ios-submission.md`.

## What I found verifying against current code
The chain is **further along than the issues say** — several gating tickets are already satisfied (the audit cited a deleted `app.json` and the wrong bundle id):
- **#298** (eas.json iOS targets) — ✅ already present in all three profiles. `development`/`preview` use `ios.simulator: false` (device builds, correct for a Linux+iPhone host); `production` omits a platform key (builds both). No eas.json change needed.
- **#304** (`ITSAppUsesNonExemptEncryption: false`) — ✅ in `app.config.ts`.
- **#305** (camera + photo-library usage strings) — ✅ in `app.config.ts`.
- Bundle id `golf.oga.app` (not the stale `app.opengolf.oga`, which is the *Android* package), `buildNumber:'1'` autoIncrement seed, privacy manifest (#299), Mapbox download-token plugin, `projectId` — all ✅.

## The runbook covers
- Device-build path for a **Linux + physical iPhone (no Mac)** host: EAS Cloud build + ad-hoc internal distribution (`eas device:create` → `eas build -p ios --profile preview`). Simulator builds are useless without a Mac.
- The **two Mapbox tokens** the build needs and how each is wired: `MAPBOX_DOWNLOADS_TOKEN` (secret, iOS CocoaPod) and `EXPO_PUBLIC_MAPBOX_TOKEN` (public, runtime, inlined at build time via `lib/maps.ts`).
- The #376 on-device smoke checklist.

## Flagged gap (not fixed here)
While verifying the font smoke: **`JetBrainsMono-Medium` is referenced in 2 places but never bundled** (no font file, not in `useFonts`) → those labels fall back to the system font on **both** platforms. Cosmetic, pre-existing, not a crash. Decision noted in the runbook: bundle it (OFL) or drop the 2 refs.

Docs-only. The actual build needs your Apple/Expo/Mapbox accounts (can't be done from here) — prerequisites are spelled out.