### PR TITLE
fix(mobile): deep-link email confirmation back into the app

### DIFF
--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -103,21 +103,12 @@ export default function Signup() {
         keyboardShouldPersistTaps="handled"
       >
       <View
-        style={{
-          backgroundColor: '#FFFFFF',
-          borderRadius: 10,
-          borderWidth: 0.5,
-          borderColor: '#E4E4E0',
-          padding: 20,
-        }}
+        className="border-oga-border bg-oga-bg-card"
+        style={{ borderRadius: 10, borderWidth: 0.5, padding: 20 }}
       >
         <Text
-          style={[TYPE.bodyBold, {
-            color: '#111111',
-            fontSize: 22,
-            fontWeight: '600',
-            marginBottom: 16,
-          }]}
+          style={[TYPE.bodyBold, { fontSize: 22, fontWeight: '600', marginBottom: 16 }]}
+          className="text-oga-text-primary"
         >
           Create your OGA account
         </Text>
@@ -126,6 +117,7 @@ export default function Signup() {
           autoCapitalize="none"
           value={username}
           onChangeText={setUsername}
+          className="bg-oga-bg-input border-oga-border text-oga-text-primary"
           style={inputStyle}
         />
         <FieldLabel>Email</FieldLabel>
@@ -134,6 +126,7 @@ export default function Signup() {
           keyboardType="email-address"
           value={email}
           onChangeText={setEmail}
+          className="bg-oga-bg-input border-oga-border text-oga-text-primary"
           style={inputStyle}
         />
         <FieldLabel>Password</FieldLabel>
@@ -141,6 +134,7 @@ export default function Signup() {
           secureTextEntry
           value={password}
           onChangeText={setPassword}
+          className="bg-oga-bg-input border-oga-border text-oga-text-primary"
           style={{ ...inputStyle, marginBottom: 14 }}
         />
         {captchaEnabled && (
@@ -161,35 +155,32 @@ export default function Signup() {
           />
         )}
         {error && (
-          <Text style={[TYPE.body, { color: '#A32D2D', fontSize: 13, marginBottom: 10 }]}>
+          <Text style={[TYPE.body, { fontSize: 13, marginBottom: 10 }]} className="text-oga-red">
             {error}
           </Text>
         )}
         <Pressable
           onPress={handleSubmit}
           disabled={!canSubmit}
+          className="bg-oga-black"
           style={{
-            backgroundColor: '#111111',
             borderRadius: 10,
             paddingVertical: 13,
             alignItems: 'center',
             opacity: !canSubmit ? 0.5 : 1,
           }}
         >
-          <Text style={[TYPE.body, { color: '#FFFFFF', fontSize: 13, fontWeight: '500' }]}>
+          <Text style={[TYPE.body, { fontSize: 13, fontWeight: '500' }]} className="text-white">
             {loading ? 'Creating…' : 'Create account'}
           </Text>
         </Pressable>
-        <Link
-          href="/(auth)/login"
-          style={[TYPE.body, {
-            color: '#0F6E56',
-            fontSize: 13,
-            marginTop: 14,
-            textAlign: 'center',
-          }]}
-        >
-          Have an account? Sign in
+        <Link href="/(auth)/login" asChild>
+          <Text
+            style={[TYPE.body, { fontSize: 13, marginTop: 14, textAlign: 'center' }]}
+            className="text-oga-green"
+          >
+            Have an account? Sign in
+          </Text>
         </Link>
       </View>
       </ScrollView>
@@ -197,15 +188,15 @@ export default function Signup() {
   )
 }
 
+// Colors come from the design tokens applied via className on each input
+// (bg-oga-bg-input / border-oga-border / text-oga-text-primary); this holds
+// the shared layout only.
 const inputStyle = {
-  backgroundColor: '#F9F9F6',
   borderWidth: 0.5,
-  borderColor: '#E4E4E0',
   borderRadius: 7,
   paddingHorizontal: 10,
   paddingVertical: 9,
   fontSize: 13,
-  color: '#111111',
   marginBottom: 12,
 } as const
 
@@ -213,13 +204,13 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
   return (
     <Text
       style={[TYPE.body, {
-        color: '#888880',
         fontSize: 11,
         fontWeight: '500',
         letterSpacing: 0.4,
         textTransform: 'uppercase',
         marginBottom: 6,
       }]}
+      className="text-oga-text-hint"
     >
       {children}
     </Text>

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -8,7 +8,8 @@ import {
   TextInput,
   View,
 } from 'react-native'
-import { Link, useRouter } from 'expo-router'
+import { Link } from 'expo-router'
+import * as Linking from 'expo-linking'
 import { WebView } from 'react-native-webview'
 import { supabase } from '../../lib/supabase'
 import { TYPE } from '../../lib/typography'
@@ -16,13 +17,13 @@ import { TYPE } from '../../lib/typography'
 const TURNSTILE_SITE_KEY = process.env.EXPO_PUBLIC_TURNSTILE_SITE_KEY
 
 export default function Signup() {
-  const router = useRouter()
   const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  const [submitted, setSubmitted] = useState(false)
 
   const captchaEnabled = Boolean(TURNSTILE_SITE_KEY)
   const canSubmit = !loading && (!captchaEnabled || captchaToken !== null)
@@ -35,6 +36,10 @@ export default function Signup() {
       password,
       options: {
         data: { username },
+        // Deep link the confirmation email back into the app (handled by
+        // app/auth-callback.tsx). Without this, GoTrue falls back to the
+        // project Site URL (a localhost/web URL) and never returns to mobile.
+        emailRedirectTo: Linking.createURL('auth-callback'),
         ...(captchaToken ? { captchaToken } : {}),
       },
     })
@@ -44,9 +49,48 @@ export default function Signup() {
       setCaptchaToken(null)
       return
     }
-    // Route through the brand splash (plays on every login), which then
-    // forwards into the app. See app/(auth)/welcome.tsx (#500).
-    router.replace('/(auth)/welcome')
+    // Email confirmation is required, so signUp returns no session yet. Show a
+    // "check your email" state rather than routing into the app; the link
+    // deep-links back in via app/auth-callback.tsx once tapped.
+    setSubmitted(true)
+  }
+
+  if (submitted) {
+    return (
+      <View className="flex-1 bg-oga-bg-page items-center justify-center px-6">
+        <View
+          style={{
+            backgroundColor: '#FFFFFF',
+            borderRadius: 10,
+            borderWidth: 0.5,
+            borderColor: '#E4E4E0',
+            padding: 20,
+            width: '100%',
+          }}
+        >
+          <Text
+            style={[TYPE.bodyBold, {
+              color: '#111111',
+              fontSize: 22,
+              fontWeight: '600',
+              marginBottom: 12,
+            }]}
+          >
+            Check your email
+          </Text>
+          <Text style={[TYPE.body, { color: '#555550', fontSize: 14, lineHeight: 20 }]}>
+            We sent a confirmation link to {email}. Open it on this device to
+            finish setting up your account.
+          </Text>
+          <Link
+            href="/(auth)/login"
+            style={[TYPE.body, { color: '#0F6E56', fontSize: 13, marginTop: 18 }]}
+          >
+            Back to sign in
+          </Link>
+        </View>
+      </View>
+    )
   }
 
   return (

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -59,34 +59,29 @@ export default function Signup() {
     return (
       <View className="flex-1 bg-oga-bg-page items-center justify-center px-6">
         <View
-          style={{
-            backgroundColor: '#FFFFFF',
-            borderRadius: 10,
-            borderWidth: 0.5,
-            borderColor: '#E4E4E0',
-            padding: 20,
-            width: '100%',
-          }}
+          className="border-oga-border bg-oga-bg-card"
+          style={{ borderRadius: 10, borderWidth: 0.5, padding: 20, width: '100%' }}
         >
           <Text
-            style={[TYPE.bodyBold, {
-              color: '#111111',
-              fontSize: 22,
-              fontWeight: '600',
-              marginBottom: 12,
-            }]}
+            style={[TYPE.bodyBold, { fontSize: 22, fontWeight: '600', marginBottom: 12 }]}
+            className="text-oga-text-primary"
           >
             Check your email
           </Text>
-          <Text style={[TYPE.body, { color: '#555550', fontSize: 14, lineHeight: 20 }]}>
+          <Text
+            style={[TYPE.body, { fontSize: 14, lineHeight: 20 }]}
+            className="text-oga-text-muted"
+          >
             We sent a confirmation link to {email}. Open it on this device to
             finish setting up your account.
           </Text>
-          <Link
-            href="/(auth)/login"
-            style={[TYPE.body, { color: '#0F6E56', fontSize: 13, marginTop: 18 }]}
-          >
-            Back to sign in
+          <Link href="/(auth)/login" asChild>
+            <Text
+              style={[TYPE.body, { fontSize: 13, marginTop: 18 }]}
+              className="text-oga-green"
+            >
+              Back to sign in
+            </Text>
           </Link>
         </View>
       </View>

--- a/apps/mobile/app/auth-callback.tsx
+++ b/apps/mobile/app/auth-callback.tsx
@@ -58,7 +58,10 @@ export default function AuthCallback() {
       </Text>
       {error && (
         <Pressable onPress={() => router.replace('/(auth)/login')}>
-          <Text style={[TYPE.body, { color: '#0F6E56', fontSize: 13, marginTop: 16 }]}>
+          <Text
+            style={[TYPE.body, { fontSize: 13, marginTop: 16 }]}
+            className="text-oga-green"
+          >
             Back to sign in
           </Text>
         </Pressable>

--- a/apps/mobile/app/auth-callback.tsx
+++ b/apps/mobile/app/auth-callback.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react'
+import { Pressable, Text, View } from 'react-native'
+import { router } from 'expo-router'
+import * as Linking from 'expo-linking'
+import { supabase } from '../lib/supabase'
+import { TYPE } from '../lib/typography'
+
+// Deep-link target for email confirmation (signup sends
+// `emailRedirectTo: oga://auth-callback`). GoTrue verifies the token
+// server-side, then redirects here with the session in the URL *fragment*
+// (implicit flow — the native client is `detectSessionInUrl: false`, and
+// expo-router only surfaces query params, never the `#` fragment). So we
+// parse the fragment by hand, set the session, then hand off to the same
+// post-login splash every other sign-in uses.
+export default function AuthCallback() {
+  const url = Linking.useURL()
+  const handled = useRef(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!url || handled.current) return
+    const fragment = url.split('#')[1]
+    if (!fragment) return
+    handled.current = true
+
+    const params = new URLSearchParams(fragment)
+    const accessToken = params.get('access_token')
+    const refreshToken = params.get('refresh_token')
+
+    if (!accessToken || !refreshToken) {
+      setError(
+        params.get('error_description') ??
+          'This confirmation link is invalid or has expired.',
+      )
+      return
+    }
+
+    supabase.auth
+      .setSession({ access_token: accessToken, refresh_token: refreshToken })
+      .then(({ error: sessionError }) => {
+        if (sessionError) {
+          handled.current = false
+          setError(sessionError.message)
+          return
+        }
+        router.replace('/(auth)/welcome')
+      })
+  }, [url])
+
+  return (
+    <View className="flex-1 items-center justify-center bg-oga-bg-page px-6">
+      <Text
+        style={TYPE.body}
+        className="text-oga-text-muted text-sm text-center"
+      >
+        {error ?? 'Confirming your account…'}
+      </Text>
+      {error && (
+        <Pressable onPress={() => router.replace('/(auth)/login')}>
+          <Text style={[TYPE.body, { color: '#0F6E56', fontSize: 13, marginTop: 16 }]}>
+            Back to sign in
+          </Text>
+        </Pressable>
+      )}
+    </View>
+  )
+}

--- a/apps/mobile/app/auth-callback.tsx
+++ b/apps/mobile/app/auth-callback.tsx
@@ -39,7 +39,8 @@ export default function AuthCallback() {
       .setSession({ access_token: accessToken, refresh_token: refreshToken })
       .then(({ error: sessionError }) => {
         if (sessionError) {
-          handled.current = false
+          // Terminal: the effect only re-runs on a new `url`, so a retry must
+          // come from re-requesting confirmation (the "Back to sign in" link).
           setError(sessionError.message)
           return
         }


### PR DESCRIPTION
Refs #509.

Mobile signup's confirmation email redirected to `localhost` and never returned to the app, because `signUp()` sent no `emailRedirectTo` (GoTrue fell back to the project Site URL) and there was no deep-link handler to establish a session.

## Changes

- **`app/(auth)/signup.tsx`** — send `emailRedirectTo: Linking.createURL('auth-callback')`; after a successful `signUp()` show a **"Check your email"** state (no session exists until the email is confirmed) instead of bouncing to the post-login splash → login.
- **`app/auth-callback.tsx`** (new route) — receives `oga://auth-callback`, parses the session from the redirect URL **fragment** (implicit flow; native client is `detectSessionInUrl: false`), calls `supabase.auth.setSession`, then routes to `/(auth)/welcome` → app.

Flow: sign up → "Check your email" → tap link → `oga://auth-callback` → session set → brand splash → onboarding/app.

## Not in this PR (required before the blocker is closed)

- **Dashboard:** add `oga://**` to the Supabase Auth Redirect URLs allow-list (dev now, prod before launch) + set a real Site URL. The code does nothing until the redirect is allow-listed.
- **Device verification:** needs an EAS dev/preview build to test the real `oga://` tap-through — Expo Go won't exercise the custom scheme. **Not verified on device yet.**

## Test plan

- [x] `npm run typecheck` (mobile) green.
- [ ] On an EAS dev build: sign up → confirm via email → app reopens signed-in.
