### PR TITLE
fix(db): tighten course_tees INSERT policy + add created_by (#222)

### DIFF
--- a/supabase/migrations/0037_course_tees_created_by.sql
+++ b/supabase/migrations/0037_course_tees_created_by.sql
@@ -23,8 +23,17 @@ create policy "Users insert own course tees"
   with check (auth.role() = 'service_role' or auth.uid() = created_by);
 
 -- UPDATE: owner or service_role. Replaces the service_role-only policy from
--- 0014 so a user can still correct a tee they created.
+-- 0014 so a user can still correct a tee they created. The with check is
+-- spelled out (rather than left to Postgres's implicit reuse of using) so the
+-- post-update constraint is auditable at a glance and can't be silently
+-- relaxed by a later edit to using alone.
 drop policy if exists "Service role can update course tees" on public.course_tees;
 create policy "Users update own course tees"
   on public.course_tees for update
-  using (auth.role() = 'service_role' or auth.uid() = created_by);
+  using (auth.role() = 'service_role' or auth.uid() = created_by)
+  with check (auth.role() = 'service_role' or auth.uid() = created_by);
+
+-- DELETE is intentionally left with no policy: course_tees is shared course
+-- data, so non-service-role deletes stay denied by default (RLS-on + no
+-- permissive policy). The crawler reseeds via service_role. Do not add an
+-- owner-delete policy without a product reason.

--- a/supabase/migrations/0037_course_tees_created_by.sql
+++ b/supabase/migrations/0037_course_tees_created_by.sql
@@ -1,0 +1,30 @@
+-- #222: attribute course_tees to their creator and tighten write policies.
+--
+-- 0008 left INSERT open to ANY authenticated user with no attribution; 0014
+-- locked UPDATE to service_role. The clients (web useCourses, mobile
+-- round/new) only upsert tees immediately after creating a NEW course — there
+-- are no pre-existing rows to collide with, and the write is explicitly
+-- best-effort. So: add a created_by owner (defaulting to the inserting user)
+-- and allow a user to write only their OWN tees; service_role (the crawler)
+-- keeps full access. No client change is needed — the existing inserts omit
+-- created_by, so the column default supplies it.
+
+alter table public.course_tees
+  add column created_by uuid
+    references public.profiles(id) on delete set null
+    default auth.uid();
+
+-- INSERT: a user may only create rows attributed to themselves (the default
+-- fills created_by = auth.uid(); an explicit mismatched created_by is
+-- rejected). service_role (auth.uid() null) inserts crawler rows freely.
+drop policy if exists "Authenticated users can insert course tees" on public.course_tees;
+create policy "Users insert own course tees"
+  on public.course_tees for insert
+  with check (auth.role() = 'service_role' or auth.uid() = created_by);
+
+-- UPDATE: owner or service_role. Replaces the service_role-only policy from
+-- 0014 so a user can still correct a tee they created.
+drop policy if exists "Service role can update course tees" on public.course_tees;
+create policy "Users update own course tees"
+  on public.course_tees for update
+  using (auth.role() = 'service_role' or auth.uid() = created_by);


### PR DESCRIPTION
## Problem
`course_tees` INSERT was open to any authenticated user with no attribution (0008). Security audit (#222).

## Fix
Add `created_by uuid` (FK→profiles, default `auth.uid()`) and restrict INSERT/UPDATE to **owner or service_role** (UPDATE was already service-role-only since 0014).

**No client change needed:** the web (`useCourses`) and mobile (`round/new`) upserts only run immediately after creating a *new* course (no pre-existing rows to conflict with, explicitly best-effort) and omit `created_by`, so the column default attributes them to the inserting user. The crawler (service_role, `auth.uid()` null) keeps full access.

⚠️ Needs `supabase db push` to **dev + prod** to apply (CI doesn't run migrations).

Refs #222.