### PR TITLE
feat(mobile): editable scorecard-first past-round logger (#514)

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -149,16 +149,17 @@ export default function AppLayout() {
           backgroundColor: '#FBF8F1',
           borderTopWidth: 1,
           borderTopColor: '#D9D2BF',
-          paddingTop: 8,
           // Explicit height + paddingBottom from safe-area insets (#300).
           // Removing height entirely shrank the bar to 49 px on Android and
           // older iPhones (no home indicator), so we set the visible content
           // band ourselves and add `insets.bottom` for iPhone X+ clearance.
           // Android gesture/3-button nav frequently reports insets.bottom≈0,
-          // so the label crowds the screen edge — add a fixed Android-only
-          // clearance band (height grows in step so the content band holds).
+          // so the label crowds the screen edge — grow the bar and split the
+          // extra between top and bottom so the icon+label stay CENTERED
+          // (an earlier bottom-only bump shoved them upward).
+          paddingTop: 8 + (Platform.OS === 'android' ? 6 : 0),
           height: 54 + insets.bottom + (Platform.OS === 'android' ? 12 : 0),
-          paddingBottom: insets.bottom + 10 + (Platform.OS === 'android' ? 12 : 0),
+          paddingBottom: insets.bottom + 10 + (Platform.OS === 'android' ? 6 : 0),
           elevation: 0,
           shadowOpacity: 0,
         },

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { ActivityIndicator, Pressable, Text, View } from 'react-native'
+import { ActivityIndicator, Platform, Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { StatusBar } from 'expo-status-bar'
@@ -154,8 +154,11 @@ export default function AppLayout() {
           // Removing height entirely shrank the bar to 49 px on Android and
           // older iPhones (no home indicator), so we set the visible content
           // band ourselves and add `insets.bottom` for iPhone X+ clearance.
-          height: 54 + insets.bottom,
-          paddingBottom: insets.bottom + 10,
+          // Android gesture/3-button nav frequently reports insets.bottom≈0,
+          // so the label crowds the screen edge — add a fixed Android-only
+          // clearance band (height grows in step so the content band holds).
+          height: 54 + insets.bottom + (Platform.OS === 'android' ? 12 : 0),
+          paddingBottom: insets.bottom + 10 + (Platform.OS === 'android' ? 12 : 0),
           elevation: 0,
           shadowOpacity: 0,
         },

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { ActivityIndicator, Platform, Pressable, Text, View } from 'react-native'
+import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { StatusBar } from 'expo-status-bar'
@@ -150,16 +150,16 @@ export default function AppLayout() {
           borderTopWidth: 1,
           borderTopColor: '#D9D2BF',
           // Explicit height + paddingBottom from safe-area insets (#300).
-          // Removing height entirely shrank the bar to 49 px on Android and
-          // older iPhones (no home indicator), so we set the visible content
-          // band ourselves and add `insets.bottom` for iPhone X+ clearance.
-          // Android gesture/3-button nav frequently reports insets.bottom≈0,
-          // so the label crowds the screen edge — grow the bar and split the
-          // extra between top and bottom so the icon+label stay CENTERED
-          // (an earlier bottom-only bump shoved them upward).
-          paddingTop: 8 + (Platform.OS === 'android' ? 6 : 0),
-          height: 54 + insets.bottom + (Platform.OS === 'android' ? 12 : 0),
-          paddingBottom: insets.bottom + 10 + (Platform.OS === 'android' ? 6 : 0),
+          // Explicit height + paddingBottom from safe-area insets (#300).
+          // Platform-neutral. height and paddingBottom carry an equal +8 over
+          // the base 54/10 so the content band [paddingTop, height-paddingBottom]
+          // is unchanged (no cramping) but the whole bar grows 8px at the bottom
+          // — lifting the icon+label ~8px off the bottom edge (device QA: label
+          // sat too low on a Galaxy S23). Keep top/bottom moving together if you
+          // retune; do NOT re-add Platform.OS bumps (the 49a283b regression).
+          paddingTop: 8,
+          height: 62 + insets.bottom,
+          paddingBottom: insets.bottom + 18,
           elevation: 0,
           shadowOpacity: 0,
         },

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -19,11 +19,21 @@ import {
   selectNudgeDrills,
   type RoundFocus,
 } from '@oga/core'
-import { getDrills, getProfile } from '@oga/supabase'
+import {
+  deleteRound,
+  getDrills,
+  getProfile,
+  updateRound,
+  upsertHoleScore,
+} from '@oga/supabase'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../../../lib/supabase'
+import { completeRound } from '../../../../lib/completeRound'
 import { ShareableScorecardCard } from '../../../../components/round/ShareableScorecardCard'
 import { PastHoleShotsSheet } from '../../../../components/round/PastHoleShotsSheet'
+import { PastRoundMap } from '../../../../components/round/PastRoundMap'
+import { ScoreCell, TabSwitcher } from '../../../../components/round/PastScorecardParts'
+import type { LatLng } from '../../../../components/round/HoleMap'
 import LiveRoundSession from '../../../../components/round/LiveRoundSession'
 import { useAuth } from '../../../../hooks/useAuth'
 import { useUnits } from '../../../../hooks/useUnits'
@@ -62,10 +72,18 @@ export default function RoundIndex() {
   const [holeScores, setHoleScores] = useState<HoleScoreRow[]>([])
   const [shots, setShots] = useState<ShotRow[]>([])
   const [courseName, setCourseName] = useState<string>('Round')
+  const [courseCenter, setCourseCenter] = useState<LatLng | null>(null)
+  // Scorecard ⇄ Map tabs (#514): the scorecard edits scores/putts/details,
+  // the map places ball + aim geometry. `mapHole` is the hole the map is
+  // focused on; its prev/next nav drives it.
+  const [view, setView] = useState<'scorecard' | 'map'>('scorecard')
+  const [mapHole, setMapHole] = useState(1)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [redirectToLive, setRedirectToLive] = useState(false)
   const [sharing, setSharing] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [savingSG, setSavingSG] = useState(false)
   const [shareTone, setShareTone] = useState<'light' | 'dark'>('light')
   // Selected hole for the read-only shots sheet. The sheet is the
   // entire past-round drill-down — we deliberately do NOT navigate
@@ -86,19 +104,27 @@ export default function RoundIndex() {
       try {
         const { data: r, error: rErr } = await supabase
           .from('rounds')
-          .select('*, courses(name)')
+          .select('*, courses(name, lat, lng)')
           .eq('id', id)
           .single()
         if (rErr || !r) throw rErr ?? new Error('Round not found')
         if (!active) return
-        const row = r as RoundRow & { courses?: { name: string | null } | null }
+        const row = r as RoundRow & {
+          courses?: { name: string | null; lat: number | null; lng: number | null } | null
+        }
         setRound(row)
         setCourseName(row.courses?.name ?? 'Round')
-        // Live round signal: total_score is set when the round completes
-        // (either Finish round or End round early). Anything else is
-        // still in progress — drop into the hole flow via <Redirect>
-        // on the next render so we can't navigate after unmount.
-        if (row.total_score == null) {
+        setCourseCenter(
+          row.courses?.lat != null && row.courses?.lng != null
+            ? { lat: row.courses.lat, lng: row.courses.lng }
+            : null,
+        )
+        // Live round signal: total_score is null while a LIVE round is in
+        // progress. Past-round entry (#514) persists a total_score sentinel
+        // at creation and lands here on the editable scorecard — never the
+        // live map. The `mode !== 'past'` guard is belt-and-suspenders for
+        // the first render before the sentinel round row is re-read.
+        if (row.total_score == null && mode !== 'past') {
           if (active) setRedirectToLive(true)
           return
         }
@@ -167,14 +193,14 @@ export default function RoundIndex() {
     () => [...holes].sort((a, b) => a.number - b.number),
     [holes],
   )
-  // Drives the scorecard row's tap affordance — a row is only tappable
-  // if its hole has shots logged. Without this gate, the → arrow
-  // promises content; tap opens a sheet that reads "No shots logged
-  // for this hole." See #247.
-  const holeScoreIdsWithShots = useMemo(
-    () => new Set(shots.map((s) => s.hole_score_id)),
-    [shots],
-  )
+  // Per-hole shot counts for the scorecard "Shots" affordance. Every row
+  // is tappable now that the scorecard is editable (#514) — the count just
+  // distinguishes "N shots →" from "+ add →".
+  const holeScoreShotCount = useMemo(() => {
+    const m = new Map<string, number>()
+    for (const s of shots) m.set(s.hole_score_id, (m.get(s.hole_score_id) ?? 0) + 1)
+    return m
+  }, [shots])
 
   // Refetch shots on screen focus. The end-round write order is:
   // total_score + hole_scores first, then pending shot inserts trickle
@@ -225,7 +251,11 @@ export default function RoundIndex() {
       <LiveRoundSession
         roundId={id}
         initialHoleNumber={initialHole}
-        mode={mode === 'past' ? 'past' : 'live'}
+        // Past entry no longer routes here (#514) — the redirect above is
+        // gated on `mode !== 'past'`, so this branch is always a live round.
+        // The LiveRoundSession `mode`/isPastMode plumbing is now dead and can
+        // be removed in a follow-up cleanup.
+        mode="live"
         onHoleChange={syncHoleToUrl}
       />
     )
@@ -294,6 +324,135 @@ export default function RoundIndex() {
       Alert.alert('Share failed', (err as Error).message)
     } finally {
       setSharing(false)
+    }
+  }
+
+  // Delete the whole round. Mirrors web RoundHeader's Delete (RLS-gated
+  // on user_id via deleteRound). No "End round early" here — this is the
+  // past-round / review surface, not the live tracker (#514).
+  function handleDelete() {
+    if (!round || !user || deleting) return
+    Alert.alert(
+      'Delete round?',
+      'This permanently removes the round and all its shots.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            setDeleting(true)
+            const { error: delErr } = await deleteRound(supabase, round.id, user.id)
+            if (delErr) {
+              setDeleting(false)
+              Alert.alert('Delete failed', delErr.message)
+              return
+            }
+            router.replace('/(app)')
+          },
+        },
+      ],
+    )
+  }
+
+  // Save SG / finalize (#514). Mirrors web's "Save SG + finalize" — runs
+  // the same completeRound pass the live End-round uses: computes per-hole +
+  // round SG from the placed shots and writes totals back. Safe to re-run
+  // (it's idempotent over the current DB state), so editing then re-saving
+  // recomputes. completeRound's pending-shot sync is a no-op for past rounds
+  // (they write straight to Supabase, never the local queue).
+  async function handleSaveSG() {
+    if (!round || !user || savingSG) return
+    setSavingSG(true)
+    try {
+      const { data: profile } = await getProfile(supabase, user.id)
+      const handicap =
+        (profile as { handicap_index?: number | null } | null)?.handicap_index ??
+        null
+      await completeRound({
+        roundId: round.id,
+        courseId: round.course_id,
+        userId: user.id,
+        handicap,
+      })
+      // Refetch round + hole_scores so the SG breakdown + totals reflect the
+      // computed values without leaving the screen.
+      const [rRes, hsRes] = await Promise.all([
+        supabase
+          .from('rounds')
+          .select('*, courses(name, lat, lng)')
+          .eq('id', round.id)
+          .single(),
+        supabase.from('hole_scores').select('*').eq('round_id', round.id),
+      ])
+      if (rRes.data) {
+        let saved = rRes.data as RoundRow & {
+          courses?: { name: string | null } | null
+        }
+        // completeRound writes `total_score: totalScore || null`, so an
+        // all-zero past round comes back null — which would re-strand it on
+        // the live map on next open (#514). Preserve the non-null sentinel.
+        if (saved.total_score == null) {
+          await updateRound(supabase, round.id, { total_score: 0 }, user.id)
+          saved = { ...saved, total_score: 0 }
+        }
+        setRound(saved)
+      }
+      if (hsRes.data) setHoleScores(hsRes.data)
+    } catch (err) {
+      Alert.alert('Save SG failed', (err as Error).message)
+    } finally {
+      setSavingSG(false)
+    }
+  }
+
+  // Inline scorecard edits (#514). Upsert the hole_score, patch local
+  // state, and keep rounds.total_score in sync so the Total header + the
+  // home list reflect the running score without a Save-SG round trip.
+  // total_score stays non-null (sentinel preserved) so routing never
+  // regresses to the live map.
+  async function persistHoleScore(
+    holeId: string,
+    patch: { score?: number; putts?: number | null },
+  ) {
+    if (!round || !user) return
+    const existing = scoresByHoleId.get(holeId)
+    const { data, error: hsErr } = await upsertHoleScore(supabase, {
+      round_id: round.id,
+      hole_id: holeId,
+      score: patch.score ?? existing?.score ?? 0,
+      ...(patch.putts !== undefined ? { putts: patch.putts } : {}),
+    })
+    if (hsErr || !data) {
+      Alert.alert('Save failed', hsErr?.message ?? 'Could not save score')
+      return
+    }
+    const updatedRow = data as HoleScoreRow
+    const nextList = (() => {
+      const idx = holeScores.findIndex((hs) => hs.hole_id === holeId)
+      if (idx === -1) return [...holeScores, updatedRow]
+      const n = holeScores.slice()
+      n[idx] = updatedRow
+      return n
+    })()
+    setHoleScores(nextList)
+    // Recompute rounds.total_score from the entered scores. Putts edits
+    // don't move the total, so skip the round write for those.
+    if (patch.score !== undefined) {
+      const byHole = new Map(nextList.map((hs) => [hs.hole_id, hs]))
+      let total = 0
+      for (const h of sortedHoles) {
+        const s = byHole.get(h.id)?.score
+        if (s != null && s > 0) total += s
+      }
+      setRound((prev) => (prev ? { ...prev, total_score: total } : prev))
+      const { error: rErr } = await updateRound(
+        supabase,
+        round.id,
+        { total_score: total },
+        user.id,
+      )
+      if (rErr) Alert.alert('Save failed', rErr.message)
     }
   }
 
@@ -395,6 +554,9 @@ export default function RoundIndex() {
         </View>
       </View>
 
+      <TabSwitcher view={view} onChange={setView} />
+
+      {view === 'scorecard' && (
       <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
         <View
           style={{
@@ -414,7 +576,7 @@ export default function RoundIndex() {
                 fontVariant: ['tabular-nums'],
               }]}
             >
-              {round.total_score ?? '—'}
+              {runningPar === 0 ? '—' : runningScore}
             </Text>
           </View>
           <View style={{ alignItems: 'flex-end' }}>
@@ -528,66 +690,57 @@ export default function RoundIndex() {
           <View
             style={{
               flexDirection: 'row',
+              alignItems: 'center',
               paddingVertical: 8,
               borderBottomWidth: 1,
               borderColor: '#D9D2BF',
             }}
           >
             <Text style={{ ...KICKER, flex: 1, color: '#8A8B7E' }}>Hole</Text>
-            <Text
-              style={{ ...KICKER, width: 44, textAlign: 'right', color: '#8A8B7E' }}
-            >
+            <Text style={{ ...KICKER, width: 32, textAlign: 'right', color: '#8A8B7E' }}>
               Par
             </Text>
-            <Text
-              style={{ ...KICKER, width: 56, textAlign: 'right', color: '#8A8B7E' }}
-            >
+            <Text style={{ ...KICKER, width: 52, textAlign: 'right', color: '#8A8B7E' }}>
               Score
             </Text>
-            <Text
-              style={{ ...KICKER, width: 56, textAlign: 'right', color: '#8A8B7E' }}
-            >
-              +/−
+            <Text style={{ ...KICKER, width: 48, textAlign: 'right', color: '#8A8B7E' }}>
+              Putts
             </Text>
-            {/* Header spacer for the row affordance arrow. */}
-            <Text style={[TYPE.body, { width: 18, marginLeft: 6 }]}> </Text>
+            <Text style={{ ...KICKER, width: 84, textAlign: 'right', color: '#8A8B7E' }}>
+              Shots
+            </Text>
           </View>
           {sortedHoles.map((h) => {
             const hs = scoresByHoleId.get(h.id)
-            const score = hs?.score ?? null
-            const d = score != null && score > 0 ? score - h.par : null
-            const hasShots = hs ? holeScoreIdsWithShots.has(hs.id) : false
+            const score = hs?.score ?? 0
+            const putts = hs?.putts ?? null
+            const d = score > 0 ? score - h.par : null
+            const shotCount = hs ? holeScoreShotCount.get(hs.id) ?? 0 : 0
+            const scoreColor =
+              d == null
+                ? '#1C211C'
+                : d < 0
+                  ? '#1F3D2C'
+                  : d > 0
+                    ? '#A33A2A'
+                    : '#5C6356'
             return (
-              <PressableTouch
+              <View
                 key={h.id}
-                accessibilityRole={hasShots ? 'button' : 'text'}
-                accessibilityLabel={
-                  hasShots
-                    ? `Hole ${h.number}, par ${h.par}, score ${score}, view shots`
-                    : `Hole ${h.number}, par ${h.par}${score != null && score > 0 ? `, score ${score}` : ', not played'}`
-                }
-                onPress={hasShots ? () => setShotsForHole(h) : undefined}
-                android_ripple={hasShots ? { color: '#EBE5D6' } : undefined}
                 style={{
                   flexDirection: 'row',
-                  paddingVertical: 10,
+                  alignItems: 'center',
                   borderBottomWidth: 1,
                   borderColor: '#EBE5D6',
                   paddingHorizontal: 6,
                 }}
               >
-                <Text
-                  style={[TYPE.kicker, {
-                    flex: 1,
-                    fontSize: 15,
-                    color: '#1C211C',
-                  }]}
-                >
+                <Text style={[TYPE.kicker, { flex: 1, fontSize: 15, color: '#1C211C' }]}>
                   {h.number}
                 </Text>
                 <Text
                   style={[TYPE.kicker, {
-                    width: 44,
+                    width: 32,
                     textAlign: 'right',
                     fontSize: 15,
                     color: '#5C6356',
@@ -596,52 +749,115 @@ export default function RoundIndex() {
                 >
                   {h.par}
                 </Text>
-                <Text
-                  style={[TYPE.kicker, {
-                    width: 56,
-                    textAlign: 'right',
-                    fontSize: 15,
-                    color: score != null && score > 0 ? '#1C211C' : '#8A8B7E',
-                    fontVariant: ['tabular-nums'],
-                    fontWeight: '500',
-                  }]}
+                <ScoreCell
+                  value={score}
+                  width={52}
+                  color={scoreColor}
+                  label={`Hole ${h.number} score`}
+                  onCommit={(n) => persistHoleScore(h.id, { score: n })}
+                />
+                <ScoreCell
+                  value={putts}
+                  width={48}
+                  color="#5C6356"
+                  label={`Hole ${h.number} putts`}
+                  onCommit={(n) => persistHoleScore(h.id, { putts: n > 0 ? n : null })}
+                />
+                <PressableTouch
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    shotCount > 0
+                      ? `Hole ${h.number}, ${shotCount} shots, edit`
+                      : `Hole ${h.number}, add shots`
+                  }
+                  onPress={() => setShotsForHole(h)}
+                  android_ripple={{ color: '#EBE5D6' }}
+                  style={{ width: 84, paddingVertical: 12, alignItems: 'flex-end' }}
                 >
-                  {score != null && score > 0 ? score : '—'}
-                </Text>
-                <Text
-                  style={[TYPE.kicker, {
-                    width: 56,
-                    textAlign: 'right',
-                    fontSize: 15,
-                    color:
-                      d == null
-                        ? '#8A8B7E'
-                        : d < 0
-                          ? '#1F3D2C'
-                          : d > 0
-                            ? '#A33A2A'
-                            : '#5C6356',
-                    fontVariant: ['tabular-nums'],
-                  }]}
-                >
-                  {d == null ? '—' : d === 0 ? 'E' : d > 0 ? `+${d}` : `${d}`}
-                </Text>
-                <Text
-                  style={[TYPE.body, {
-                    width: 18,
-                    textAlign: 'right',
-                    fontSize: 14,
-                    color: '#8A8B7E',
-                    marginLeft: 6,
-                  }]}
-                >
-                  {hasShots ? '→' : ''}
-                </Text>
-              </PressableTouch>
+                  <Text
+                    style={[TYPE.body, {
+                      fontSize: 13,
+                      color: shotCount > 0 ? '#1F3D2C' : '#8A8B7E',
+                    }]}
+                  >
+                    {shotCount > 0
+                      ? `${shotCount} shot${shotCount === 1 ? '' : 's'} →`
+                      : '+ add →'}
+                  </Text>
+                </PressableTouch>
+              </View>
             )
           })}
         </View>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Save strokes gained"
+          accessibilityState={{ disabled: savingSG }}
+          onPress={handleSaveSG}
+          disabled={savingSG}
+          style={{
+            marginTop: 28,
+            paddingVertical: 14,
+            alignItems: 'center',
+            backgroundColor: savingSG ? '#5C6356' : '#1F3D2C',
+            borderRadius: 2,
+            opacity: savingSG ? 0.7 : 1,
+          }}
+        >
+          <Text style={{ ...KICKER, color: '#F2EEE5' }}>
+            {savingSG ? 'Saving…' : 'Save SG'}
+          </Text>
+        </Pressable>
+
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Delete round"
+          accessibilityState={{ disabled: deleting }}
+          onPress={handleDelete}
+          disabled={deleting}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          style={{
+            marginTop: 16,
+            paddingVertical: 12,
+            alignItems: 'center',
+            opacity: deleting ? 0.5 : 1,
+          }}
+        >
+          <Text style={{ ...KICKER, color: '#A33A2A' }}>
+            {deleting ? 'Deleting…' : 'Delete round'}
+          </Text>
+        </Pressable>
       </ScrollView>
+      )}
+
+      {view === 'map' && round && user && (
+        <PastRoundMap
+          roundId={round.id}
+          userId={user.id}
+          holes={sortedHoles}
+          holeScores={holeScores}
+          shots={shots}
+          courseCenter={courseCenter}
+          holeNumber={mapHole}
+          onHoleChange={setMapHole}
+          onShotUpserted={(s) =>
+            setShots((prev) => {
+              const i = prev.findIndex((x) => x.id === s.id)
+              if (i === -1) return [...prev, s]
+              const n = prev.slice()
+              n[i] = s
+              return n
+            })
+          }
+          onShotRemoved={(shotId) =>
+            setShots((prev) => prev.filter((x) => x.id !== shotId))
+          }
+          onHoleScoreChanged={(hs) =>
+            setHoleScores((prev) => prev.map((x) => (x.id === hs.id ? hs : x)))
+          }
+        />
+      )}
       <PastHoleShotsSheet
         visible={shotsForHole != null}
         holeNumber={shotsForHole?.number ?? null}

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -467,14 +467,19 @@ export default function RoundIndex() {
         const s = byHole.get(h.id)?.score
         if (s != null && s > 0) total += s
       }
-      setRound((prev) => (prev ? { ...prev, total_score: total } : prev))
+      // Write first, then reflect locally — an optimistic setRound here left
+      // the header total contradicting the DB with no rollback on failure.
       const { error: rErr } = await updateRound(
         supabase,
         round.id,
         { total_score: total },
         user.id,
       )
-      if (rErr) Alert.alert('Save failed', rErr.message)
+      if (rErr) {
+        Alert.alert('Save failed', rErr.message)
+        return
+      }
+      setRound((prev) => (prev ? { ...prev, total_score: total } : prev))
     }
   }
 

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -327,6 +327,28 @@ export default function RoundIndex() {
     }
   }
 
+  // Leaving a not-yet-finalized round (completed_at null) warns first and
+  // points the player at where to resume it — a logged-but-unfinished past
+  // round otherwise looks like a finished "0" round in the list (#514 QA).
+  function handleLeave() {
+    if (round && round.completed_at == null) {
+      Alert.alert(
+        'Leave this round?',
+        "It isn't finished. Your scores and shots are saved — resume it anytime from Recent rounds on the Home screen.",
+        [
+          { text: 'Keep logging', style: 'cancel' },
+          {
+            text: 'Leave',
+            style: 'destructive',
+            onPress: () => router.replace('/(app)'),
+          },
+        ],
+      )
+      return
+    }
+    router.replace('/(app)')
+  }
+
   // Delete the whole round. Mirrors web RoundHeader's Delete (RLS-gated
   // on user_id via deleteRound). No "End round early" here — this is the
   // past-round / review surface, not the live tracker (#514).
@@ -489,7 +511,7 @@ export default function RoundIndex() {
         }}
       >
         <Pressable
-          onPress={() => router.replace('/(app)')}
+          onPress={handleLeave}
           hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
           style={{ padding: 6 }}
         >

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -173,6 +173,11 @@ export default function NewRound() {
         user_id: user.id,
         course_id: courseId,
         played_at: today,
+        // Past-round entry persists a total_score sentinel (0) at creation
+        // so re-opening the round from the home list routes to the editable
+        // scorecard, never the live map state machine. Live rounds leave
+        // total_score null — that's the in-progress signal. See #514.
+        ...(mode === 'past' ? { total_score: 0 } : {}),
       })
       if (roundError || !round) throw roundError ?? new Error('Round insert failed')
 

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -47,6 +47,11 @@ interface HoleMapProps {
    */
   roundPin?: LatLng | null
   tee?: LatLng | null
+  // Two dots framing the tee shot (perpendicular to the line of play), used
+  // by the past-round logger in place of the single TeeBadge. The caller
+  // (PastRoundMap) computes the positions; we only render them. When set,
+  // it supersedes the `tee` badge.
+  teeBox?: [LatLng, LatLng] | null
   aim?: LatLng | null
   ball?: LatLng | null
   /**
@@ -165,11 +170,23 @@ function extractCoord(feature: unknown): LatLng | null {
   return { lat, lng }
 }
 
+// Tee-box dot — small forest-ringed cream circle, rendered as a pair flanking
+// the tee shot (see PastRoundMap). Deliberately understated vs the old badge.
+const TEE_DOT = {
+  width: 12,
+  height: 12,
+  borderRadius: 6,
+  backgroundColor: '#FBF8F1',
+  borderWidth: 2,
+  borderColor: '#5C6356',
+}
+
 export function HoleMap({
   center,
   pin,
   roundPin,
   tee,
+  teeBox,
   aim,
   ball,
   handicap,
@@ -715,7 +732,17 @@ export function HoleMap({
             </Mapbox.ShapeSource>
           )}
 
-          {!isPinMode && tee && (
+          {!isPinMode && teeBox && (
+            <>
+              <Mapbox.PointAnnotation id="teeL" coordinate={toCoord(teeBox[0])}>
+                <View style={TEE_DOT} />
+              </Mapbox.PointAnnotation>
+              <Mapbox.PointAnnotation id="teeR" coordinate={toCoord(teeBox[1])}>
+                <View style={TEE_DOT} />
+              </Mapbox.PointAnnotation>
+            </>
+          )}
+          {!isPinMode && !teeBox && tee && (
             <Mapbox.PointAnnotation id="tee" coordinate={toCoord(tee)}>
               <TeeBadge />
             </Mapbox.PointAnnotation>

--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -1,15 +1,26 @@
 import { useState } from 'react'
-import { Modal, Pressable, ScrollView, Text, View } from 'react-native'
+import { Modal, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { PressableTouch } from '../ui/PressableTouch'
 import {
   DEFAULT_BAG,
+  LIE_SLOPES_FORWARD,
+  LIE_SLOPES_SIDE,
   LIE_TYPE_LABELS,
   LIE_TYPES,
   SHOT_RESULTS,
+  combinedBreakDirection,
+  combinedPuttResult,
   formatClubLabel,
   formatDistance,
+  type BreakDirectionHorizontal,
+  type BreakDirectionVertical,
   type DistanceUnit,
+  type GreenSpeed,
+  type LieSlopeForward,
+  type LieSlopeSide,
   type LieType,
+  type PuttDirectionResult,
+  type PuttDistanceResult,
   type ShotResult,
 } from '@oga/core'
 import type { Database } from '@oga/supabase'
@@ -19,6 +30,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { FONT, TYPE } from '../../lib/typography'
 
 type ShotRow = Database['public']['Tables']['shots']['Row']
+type ShotUpdate = Database['public']['Tables']['shots']['Update']
 
 const KICKER: import('react-native').TextStyle = {
   color: '#8A8B7E',
@@ -39,6 +51,34 @@ const SHOT_RESULT_LABELS: Record<ShotResult, string> = {
   topped: 'Topped',
   penalty: 'Penalty',
   ob: 'OB',
+}
+
+const FORWARD_LABELS: Record<LieSlopeForward, string> = {
+  uphill: 'Uphill',
+  level: 'Level',
+  downhill: 'Downhill',
+}
+const SIDE_LABELS: Record<LieSlopeSide, string> = {
+  ball_above: 'Ball above',
+  ball_below: 'Ball below',
+}
+const GREEN_SPEEDS: GreenSpeed[] = ['slow', 'medium', 'fast']
+const GREEN_SPEED_LABELS: Record<GreenSpeed, string> = {
+  slow: 'Slow',
+  medium: 'Medium',
+  fast: 'Fast',
+}
+const BREAK_V: BreakDirectionVertical[] = ['uphill', 'downhill', 'flat']
+const BREAK_V_LABELS: Record<BreakDirectionVertical, string> = {
+  uphill: 'Uphill',
+  downhill: 'Downhill',
+  flat: 'Flat',
+}
+const BREAK_H: BreakDirectionHorizontal[] = ['left_to_right', 'right_to_left', 'straight']
+const BREAK_H_LABELS: Record<BreakDirectionHorizontal, string> = {
+  left_to_right: 'L → R',
+  right_to_left: 'R → L',
+  straight: 'Straight',
 }
 
 interface PastHoleShotsSheetProps {
@@ -68,10 +108,7 @@ export function PastHoleShotsSheet({
 
   const sortedShots = [...shots].sort((a, b) => a.shot_number - b.shot_number)
 
-  async function handleSave(
-    shotId: string,
-    updates: { club: string | null; lie_type: string | null; shot_result: string | null },
-  ) {
+  async function handleSave(shotId: string, updates: ShotUpdate) {
     setSaving(true)
     const { data, error } = await supabase
       .from('shots')
@@ -105,82 +142,82 @@ export function PastHoleShotsSheet({
           <EditShotSheet
             shot={editingShot}
             clubs={clubs}
-            unit={unit}
             saving={saving}
             onSave={(updates) => handleSave(editingShot.id, updates)}
             onClose={() => setEditingShot(null)}
           />
         ) : (
-        <View
-          style={{
-            backgroundColor: '#FBF8F1',
-            borderTopLeftRadius: 12,
-            borderTopRightRadius: 12,
-            paddingHorizontal: 18,
-            paddingTop: 14,
-            paddingBottom: insets.bottom + 28,
-            maxHeight: '80%',
-          }}
-        >
           <View
             style={{
-              alignSelf: 'center',
-              width: 32,
-              height: 4,
-              borderRadius: 2,
-              backgroundColor: '#D9D2BF',
-              marginBottom: 14,
+              backgroundColor: '#FBF8F1',
+              borderTopLeftRadius: 12,
+              borderTopRightRadius: 12,
+              paddingHorizontal: 18,
+              paddingTop: 14,
+              paddingBottom: insets.bottom + 28,
+              maxHeight: '80%',
             }}
-          />
-          <Text style={{ ...KICKER, marginBottom: 4 }}>
-            Hole {holeNumber ?? '—'}
-            {par != null ? ` · Par ${par}` : ''}
-          </Text>
-          <Text
-            style={[TYPE.serif, {
-              color: '#1C211C',
-              fontSize: 22,
-              fontStyle: 'italic',
-              fontWeight: '500',
-              marginBottom: 14,
-            }]}
           >
-            {sortedShots.length} shot{sortedShots.length === 1 ? '' : 's'}
-          </Text>
-
-          {sortedShots.length === 0 ? (
-            <Text style={[TYPE.body, { color: '#5C6356', fontSize: 14, lineHeight: 20 }]}>
-              No shots logged for this hole.
+            <View
+              style={{
+                alignSelf: 'center',
+                width: 32,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: '#D9D2BF',
+                marginBottom: 14,
+              }}
+            />
+            <Text style={{ ...KICKER, marginBottom: 4 }}>
+              Hole {holeNumber ?? '—'}
+              {par != null ? ` · Par ${par}` : ''}
             </Text>
-          ) : (
-            <ScrollView style={{ maxHeight: '85%' }}>
-              {sortedShots.map((s) => (
-                <ShotRowView
-                  key={s.id}
-                  shot={s}
-                  unit={unit}
-                  onPress={() => setEditingShot(s)}
-                />
-              ))}
-            </ScrollView>
-          )}
+            <Text
+              style={[TYPE.serif, {
+                color: '#1C211C',
+                fontSize: 22,
+                fontStyle: 'italic',
+                fontWeight: '500',
+                marginBottom: 14,
+              }]}
+            >
+              {sortedShots.length} shot{sortedShots.length === 1 ? '' : 's'}
+            </Text>
 
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Close hole shots"
-            onPress={onClose}
-            style={{
-              marginTop: 14,
-              paddingVertical: 12,
-              alignItems: 'center',
-              borderWidth: 1,
-              borderColor: '#D9D2BF',
-              borderRadius: 2,
-            }}
-          >
-            <Text style={{ ...KICKER, color: '#5C6356' }}>Close</Text>
-          </Pressable>
-        </View>
+            {sortedShots.length === 0 ? (
+              <Text style={[TYPE.body, { color: '#5C6356', fontSize: 14, lineHeight: 20 }]}>
+                No shots logged for this hole. Place them on the Map tab, then
+                edit their details here.
+              </Text>
+            ) : (
+              <ScrollView style={{ maxHeight: '85%' }}>
+                {sortedShots.map((s) => (
+                  <ShotRowView
+                    key={s.id}
+                    shot={s}
+                    unit={unit}
+                    onPress={() => setEditingShot(s)}
+                  />
+                ))}
+              </ScrollView>
+            )}
+
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Close hole shots"
+              onPress={onClose}
+              style={{
+                marginTop: 14,
+                paddingVertical: 12,
+                alignItems: 'center',
+                borderWidth: 1,
+                borderColor: '#D9D2BF',
+                borderRadius: 2,
+              }}
+            >
+              <Text style={{ ...KICKER, color: '#5C6356' }}>Close</Text>
+            </Pressable>
+          </View>
         )}
       </View>
     </Modal>
@@ -196,10 +233,27 @@ function ShotRowView({
   unit: DistanceUnit
   onPress: () => void
 }) {
-  const clubLabel = shot.club ? formatClubLabel({ club_type: shot.club }) : '—'
+  const isPutt = shot.lie_type === 'green' || shot.club === 'putter'
+  const clubLabel = isPutt
+    ? 'Putt'
+    : shot.club
+      ? formatClubLabel({ club_type: shot.club })
+      : '—'
   const lieLabel = shot.lie_type ? LIE_TYPE_LABELS[shot.lie_type as LieType] : null
   const distanceLabel =
     shot.distance_to_target != null ? formatDistance(shot.distance_to_target, unit) : null
+  const sub = isPutt
+    ? [
+        shot.putt_distance_ft != null ? `${shot.putt_distance_ft} ft` : null,
+        shot.putt_result === 'made'
+          ? 'Made'
+          : [shot.putt_distance_result, shot.putt_direction_result]
+              .filter(Boolean)
+              .join(' '),
+      ]
+        .filter(Boolean)
+        .join(' · ')
+    : [lieLabel, distanceLabel].filter(Boolean).join(' · ')
 
   return (
     <PressableTouch
@@ -223,9 +277,9 @@ function ShotRowView({
         <Text style={[TYPE.bodyBold, { color: '#1C211C', fontSize: 15, fontWeight: '500', textTransform: 'capitalize' }]}>
           {clubLabel}
         </Text>
-        {(lieLabel || distanceLabel) && (
+        {sub.length > 0 && (
           <Text style={[TYPE.body, { color: '#5C6356', fontSize: 12, marginTop: 2 }]}>
-            {[lieLabel, distanceLabel].filter(Boolean).join(' · ')}
+            {sub}
           </Text>
         )}
       </View>
@@ -237,17 +291,134 @@ function ShotRowView({
 interface EditShotSheetProps {
   shot: ShotRow
   clubs: readonly { club_type: string; name?: string | null }[]
-  unit: DistanceUnit
   saving: boolean
-  onSave: (updates: { club: string | null; lie_type: string | null; shot_result: string | null }) => void
+  onSave: (updates: ShotUpdate) => void
   onClose: () => void
+}
+
+// Reusable horizontal chip selector — the editor has ~10 of these so a
+// shared row keeps it readable.
+function ChipRow<T extends string>({
+  label,
+  options,
+  value,
+  onSelect,
+}: {
+  label: string
+  options: { value: T; label: string }[]
+  value: T | null
+  onSelect: (v: T) => void
+}) {
+  return (
+    <View style={{ marginBottom: 18 }}>
+      <Text style={{ ...KICKER, marginBottom: 8 }}>{label}</Text>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <View style={{ flexDirection: 'row', gap: 6 }}>
+          {options.map((o) => {
+            const active = value === o.value
+            return (
+              <Pressable
+                key={o.value}
+                onPress={() => onSelect(o.value)}
+                style={{
+                  paddingHorizontal: 10,
+                  paddingVertical: 8,
+                  borderRadius: 2,
+                  backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
+                }}
+              >
+                <Text style={[TYPE.body, { color: active ? '#F2EEE5' : '#1C211C', fontSize: 12 }]}>
+                  {o.label}
+                </Text>
+              </Pressable>
+            )
+          })}
+        </View>
+      </ScrollView>
+    </View>
+  )
 }
 
 function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetProps) {
   const insets = useSafeAreaInsets()
   const [club, setClub] = useState<string | null>(shot.club ?? null)
-  const [lieType, setLieType] = useState<string | null>(shot.lie_type ?? null)
-  const [shotResult, setShotResult] = useState<string | null>(shot.shot_result ?? null)
+  const [lieType, setLieType] = useState<LieType | null>(
+    (shot.lie_type as LieType | null) ?? null,
+  )
+  const [shotResult, setShotResult] = useState<ShotResult | null>(
+    (shot.shot_result as ShotResult | null) ?? null,
+  )
+  const [slopeForward, setSlopeForward] = useState<LieSlopeForward | null>(
+    (shot.lie_slope_forward as LieSlopeForward | null) ?? null,
+  )
+  const [slopeSide, setSlopeSide] = useState<LieSlopeSide | null>(
+    (shot.lie_slope_side as LieSlopeSide | null) ?? null,
+  )
+  // Putt state.
+  const [puttMade, setPuttMade] = useState<boolean>(shot.putt_result === 'made')
+  const [puttDistanceFt, setPuttDistanceFt] = useState<string>(
+    shot.putt_distance_ft != null ? String(shot.putt_distance_ft) : '',
+  )
+  const [distanceResult, setDistanceResult] = useState<PuttDistanceResult | null>(
+    (shot.putt_distance_result as PuttDistanceResult | null) ?? null,
+  )
+  const [directionResult, setDirectionResult] = useState<PuttDirectionResult | null>(
+    (shot.putt_direction_result as PuttDirectionResult | null) ?? null,
+  )
+  const [greenSpeed, setGreenSpeed] = useState<GreenSpeed | null>(
+    (shot.green_speed as GreenSpeed | null) ?? null,
+  )
+  const [breakV, setBreakV] = useState<BreakDirectionVertical | null>(
+    (shot.break_direction_vertical as BreakDirectionVertical | null) ?? null,
+  )
+  const [breakH, setBreakH] = useState<BreakDirectionHorizontal | null>(
+    (shot.break_direction_horizontal as BreakDirectionHorizontal | null) ?? null,
+  )
+
+  const isPutt = lieType === 'green'
+
+  function handleSavePress() {
+    if (isPutt) {
+      const distance = puttMade ? null : distanceResult
+      const direction = puttMade ? null : directionResult
+      onSave({
+        club: 'putter',
+        lie_type: 'green',
+        lie_slope_forward: null,
+        lie_slope_side: null,
+        shot_result: null,
+        penalty: false,
+        ob: false,
+        putt_distance_ft: puttDistanceFt === '' ? null : Number(puttDistanceFt),
+        putt_result: combinedPuttResult({ made: puttMade, distance, direction }),
+        putt_distance_result: distance,
+        putt_direction_result: direction,
+        green_speed: greenSpeed,
+        break_direction: combinedBreakDirection({ vertical: breakV, horizontal: breakH }),
+        break_direction_vertical: breakV,
+        break_direction_horizontal: breakH,
+      })
+      return
+    }
+    onSave({
+      club,
+      lie_type: lieType,
+      lie_slope_forward: slopeForward,
+      lie_slope_side: slopeSide,
+      shot_result: shotResult,
+      penalty: shotResult === 'penalty',
+      ob: shotResult === 'ob',
+      // Clear putt-only columns when this isn't a putt.
+      putt_distance_ft: null,
+      putt_result: null,
+      putt_distance_result: null,
+      putt_direction_result: null,
+      green_speed: null,
+      break_direction: null,
+      break_direction_vertical: null,
+      break_direction_horizontal: null,
+    })
+  }
 
   return (
     <View
@@ -284,80 +455,112 @@ function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetPr
       </Text>
 
       <ScrollView showsVerticalScrollIndicator={false}>
-        <Text style={{ ...KICKER, marginBottom: 8 }}>Club</Text>
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ marginBottom: 18 }}>
-          <View style={{ flexDirection: 'row', gap: 6 }}>
-            {clubs.map((c) => {
-              const active = club === c.club_type
-              return (
-                <Pressable
-                  key={c.club_type}
-                  onPress={() => setClub(c.club_type)}
-                  style={{
-                    paddingHorizontal: 10,
-                    paddingVertical: 8,
-                    borderRadius: 2,
-                    backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
-                  }}
-                >
-                  <Text style={[TYPE.body, { color: active ? '#F2EEE5' : '#1C211C', fontSize: 12 }]}>
-                    {formatClubLabel({ club_type: c.club_type })}
-                  </Text>
-                </Pressable>
-              )
-            })}
-          </View>
-        </ScrollView>
+        <ChipRow
+          label="Lie"
+          options={LIE_TYPES.map((lt) => ({ value: lt, label: LIE_TYPE_LABELS[lt] }))}
+          value={lieType}
+          onSelect={(lt) => setLieType(lt)}
+        />
 
-        <Text style={{ ...KICKER, marginBottom: 8 }}>Lie</Text>
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ marginBottom: 18 }}>
-          <View style={{ flexDirection: 'row', gap: 6 }}>
-            {LIE_TYPES.map((lt) => {
-              const active = lieType === lt
-              return (
-                <Pressable
-                  key={lt}
-                  onPress={() => setLieType(lt)}
-                  style={{
-                    paddingHorizontal: 10,
-                    paddingVertical: 8,
-                    borderRadius: 2,
-                    backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
-                  }}
-                >
-                  <Text style={[TYPE.body, { color: active ? '#F2EEE5' : '#1C211C', fontSize: 12 }]}>
-                    {LIE_TYPE_LABELS[lt as LieType]}
-                  </Text>
-                </Pressable>
-              )
-            })}
-          </View>
-        </ScrollView>
+        {isPutt ? (
+          <>
+            <View style={{ flexDirection: 'row', gap: 8, marginBottom: 18 }}>
+              <ResultToggle label="Made" active={puttMade} onPress={() => setPuttMade(true)} />
+              <ResultToggle label="Missed" active={!puttMade} onPress={() => setPuttMade(false)} />
+            </View>
 
-        <Text style={{ ...KICKER, marginBottom: 8 }}>Result</Text>
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ marginBottom: 18 }}>
-          <View style={{ flexDirection: 'row', gap: 6 }}>
-            {SHOT_RESULTS.map((r) => {
-              const active = shotResult === r
-              return (
-                <Pressable
-                  key={r}
-                  onPress={() => setShotResult(r)}
-                  style={{
-                    paddingHorizontal: 10,
-                    paddingVertical: 8,
-                    borderRadius: 2,
-                    backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
-                  }}
-                >
-                  <Text style={[TYPE.body, { color: active ? '#F2EEE5' : '#1C211C', fontSize: 12 }]}>
-                    {SHOT_RESULT_LABELS[r as ShotResult]}
-                  </Text>
-                </Pressable>
-              )
-            })}
-          </View>
-        </ScrollView>
+            <Text style={{ ...KICKER, marginBottom: 8 }}>Putt distance (ft)</Text>
+            <TextInput
+              value={puttDistanceFt}
+              onChangeText={(t) => setPuttDistanceFt(t.replace(/[^0-9]/g, '').slice(0, 3))}
+              keyboardType="number-pad"
+              placeholder="—"
+              placeholderTextColor="#C4BCA8"
+              accessibilityLabel="Putt distance in feet"
+              style={[TYPE.body, {
+                backgroundColor: '#EBE5D6',
+                borderRadius: 2,
+                paddingHorizontal: 12,
+                paddingVertical: 10,
+                fontSize: 15,
+                color: '#1C211C',
+                marginBottom: 18,
+              }]}
+            />
+
+            {!puttMade && (
+              <>
+                <ChipRow
+                  label="Miss — distance"
+                  options={[
+                    { value: 'short' as PuttDistanceResult, label: 'Short' },
+                    { value: 'long' as PuttDistanceResult, label: 'Long' },
+                  ]}
+                  value={distanceResult}
+                  onSelect={(v) => setDistanceResult(v)}
+                />
+                <ChipRow
+                  label="Miss — direction"
+                  options={[
+                    { value: 'left' as PuttDirectionResult, label: 'Left' },
+                    { value: 'right' as PuttDirectionResult, label: 'Right' },
+                  ]}
+                  value={directionResult}
+                  onSelect={(v) => setDirectionResult(v)}
+                />
+              </>
+            )}
+
+            <ChipRow
+              label="Green speed"
+              options={GREEN_SPEEDS.map((g) => ({ value: g, label: GREEN_SPEED_LABELS[g] }))}
+              value={greenSpeed}
+              onSelect={(v) => setGreenSpeed(v)}
+            />
+            <ChipRow
+              label="Break — vertical"
+              options={BREAK_V.map((b) => ({ value: b, label: BREAK_V_LABELS[b] }))}
+              value={breakV}
+              onSelect={(v) => setBreakV(v)}
+            />
+            <ChipRow
+              label="Break — horizontal"
+              options={BREAK_H.map((b) => ({ value: b, label: BREAK_H_LABELS[b] }))}
+              value={breakH}
+              onSelect={(v) => setBreakH(v)}
+            />
+          </>
+        ) : (
+          <>
+            <ChipRow
+              label="Club"
+              options={clubs.map((c) => ({
+                value: c.club_type,
+                label: formatClubLabel({ club_type: c.club_type }),
+              }))}
+              value={club}
+              onSelect={(v) => setClub(v)}
+            />
+            <ChipRow
+              label="Lie slope — forward"
+              options={LIE_SLOPES_FORWARD.map((s) => ({ value: s, label: FORWARD_LABELS[s] }))}
+              value={slopeForward}
+              onSelect={(v) => setSlopeForward(v)}
+            />
+            <ChipRow
+              label="Lie slope — side"
+              options={LIE_SLOPES_SIDE.map((s) => ({ value: s, label: SIDE_LABELS[s] }))}
+              value={slopeSide}
+              onSelect={(v) => setSlopeSide(v)}
+            />
+            <ChipRow
+              label="Result"
+              options={SHOT_RESULTS.map((r) => ({ value: r, label: SHOT_RESULT_LABELS[r] }))}
+              value={shotResult}
+              onSelect={(v) => setShotResult(v)}
+            />
+          </>
+        )}
       </ScrollView>
 
       <View style={{ flexDirection: 'row', gap: 10, marginTop: 8 }}>
@@ -378,7 +581,7 @@ function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetPr
           accessibilityRole="button"
           accessibilityLabel="Save shot edits"
           disabled={saving}
-          onPress={() => onSave({ club, lie_type: lieType, shot_result: shotResult })}
+          onPress={handleSavePress}
           style={{
             flex: 2,
             paddingVertical: 12,
@@ -392,5 +595,35 @@ function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetPr
         </Pressable>
       </View>
     </View>
+  )
+}
+
+function ResultToggle({
+  label,
+  active,
+  onPress,
+}: {
+  label: string
+  active: boolean
+  onPress: () => void
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      accessibilityLabel={label}
+      onPress={onPress}
+      style={{
+        flex: 1,
+        paddingVertical: 12,
+        alignItems: 'center',
+        borderRadius: 2,
+        backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
+      }}
+    >
+      <Text style={[TYPE.body, { color: active ? '#F2EEE5' : '#1C211C', fontSize: 13 }]}>
+        {label}
+      </Text>
+    </Pressable>
   )
 }

--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -108,7 +108,11 @@ export function PastHoleShotsSheet({
 
   const sortedShots = [...shots].sort((a, b) => a.shot_number - b.shot_number)
 
-  async function handleSave(shotId: string, updates: ShotUpdate) {
+  async function handleSave(
+    shotId: string,
+    updates: ShotUpdate,
+    next?: ShotRow | null,
+  ) {
     setSaving(true)
     const { data, error } = await supabase
       .from('shots')
@@ -118,8 +122,9 @@ export function PastHoleShotsSheet({
       .single()
     setSaving(false)
     if (!error && data) {
-      setEditingShot(null)
       onShotUpdated?.(data as ShotRow)
+      // next set by the editor's prev/next nav; null closes the editor.
+      setEditingShot(next ?? null)
     }
   }
 
@@ -140,10 +145,12 @@ export function PastHoleShotsSheet({
         />
         {editingShot ? (
           <EditShotSheet
+            key={editingShot.id}
             shot={editingShot}
+            allShots={sortedShots}
             clubs={clubs}
             saving={saving}
-            onSave={(updates) => handleSave(editingShot.id, updates)}
+            onSave={(updates, next) => handleSave(editingShot.id, updates, next)}
             onClose={() => setEditingShot(null)}
           />
         ) : (
@@ -290,9 +297,10 @@ function ShotRowView({
 
 interface EditShotSheetProps {
   shot: ShotRow
+  allShots: ShotRow[]
   clubs: readonly { club_type: string; name?: string | null }[]
   saving: boolean
-  onSave: (updates: ShotUpdate) => void
+  onSave: (updates: ShotUpdate, next?: ShotRow | null) => void
   onClose: () => void
 }
 
@@ -339,7 +347,14 @@ function ChipRow<T extends string>({
   )
 }
 
-function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetProps) {
+function EditShotSheet({
+  shot,
+  allShots,
+  clubs,
+  saving,
+  onSave,
+  onClose,
+}: EditShotSheetProps) {
   const insets = useSafeAreaInsets()
   const [club, setClub] = useState<string | null>(shot.club ?? null)
   const [lieType, setLieType] = useState<LieType | null>(
@@ -377,11 +392,16 @@ function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetPr
 
   const isPutt = lieType === 'green'
 
-  function handleSavePress() {
+  const idx = allShots.findIndex((s) => s.id === shot.id)
+  const prevShot = idx > 0 ? allShots[idx - 1]! : null
+  const nextShot =
+    idx >= 0 && idx < allShots.length - 1 ? allShots[idx + 1]! : null
+
+  function buildUpdates(): ShotUpdate {
     if (isPutt) {
       const distance = puttMade ? null : distanceResult
       const direction = puttMade ? null : directionResult
-      onSave({
+      return {
         club: 'putter',
         lie_type: 'green',
         lie_slope_forward: null,
@@ -397,10 +417,9 @@ function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetPr
         break_direction: combinedBreakDirection({ vertical: breakV, horizontal: breakH }),
         break_direction_vertical: breakV,
         break_direction_horizontal: breakH,
-      })
-      return
+      }
     }
-    onSave({
+    return {
       club,
       lie_type: lieType,
       lie_slope_forward: slopeForward,
@@ -417,7 +436,11 @@ function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetPr
       break_direction: null,
       break_direction_vertical: null,
       break_direction_horizontal: null,
-    })
+    }
+  }
+
+  function handleSavePress() {
+    onSave(buildUpdates())
   }
 
   return (
@@ -442,17 +465,48 @@ function EditShotSheet({ shot, clubs, saving, onSave, onClose }: EditShotSheetPr
           marginBottom: 14,
         }}
       />
-      <Text
-        style={[TYPE.serif, {
-          color: '#1C211C',
-          fontSize: 17,
-          fontStyle: 'italic',
-          fontWeight: '500',
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
           marginBottom: 18,
-        }]}
+        }}
       >
-        Edit shot {shot.shot_number}
-      </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Previous shot"
+          accessibilityState={{ disabled: !prevShot || saving }}
+          disabled={!prevShot || saving}
+          onPress={() => onSave(buildUpdates(), prevShot)}
+          hitSlop={8}
+          style={{ padding: 4, opacity: prevShot ? 1 : 0.3 }}
+        >
+          <Text style={{ ...KICKER, color: '#5C6356' }}>‹ Prev</Text>
+        </Pressable>
+        <Text
+          style={[TYPE.serif, {
+            color: '#1C211C',
+            fontSize: 17,
+            fontStyle: 'italic',
+            fontWeight: '500',
+          }]}
+        >
+          Shot {shot.shot_number}
+          {allShots.length > 1 ? ` of ${allShots.length}` : ''}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Next shot"
+          accessibilityState={{ disabled: !nextShot || saving }}
+          disabled={!nextShot || saving}
+          onPress={() => onSave(buildUpdates(), nextShot)}
+          hitSlop={8}
+          style={{ padding: 4, opacity: nextShot ? 1 : 0.3 }}
+        >
+          <Text style={{ ...KICKER, color: '#5C6356' }}>Next ›</Text>
+        </Pressable>
+      </View>
 
       <ScrollView showsVerticalScrollIndicator={false}>
         <ChipRow

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -1,13 +1,20 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Alert, Pressable, Text, View } from 'react-native'
+import { Alert, Modal, Pressable, Text, View } from 'react-native'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { DEFAULT_HANDICAP } from '@oga/core'
+import {
+  DEFAULT_HANDICAP,
+  combinedBreakDirection,
+  combinedPuttResult,
+} from '@oga/core'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { distanceYards } from '../../lib/maps'
 import { FONT, TYPE } from '../../lib/typography'
 import { HoleMap, type LatLng } from './HoleMap'
 import type { HoleMapPhase } from './HoleMap.types'
+import { PuttingSheet, type PuttingValue } from './PuttingSheet'
+import { PUTTING_RADIUS_YARDS } from './hole/types'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
@@ -112,6 +119,9 @@ export function PastRoundMap({
   const [placed, setPlaced] = useState<PlacedShot[]>([])
   const [activeIdx, setActiveIdx] = useState(0)
   const [mode, setMode] = useState<PlacementMode>('PLACE_BALL')
+  // When set, the green-shot putting sheet is open for this shot index,
+  // seeded with the auto-derived start→pin distance (feet).
+  const [puttSheet, setPuttSheet] = useState<{ idx: number; distanceFt: number } | null>(null)
   const aimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Clear a pending aim-debounce on unmount (e.g. switching to the Scorecard
@@ -239,16 +249,78 @@ export function PastRoundMap({
           prev.map((s, i) => (i === idx ? { ...s, id: saved.id } : s)),
         )
         onShotUpserted(saved)
-        await syncScore(placed.filter((s) => s.start != null).length)
+        // Count idx as started: the closure `placed` predates this shot's
+        // start being set, so filtering it directly under-counts by one
+        // (the score off-by-one — every hole read one stroke low). See #514 QA.
+        await syncScore(
+          placed.filter((s, i) => (i === idx ? true : s.start != null)).length,
+        )
       }
     }
   }
 
   function handleSetBall(loc: LatLng) {
+    const wasInitial = active?.start == null
     setPlaced((prev) =>
       prev.map((s, i) => (i === activeIdx ? { ...s, start: loc } : s)),
     )
     persistShotAt(activeIdx, { start: loc })
+    // Auto-advance after the FIRST placement of a shot (mirrors the live
+    // flow the user liked). Within the putting radius of the pin → open the
+    // putting sheet with the distance auto-derived (no map aim); otherwise
+    // drop straight into aim mode.
+    if (wasInitial) {
+      if (effectivePin && distanceYards(loc, effectivePin) <= PUTTING_RADIUS_YARDS) {
+        setPuttSheet({
+          idx: activeIdx,
+          distanceFt: Math.round(distanceYards(loc, effectivePin) * 3),
+        })
+      } else {
+        setMode('SET_AIM')
+      }
+    }
+  }
+
+  // Save the green shot as a putt: the start was already persisted on
+  // placement, so this UPDATEs that row with the putt fields (mirrors the
+  // live persistPutt column mapping). Distance came from the placement.
+  async function handlePuttSave(idx: number, value: PuttingValue) {
+    const shot = placed[idx]
+    if (!shot?.id) {
+      setPuttSheet(null)
+      return
+    }
+    const made = value.puttMade ?? false
+    const distance = made ? null : value.puttDistanceResult ?? null
+    const direction = made ? null : value.puttDirectionResult ?? null
+    const { data, error } = await supabase
+      .from('shots')
+      .update({
+        club: 'putter',
+        lie_type: 'green',
+        putt_distance_ft: value.puttDistanceFt ?? null,
+        putt_result: combinedPuttResult({ made, distance, direction }),
+        putt_distance_result: distance,
+        putt_direction_result: direction,
+        putt_slope_pct: value.puttSlopePct ?? null,
+        green_speed: value.greenSpeed ?? null,
+        break_direction: combinedBreakDirection({
+          vertical: value.breakDirectionVertical,
+          horizontal: value.breakDirectionHorizontal,
+        }),
+        break_direction_vertical: value.breakDirectionVertical ?? null,
+        break_direction_horizontal: value.breakDirectionHorizontal ?? null,
+      })
+      .eq('id', shot.id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (error) {
+      Alert.alert('Save failed', error.message)
+      return
+    }
+    if (data) onShotUpserted(data as ShotRow)
+    setPuttSheet(null)
   }
 
   function handleSetAim(loc: LatLng) {
@@ -473,6 +545,35 @@ export function PastRoundMap({
           </Pressable>
         </View>
       </View>
+
+      {puttSheet && (
+        <Modal
+          visible
+          transparent
+          animationType="slide"
+          onRequestClose={() => setPuttSheet(null)}
+        >
+          {/* Modal renders to a separate native window on Android, so the
+              app-root GestureHandlerRootView doesn't reach the GreenDiagram
+              aim handle inside — re-root it here (mirrors HoleModals). */}
+          <GestureHandlerRootView style={{ flex: 1 }}>
+            <View
+              style={{
+                flex: 1,
+                justifyContent: 'flex-end',
+                backgroundColor: 'rgba(0,0,0,0.4)',
+              }}
+            >
+              <PuttingSheet
+                shotNumber={placed[puttSheet.idx]?.shotNumber ?? 1}
+                initialDistanceFt={puttSheet.distanceFt}
+                onSave={(v) => handlePuttSave(puttSheet.idx, v)}
+                onClose={() => setPuttSheet(null)}
+              />
+            </View>
+          </GestureHandlerRootView>
+        </Modal>
+      )}
     </View>
   )
 }

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -1,0 +1,519 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Alert, Pressable, Text, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { DEFAULT_HANDICAP } from '@oga/core'
+import type { Database } from '@oga/supabase'
+import { supabase } from '../../lib/supabase'
+import { distanceYards } from '../../lib/maps'
+import { FONT, TYPE } from '../../lib/typography'
+import { HoleMap, type LatLng } from './HoleMap'
+import type { HoleMapPhase } from './HoleMap.types'
+
+type HoleRow = Database['public']['Tables']['holes']['Row']
+type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
+type ShotRow = Database['public']['Tables']['shots']['Row']
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+  fontFamily: FONT.mono,
+}
+
+// Debounce window for persisting an aim drag. The aim handle fires updates
+// at ~25 Hz while dragging (HoleMap throttles to 40ms); we keep the marker
+// tracking the finger locally and only write the settled position.
+const AIM_PERSIST_DEBOUNCE_MS = 500
+
+// Past-round placement only places geometry — the start position of each
+// shot and (optionally) its aim. All shot *details* (club, lie, result,
+// putt axes) are edited on the scorecard sheet. Distances are derived from
+// the placed start → pin and stored so the SG pass needs no recompute. This
+// deliberately reuses HoleMap (the renderer) but NOT LiveRoundSession (the
+// live GPS state machine) — see #514.
+interface PlacedShot {
+  id: string | null
+  shotNumber: number
+  start: LatLng | null
+  aim: LatLng | null
+}
+
+type PlacementMode = Extract<HoleMapPhase, 'PLACE_BALL' | 'SET_AIM' | 'PIN'>
+
+interface PastRoundMapProps {
+  roundId: string
+  userId: string
+  holes: HoleRow[]
+  holeScores: HoleScoreRow[]
+  shots: ShotRow[]
+  courseCenter: LatLng | null
+  holeNumber: number
+  onHoleChange: (next: number) => void
+  onShotUpserted: (shot: ShotRow) => void
+  onShotRemoved: (shotId: string) => void
+  onHoleScoreChanged: (holeScore: HoleScoreRow) => void
+}
+
+const OKC_FALLBACK: LatLng = { lat: 35.5, lng: -97.5 }
+
+export function PastRoundMap({
+  roundId,
+  userId,
+  holes,
+  holeScores,
+  shots,
+  courseCenter,
+  holeNumber,
+  onHoleChange,
+  onShotUpserted,
+  onShotRemoved,
+  onHoleScoreChanged,
+}: PastRoundMapProps) {
+  const insets = useSafeAreaInsets()
+
+  const currentHole = useMemo(
+    () => holes.find((h) => h.number === holeNumber) ?? null,
+    [holes, holeNumber],
+  )
+  const currentHoleScore = useMemo(
+    () =>
+      currentHole
+        ? holeScores.find((hs) => hs.hole_id === currentHole.id) ?? null
+        : null,
+    [holeScores, currentHole],
+  )
+
+  const storedPin: LatLng | null = useMemo(
+    () =>
+      currentHole?.pin_lat != null && currentHole?.pin_lng != null
+        ? { lat: currentHole.pin_lat, lng: currentHole.pin_lng }
+        : null,
+    [currentHole],
+  )
+  const roundPin: LatLng | null = useMemo(
+    () =>
+      currentHoleScore?.pin_lat != null && currentHoleScore?.pin_lng != null
+        ? { lat: currentHoleScore.pin_lat, lng: currentHoleScore.pin_lng }
+        : null,
+    [currentHoleScore],
+  )
+  const effectivePin = roundPin ?? storedPin
+  const tee: LatLng | null = useMemo(
+    () =>
+      currentHole?.tee_lat != null && currentHole?.tee_lng != null
+        ? { lat: currentHole.tee_lat, lng: currentHole.tee_lng }
+        : null,
+    [currentHole],
+  )
+  const center = effectivePin ?? tee ?? courseCenter ?? OKC_FALLBACK
+
+  const [placed, setPlaced] = useState<PlacedShot[]>([])
+  const [activeIdx, setActiveIdx] = useState(0)
+  const [mode, setMode] = useState<PlacementMode>('PLACE_BALL')
+  const aimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Clear a pending aim-debounce on unmount (e.g. switching to the Scorecard
+  // tab mid-drag) so it can't fire a write against a torn-down component.
+  useEffect(() => {
+    return () => {
+      if (aimTimerRef.current) clearTimeout(aimTimerRef.current)
+    }
+  }, [])
+
+  // Re-seed the placement list whenever the hole changes (NOT on every
+  // shots-prop change, which would clobber an in-progress placement). The
+  // ref tracks which hole_score we've seeded so a parent shots update from
+  // our own persist doesn't reset the user's work.
+  const seededForRef = useRef<string | null>(null)
+  useEffect(() => {
+    const key = currentHoleScore?.id ?? `none-${holeNumber}`
+    if (seededForRef.current === key) return
+    seededForRef.current = key
+    const hsId = currentHoleScore?.id
+    const existing = hsId
+      ? shots
+          .filter(
+            (s) => s.hole_score_id === hsId && s.start_lat != null && s.start_lng != null,
+          )
+          .sort((a, b) => a.shot_number - b.shot_number)
+          .map<PlacedShot>((s) => ({
+            id: s.id,
+            shotNumber: s.shot_number,
+            start: { lat: s.start_lat as number, lng: s.start_lng as number },
+            aim:
+              s.aim_lat != null && s.aim_lng != null
+                ? { lat: s.aim_lat, lng: s.aim_lng }
+                : null,
+          }))
+      : []
+    const seeded =
+      existing.length > 0
+        ? existing
+        : [{ id: null, shotNumber: 1, start: null, aim: null }]
+    setPlaced(seeded)
+    setActiveIdx(seeded.length - 1)
+    setMode('PLACE_BALL')
+  }, [currentHoleScore?.id, holeNumber, shots])
+
+  const active = placed[activeIdx] ?? null
+  const previousStarts = useMemo(
+    () =>
+      placed
+        .slice(0, activeIdx)
+        .map((s) => s.start)
+        .filter((p): p is LatLng => p != null),
+    [placed, activeIdx],
+  )
+
+  const startedCount = useMemo(
+    () => placed.filter((s) => s.start != null).length,
+    [placed],
+  )
+
+  // Keep hole_scores.score honest with the placed-shot count (a placed shot
+  // IS a stroke). Pure score-only entry on the scorecard is untouched —
+  // this only fires when the map owns shot creation for the hole.
+  async function syncScore(count: number) {
+    if (!currentHoleScore) return
+    const { data, error } = await supabase
+      .from('hole_scores')
+      .update({ score: count })
+      .eq('id', currentHoleScore.id)
+      .eq('round_id', roundId)
+      .select()
+      .single()
+    if (!error && data) onHoleScoreChanged(data as HoleScoreRow)
+  }
+
+  async function persistShotAt(
+    idx: number,
+    next: { start?: LatLng | null; aim?: LatLng | null },
+  ) {
+    if (!currentHoleScore) return
+    const shot = placed[idx]
+    if (!shot) return
+    const start = next.start !== undefined ? next.start : shot.start
+    const aim = next.aim !== undefined ? next.aim : shot.aim
+    if (!start) return
+    const distance = effectivePin
+      ? Math.round(distanceYards(start, effectivePin))
+      : null
+    const row = {
+      hole_score_id: currentHoleScore.id,
+      user_id: userId,
+      shot_number: shot.shotNumber,
+      start_lat: start.lat,
+      start_lng: start.lng,
+      aim_lat: aim?.lat ?? null,
+      aim_lng: aim?.lng ?? null,
+      distance_to_target: distance,
+    }
+    if (shot.id) {
+      const { data, error } = await supabase
+        .from('shots')
+        .update(row)
+        .eq('id', shot.id)
+        .eq('user_id', userId)
+        .select()
+        .single()
+      if (error) {
+        Alert.alert('Save failed', error.message)
+        return
+      }
+      if (data) onShotUpserted(data as ShotRow)
+    } else {
+      const { data, error } = await supabase
+        .from('shots')
+        .insert(row)
+        .select()
+        .single()
+      if (error) {
+        Alert.alert('Save failed', error.message)
+        return
+      }
+      if (data) {
+        const saved = data as ShotRow
+        setPlaced((prev) =>
+          prev.map((s, i) => (i === idx ? { ...s, id: saved.id } : s)),
+        )
+        onShotUpserted(saved)
+        await syncScore(placed.filter((s) => s.start != null).length)
+      }
+    }
+  }
+
+  function handleSetBall(loc: LatLng) {
+    setPlaced((prev) =>
+      prev.map((s, i) => (i === activeIdx ? { ...s, start: loc } : s)),
+    )
+    persistShotAt(activeIdx, { start: loc })
+  }
+
+  function handleSetAim(loc: LatLng) {
+    setPlaced((prev) =>
+      prev.map((s, i) => (i === activeIdx ? { ...s, aim: loc } : s)),
+    )
+    if (aimTimerRef.current) clearTimeout(aimTimerRef.current)
+    aimTimerRef.current = setTimeout(() => {
+      persistShotAt(activeIdx, { aim: loc })
+    }, AIM_PERSIST_DEBOUNCE_MS)
+  }
+
+  async function handleSetPin(loc: LatLng) {
+    if (!currentHoleScore) return
+    if (!Number.isFinite(loc.lat) || !Number.isFinite(loc.lng)) return
+    const { data, error } = await supabase
+      .from('hole_scores')
+      .update({ pin_lat: loc.lat, pin_lng: loc.lng })
+      .eq('id', currentHoleScore.id)
+      .eq('round_id', roundId)
+      .select()
+      .single()
+    if (error) {
+      Alert.alert('Pin save failed', error.message)
+      return
+    }
+    if (data) onHoleScoreChanged(data as HoleScoreRow)
+    setMode('PLACE_BALL')
+  }
+
+  function handleAddShot() {
+    if (!active?.start) return // don't stack two empty drafts
+    if (aimTimerRef.current) clearTimeout(aimTimerRef.current)
+    setPlaced((prev) => [
+      ...prev,
+      { id: null, shotNumber: prev.length + 1, start: null, aim: null },
+    ])
+    setActiveIdx(placed.length)
+    setMode('PLACE_BALL')
+  }
+
+  async function handleRemoveShot() {
+    if (!active) return
+    if (aimTimerRef.current) clearTimeout(aimTimerRef.current)
+    if (active.id) {
+      const { error } = await supabase
+        .from('shots')
+        .delete()
+        .eq('id', active.id)
+        .eq('user_id', userId)
+      if (error) {
+        Alert.alert('Remove failed', error.message)
+        return
+      }
+      onShotRemoved(active.id)
+    }
+    const nextPlaced = placed.filter((_, i) => i !== activeIdx)
+    const ensured =
+      nextPlaced.length > 0
+        ? nextPlaced.map((s, i) => ({ ...s, shotNumber: i + 1 }))
+        : [{ id: null, shotNumber: 1, start: null, aim: null }]
+    setPlaced(ensured)
+    setActiveIdx(Math.max(0, ensured.length - 1))
+    setMode('PLACE_BALL')
+    await syncScore(ensured.filter((s) => s.start != null).length)
+  }
+
+  function goToHole(next: number) {
+    if (next < 1 || next > holes.length) return
+    if (aimTimerRef.current) clearTimeout(aimTimerRef.current)
+    onHoleChange(next)
+  }
+
+  const par = currentHole?.par ?? null
+
+  return (
+    <View style={{ flex: 1, backgroundColor: '#1C211C' }}>
+      {/* Hole nav strip */}
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          backgroundColor: '#1C211C',
+          paddingHorizontal: 14,
+          paddingVertical: 10,
+          borderBottomWidth: 1,
+          borderBottomColor: 'rgba(242,238,229,0.12)',
+        }}
+      >
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Previous hole"
+          disabled={holeNumber <= 1}
+          onPress={() => goToHole(holeNumber - 1)}
+          hitSlop={10}
+          style={{ padding: 6, opacity: holeNumber <= 1 ? 0.35 : 1 }}
+        >
+          <Text style={{ ...KICKER, color: 'rgba(242,238,229,0.75)' }}>‹ Prev</Text>
+        </Pressable>
+        <Text
+          style={[TYPE.serif, {
+            color: '#F2EEE5',
+            fontSize: 16,
+            fontStyle: 'italic',
+            fontWeight: '500',
+          }]}
+        >
+          Hole {holeNumber}
+          {par != null ? ` · Par ${par}` : ''}
+        </Text>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Next hole"
+          disabled={holeNumber >= holes.length}
+          onPress={() => goToHole(holeNumber + 1)}
+          hitSlop={10}
+          style={{ padding: 6, opacity: holeNumber >= holes.length ? 0.35 : 1 }}
+        >
+          <Text style={{ ...KICKER, color: 'rgba(242,238,229,0.75)' }}>Next ›</Text>
+        </Pressable>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <HoleMap
+          center={center}
+          pin={storedPin}
+          roundPin={roundPin}
+          tee={tee}
+          aim={active?.aim ?? null}
+          ball={active?.start ?? null}
+          previousShots={previousStarts}
+          phase={mode}
+          missingHoleLayout={!effectivePin && !tee}
+          gpsPosition={null}
+          courseCenter={courseCenter}
+          holeNumber={holeNumber}
+          onSetAim={handleSetAim}
+          onSetBall={handleSetBall}
+          onPlacePin={handleSetPin}
+          showLocationPuck={false}
+          overlayMode="tee"
+          arcWidthYards={0}
+          circleRadiusYards={0}
+          dotsVisible={false}
+          dispersionPoints={null}
+          handicap={DEFAULT_HANDICAP}
+        />
+      </View>
+
+      {/* Bottom controls */}
+      <View
+        style={{
+          backgroundColor: '#1C211C',
+          paddingHorizontal: 14,
+          paddingTop: 10,
+          paddingBottom: insets.bottom + 12,
+          borderTopWidth: 1,
+          borderTopColor: 'rgba(242,238,229,0.12)',
+          gap: 10,
+        }}
+      >
+        <View style={{ flexDirection: 'row', gap: 8 }}>
+          <ModeChip
+            label="Ball"
+            active={mode === 'PLACE_BALL'}
+            onPress={() => setMode('PLACE_BALL')}
+          />
+          <ModeChip
+            label="Aim"
+            active={mode === 'SET_AIM'}
+            disabled={!active?.start}
+            onPress={() => setMode('SET_AIM')}
+          />
+          <ModeChip label="Pin" active={mode === 'PIN'} onPress={() => setMode('PIN')} />
+        </View>
+
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Remove this shot"
+            onPress={handleRemoveShot}
+            disabled={!active?.start && placed.length <= 1}
+            style={{
+              paddingVertical: 12,
+              paddingHorizontal: 14,
+              borderWidth: 1,
+              borderColor: 'rgba(242,238,229,0.3)',
+              borderRadius: 2,
+              opacity: !active?.start && placed.length <= 1 ? 0.4 : 1,
+            }}
+          >
+            <Text style={{ ...KICKER, color: '#E0B7AC' }}>Remove</Text>
+          </Pressable>
+          <Text
+            style={[TYPE.kicker, {
+              flex: 1,
+              textAlign: 'center',
+              color: 'rgba(242,238,229,0.7)',
+              fontSize: 12,
+              fontVariant: ['tabular-nums'],
+            }]}
+          >
+            {startedCount === 0
+              ? 'Tap the map to place shot 1'
+              : `${startedCount} shot${startedCount === 1 ? '' : 's'} placed`}
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Add another shot"
+            onPress={handleAddShot}
+            disabled={!active?.start}
+            style={{
+              paddingVertical: 12,
+              paddingHorizontal: 14,
+              backgroundColor: !active?.start ? '#3A4138' : '#2E7D52',
+              borderRadius: 2,
+              opacity: !active?.start ? 0.5 : 1,
+            }}
+          >
+            <Text style={{ ...KICKER, color: '#F2EEE5' }}>+ Shot</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+function ModeChip({
+  label,
+  active,
+  disabled,
+  onPress,
+}: {
+  label: string
+  active: boolean
+  disabled?: boolean
+  onPress: () => void
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: active, disabled }}
+      disabled={disabled}
+      onPress={onPress}
+      style={{
+        flex: 1,
+        paddingVertical: 10,
+        alignItems: 'center',
+        borderRadius: 2,
+        backgroundColor: active ? '#F2EEE5' : 'transparent',
+        borderWidth: 1,
+        borderColor: active ? '#F2EEE5' : 'rgba(242,238,229,0.3)',
+        opacity: disabled ? 0.4 : 1,
+      }}
+    >
+      <Text
+        style={{
+          ...KICKER,
+          color: active ? '#1C211C' : 'rgba(242,238,229,0.8)',
+        }}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  )
+}

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -145,13 +145,14 @@ export function PastRoundMap({
     const existing = hsId
       ? shots
           .filter(
-            (s) => s.hole_score_id === hsId && s.start_lat != null && s.start_lng != null,
+            (s): s is ShotRow & { start_lat: number; start_lng: number } =>
+              s.hole_score_id === hsId && s.start_lat != null && s.start_lng != null,
           )
           .sort((a, b) => a.shot_number - b.shot_number)
           .map<PlacedShot>((s) => ({
             id: s.id,
             shotNumber: s.shot_number,
-            start: { lat: s.start_lat as number, lng: s.start_lng as number },
+            start: { lat: s.start_lat, lng: s.start_lng },
             aim:
               s.aim_lat != null && s.aim_lng != null
                 ? { lat: s.aim_lat, lng: s.aim_lng }
@@ -228,7 +229,11 @@ export function PastRoundMap({
       .eq('round_id', roundId)
       .select()
       .single()
-    if (!error && data) onHoleScoreChanged(data as HoleScoreRow)
+    if (error) {
+      Alert.alert('Save failed', error.message)
+      return
+    }
+    if (data) onHoleScoreChanged(data as HoleScoreRow)
   }
 
   async function persistShotAt(
@@ -321,26 +326,31 @@ export function PastRoundMap({
     setGreenPromptIdx(null)
     if (idx == null) return
     const shot = placed[idx]
-    if (shot?.id) {
-      const distFt =
-        shot.start && effectivePin
-          ? Math.round(distanceYards(shot.start, effectivePin) * 3)
-          : null
-      const { data, error } = await supabase
-        .from('shots')
-        .update({ lie_type: 'green', club: 'putter', putt_distance_ft: distFt })
-        .eq('id', shot.id)
-        .eq('user_id', userId)
-        .select()
-        .single()
-      if (error) {
-        Alert.alert('Save failed', error.message)
-        return
-      }
-      if (data) onShotUpserted(data as ShotRow)
+    if (!shot?.id) {
+      // The placement INSERT failed (rare — handleSetBall awaits it). Don't
+      // silently advance as if the putt were recorded; surface it so the
+      // player can re-place the ball.
+      Alert.alert('Save failed', "That shot didn't save — try placing the ball again.")
+      return
     }
+    const distFt =
+      shot.start && effectivePin
+        ? Math.round(distanceYards(shot.start, effectivePin) * 3)
+        : null
+    const { data, error } = await supabase
+      .from('shots')
+      .update({ lie_type: 'green', club: 'putter', putt_distance_ft: distFt })
+      .eq('id', shot.id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (error) {
+      Alert.alert('Save failed', error.message)
+      return
+    }
+    if (data) onShotUpserted(data as ShotRow)
     // Advance to the next shot (reuses the +Shot path) so you can place the
-    // next ball immediately.
+    // next ball immediately — only after the putt mark persisted.
     handleAddShot()
   }
 

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -1,19 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Alert, Modal, Pressable, Text, View } from 'react-native'
-import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { Alert, Pressable, Text, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import {
-  DEFAULT_HANDICAP,
-  combinedBreakDirection,
-  combinedPuttResult,
-} from '@oga/core'
+import { DEFAULT_HANDICAP, bearingDegrees, destinationYards } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { distanceYards } from '../../lib/maps'
 import { FONT, TYPE } from '../../lib/typography'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { HoleMap, type LatLng } from './HoleMap'
 import type { HoleMapPhase } from './HoleMap.types'
-import { PuttingSheet, type PuttingValue } from './PuttingSheet'
 import { PUTTING_RADIUS_YARDS } from './hole/types'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
@@ -48,6 +43,10 @@ interface PlacedShot {
 }
 
 type PlacementMode = Extract<HoleMapPhase, 'PLACE_BALL' | 'SET_AIM' | 'PIN'>
+
+// Half-width of the tee box (each dot sits this far to either side of the
+// tee shot, perpendicular to the line of play). ~4 yd ≈ a real teeing ground.
+const TEE_BOX_HALF_YARDS = 4
 
 interface PastRoundMapProps {
   roundId: string
@@ -119,9 +118,12 @@ export function PastRoundMap({
   const [placed, setPlaced] = useState<PlacedShot[]>([])
   const [activeIdx, setActiveIdx] = useState(0)
   const [mode, setMode] = useState<PlacementMode>('PLACE_BALL')
-  // When set, the green-shot putting sheet is open for this shot index,
-  // seeded with the auto-derived start→pin distance (feet).
-  const [puttSheet, setPuttSheet] = useState<{ idx: number; distanceFt: number } | null>(null)
+  // When set (a shot index), the "On the green?" prompt is showing for a ball
+  // just placed within putting range (mirrors the live round's prompt). Yes
+  // marks it a putt + advances; No drops into aiming. Putt DETAILS (made /
+  // short-long / left-right / break) are edited on the scorecard
+  // (PastHoleShotsSheet), web-parity — never inline here.
+  const [greenPromptIdx, setGreenPromptIdx] = useState<number | null>(null)
   const aimTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   // Clear a pending aim-debounce on unmount (e.g. switching to the Scorecard
@@ -139,8 +141,6 @@ export function PastRoundMap({
   const seededForRef = useRef<string | null>(null)
   useEffect(() => {
     const key = currentHoleScore?.id ?? `none-${holeNumber}`
-    if (seededForRef.current === key) return
-    seededForRef.current = key
     const hsId = currentHoleScore?.id
     const existing = hsId
       ? shots
@@ -158,6 +158,21 @@ export function PastRoundMap({
                 : null,
           }))
       : []
+    if (seededForRef.current === key) {
+      // `shots` load AFTER `hole_scores` (parent's useFocusEffect), so the
+      // first seed for a hole can land before the real shots arrive → an
+      // empty draft. Adopt the real shots when they show up, but ONLY while
+      // the user hasn't started placing (every entry still an un-persisted
+      // draft) so our own persist writes never clobber in-progress work.
+      // Once adopted, `placed` has ids → this branch is a no-op (loop-safe).
+      if (existing.length > 0 && placed.every((s) => s.id == null)) {
+        setPlaced(existing)
+        setActiveIdx(existing.length - 1)
+        setMode('PLACE_BALL')
+      }
+      return
+    }
+    seededForRef.current = key
     const seeded =
       existing.length > 0
         ? existing
@@ -165,7 +180,7 @@ export function PastRoundMap({
     setPlaced(seeded)
     setActiveIdx(seeded.length - 1)
     setMode('PLACE_BALL')
-  }, [currentHoleScore?.id, holeNumber, shots])
+  }, [currentHoleScore?.id, holeNumber, shots, placed])
 
   const active = placed[activeIdx] ?? null
   const previousStarts = useMemo(
@@ -181,6 +196,25 @@ export function PastRoundMap({
     () => placed.filter((s) => s.start != null).length,
     [placed],
   )
+
+  // Tee box = two dots flanking the tee shot, perpendicular to the line of
+  // play, so you place the drive between them. The tee IS where you hit shot
+  // 1, so it's derived from the first placed shot (falling back to the stored
+  // course tee until one is placed), oriented toward that shot's aim, then the
+  // pin. No separate placement / storage — nothing to "move," so no round-state
+  // gating needed.
+  const teeBox = useMemo<[LatLng, LatLng] | null>(() => {
+    const origin = placed[0]?.start ?? tee
+    if (!origin) return null
+    const toward = placed[0]?.aim ?? effectivePin
+    const heading = toward
+      ? bearingDegrees(origin.lat, origin.lng, toward.lat, toward.lng)
+      : 0
+    return [
+      destinationYards(origin, heading - 90, TEE_BOX_HALF_YARDS),
+      destinationYards(origin, heading + 90, TEE_BOX_HALF_YARDS),
+    ]
+  }, [placed, tee, effectivePin])
 
   // Keep hole_scores.score honest with the placed-shot count (a placed shot
   // IS a stroke). Pure score-only entry on the scorecard is untouched —
@@ -259,68 +293,61 @@ export function PastRoundMap({
     }
   }
 
-  function handleSetBall(loc: LatLng) {
+  async function handleSetBall(loc: LatLng) {
     const wasInitial = active?.start == null
     setPlaced((prev) =>
       prev.map((s, i) => (i === activeIdx ? { ...s, start: loc } : s)),
     )
-    persistShotAt(activeIdx, { start: loc })
-    // Auto-advance after the FIRST placement of a shot (mirrors the live
-    // flow the user liked). Within the putting radius of the pin → open the
-    // putting sheet with the distance auto-derived (no map aim); otherwise
-    // drop straight into aim mode.
-    if (wasInitial) {
-      if (effectivePin && distanceYards(loc, effectivePin) <= PUTTING_RADIUS_YARDS) {
-        setPuttSheet({
-          idx: activeIdx,
-          distanceFt: Math.round(distanceYards(loc, effectivePin) * 3),
-        })
-      } else {
-        setMode('SET_AIM')
-      }
+    // Await the placement INSERT so the row + id exist before any follow-up
+    // (a putt confirmation may update it). Only branch on the FIRST placement.
+    await persistShotAt(activeIdx, { start: loc })
+    if (!wasInitial) return
+    // Within putting range of the pin → ask "On the green?" (mirrors the live
+    // prompt) instead of forcing aim or an inline detail sheet. A putt skips
+    // aiming entirely; a non-putt goes to aim as usual.
+    if (effectivePin && distanceYards(loc, effectivePin) <= PUTTING_RADIUS_YARDS) {
+      setGreenPromptIdx(activeIdx)
+    } else {
+      setMode('SET_AIM')
     }
   }
 
-  // Save the green shot as a putt: the start was already persisted on
-  // placement, so this UPDATEs that row with the putt fields (mirrors the
-  // live persistPutt column mapping). Distance came from the placement.
-  async function handlePuttSave(idx: number, value: PuttingValue) {
+  // "On the green?" → Yes: it's a putt. Mark lie/club + pre-fill the putt
+  // distance (start→pin) so the scorecard's putt editor is ready, then advance
+  // to a fresh shot so the next ball can be placed. NO aim, NO inline details —
+  // made / short-long / left-right / break are set on the scorecard.
+  async function handleGreenYes() {
+    const idx = greenPromptIdx
+    setGreenPromptIdx(null)
+    if (idx == null) return
     const shot = placed[idx]
-    if (!shot?.id) {
-      setPuttSheet(null)
-      return
+    if (shot?.id) {
+      const distFt =
+        shot.start && effectivePin
+          ? Math.round(distanceYards(shot.start, effectivePin) * 3)
+          : null
+      const { data, error } = await supabase
+        .from('shots')
+        .update({ lie_type: 'green', club: 'putter', putt_distance_ft: distFt })
+        .eq('id', shot.id)
+        .eq('user_id', userId)
+        .select()
+        .single()
+      if (error) {
+        Alert.alert('Save failed', error.message)
+        return
+      }
+      if (data) onShotUpserted(data as ShotRow)
     }
-    const made = value.puttMade ?? false
-    const distance = made ? null : value.puttDistanceResult ?? null
-    const direction = made ? null : value.puttDirectionResult ?? null
-    const { data, error } = await supabase
-      .from('shots')
-      .update({
-        club: 'putter',
-        lie_type: 'green',
-        putt_distance_ft: value.puttDistanceFt ?? null,
-        putt_result: combinedPuttResult({ made, distance, direction }),
-        putt_distance_result: distance,
-        putt_direction_result: direction,
-        putt_slope_pct: value.puttSlopePct ?? null,
-        green_speed: value.greenSpeed ?? null,
-        break_direction: combinedBreakDirection({
-          vertical: value.breakDirectionVertical,
-          horizontal: value.breakDirectionHorizontal,
-        }),
-        break_direction_vertical: value.breakDirectionVertical ?? null,
-        break_direction_horizontal: value.breakDirectionHorizontal ?? null,
-      })
-      .eq('id', shot.id)
-      .eq('user_id', userId)
-      .select()
-      .single()
-    if (error) {
-      Alert.alert('Save failed', error.message)
-      return
-    }
-    if (data) onShotUpserted(data as ShotRow)
-    setPuttSheet(null)
+    // Advance to the next shot (reuses the +Shot path) so you can place the
+    // next ball immediately.
+    handleAddShot()
+  }
+
+  // "On the green?" → No: not a putt (chip / bunker / fringe). Aim as usual.
+  function handleGreenNo() {
+    setGreenPromptIdx(null)
+    setMode('SET_AIM')
   }
 
   function handleSetAim(loc: LatLng) {
@@ -450,6 +477,7 @@ export function PastRoundMap({
           pin={storedPin}
           roundPin={roundPin}
           tee={tee}
+          teeBox={teeBox}
           aim={active?.aim ?? null}
           ball={active?.start ?? null}
           previousShots={previousStarts}
@@ -546,34 +574,17 @@ export function PastRoundMap({
         </View>
       </View>
 
-      {puttSheet && (
-        <Modal
-          visible
-          transparent
-          animationType="slide"
-          onRequestClose={() => setPuttSheet(null)}
-        >
-          {/* Modal renders to a separate native window on Android, so the
-              app-root GestureHandlerRootView doesn't reach the GreenDiagram
-              aim handle inside — re-root it here (mirrors HoleModals). */}
-          <GestureHandlerRootView style={{ flex: 1 }}>
-            <View
-              style={{
-                flex: 1,
-                justifyContent: 'flex-end',
-                backgroundColor: 'rgba(0,0,0,0.4)',
-              }}
-            >
-              <PuttingSheet
-                shotNumber={placed[puttSheet.idx]?.shotNumber ?? 1}
-                initialDistanceFt={puttSheet.distanceFt}
-                onSave={(v) => handlePuttSave(puttSheet.idx, v)}
-                onClose={() => setPuttSheet(null)}
-              />
-            </View>
-          </GestureHandlerRootView>
-        </Modal>
-      )}
+      {/* "On the green?" — mirrors the live round prompt. Yes → it's a putt
+          (no aim, details on the scorecard); No → aim as a chip/bunker shot. */}
+      <ConfirmDialog
+        visible={greenPromptIdx != null}
+        title="On the green?"
+        message="Within 30 yd of the pin — were you putting, or chipping/in a bunker?"
+        confirmLabel="Yes, I'm putting"
+        cancelLabel="No"
+        onConfirm={handleGreenYes}
+        onCancel={handleGreenNo}
+      />
     </View>
   )
 }

--- a/apps/mobile/components/round/PastScorecardParts.tsx
+++ b/apps/mobile/components/round/PastScorecardParts.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import { Pressable, Text, TextInput, View } from 'react-native'
+import { FONT, TYPE } from '../../lib/typography'
+
+// Leaf presentational pieces of the editable past-round scorecard (#514),
+// split out of the route screen to keep it under the 1000-line limit.
+
+const KICKER: import('react-native').TextStyle = {
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+  fontFamily: FONT.mono,
+}
+
+// Scorecard ⇄ Map segmented control. Sits in the dark header band.
+export function TabSwitcher({
+  view,
+  onChange,
+}: {
+  view: 'scorecard' | 'map'
+  onChange: (v: 'scorecard' | 'map') => void
+}) {
+  const tabs: { key: 'scorecard' | 'map'; label: string }[] = [
+    { key: 'scorecard', label: 'Scorecard' },
+    { key: 'map', label: 'Map' },
+  ]
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        backgroundColor: '#1C211C',
+        paddingHorizontal: 14,
+        paddingBottom: 10,
+        gap: 8,
+      }}
+    >
+      {tabs.map((t) => {
+        const active = view === t.key
+        return (
+          <Pressable
+            key={t.key}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: active }}
+            accessibilityLabel={t.label}
+            onPress={() => onChange(t.key)}
+            style={{
+              flex: 1,
+              paddingVertical: 9,
+              alignItems: 'center',
+              borderRadius: 2,
+              backgroundColor: active ? '#F2EEE5' : 'transparent',
+              borderWidth: 1,
+              borderColor: active ? '#F2EEE5' : 'rgba(242,238,229,0.3)',
+            }}
+          >
+            <Text
+              style={{
+                ...KICKER,
+                color: active ? '#1C211C' : 'rgba(242,238,229,0.8)',
+              }}
+            >
+              {t.label}
+            </Text>
+          </Pressable>
+        )
+      })}
+    </View>
+  )
+}
+
+// Inline numeric cell for the editable scorecard. Score 0 / null renders as
+// the em-dash placeholder — a fresh past round seeds every hole_score at 0,
+// so 0 means "not entered yet", not "scored zero".
+export function ScoreCell({
+  value,
+  onCommit,
+  label,
+  width,
+  color,
+}: {
+  value: number | null
+  onCommit: (n: number) => void
+  label: string
+  width: number
+  color?: string
+}) {
+  const [text, setText] = useState(value && value > 0 ? String(value) : '')
+  // Re-sync when the persisted value changes from elsewhere (e.g. a
+  // Save-SG recompute or a sibling edit) so the cell never goes stale.
+  useEffect(() => {
+    setText(value && value > 0 ? String(value) : '')
+  }, [value])
+  return (
+    <TextInput
+      value={text}
+      onChangeText={(t) => setText(t.replace(/[^0-9]/g, '').slice(0, 2))}
+      onEndEditing={() => {
+        const n = text === '' ? 0 : parseInt(text, 10)
+        if (n !== (value ?? 0)) onCommit(n)
+      }}
+      keyboardType="number-pad"
+      returnKeyType="done"
+      placeholder="—"
+      placeholderTextColor="#C4BCA8"
+      selectTextOnFocus
+      accessibilityLabel={label}
+      style={[TYPE.kicker, {
+        width,
+        textAlign: 'right',
+        fontSize: 15,
+        paddingVertical: 12,
+        color: color ?? '#1C211C',
+        fontVariant: ['tabular-nums'],
+      }]}
+    />
+  )
+}


### PR DESCRIPTION
## What
Mobile editable past-round logger (web-parity). Scorecard ⇄ Map tabs: the **map creates shots** (tap to place ball, aim, pin), the **scorecard edits details** (club / lie / slope / result + two-axis putt). Past-round entry uses a `total_score=0` sentinel (no migration); reuses `HoleMap` (the renderer), not the live GPS state machine. Save-SG + Delete + Share; no End-early.

## On-device QA fixes (final commit)
- **Tab bar** — reverted the band to its pre-regression values + ~8px bottom clearance (Galaxy S23 QA).
- **Duplicate-key on saved-round shot placement** — shots load after hole_scores, so the seed could lock an empty draft and block the re-seed → a placement INSERTed a colliding `shot_number`. Now adopts late-arriving shots while nothing's placed yet (loop-safe, no clobber).
- **Tee box** — two dots flanking the tee shot (derived from the first ball, oriented toward aim/pin) replace the oversized badge. No migration.
- **Green flow** — placing within putting range now shows the live round's *"On the green?"* prompt instead of auto-opening a detail sheet: **Yes** marks a putt (lie/club + derived distance) and advances to the next ball; **No** goes to aim. Putt details (made / short-long / left-right / break) are edited on the scorecard, exactly like web.

Refs #514. QA'd on device across SDK52 + Learn combined builds this session.