### PR TITLE
fix(mobile): show in-progress rounds in Home + All Rounds lists

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
 import { formatSG } from '@oga/core'
-import { deleteRound, getProfile, getRecentSGData } from '@oga/supabase'
+import { deleteRound, getProfile, getRecentRounds } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
@@ -97,11 +97,11 @@ export default function Home() {
       }
       if (data) setProfile(data as unknown as Profile)
     })
-    getRecentSGData(supabase, user.id, 20).then(({ data, error }) => {
+    getRecentRounds(supabase, user.id, 20).then(({ data, error }) => {
       if (!active) return
       if (error) {
         // eslint-disable-next-line no-console
-        console.error('[home/getRecentSGData]', error.message)
+        console.error('[home/getRecentRounds]', error.message)
         return
       }
       if (data) setRounds(data as RecentRound[])

--- a/apps/mobile/app/(app)/rounds.tsx
+++ b/apps/mobile/app/(app)/rounds.tsx
@@ -9,7 +9,7 @@ import {
 import { Link } from 'expo-router'
 import { Swipeable } from 'react-native-gesture-handler'
 import { formatSG } from '@oga/core'
-import { deleteRound, getRecentSGData } from '@oga/supabase'
+import { deleteRound, getRecentRounds } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { AppBar } from '../../components/ui/AppBar'
@@ -55,11 +55,11 @@ export default function RoundsList() {
   useEffect(() => {
     if (!user) return
     let active = true
-    getRecentSGData(supabase, user.id, 500).then(({ data, error }) => {
+    getRecentRounds(supabase, user.id, 500).then(({ data, error }) => {
       if (!active) return
       if (error) {
         // eslint-disable-next-line no-console
-        console.error('[rounds/getRecentSGData]', error.message)
+        console.error('[rounds/getRecentRounds]', error.message)
         return
       }
       if (data) setRounds(data as RoundRow[])

--- a/packages/supabase/src/queries/rounds.ts
+++ b/packages/supabase/src/queries/rounds.ts
@@ -79,11 +79,8 @@ export function getRecentSGData(client: OgaSupabaseClient, userId: string, limit
     .limit(limit)
 }
 
-// Same shape as getRecentSGData but WITHOUT the `sg_total IS NOT NULL` filter,
-// so in-progress (live, sg_total null) and freshly-created past rounds still
-// appear in the round LISTS. The SG dashboard keeps using getRecentSGData
-// (it legitimately wants only rounds with computed SG). List UIs render `—`
-// for null score/SG.
+// List views include in-progress rounds; the SG dashboard intentionally
+// keeps getRecentSGData (only rounds with computed SG).
 export function getRecentRounds(client: OgaSupabaseClient, userId: string, limit = 10) {
   return client
     .from('rounds')

--- a/packages/supabase/src/queries/rounds.ts
+++ b/packages/supabase/src/queries/rounds.ts
@@ -79,6 +79,22 @@ export function getRecentSGData(client: OgaSupabaseClient, userId: string, limit
     .limit(limit)
 }
 
+// Same shape as getRecentSGData but WITHOUT the `sg_total IS NOT NULL` filter,
+// so in-progress (live, sg_total null) and freshly-created past rounds still
+// appear in the round LISTS. The SG dashboard keeps using getRecentSGData
+// (it legitimately wants only rounds with computed SG). List UIs render `—`
+// for null score/SG.
+export function getRecentRounds(client: OgaSupabaseClient, userId: string, limit = 10) {
+  return client
+    .from('rounds')
+    .select(
+      'id, played_at, sg_off_tee, sg_approach, sg_around_green, sg_putting, sg_total, total_score, courses(name)',
+    )
+    .eq('user_id', userId)
+    .order('played_at', { ascending: false })
+    .limit(limit)
+}
+
 // Rounds with full hole-score and shot detail nested. Used by the stats
 // page to compute per-band, per-club, and per-lie aggregates client-side.
 //


### PR DESCRIPTION
## Problem
In-progress (live) rounds never appeared in the Home or All Rounds lists, so they couldn't be reopened or resumed.

## Cause
Both lists load via `getRecentSGData`, which filters `.not('sg_total','is',null)`. A live round has `sg_total = null` until it's finalized, so it was filtered out entirely.

## Fix
Add `getRecentRounds` (identical select, **without** the SG filter) and point the two mobile list screens at it. The SG dashboard keeps `getRecentSGData` (it should only show rounds with computed SG). Both list UIs already render `—` for null score/SG, so unfinished rounds show cleanly and tapping resumes the live session.

Pre-existing live-round bug, independent of the past-round logger (#514).