### PR TITLE
fix(mobile): allow about:blank/about:srcdoc so iOS Turnstile loads (#405)

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -98,7 +98,11 @@ export default function Login() {
         {captchaEnabled && (
           <WebView
             source={{ uri: `https://oga.golf/captcha.html?siteKey=${encodeURIComponent(TURNSTILE_SITE_KEY ?? '')}` }}
-            originWhitelist={['https://*', 'http://*', 'about:']}
+            // about:blank + about:srcdoc required for the Turnstile challenge
+            // iframe to load inside iOS WKWebView — without them iOS filters the
+            // sub-frame and the widget hangs on "Verifying…" (#405). Per
+            // Cloudflare's Turnstile mobile-implementation docs.
+            originWhitelist={['https://*', 'http://*', 'about:blank', 'about:srcdoc']}
             onMessage={(event) => {
               try {
                 const msg = JSON.parse(event.nativeEvent.data)

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -140,7 +140,11 @@ export default function Signup() {
         {captchaEnabled && (
           <WebView
             source={{ uri: `https://oga.golf/captcha.html?siteKey=${encodeURIComponent(TURNSTILE_SITE_KEY ?? '')}` }}
-            originWhitelist={['https://*', 'http://*', 'about:']}
+            // about:blank + about:srcdoc required for the Turnstile challenge
+            // iframe to load inside iOS WKWebView — without them iOS filters the
+            // sub-frame and the widget hangs on "Verifying…" (#405). Per
+            // Cloudflare's Turnstile mobile-implementation docs.
+            originWhitelist={['https://*', 'http://*', 'about:blank', 'about:srcdoc']}
             onMessage={(event) => {
               try {
                 const msg = JSON.parse(event.nativeEvent.data)


### PR DESCRIPTION
Refs #405.

Mobile signup/login Turnstile hung on "Verifying…" on **iOS only** — sign-up was impossible because `captchaToken` was never set.

## Root cause

`react-native-webview` applies `originWhitelist` to **sub-frames** on iOS (not just top-level navigation, which is all Android gates). Turnstile's managed challenge renders its interactive UI in an `about:srcdoc` iframe; the bare `'about:'` entry didn't match it, so iOS silently filtered the iframe and the widget spun forever with no `error-callback`. Web + Android worked because they don't apply the allowlist to the sub-frame.

This is the configuration Cloudflare's [Turnstile mobile-implementation docs](https://developers.cloudflare.com/turnstile/get-started/mobile-implementation/) require (allow `about:blank` + `about:srcdoc`). Shared pieces (sitekey domain allowlist, `captcha.html`, its CSP) are exonerated since web + Android pass.

## Change

```diff
- originWhitelist={['https://*', 'http://*', 'about:']}
+ originWhitelist={['https://*', 'http://*', 'about:blank', 'about:srcdoc']}
```
Applied to both `app/(auth)/login.tsx` and `app/(auth)/signup.tsx`.

## Verification

- [x] `npm run typecheck` (mobile) green.
- [ ] **Device-unverified** — only reproduces on a physical iOS build. The EAS **preview Turnstile key must be re-enabled** (currently disabled for the captcha-free bypass) to validate the round-trip on device before closing #405.
