### PR TITLE
feat(mobile): Practice tab — plan generator + view (#511) [WIP]

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -229,6 +229,8 @@ export default function AppLayout() {
           so it collapses to a single hidden tab route. This is what makes
           "← Back" from an article pop to the list instead of the Home tab. */}
       <Tabs.Screen name="learn" options={{ href: null }} />
+      {/* Drill library is pushed from the Practice tab, not its own tab. */}
+      <Tabs.Screen name="drills" options={{ href: null }} />
       <Tabs.Screen name="bag" options={{ href: null }} />
       <Tabs.Screen name="rounds" options={{ href: null }} />
       <Tabs.Screen name="round/new" options={{ href: null }} />

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -3,7 +3,6 @@ import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { StatusBar } from 'expo-status-bar'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { ErrorBoundary } from '../../components/errors/ErrorBoundary'
@@ -21,7 +20,6 @@ export default function AppLayout() {
   const { user, loading: authLoading } = useAuth()
   const [profileState, setProfileState] = useState<ProfileState>('loading')
   const [retryNonce, setRetryNonce] = useState(0)
-  const insets = useSafeAreaInsets()
 
   useEffect(() => {
     if (authLoading) return
@@ -149,17 +147,15 @@ export default function AppLayout() {
           backgroundColor: '#FBF8F1',
           borderTopWidth: 1,
           borderTopColor: '#D9D2BF',
-          // Explicit height + paddingBottom from safe-area insets (#300).
-          // Explicit height + paddingBottom from safe-area insets (#300).
-          // Platform-neutral. height and paddingBottom carry an equal +8 over
-          // the base 54/10 so the content band [paddingTop, height-paddingBottom]
-          // is unchanged (no cramping) but the whole bar grows 8px at the bottom
-          // — lifting the icon+label ~8px off the bottom edge (device QA: label
-          // sat too low on a Galaxy S23). Keep top/bottom moving together if you
-          // retune; do NOT re-add Platform.OS bumps (the 49a283b regression).
           paddingTop: 8,
-          height: 62 + insets.bottom,
-          paddingBottom: insets.bottom + 18,
+          paddingBottom: 10,
+          // Height omitted (#300) so react-navigation/bottom-tabs adds the
+          // safe-area inset automatically — required for home-indicator / nav-bar
+          // clearance. Do NOT set an explicit `height` or hand-roll
+          // `paddingBottom: insets.bottom + N`: that double-counts the inset and
+          // pushes the label too low (the regression behind the repeated
+          // Galaxy S23 "label sits too low" reports). This is the known-good
+          // d2985ca config — restore it, don't re-nudge.
           elevation: 0,
           shadowOpacity: 0,
         },

--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, Pressable, Text, View } from 'react-native'
 import { Tabs, Redirect } from 'expo-router'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { StatusBar } from 'expo-status-bar'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { ErrorBoundary } from '../../components/errors/ErrorBoundary'
@@ -20,6 +21,7 @@ export default function AppLayout() {
   const { user, loading: authLoading } = useAuth()
   const [profileState, setProfileState] = useState<ProfileState>('loading')
   const [retryNonce, setRetryNonce] = useState(0)
+  const insets = useSafeAreaInsets()
 
   useEffect(() => {
     if (authLoading) return
@@ -148,14 +150,14 @@ export default function AppLayout() {
           borderTopWidth: 1,
           borderTopColor: '#D9D2BF',
           paddingTop: 8,
-          paddingBottom: 10,
-          // Height omitted (#300) so react-navigation/bottom-tabs adds the
-          // safe-area inset automatically — required for home-indicator / nav-bar
-          // clearance. Do NOT set an explicit `height` or hand-roll
-          // `paddingBottom: insets.bottom + N`: that double-counts the inset and
-          // pushes the label too low (the regression behind the repeated
-          // Galaxy S23 "label sits too low" reports). This is the known-good
-          // d2985ca config — restore it, don't re-nudge.
+          // Explicit height + inset so the label never clips. Auto-height
+          // (omitting this) under-reserves space on the Galaxy S23's nav setup
+          // and the label gets cut off at the bottom. The label is lifted off
+          // the bottom by tabBarLabelStyle.marginBottom below — that moves the
+          // TEXT independent of the icon (which stays put). Two knobs:
+          // marginBottom = how high the label sits; height = clip headroom.
+          height: 64 + insets.bottom,
+          paddingBottom: insets.bottom + 6,
           elevation: 0,
           shadowOpacity: 0,
         },
@@ -163,6 +165,8 @@ export default function AppLayout() {
           fontSize: 10,
           fontWeight: '500',
           letterSpacing: 0.4,
+          // Lifts the label up off the bottom edge without moving the icon.
+          marginBottom: 8,
         },
         tabBarActiveTintColor: '#1F3D2C',
         tabBarInactiveTintColor: '#8A8B7E',

--- a/apps/mobile/app/(app)/drills.tsx
+++ b/apps/mobile/app/(app)/drills.tsx
@@ -147,7 +147,7 @@ function FilterRow<T extends string>({
   return (
     <View style={{ marginBottom: 12 }}>
       <Text style={{ ...KICKER, marginBottom: 8 }}>{label}</Text>
-      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 8 }}>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
         {chips.map((chip) => {
           const selected = chip.value === active
           return (
@@ -177,7 +177,7 @@ function FilterRow<T extends string>({
             </Pressable>
           )
         })}
-      </ScrollView>
+      </View>
     </View>
   )
 }

--- a/apps/mobile/app/(app)/drills.tsx
+++ b/apps/mobile/app/(app)/drills.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
+import { useRouter } from 'expo-router'
+import { getDrills } from '@oga/supabase'
+import type { Database } from '@oga/supabase'
+import type { BlockType, PlanCategory } from '@oga/core'
+import { AppBar } from '../../components/ui/AppBar'
+import {
+  BLOCK_TYPE_LABEL,
+  CATEGORY_LABEL,
+  FACILITY_LABEL,
+  renderInstructions,
+} from '../../components/practice/drillDisplay'
+import { TYPE } from '../../lib/typography'
+import { supabase } from '../../lib/supabase'
+
+type Drill = Database['public']['Tables']['drills']['Row']
+
+const INK = '#1C211C'
+const INK_DIM = '#5C6356'
+const INK_MUTE = '#8A8B7E'
+const LINE = '#D9D2BF'
+const ACCENT = '#1F3D2C'
+const CREAM = '#F2EEE5'
+const NEG = '#A33A2A'
+
+const KICKER: import('react-native').TextStyle = {
+  ...TYPE.kicker,
+  color: INK_MUTE,
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+// Category order mirrors a round — off the tee through the green.
+const CATEGORIES: PlanCategory[] = ['off_tee', 'approach', 'around_green', 'putting']
+const MODES: BlockType[] = ['warmup', 'blocked', 'random', 'skill_game', 'pressure_game', 'on_course']
+
+export default function Drills() {
+  const router = useRouter()
+  const [drills, setDrills] = useState<Drill[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [category, setCategory] = useState<PlanCategory | 'all'>('all')
+  const [mode, setMode] = useState<BlockType | 'all'>('all')
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+    getDrills(supabase, {}).then(({ data, error: dErr }) => {
+      if (!active) return
+      if (dErr) setError(dErr.message)
+      else setDrills((data ?? []) as Drill[])
+      setLoading(false)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const filtered = useMemo(
+    () =>
+      drills.filter(
+        (d) =>
+          (category === 'all' || d.category === category) &&
+          (mode === 'all' || d.drill_type === mode),
+      ),
+    [drills, category, mode],
+  )
+
+  return (
+    <View style={{ flex: 1, backgroundColor: CREAM }}>
+      <AppBar eyebrow="Practice" title="Drill library" />
+      <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 48 }}>
+        <Pressable hitSlop={6} onPress={() => router.back()} style={{ marginBottom: 16 }}>
+          <Text style={{ ...KICKER, color: INK_MUTE }}>← Practice plan</Text>
+        </Pressable>
+
+        <Text
+          style={[TYPE.serif, { color: INK, fontSize: 26, fontWeight: '500', lineHeight: 31, marginBottom: 6 }]}
+        >
+          The full set
+        </Text>
+        <Text style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 20, marginBottom: 18 }]}>
+          Every drill the plan generator can draw from. Each one explains the why,
+          the how, and the rep target — no gimmicks.
+        </Text>
+
+        <FilterRow
+          label="Part of the game"
+          active={category}
+          options={CATEGORIES}
+          labelFor={(c) => CATEGORY_LABEL[c]}
+          onPick={setCategory}
+        />
+        <FilterRow
+          label="Practice mode"
+          active={mode}
+          options={MODES}
+          labelFor={(m) => BLOCK_TYPE_LABEL[m]}
+          onPick={setMode}
+        />
+
+        {loading ? (
+          <View style={{ paddingTop: 32, alignItems: 'center' }}>
+            <ActivityIndicator color={ACCENT} />
+          </View>
+        ) : error ? (
+          <Text style={[TYPE.body, { color: NEG, fontSize: 13, marginTop: 24 }]}>{error}</Text>
+        ) : (
+          <>
+            <Text style={{ ...KICKER, marginTop: 22, marginBottom: 2 }}>
+              {filtered.length} drill{filtered.length === 1 ? '' : 's'}
+            </Text>
+            {filtered.length === 0 ? (
+              <Text style={[TYPE.serif, { color: INK_DIM, fontSize: 17, fontStyle: 'italic', paddingTop: 14 }]}>
+                No drills match those filters.
+              </Text>
+            ) : (
+              filtered.map((drill) => <DrillCard key={drill.id} drill={drill} />)
+            )}
+          </>
+        )}
+      </ScrollView>
+    </View>
+  )
+}
+
+function FilterRow<T extends string>({
+  label,
+  active,
+  options,
+  labelFor,
+  onPick,
+}: {
+  label: string
+  active: T | 'all'
+  options: T[]
+  labelFor: (value: T) => string
+  onPick: (value: T | 'all') => void
+}) {
+  const chips: Array<{ value: T | 'all'; label: string }> = [
+    { value: 'all', label: 'All' },
+    ...options.map((o) => ({ value: o, label: labelFor(o) })),
+  ]
+  return (
+    <View style={{ marginBottom: 12 }}>
+      <Text style={{ ...KICKER, marginBottom: 8 }}>{label}</Text>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={{ gap: 8 }}>
+        {chips.map((chip) => {
+          const selected = chip.value === active
+          return (
+            <Pressable
+              key={chip.value}
+              accessibilityRole="button"
+              accessibilityState={{ selected }}
+              onPress={() => onPick(chip.value)}
+              style={{
+                paddingHorizontal: 12,
+                paddingVertical: 7,
+                borderRadius: 2,
+                borderWidth: selected ? 0 : 1,
+                borderColor: LINE,
+                backgroundColor: selected ? ACCENT : '#FBF8F1',
+              }}
+            >
+              <Text
+                style={[TYPE.bodyBold, {
+                  fontSize: 12,
+                  fontWeight: '600',
+                  color: selected ? CREAM : INK_DIM,
+                }]}
+              >
+                {chip.label}
+              </Text>
+            </Pressable>
+          )
+        })}
+      </ScrollView>
+    </View>
+  )
+}
+
+function DrillCard({ drill }: { drill: Drill }) {
+  const [open, setOpen] = useState(false)
+  const facilities = drill.facility ?? []
+  const instructions = drill.instructions?.trim() || drill.description?.trim() || ''
+  const canExpand = instructions.length > 0
+  return (
+    <View style={{ borderBottomWidth: 1, borderColor: LINE, paddingVertical: 16 }}>
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: 12 }}>
+        <Pressable onPress={() => canExpand && setOpen((o) => !o)} disabled={!canExpand} style={{ flex: 1 }}>
+          <Text style={[TYPE.serif, { color: INK, fontSize: 18, fontStyle: 'italic', fontWeight: '500', lineHeight: 23 }]}>
+            {drill.name}
+            {canExpand ? <Text style={{ color: INK_MUTE, fontSize: 13 }}>{open ? '  ▲' : '  ▼'}</Text> : null}
+          </Text>
+        </Pressable>
+        <View style={{ alignItems: 'flex-end', minWidth: 64 }}>
+          {drill.duration_min != null ? (
+            <Text style={[TYPE.serif, { color: INK, fontSize: 18, fontStyle: 'italic', lineHeight: 20 }]}>
+              {drill.duration_min} min
+            </Text>
+          ) : null}
+          <Text style={{ ...KICKER, color: ACCENT, fontSize: 9, letterSpacing: 1.6, marginTop: 4, textAlign: 'right' }}>
+            {BLOCK_TYPE_LABEL[drill.drill_type as BlockType] ?? drill.drill_type}
+          </Text>
+        </View>
+      </View>
+
+      {facilities.length > 0 ? (
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
+          {facilities.map((f) => (
+            <Text
+              key={f}
+              style={{
+                ...KICKER,
+                color: INK_DIM,
+                fontSize: 9,
+                backgroundColor: '#E8E2D2',
+                paddingHorizontal: 8,
+                paddingVertical: 3,
+                borderRadius: 2,
+                overflow: 'hidden',
+              }}
+            >
+              {FACILITY_LABEL[f] ?? f}
+            </Text>
+          ))}
+        </View>
+      ) : null}
+
+      {open && canExpand ? (
+        <View style={{ borderTopWidth: 1, borderColor: LINE, marginTop: 14, paddingTop: 14 }}>
+          {renderInstructions(instructions)}
+          {drill.source ? (
+            <Text style={{ ...KICKER, color: INK_MUTE, fontSize: 9, marginTop: 14 }}>via {drill.source}</Text>
+          ) : null}
+        </View>
+      ) : null}
+    </View>
+  )
+}

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -1,9 +1,16 @@
 import { useEffect, useMemo, useState } from 'react'
 import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Link } from 'expo-router'
-import type { BlockType, PlanCategory, StoredBlock, StoredFocusArea, StoredSession } from '@oga/core'
+import type { StoredBlock, StoredFocusArea, StoredSession } from '@oga/core'
 import { AppBar } from '../../components/ui/AppBar'
 import { PressableTouch } from '../../components/ui/PressableTouch'
+import {
+  BLOCK_TYPE_LABEL,
+  CATEGORY_LABEL,
+  FACILITY_LABEL,
+  normalizeCategoryProse,
+  renderInstructions,
+} from '../../components/practice/drillDisplay'
 import { TYPE } from '../../lib/typography'
 import { usePracticePlan, type DrillCard as DrillRow } from '../../hooks/usePracticePlan'
 
@@ -26,29 +33,6 @@ const KICKER: import('react-native').TextStyle = {
 
 const FEEDBACK_MAX = 500
 
-// Display labels mirror the web Practice page (PracticePlanPage.tsx). Keep these
-// in sync — they're the human-readable face of the @oga/core enums.
-const CATEGORY_LABEL: Record<PlanCategory, string> = {
-  off_tee: 'Off the tee',
-  approach: 'Approach',
-  around_green: 'Around the green',
-  putting: 'Putting',
-}
-const BLOCK_TYPE_LABEL: Record<BlockType, string> = {
-  warmup: 'Warm-up',
-  blocked: 'Blocked',
-  random: 'Random',
-  skill_game: 'Skill game',
-  pressure_game: 'Pressure game',
-  on_course: 'On course',
-}
-const FACILITY_LABEL: Record<string, string> = {
-  range: 'Range',
-  short_game: 'Short game',
-  putting: 'Putting green',
-  sim: 'Simulator',
-}
-
 // plan.drills is jsonb `{ sessions: StoredSession[] }`; focus_areas is
 // jsonb StoredFocusArea[]. Mirror web's asDrills/asFocusAreas guards.
 function asSessions(value: unknown): StoredSession[] {
@@ -59,14 +43,6 @@ function asSessions(value: unknown): StoredSession[] {
 }
 function asFocusAreas(value: unknown): StoredFocusArea[] {
   return Array.isArray(value) ? (value as StoredFocusArea[]) : []
-}
-
-// UI safety net: rewrite any leaked raw snake_case category enums in displayed
-// prose. `approach`/`putting` are already readable words and left untouched.
-function normalizeCategoryProse(text: string): string {
-  return text
-    .replace(/\boff_tee\b/gi, 'off the tee')
-    .replace(/\baround_green\b/gi, 'around the green')
 }
 
 // `valid_until` / `generated_at` are bare date strings (YYYY-MM-DD). Compare to
@@ -84,49 +60,6 @@ function formatDate(value: string | null): string {
   const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value) ? new Date(`${value}T00:00:00`) : new Date(value)
   if (Number.isNaN(parsed.getTime())) return ''
   return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
-}
-
-// Tiny markdown-ish renderer scoped to the drill `instructions` format, ported
-// from web's renderInstructions. Tokenize left-to-right into complete tokens
-// (**bold** | *italic* | plain), then group: each **bold** header starts a new
-// paragraph; following plain/italic text belongs to that section.
-type Seg = { kind: 'b' | 'i' | 't'; text: string }
-function renderInstructions(text: string) {
-  const tokens = text.match(/\*\*[^*]+\*\*|\*[^*]+\*|[^*]+/g) ?? []
-  const paras: Seg[][] = []
-  let cur: Seg[] = []
-  for (const tok of tokens) {
-    if (tok.startsWith('**')) {
-      if (cur.length) paras.push(cur)
-      cur = [{ kind: 'b', text: tok.slice(2, -2) }]
-    } else if (tok.startsWith('*')) {
-      cur.push({ kind: 'i', text: tok.slice(1, -1) })
-    } else {
-      cur.push({ kind: 't', text: tok })
-    }
-  }
-  if (cur.length) paras.push(cur)
-
-  return paras.map((para, pi) => (
-    <Text
-      key={pi}
-      style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 21, marginTop: pi === 0 ? 0 : 12 }]}
-    >
-      {para.map((seg, si) =>
-        seg.kind === 'b' ? (
-          <Text key={si} style={{ color: INK, fontWeight: '600' }}>
-            {seg.text}
-          </Text>
-        ) : seg.kind === 'i' ? (
-          <Text key={si} style={{ fontStyle: 'italic' }}>
-            {seg.text}
-          </Text>
-        ) : (
-          <Text key={si}>{seg.text}</Text>
-        ),
-      )}
-    </Text>
-  ))
 }
 
 export default function Practice() {
@@ -238,6 +171,16 @@ export default function Practice() {
                 {plan.based_on_rounds === 1 ? '' : 's'}
               </Text>
             ) : null}
+
+            <View style={{ borderTopWidth: 1, borderColor: LINE, marginTop: 28, paddingTop: 18 }}>
+              <Link href={'/(app)/drills' as never} asChild>
+                <Pressable hitSlop={6}>
+                  <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
+                    Browse all drills →
+                  </Text>
+                </Pressable>
+              </Link>
+            </View>
           </>
         )}
       </ScrollView>
@@ -305,8 +248,15 @@ function NoPlan({
 
       <View style={{ borderTopWidth: 1, borderColor: LINE, paddingTop: 14, marginTop: 28 }}>
         <Text style={{ ...KICKER, marginBottom: 10 }}>Reference</Text>
-        <Link href={'/(app)/learn' as never} asChild>
+        <Link href={'/(app)/drills' as never} asChild>
           <Pressable>
+            <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
+              Browse all drills →
+            </Text>
+          </Pressable>
+        </Link>
+        <Link href={'/(app)/learn' as never} asChild>
+          <Pressable style={{ marginTop: 10 }}>
             <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
               Learn the stats →
             </Text>

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -73,7 +73,10 @@ export default function Practice() {
   const { plan, drillsById, loading, generating, error, loadDrills, generate, toggleCompletion, submitFeedback } =
     usePracticePlan()
 
-  const sessions = useMemo(() => asSessions(plan?.drills), [plan])
+  // Key on plan.drills, not plan: a completion toggle replaces the plan object
+  // but leaves drills untouched, so this keeps a stable identity and avoids a
+  // redundant getDrillsByIds refetch (via drillIds) on every checkbox tap.
+  const sessions = useMemo(() => asSessions(plan?.drills), [plan?.drills])
   const focusAreas = useMemo(() => asFocusAreas(plan?.focus_areas), [plan])
   const drillIds = useMemo(
     () =>
@@ -169,7 +172,7 @@ export default function Practice() {
             ))}
 
             {plan.id ? (
-              <FeedbackSection initial={plan.feedback ?? ''} onSave={submitFeedback} />
+              <FeedbackSection key={plan.id} initial={plan.feedback ?? ''} onSave={submitFeedback} />
             ) : null}
 
             {plan.based_on_rounds ? (

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -1,117 +1,348 @@
-import { Pressable, ScrollView, Text, View } from 'react-native'
+import { useEffect, useMemo, useState } from 'react'
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
 import { Link } from 'expo-router'
+import type { StoredFocusArea, StoredSession } from '@oga/core'
 import { AppBar } from '../../components/ui/AppBar'
+import { PressableTouch } from '../../components/ui/PressableTouch'
 import { TYPE } from '../../lib/typography'
+import { usePracticePlan, type DrillCard as DrillRow } from '../../hooks/usePracticePlan'
+
+const INK = '#1C211C'
+const INK_DIM = '#5C6356'
+const INK_MUTE = '#8A8B7E'
+const LINE = '#D9D2BF'
+const ACCENT = '#1F3D2C'
+const CREAM = '#F2EEE5'
 
 const KICKER: import('react-native').TextStyle = {
   ...TYPE.kicker,
-  color: '#8A8B7E',
+  color: INK_MUTE,
   fontSize: 10,
   fontWeight: '500',
   letterSpacing: 1.4,
   textTransform: 'uppercase',
 }
 
-export default function Practice() {
-  return (
-    <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
-      <AppBar eyebrow="Today's focus" title="Practice" />
-      <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
-        <Text
-          style={[TYPE.serif, {
-            color: '#1C211C',
-            fontSize: 28,
-            fontStyle: 'italic',
-            fontWeight: '500',
-            marginBottom: 8,
-            lineHeight: 32,
-          }]}
-        >
-          A column, not a checklist.
-        </Text>
-        <Text
-          style={[TYPE.body, {
-            color: '#5C6356',
-            fontSize: 14,
-            lineHeight: 20,
-            marginBottom: 22,
-          }]}
-        >
-          Once you've logged enough rounds, this tab will read like a coach's
-          column — a short opinion on where the strokes are leaking and three
-          drills sized to your facilities.
-        </Text>
+// plan.drills is jsonb `{ sessions: StoredSession[] }`; focus_areas is
+// jsonb StoredFocusArea[]. Mirror web's asDrills/asFocusAreas guards.
+function asSessions(value: unknown): StoredSession[] {
+  if (value && typeof value === 'object' && Array.isArray((value as { sessions?: unknown }).sessions)) {
+    return (value as { sessions: StoredSession[] }).sessions
+  }
+  return []
+}
+function asFocusAreas(value: unknown): StoredFocusArea[] {
+  return Array.isArray(value) ? (value as StoredFocusArea[]) : []
+}
 
-        <View
-          style={{
-            borderTopWidth: 1,
-            borderColor: '#D9D2BF',
-            paddingTop: 14,
-          }}
-        >
-          <Text style={{ ...KICKER, marginBottom: 12 }}>Coming in phase 5</Text>
+export default function Practice() {
+  const { plan, drillsById, loading, generating, error, loadDrills, generate, toggleCompletion } =
+    usePracticePlan()
+
+  const sessions = useMemo(() => asSessions(plan?.drills), [plan])
+  const focusAreas = useMemo(() => asFocusAreas(plan?.focus_areas), [plan])
+  const drillIds = useMemo(
+    () =>
+      sessions.flatMap((s) =>
+        s.blocks.map((b) => b.drill_id).filter((id): id is string => id !== undefined),
+      ),
+    [sessions],
+  )
+  // Resolve the plan's drill rows once the plan (and its ids) are known.
+  useEffect(() => {
+    loadDrills(drillIds)
+  }, [loadDrills, drillIds])
+
+  const completed = new Set(plan?.completed_drill_ids ?? [])
+
+  return (
+    <View style={{ flex: 1, backgroundColor: CREAM }}>
+      <AppBar eyebrow="Today's focus" title="Practice" />
+      <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 48 }}>
+        {loading ? (
+          <View style={{ paddingTop: 48, alignItems: 'center' }}>
+            <ActivityIndicator color={ACCENT} />
+          </View>
+        ) : !plan ? (
+          <NoPlan generating={generating} error={error} onGenerate={generate} />
+        ) : (
+          <>
+            <Text style={{ ...KICKER, marginBottom: 8 }}>
+              Practice plan{plan.based_on_rounds ? ` · ${plan.based_on_rounds} rounds` : ''}
+            </Text>
+            <Text
+              style={[TYPE.serif, {
+                color: INK,
+                fontSize: 26,
+                fontStyle: 'italic',
+                fontWeight: '500',
+                lineHeight: 31,
+                marginBottom: 18,
+              }]}
+            >
+              {plan.ai_insight ?? 'Your practice plan'}
+            </Text>
+
+            {error ? (
+              <Text style={[TYPE.body, { color: '#A33A2A', fontSize: 13, marginBottom: 14 }]}>
+                {error}
+              </Text>
+            ) : null}
+
+            {plan.coach_note ? <ReasoningPanel note={plan.coach_note} /> : null}
+
+            {focusAreas.length > 0 ? <FocusAreas areas={focusAreas} /> : null}
+
+            {sessions.map((session, i) => (
+              <SessionBlock
+                key={`session-${i}`}
+                session={session}
+                sessionNumber={i + 1}
+                drillsById={drillsById}
+                completed={completed}
+                onToggle={toggleCompletion}
+              />
+            ))}
+
+            {plan.based_on_rounds ? (
+              <Text style={{ ...KICKER, paddingTop: 4 }}>
+                Based on your last {plan.based_on_rounds} round
+                {plan.based_on_rounds === 1 ? '' : 's'}
+              </Text>
+            ) : null}
+          </>
+        )}
+      </ScrollView>
+    </View>
+  )
+}
+
+function NoPlan({
+  generating,
+  error,
+  onGenerate,
+}: {
+  generating: boolean
+  error: string | null
+  onGenerate: () => void
+}) {
+  return (
+    <View>
+      <Text
+        style={[TYPE.serif, {
+          color: INK,
+          fontSize: 28,
+          fontStyle: 'italic',
+          fontWeight: '500',
+          lineHeight: 32,
+          marginBottom: 8,
+        }]}
+      >
+        A column, not a checklist.
+      </Text>
+      <Text style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 20, marginBottom: 22 }]}>
+        Generate a plan calibrated to your recent rounds — a short read on where
+        the strokes are leaking and drills sized to your facilities.
+      </Text>
+
+      <PressableTouch
+        accessibilityRole="button"
+        accessibilityLabel="Generate this week's plan"
+        disabled={generating}
+        onPress={onGenerate}
+        style={{
+          backgroundColor: generating ? '#3A4138' : ACCENT,
+          borderRadius: 2,
+          paddingVertical: 16,
+          alignItems: 'center',
+          opacity: generating ? 0.7 : 1,
+        }}
+      >
+        {generating ? (
+          <ActivityIndicator color={CREAM} />
+        ) : (
+          <Text style={[TYPE.serif, { color: CREAM, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
+            Generate this week&rsquo;s plan
+          </Text>
+        )}
+      </PressableTouch>
+      {generating ? (
+        <Text style={[TYPE.body, { color: INK_MUTE, fontSize: 12, textAlign: 'center', marginTop: 10 }]}>
+          Reading your rounds and writing the plan… this takes a few seconds.
+        </Text>
+      ) : null}
+      {error ? (
+        <Text style={[TYPE.body, { color: '#A33A2A', fontSize: 13, marginTop: 12 }]}>{error}</Text>
+      ) : null}
+
+      <View style={{ borderTopWidth: 1, borderColor: LINE, paddingTop: 14, marginTop: 28 }}>
+        <Text style={{ ...KICKER, marginBottom: 10 }}>Reference</Text>
+        <Link href={'/(app)/learn' as never} asChild>
+          <Pressable>
+            <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
+              Learn the stats →
+            </Text>
+          </Pressable>
+        </Link>
+      </View>
+    </View>
+  )
+}
+
+function ReasoningPanel({ note }: { note: string }) {
+  return (
+    <View style={{ borderLeftWidth: 2, borderColor: ACCENT, paddingLeft: 14, marginBottom: 24 }}>
+      <Text style={[TYPE.body, { color: INK_DIM, fontSize: 15, lineHeight: 22 }]}>{note}</Text>
+    </View>
+  )
+}
+
+function FocusAreas({ areas }: { areas: StoredFocusArea[] }) {
+  return (
+    <View style={{ marginBottom: 24 }}>
+      <Text style={{ ...KICKER, marginBottom: 10 }}>Focus areas</Text>
+      {areas.map((a, i) => (
+        <View key={`focus-${i}`} style={{ marginBottom: 12 }}>
           <Text
-            style={[TYPE.body, {
-              color: '#1C211C',
-              fontSize: 15,
-              lineHeight: 22,
+            style={[TYPE.serif, {
+              color: INK,
+              fontSize: 16,
+              fontStyle: 'italic',
+              fontWeight: '500',
+              textTransform: 'capitalize',
             }]}
           >
-            Drills are calibrated to skill level and goal. A handicap-22 player
-            never sees a competitive tempo drill; a single-digit player never
-            sees a learn-to-grip routine.
+            {a.category.replace(/_/g, ' ')}
+          </Text>
+          <Text style={[TYPE.body, { color: INK_DIM, fontSize: 13, lineHeight: 19, marginTop: 2 }]}>
+            {a.reason}
           </Text>
         </View>
+      ))}
+    </View>
+  )
+}
 
-        <View
-          style={{
-            borderTopWidth: 1,
-            borderColor: '#D9D2BF',
-            paddingTop: 14,
-            marginTop: 22,
-          }}
-        >
-          <Text style={{ ...KICKER, marginBottom: 12 }}>Resources</Text>
-          {/* `as never` because expo-router's typed routes file regenerates
-              on dev-server start; the learn route is wired in (app)/_layout.tsx. */}
-          <Link href={'/(app)/learn' as never} asChild>
-            <Pressable
-              style={{
-                borderWidth: 1,
-                borderColor: '#1F3D2C',
-                borderRadius: 2,
-                paddingVertical: 16,
-                paddingHorizontal: 14,
-              }}
-            >
-              <Text style={{ ...KICKER, color: '#5C6356', marginBottom: 6 }}>
-                Reference
-              </Text>
-              <Text
-                style={[TYPE.serif, {
-                  color: '#1F3D2C',
-                  fontSize: 17,
-                  fontStyle: 'italic',
-                  fontWeight: '500',
-                }]}
-              >
-                Learn the stats →
-              </Text>
-              <Text
-                style={[TYPE.body, {
-                  color: '#5C6356',
-                  fontSize: 13,
-                  marginTop: 6,
-                  lineHeight: 18,
-                }]}
-              >
-                Glossary of strokes gained, GIR, scrambling, and how the
-                numbers stack up across the field.
-              </Text>
-            </Pressable>
-          </Link>
-        </View>
-      </ScrollView>
+function SessionBlock({
+  session,
+  sessionNumber,
+  drillsById,
+  completed,
+  onToggle,
+}: {
+  session: StoredSession
+  sessionNumber: number
+  drillsById: Record<string, DrillRow>
+  completed: Set<string>
+  onToggle: (blockId: string) => void
+}) {
+  const blocks = [...session.blocks].sort((a, b) => a.order - b.order)
+  const doneCount = blocks.filter((b) => completed.has(b.id)).length
+  return (
+    <View style={{ borderTopWidth: 1, borderColor: LINE, paddingTop: 18, marginBottom: 28 }}>
+      <Text style={{ ...KICKER, marginBottom: 6 }}>
+        Session {sessionNumber} · {session.total_minutes} min
+        {doneCount > 0 ? ` · ${doneCount} of ${blocks.length} done` : ''}
+      </Text>
+      <Text
+        style={[TYPE.serif, { color: INK, fontSize: 21, fontWeight: '500', lineHeight: 26, marginBottom: 6 }]}
+      >
+        {session.title}
+      </Text>
+      {blocks.map((block, i) => (
+        <DrillRowItem
+          key={block.id ?? `${block.drill_id}-${i}`}
+          index={i + 1}
+          drill={block.drill_id ? drillsById[block.drill_id] : undefined}
+          minutes={block.minutes}
+          rationale={block.rationale}
+          completed={completed.has(block.id)}
+          onToggle={() => onToggle(block.id)}
+        />
+      ))}
+    </View>
+  )
+}
+
+function DrillRowItem({
+  index,
+  drill,
+  minutes,
+  rationale,
+  completed,
+  onToggle,
+}: {
+  index: number
+  drill: DrillRow | undefined
+  minutes: number
+  rationale: string
+  completed: boolean
+  onToggle: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const name = drill?.name ?? 'Drill'
+  const instructions = drill?.instructions?.trim() || drill?.description?.trim() || ''
+  const canExpand = instructions.length > 0
+  return (
+    <View style={{ borderTopWidth: 1, borderColor: LINE, paddingVertical: 16, flexDirection: 'row', gap: 12 }}>
+      <Pressable
+        accessibilityRole="checkbox"
+        accessibilityState={{ checked: completed }}
+        accessibilityLabel={`Mark ${name} done`}
+        onPress={onToggle}
+        hitSlop={8}
+        style={{
+          width: 20,
+          height: 20,
+          borderRadius: 2,
+          marginTop: 3,
+          borderWidth: completed ? 0 : 1,
+          borderColor: '#9F9580',
+          backgroundColor: completed ? ACCENT : 'transparent',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        {completed ? <Text style={{ color: CREAM, fontSize: 12, fontWeight: '700' }}>✓</Text> : null}
+      </Pressable>
+
+      <Text
+        style={[TYPE.serif, { color: INK_MUTE, fontSize: 24, fontStyle: 'italic', lineHeight: 26, minWidth: 30 }]}
+      >
+        {String(index).padStart(2, '0')}
+      </Text>
+
+      <View style={{ flex: 1 }}>
+        <Pressable onPress={() => canExpand && setOpen((o) => !o)} disabled={!canExpand}>
+          <Text
+            style={[TYPE.serif, {
+              color: completed ? INK_MUTE : INK,
+              fontSize: 18,
+              fontStyle: 'italic',
+              fontWeight: '500',
+              lineHeight: 23,
+            }]}
+          >
+            {name}
+            {canExpand ? (
+              <Text style={{ color: INK_MUTE, fontSize: 13 }}>{open ? '  ▲' : '  ▼'}</Text>
+            ) : null}
+          </Text>
+        </Pressable>
+        <Text style={{ ...KICKER, marginTop: 4 }}>
+          {minutes} min{drill?.facility?.length ? ` · ${drill.facility.join(', ')}` : ''}
+        </Text>
+        {rationale ? (
+          <Text style={[TYPE.body, { color: INK_DIM, fontSize: 13, lineHeight: 19, marginTop: 6 }]}>
+            {rationale}
+          </Text>
+        ) : null}
+        {open && canExpand ? (
+          <Text style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 21, marginTop: 8 }]}>
+            {instructions}
+          </Text>
+        ) : null}
+      </View>
     </View>
   )
 }

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
-import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
+import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Link } from 'expo-router'
-import type { StoredFocusArea, StoredSession } from '@oga/core'
+import type { BlockType, PlanCategory, StoredBlock, StoredFocusArea, StoredSession } from '@oga/core'
 import { AppBar } from '../../components/ui/AppBar'
 import { PressableTouch } from '../../components/ui/PressableTouch'
 import { TYPE } from '../../lib/typography'
@@ -13,6 +13,7 @@ const INK_MUTE = '#8A8B7E'
 const LINE = '#D9D2BF'
 const ACCENT = '#1F3D2C'
 const CREAM = '#F2EEE5'
+const NEG = '#A33A2A'
 
 const KICKER: import('react-native').TextStyle = {
   ...TYPE.kicker,
@@ -21,6 +22,31 @@ const KICKER: import('react-native').TextStyle = {
   fontWeight: '500',
   letterSpacing: 1.4,
   textTransform: 'uppercase',
+}
+
+const FEEDBACK_MAX = 500
+
+// Display labels mirror the web Practice page (PracticePlanPage.tsx). Keep these
+// in sync — they're the human-readable face of the @oga/core enums.
+const CATEGORY_LABEL: Record<PlanCategory, string> = {
+  off_tee: 'Off the tee',
+  approach: 'Approach',
+  around_green: 'Around the green',
+  putting: 'Putting',
+}
+const BLOCK_TYPE_LABEL: Record<BlockType, string> = {
+  warmup: 'Warm-up',
+  blocked: 'Blocked',
+  random: 'Random',
+  skill_game: 'Skill game',
+  pressure_game: 'Pressure game',
+  on_course: 'On course',
+}
+const FACILITY_LABEL: Record<string, string> = {
+  range: 'Range',
+  short_game: 'Short game',
+  putting: 'Putting green',
+  sim: 'Simulator',
 }
 
 // plan.drills is jsonb `{ sessions: StoredSession[] }`; focus_areas is
@@ -35,8 +61,76 @@ function asFocusAreas(value: unknown): StoredFocusArea[] {
   return Array.isArray(value) ? (value as StoredFocusArea[]) : []
 }
 
+// UI safety net: rewrite any leaked raw snake_case category enums in displayed
+// prose. `approach`/`putting` are already readable words and left untouched.
+function normalizeCategoryProse(text: string): string {
+  return text
+    .replace(/\boff_tee\b/gi, 'off the tee')
+    .replace(/\baround_green\b/gi, 'around the green')
+}
+
+// `valid_until` / `generated_at` are bare date strings (YYYY-MM-DD). Compare to
+// today's *local* date so a plan stays current through the whole of its final day.
+function todayDateString(): string {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  const d = String(now.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+function formatDate(value: string | null): string {
+  if (!value) return ''
+  // Parse a bare date string as local, not UTC, to avoid an off-by-one day.
+  const parsed = /^\d{4}-\d{2}-\d{2}$/.test(value) ? new Date(`${value}T00:00:00`) : new Date(value)
+  if (Number.isNaN(parsed.getTime())) return ''
+  return parsed.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+// Tiny markdown-ish renderer scoped to the drill `instructions` format, ported
+// from web's renderInstructions. Tokenize left-to-right into complete tokens
+// (**bold** | *italic* | plain), then group: each **bold** header starts a new
+// paragraph; following plain/italic text belongs to that section.
+type Seg = { kind: 'b' | 'i' | 't'; text: string }
+function renderInstructions(text: string) {
+  const tokens = text.match(/\*\*[^*]+\*\*|\*[^*]+\*|[^*]+/g) ?? []
+  const paras: Seg[][] = []
+  let cur: Seg[] = []
+  for (const tok of tokens) {
+    if (tok.startsWith('**')) {
+      if (cur.length) paras.push(cur)
+      cur = [{ kind: 'b', text: tok.slice(2, -2) }]
+    } else if (tok.startsWith('*')) {
+      cur.push({ kind: 'i', text: tok.slice(1, -1) })
+    } else {
+      cur.push({ kind: 't', text: tok })
+    }
+  }
+  if (cur.length) paras.push(cur)
+
+  return paras.map((para, pi) => (
+    <Text
+      key={pi}
+      style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 21, marginTop: pi === 0 ? 0 : 12 }]}
+    >
+      {para.map((seg, si) =>
+        seg.kind === 'b' ? (
+          <Text key={si} style={{ color: INK, fontWeight: '600' }}>
+            {seg.text}
+          </Text>
+        ) : seg.kind === 'i' ? (
+          <Text key={si} style={{ fontStyle: 'italic' }}>
+            {seg.text}
+          </Text>
+        ) : (
+          <Text key={si}>{seg.text}</Text>
+        ),
+      )}
+    </Text>
+  ))
+}
+
 export default function Practice() {
-  const { plan, drillsById, loading, generating, error, loadDrills, generate, toggleCompletion } =
+  const { plan, drillsById, loading, generating, error, loadDrills, generate, toggleCompletion, submitFeedback } =
     usePracticePlan()
 
   const sessions = useMemo(() => asSessions(plan?.drills), [plan])
@@ -55,6 +149,14 @@ export default function Practice() {
 
   const completed = new Set(plan?.completed_drill_ids ?? [])
 
+  // No-regenerate-within-window: only offer Generate once the plan's date passed.
+  const isExpired = !!plan?.valid_until && plan.valid_until < todayDateString()
+  const kicker = !plan
+    ? ''
+    : isExpired
+      ? `Last week's plan · valid through ${formatDate(plan.valid_until)}`
+      : `Practice plan · week of ${formatDate(plan.generated_at)}${plan.valid_until ? ` · valid through ${formatDate(plan.valid_until)}` : ''}`
+
   return (
     <View style={{ flex: 1, backgroundColor: CREAM }}>
       <AppBar eyebrow="Today's focus" title="Practice" />
@@ -67,9 +169,7 @@ export default function Practice() {
           <NoPlan generating={generating} error={error} onGenerate={generate} />
         ) : (
           <>
-            <Text style={{ ...KICKER, marginBottom: 8 }}>
-              Practice plan{plan.based_on_rounds ? ` · ${plan.based_on_rounds} rounds` : ''}
-            </Text>
+            <Text style={{ ...KICKER, marginBottom: 8 }}>{kicker}</Text>
             <Text
               style={[TYPE.serif, {
                 color: INK,
@@ -77,16 +177,40 @@ export default function Practice() {
                 fontStyle: 'italic',
                 fontWeight: '500',
                 lineHeight: 31,
-                marginBottom: 18,
+                marginBottom: isExpired ? 14 : 18,
               }]}
             >
               {plan.ai_insight ?? 'Your practice plan'}
             </Text>
 
+            {/* Regenerate affordance — only once the current plan has expired. */}
+            {isExpired ? (
+              <PressableTouch
+                accessibilityRole="button"
+                accessibilityLabel="Generate this week's plan"
+                disabled={generating}
+                onPress={generate}
+                style={{
+                  backgroundColor: generating ? '#3A4138' : ACCENT,
+                  borderRadius: 2,
+                  paddingVertical: 13,
+                  alignItems: 'center',
+                  marginBottom: 22,
+                  opacity: generating ? 0.7 : 1,
+                }}
+              >
+                {generating ? (
+                  <ActivityIndicator color={CREAM} />
+                ) : (
+                  <Text style={[TYPE.serif, { color: CREAM, fontSize: 16, fontStyle: 'italic', fontWeight: '500' }]}>
+                    Generate this week&rsquo;s plan
+                  </Text>
+                )}
+              </PressableTouch>
+            ) : null}
+
             {error ? (
-              <Text style={[TYPE.body, { color: '#A33A2A', fontSize: 13, marginBottom: 14 }]}>
-                {error}
-              </Text>
+              <Text style={[TYPE.body, { color: NEG, fontSize: 13, marginBottom: 14 }]}>{error}</Text>
             ) : null}
 
             {plan.coach_note ? <ReasoningPanel note={plan.coach_note} /> : null}
@@ -103,6 +227,10 @@ export default function Practice() {
                 onToggle={toggleCompletion}
               />
             ))}
+
+            {plan.id ? (
+              <FeedbackSection initial={plan.feedback ?? ''} onSave={submitFeedback} />
+            ) : null}
 
             {plan.based_on_rounds ? (
               <Text style={{ ...KICKER, paddingTop: 4 }}>
@@ -172,7 +300,7 @@ function NoPlan({
         </Text>
       ) : null}
       {error ? (
-        <Text style={[TYPE.body, { color: '#A33A2A', fontSize: 13, marginTop: 12 }]}>{error}</Text>
+        <Text style={[TYPE.body, { color: NEG, fontSize: 13, marginTop: 12 }]}>{error}</Text>
       ) : null}
 
       <View style={{ borderTopWidth: 1, borderColor: LINE, paddingTop: 14, marginTop: 28 }}>
@@ -192,7 +320,9 @@ function NoPlan({
 function ReasoningPanel({ note }: { note: string }) {
   return (
     <View style={{ borderLeftWidth: 2, borderColor: ACCENT, paddingLeft: 14, marginBottom: 24 }}>
-      <Text style={[TYPE.body, { color: INK_DIM, fontSize: 15, lineHeight: 22 }]}>{note}</Text>
+      <Text style={[TYPE.body, { color: INK_DIM, fontSize: 15, lineHeight: 22 }]}>
+        {normalizeCategoryProse(note)}
+      </Text>
     </View>
   )
 }
@@ -200,23 +330,27 @@ function ReasoningPanel({ note }: { note: string }) {
 function FocusAreas({ areas }: { areas: StoredFocusArea[] }) {
   return (
     <View style={{ marginBottom: 24 }}>
-      <Text style={{ ...KICKER, marginBottom: 10 }}>Focus areas</Text>
+      <Text style={{ ...KICKER, marginBottom: 10 }}>What to work on</Text>
       {areas.map((a, i) => (
-        <View key={`focus-${i}`} style={{ marginBottom: 12 }}>
-          <Text
-            style={[TYPE.serif, {
-              color: INK,
-              fontSize: 16,
-              fontStyle: 'italic',
-              fontWeight: '500',
-              textTransform: 'capitalize',
-            }]}
-          >
-            {a.category.replace(/_/g, ' ')}
+        <View key={`focus-${i}`} style={{ marginBottom: 14 }}>
+          <Text style={[TYPE.serif, { color: INK, fontSize: 16, fontStyle: 'italic', fontWeight: '500' }]}>
+            {CATEGORY_LABEL[a.category] ?? a.category}
           </Text>
           <Text style={[TYPE.body, { color: INK_DIM, fontSize: 13, lineHeight: 19, marginTop: 2 }]}>
-            {a.reason}
+            {normalizeCategoryProse(a.reason)}
           </Text>
+          {a.article ? (
+            <Link
+              href={{ pathname: '/(app)/learn/[article]', params: { article: a.article.slug } }}
+              asChild
+            >
+              <Pressable hitSlop={6} style={{ marginTop: 6 }}>
+                <Text style={[TYPE.body, { color: ACCENT, fontSize: 13, fontWeight: '600' }]}>
+                  {a.article.title} →
+                </Text>
+              </Pressable>
+            </Link>
+          ) : null}
         </View>
       ))}
     </View>
@@ -253,9 +387,8 @@ function SessionBlock({
         <DrillRowItem
           key={block.id ?? `${block.drill_id}-${i}`}
           index={i + 1}
+          block={block}
           drill={block.drill_id ? drillsById[block.drill_id] : undefined}
-          minutes={block.minutes}
-          rationale={block.rationale}
           completed={completed.has(block.id)}
           onToggle={() => onToggle(block.id)}
         />
@@ -266,21 +399,20 @@ function SessionBlock({
 
 function DrillRowItem({
   index,
+  block,
   drill,
-  minutes,
-  rationale,
   completed,
   onToggle,
 }: {
   index: number
+  block: StoredBlock
   drill: DrillRow | undefined
-  minutes: number
-  rationale: string
   completed: boolean
   onToggle: () => void
 }) {
   const [open, setOpen] = useState(false)
   const name = drill?.name ?? 'Drill'
+  const facilities = drill?.facility ?? []
   const instructions = drill?.instructions?.trim() || drill?.description?.trim() || ''
   const canExpand = instructions.length > 0
   return (
@@ -313,35 +445,146 @@ function DrillRowItem({
       </Text>
 
       <View style={{ flex: 1 }}>
-        <Pressable onPress={() => canExpand && setOpen((o) => !o)} disabled={!canExpand}>
-          <Text
-            style={[TYPE.serif, {
-              color: completed ? INK_MUTE : INK,
-              fontSize: 18,
-              fontStyle: 'italic',
-              fontWeight: '500',
-              lineHeight: 23,
-            }]}
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: 10 }}>
+          <Pressable
+            onPress={() => canExpand && setOpen((o) => !o)}
+            disabled={!canExpand}
+            style={{ flex: 1 }}
           >
-            {name}
-            {canExpand ? (
-              <Text style={{ color: INK_MUTE, fontSize: 13 }}>{open ? '  ▲' : '  ▼'}</Text>
+            <Text
+              style={[TYPE.serif, {
+                color: completed ? INK_MUTE : INK,
+                fontSize: 18,
+                fontStyle: 'italic',
+                fontWeight: '500',
+                lineHeight: 23,
+              }]}
+            >
+              {name}
+              {canExpand ? (
+                <Text style={{ color: INK_MUTE, fontSize: 13 }}>{open ? '  ▲' : '  ▼'}</Text>
+              ) : null}
+            </Text>
+          </Pressable>
+
+          {/* Right rail — minutes + block type tag + optional target. */}
+          <View style={{ alignItems: 'flex-end', minWidth: 64 }}>
+            <Text style={[TYPE.serif, { color: INK, fontSize: 18, fontStyle: 'italic', lineHeight: 20 }]}>
+              {block.minutes} min
+            </Text>
+            <Text
+              style={{ ...KICKER, color: ACCENT, fontSize: 9, letterSpacing: 1.6, marginTop: 4, textAlign: 'right' }}
+            >
+              {BLOCK_TYPE_LABEL[block.type] ?? block.type}
+            </Text>
+            {block.target != null ? (
+              <Text style={{ ...KICKER, fontSize: 9, marginTop: 6, textAlign: 'right' }}>
+                Target: {block.target}
+              </Text>
             ) : null}
-          </Text>
-        </Pressable>
-        <Text style={{ ...KICKER, marginTop: 4 }}>
-          {minutes} min{drill?.facility?.length ? ` · ${drill.facility.join(', ')}` : ''}
-        </Text>
-        {rationale ? (
+          </View>
+        </View>
+
+        {block.rationale ? (
           <Text style={[TYPE.body, { color: INK_DIM, fontSize: 13, lineHeight: 19, marginTop: 6 }]}>
-            {rationale}
+            {block.rationale}
           </Text>
         ) : null}
+
+        {facilities.length > 0 ? (
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
+            {facilities.map((f) => (
+              <Text
+                key={f}
+                style={{
+                  ...KICKER,
+                  color: INK_DIM,
+                  fontSize: 9,
+                  backgroundColor: '#E8E2D2',
+                  paddingHorizontal: 8,
+                  paddingVertical: 3,
+                  borderRadius: 2,
+                  overflow: 'hidden',
+                }}
+              >
+                {FACILITY_LABEL[f] ?? f}
+              </Text>
+            ))}
+          </View>
+        ) : null}
+
         {open && canExpand ? (
-          <Text style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 21, marginTop: 8 }]}>
-            {instructions}
-          </Text>
+          <View style={{ borderTopWidth: 1, borderColor: LINE, marginTop: 14, paddingTop: 14 }}>
+            {renderInstructions(instructions)}
+            {drill?.source ? (
+              <Text style={{ ...KICKER, color: INK_MUTE, fontSize: 9, marginTop: 14 }}>
+                via {drill.source}
+              </Text>
+            ) : null}
+          </View>
         ) : null}
+      </View>
+    </View>
+  )
+}
+
+function FeedbackSection({
+  initial,
+  onSave,
+}: {
+  initial: string
+  onSave: (feedback: string) => Promise<void> | void
+}) {
+  const [value, setValue] = useState(initial)
+  // Track the last persisted value so blur only saves real edits and the
+  // "Saved" indicator clears the moment the user edits again.
+  const [savedValue, setSavedValue] = useState(initial)
+  const [saving, setSaving] = useState(false)
+
+  const handleBlur = async () => {
+    const next = value.trim()
+    if (next === savedValue.trim()) return
+    if (next.length === 0 && savedValue.trim().length === 0) return
+    setSaving(true)
+    await onSave(next)
+    setSavedValue(next)
+    setSaving(false)
+  }
+
+  const showSaved = !saving && value.trim() === savedValue.trim() && savedValue.trim().length > 0
+
+  return (
+    <View style={{ borderTopWidth: 1, borderColor: LINE, paddingTop: 18, marginBottom: 28 }}>
+      <Text style={{ ...KICKER, marginBottom: 8 }}>Before next week</Text>
+      <Text style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 20, marginBottom: 12 }]}>
+        One note on how this plan landed — what worked, what felt off. Next week&rsquo;s plan reads it.
+      </Text>
+      <TextInput
+        value={value}
+        onChangeText={setValue}
+        onBlur={handleBlur}
+        maxLength={FEEDBACK_MAX}
+        multiline
+        textAlignVertical="top"
+        placeholder="What worked, what felt off…"
+        placeholderTextColor={INK_MUTE}
+        style={[TYPE.body, {
+          minHeight: 92,
+          color: INK,
+          backgroundColor: '#FBF8F1',
+          borderWidth: 1,
+          borderColor: LINE,
+          borderRadius: 2,
+          padding: 12,
+          fontSize: 15,
+          lineHeight: 21,
+        }]}
+      />
+      <View style={{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginTop: 6 }}>
+        <Text style={{ ...KICKER, fontSize: 9 }}>{saving ? 'Saving…' : showSaved ? 'Saved' : ''}</Text>
+        <Text style={{ ...KICKER, fontSize: 9 }}>
+          {value.length} / {FEEDBACK_MAX}
+        </Text>
       </View>
     </View>
   )

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -8,7 +8,6 @@ import {
   BLOCK_TYPE_LABEL,
   CATEGORY_LABEL,
   FACILITY_LABEL,
-  normalizeCategoryProse,
   renderInstructions,
 } from '../../components/practice/drillDisplay'
 import { TYPE } from '../../lib/typography'
@@ -43,6 +42,14 @@ function asSessions(value: unknown): StoredSession[] {
 }
 function asFocusAreas(value: unknown): StoredFocusArea[] {
   return Array.isArray(value) ? (value as StoredFocusArea[]) : []
+}
+
+// UI safety net: rewrite any leaked raw snake_case category enums in displayed
+// prose (coach_note / focus reasons). `approach`/`putting` are already readable.
+function normalizeCategoryProse(text: string): string {
+  return text
+    .replace(/\boff_tee\b/gi, 'off the tee')
+    .replace(/\baround_green\b/gi, 'around the green')
 }
 
 // `valid_until` / `generated_at` are bare date strings (YYYY-MM-DD). Compare to
@@ -136,7 +143,7 @@ export default function Practice() {
                   <ActivityIndicator color={CREAM} />
                 ) : (
                   <Text style={[TYPE.serif, { color: CREAM, fontSize: 16, fontStyle: 'italic', fontWeight: '500' }]}>
-                    Generate this week&rsquo;s plan
+                    Generate this week’s plan
                   </Text>
                 )}
               </PressableTouch>
@@ -233,7 +240,7 @@ function NoPlan({
           <ActivityIndicator color={CREAM} />
         ) : (
           <Text style={[TYPE.serif, { color: CREAM, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
-            Generate this week&rsquo;s plan
+            Generate this week’s plan
           </Text>
         )}
       </PressableTouch>
@@ -507,7 +514,7 @@ function FeedbackSection({
     <View style={{ borderTopWidth: 1, borderColor: LINE, paddingTop: 18, marginBottom: 28 }}>
       <Text style={{ ...KICKER, marginBottom: 8 }}>Before next week</Text>
       <Text style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 20, marginBottom: 12 }]}>
-        One note on how this plan landed — what worked, what felt off. Next week&rsquo;s plan reads it.
+        One note on how this plan landed — what worked, what felt off. Next week’s plan reads it.
       </Text>
       <TextInput
         value={value}

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -395,19 +395,25 @@ function DrillRowItem({
         {completed ? <Text style={{ color: CREAM, fontSize: 12, fontWeight: '700' }}>✓</Text> : null}
       </Pressable>
 
-      <Text
-        style={[TYPE.serif, { color: INK_MUTE, fontSize: 24, fontStyle: 'italic', lineHeight: 26, minWidth: 30 }]}
+      {/* The whole row (everything but the checkbox) toggles expand, so a thumb
+          tap anywhere on the card opens it — not just the chevron. Matches the
+          drill-library card affordance. */}
+      <Pressable
+        onPress={() => canExpand && setOpen((o) => !o)}
+        disabled={!canExpand}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: open }}
+        accessibilityLabel={`${name}${canExpand ? `, tap to ${open ? 'collapse' : 'expand'}` : ''}`}
+        style={{ flex: 1, flexDirection: 'row', gap: 12 }}
       >
-        {String(index).padStart(2, '0')}
-      </Text>
+        <Text
+          style={[TYPE.serif, { color: INK_MUTE, fontSize: 24, fontStyle: 'italic', lineHeight: 26, minWidth: 30 }]}
+        >
+          {String(index).padStart(2, '0')}
+        </Text>
 
-      <View style={{ flex: 1 }}>
-        <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: 10 }}>
-          <Pressable
-            onPress={() => canExpand && setOpen((o) => !o)}
-            disabled={!canExpand}
-            style={{ flex: 1 }}
-          >
+        <View style={{ flex: 1 }}>
+          <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: 10 }}>
             <Text
               style={[TYPE.serif, {
                 color: completed ? INK_MUTE : INK,
@@ -415,6 +421,7 @@ function DrillRowItem({
                 fontStyle: 'italic',
                 fontWeight: '500',
                 lineHeight: 23,
+                flex: 1,
               }]}
             >
               {name}
@@ -422,65 +429,65 @@ function DrillRowItem({
                 <Text style={{ color: INK_MUTE, fontSize: 13 }}>{open ? '  ▲' : '  ▼'}</Text>
               ) : null}
             </Text>
-          </Pressable>
 
-          {/* Right rail — minutes + block type tag + optional target. */}
-          <View style={{ alignItems: 'flex-end', minWidth: 64 }}>
-            <Text style={[TYPE.serif, { color: INK, fontSize: 18, fontStyle: 'italic', lineHeight: 20 }]}>
-              {block.minutes} min
-            </Text>
-            <Text
-              style={{ ...KICKER, color: ACCENT, fontSize: 9, letterSpacing: 1.6, marginTop: 4, textAlign: 'right' }}
-            >
-              {BLOCK_TYPE_LABEL[block.type] ?? block.type}
-            </Text>
-            {block.target != null ? (
-              <Text style={{ ...KICKER, fontSize: 9, marginTop: 6, textAlign: 'right' }}>
-                Target: {block.target}
+            {/* Right rail — minutes + block type tag + optional target. */}
+            <View style={{ alignItems: 'flex-end', minWidth: 64 }}>
+              <Text style={[TYPE.serif, { color: INK, fontSize: 18, fontStyle: 'italic', lineHeight: 20 }]}>
+                {block.minutes} min
               </Text>
-            ) : null}
-          </View>
-        </View>
-
-        {block.rationale ? (
-          <Text style={[TYPE.body, { color: INK_DIM, fontSize: 13, lineHeight: 19, marginTop: 6 }]}>
-            {block.rationale}
-          </Text>
-        ) : null}
-
-        {facilities.length > 0 ? (
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
-            {facilities.map((f) => (
               <Text
-                key={f}
-                style={{
-                  ...KICKER,
-                  color: INK_DIM,
-                  fontSize: 9,
-                  backgroundColor: '#E8E2D2',
-                  paddingHorizontal: 8,
-                  paddingVertical: 3,
-                  borderRadius: 2,
-                  overflow: 'hidden',
-                }}
+                style={{ ...KICKER, color: ACCENT, fontSize: 9, letterSpacing: 1.6, marginTop: 4, textAlign: 'right' }}
               >
-                {FACILITY_LABEL[f] ?? f}
+                {BLOCK_TYPE_LABEL[block.type] ?? block.type}
               </Text>
-            ))}
+              {block.target != null ? (
+                <Text style={{ ...KICKER, fontSize: 9, marginTop: 6, textAlign: 'right' }}>
+                  Target: {block.target}
+                </Text>
+              ) : null}
+            </View>
           </View>
-        ) : null}
 
-        {open && canExpand ? (
-          <View style={{ borderTopWidth: 1, borderColor: LINE, marginTop: 14, paddingTop: 14 }}>
-            {renderInstructions(instructions)}
-            {drill?.source ? (
-              <Text style={{ ...KICKER, color: INK_MUTE, fontSize: 9, marginTop: 14 }}>
-                via {drill.source}
-              </Text>
-            ) : null}
-          </View>
-        ) : null}
-      </View>
+          {block.rationale ? (
+            <Text style={[TYPE.body, { color: INK_DIM, fontSize: 13, lineHeight: 19, marginTop: 6 }]}>
+              {block.rationale}
+            </Text>
+          ) : null}
+
+          {facilities.length > 0 ? (
+            <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
+              {facilities.map((f) => (
+                <Text
+                  key={f}
+                  style={{
+                    ...KICKER,
+                    color: INK_DIM,
+                    fontSize: 9,
+                    backgroundColor: '#E8E2D2',
+                    paddingHorizontal: 8,
+                    paddingVertical: 3,
+                    borderRadius: 2,
+                    overflow: 'hidden',
+                  }}
+                >
+                  {FACILITY_LABEL[f] ?? f}
+                </Text>
+              ))}
+            </View>
+          ) : null}
+
+          {open && canExpand ? (
+            <View style={{ borderTopWidth: 1, borderColor: LINE, marginTop: 14, paddingTop: 14 }}>
+              {renderInstructions(instructions)}
+              {drill?.source ? (
+                <Text style={{ ...KICKER, color: INK_MUTE, fontSize: 9, marginTop: 14 }}>
+                  via {drill.source}
+                </Text>
+              ) : null}
+            </View>
+          ) : null}
+        </View>
+      </Pressable>
     </View>
   )
 }

--- a/apps/mobile/components/practice/drillDisplay.tsx
+++ b/apps/mobile/components/practice/drillDisplay.tsx
@@ -32,14 +32,6 @@ export const FACILITY_LABEL: Record<string, string> = {
   sim: 'Simulator',
 }
 
-// UI safety net: rewrite any leaked raw snake_case category enums in displayed
-// prose. `approach`/`putting` are already readable words and left untouched.
-export function normalizeCategoryProse(text: string): string {
-  return text
-    .replace(/\boff_tee\b/gi, 'off the tee')
-    .replace(/\baround_green\b/gi, 'around the green')
-}
-
 // Tiny markdown-ish renderer scoped to the drill `instructions` format, ported
 // from web's renderInstructions. Tokenize left-to-right into complete tokens
 // (**bold** | *italic* | plain), then group: each **bold** header starts a new

--- a/apps/mobile/components/practice/drillDisplay.tsx
+++ b/apps/mobile/components/practice/drillDisplay.tsx
@@ -1,0 +1,84 @@
+import { Text } from 'react-native'
+import type { BlockType, PlanCategory } from '@oga/core'
+import { TYPE } from '../../lib/typography'
+
+// Shared drill-display vocabulary + the instructions renderer, used by both the
+// Practice plan screen (plan blocks) and the Drill library screen (browse-all).
+// Mirrors apps/web/src/pages/practice/drillDisplay.tsx — keep the two in sync.
+// Extracted because renderInstructions is substantial and must render drills
+// identically across the two surfaces.
+
+const INK = '#1C211C'
+const INK_DIM = '#5C6356'
+
+export const CATEGORY_LABEL: Record<PlanCategory, string> = {
+  off_tee: 'Off the tee',
+  approach: 'Approach',
+  around_green: 'Around the green',
+  putting: 'Putting',
+}
+export const BLOCK_TYPE_LABEL: Record<BlockType, string> = {
+  warmup: 'Warm-up',
+  blocked: 'Blocked',
+  random: 'Random',
+  skill_game: 'Skill game',
+  pressure_game: 'Pressure game',
+  on_course: 'On course',
+}
+export const FACILITY_LABEL: Record<string, string> = {
+  range: 'Range',
+  short_game: 'Short game',
+  putting: 'Putting green',
+  sim: 'Simulator',
+}
+
+// UI safety net: rewrite any leaked raw snake_case category enums in displayed
+// prose. `approach`/`putting` are already readable words and left untouched.
+export function normalizeCategoryProse(text: string): string {
+  return text
+    .replace(/\boff_tee\b/gi, 'off the tee')
+    .replace(/\baround_green\b/gi, 'around the green')
+}
+
+// Tiny markdown-ish renderer scoped to the drill `instructions` format, ported
+// from web's renderInstructions. Tokenize left-to-right into complete tokens
+// (**bold** | *italic* | plain), then group: each **bold** header starts a new
+// paragraph; following plain/italic text belongs to that section.
+type Seg = { kind: 'b' | 'i' | 't'; text: string }
+export function renderInstructions(text: string) {
+  const tokens = text.match(/\*\*[^*]+\*\*|\*[^*]+\*|[^*]+/g) ?? []
+  const paras: Seg[][] = []
+  let cur: Seg[] = []
+  for (const tok of tokens) {
+    if (tok.startsWith('**')) {
+      if (cur.length) paras.push(cur)
+      cur = [{ kind: 'b', text: tok.slice(2, -2) }]
+    } else if (tok.startsWith('*')) {
+      cur.push({ kind: 'i', text: tok.slice(1, -1) })
+    } else {
+      cur.push({ kind: 't', text: tok })
+    }
+  }
+  if (cur.length) paras.push(cur)
+
+  return paras.map((para, pi) => (
+    <Text
+      key={pi}
+      style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 21, marginTop: pi === 0 ? 0 : 12 }]}
+    >
+      {para.map((seg, si) =>
+        seg.kind === 'b' ? (
+          <Text key={si} style={{ color: INK, fontWeight: '600' }}>
+            {seg.text}
+          </Text>
+        ) : seg.kind === 'i' ? (
+          <Text key={si} style={{ fontStyle: 'italic' }}>
+            {seg.text}
+          </Text>
+        ) : (
+          <Text key={si}>{seg.text}</Text>
+        ),
+      )}
+    </Text>
+  ))
+}

--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -120,7 +120,6 @@ interface HoleMapProps {
   onSetAim: (loc: LatLng) => void
   onSetBall: (loc: LatLng) => void
   onPlacePin?: (loc: LatLng) => void
-  onPlaceTee?: (loc: LatLng) => void
   /**
    * Whether to mount the Mapbox LocationPuck. The puck owns its own
    * native GPS subscription that bypasses expo-location, and setting
@@ -200,7 +199,6 @@ export function HoleMap({
   onSetAim,
   onSetBall,
   onPlacePin,
-  onPlaceTee,
   showLocationPuck,
   overlayMode,
   arcWidthYards,
@@ -217,7 +215,6 @@ export function HoleMap({
   const [styleLoaded, setStyleLoaded] = useState(false)
 
   const isPinMode = phase === 'PIN'
-  const isTeeMode = phase === 'TEE'
   const isAimPhase = phase === 'SET_AIM'
   const isPlaceBallPhase = phase === 'PLACE_BALL'
 
@@ -563,10 +560,6 @@ export function HoleMap({
       onPlacePin?.(c)
       return
     }
-    if (isTeeMode) {
-      onPlaceTee?.(c)
-      return
-    }
     // Tap-to-place-ball is only meaningful in PLACE_BALL. In SET_AIM we
     // don't want stray taps moving the just-confirmed ball position.
     if (isPlaceBallPhase) {
@@ -624,7 +617,7 @@ export function HoleMap({
           {/* Fixed-geometry aim overlay (T4), drawn under the aim line. Arc
               band = a wide translucent stroke (the "fill") + a thin crisp
               core, so it reads as an area, not the old invisible hairline. */}
-          {styleLoaded && !isPinMode && !isTeeMode && overlayArc && (
+          {styleLoaded && !isPinMode && overlayArc && (
             <Mapbox.ShapeSource id="overlayArc" shape={overlayArc}>
               <Mapbox.LineLayer
                 id="overlayArcFill"
@@ -650,7 +643,7 @@ export function HoleMap({
           )}
 
           {/* Approach circle ring — translucent fill + thin border. */}
-          {styleLoaded && !isPinMode && !isTeeMode && overlayCircle && (
+          {styleLoaded && !isPinMode && overlayCircle && (
             <Mapbox.ShapeSource id="overlayCircle" shape={overlayCircle}>
               <Mapbox.FillLayer
                 id="overlayCircleFill"
@@ -664,7 +657,7 @@ export function HoleMap({
           )}
 
           {/* Single-color historical-shot dots (dispersion toggle). */}
-          {styleLoaded && !isPinMode && !isTeeMode && overlayDots && (
+          {styleLoaded && !isPinMode && overlayDots && (
             <Mapbox.ShapeSource id="overlayDots" shape={overlayDots}>
               <Mapbox.CircleLayer
                 id="overlayDotsLayer"
@@ -785,7 +778,7 @@ export function HoleMap({
           )}
 
           {/* Render whenever an aim exists — NOT gated on showAim — so the
-              annotation never unmounts when the player dips into PIN/TEE
+              annotation never unmounts when the player dips into PIN
               placement. @rnmapbox PointAnnotation loses its native drag
               gesture on an unmount→remount under a reused id; keeping it
               mounted (draggable still gated to SET_AIM) preserves the drag
@@ -854,7 +847,7 @@ export function HoleMap({
           )}
 
           {/* Render whenever a ball exists — same reasoning as the aim
-              annotation above: never unmount during PIN/TEE placement, or
+              annotation above: never unmount during PIN placement, or
               the @rnmapbox drag gesture is lost on remount. draggable stays
               gated to PLACE_BALL so the ball can't be dragged mid-aim. */}
           {ball && (
@@ -898,10 +891,10 @@ export function HoleMap({
 
         {/* No hint during SET_AIM — the aim line auto-spawns to the pin with a
             draggable midpoint, so the old "long-press to set aim" reminder is
-            obsolete. Pin/tee placement + ball-drag hints still show. */}
-        {!isAimPhase && <TopHint isPinMode={isPinMode} isTeeMode={isTeeMode} />}
-        {missingHoleLayout && !isPinMode && !isTeeMode && <MissingLayoutBanner />}
-        {!isPinMode && !isTeeMode && pinDistance !== null && (
+            obsolete. Pin placement + ball-drag hints still show. */}
+        {!isAimPhase && <TopHint isPinMode={isPinMode} />}
+        {missingHoleLayout && !isPinMode && <MissingLayoutBanner />}
+        {!isPinMode && pinDistance !== null && (
           <>
             <ToHolePill display={toDisplay(pinDistance)} />
             <ExpStrokesPill value={liveStrokes.expected} />
@@ -911,7 +904,7 @@ export function HoleMap({
             expected strokes, and the dispersion overlay all need one. Skipped
             when the whole hole layout is missing (MissingLayoutBanner covers
             that case). */}
-        {!isPinMode && !isTeeMode && !effectivePin && !missingHoleLayout && (
+        {!isPinMode && !effectivePin && !missingHoleLayout && (
           <PinFirstCta />
         )}
         {isPlaceBallPhase && (

--- a/apps/mobile/components/round/HoleMap.types.ts
+++ b/apps/mobile/components/round/HoleMap.types.ts
@@ -8,6 +8,5 @@ export interface LatLng {
  * `SET_AIM`    — ball locked, long-press drops aim, camera rotates so
  *                play direction is up.
  * `PIN`        — pin placement modality (orthogonal to the shot flow).
- * `TEE`        — tee box placement modality (orthogonal to the shot flow).
  */
-export type HoleMapPhase = 'PLACE_BALL' | 'SET_AIM' | 'PIN' | 'TEE'
+export type HoleMapPhase = 'PLACE_BALL' | 'SET_AIM' | 'PIN'

--- a/apps/mobile/components/round/HoleMapOverlays.tsx
+++ b/apps/mobile/components/round/HoleMapOverlays.tsx
@@ -18,10 +18,9 @@ const HUD_KICKER = {
 
 interface TopHintProps {
   isPinMode: boolean
-  isTeeMode: boolean
 }
 
-export function TopHint({ isPinMode, isTeeMode }: TopHintProps) {
+export function TopHint({ isPinMode }: TopHintProps) {
   return (
     <View
       style={{
@@ -54,9 +53,7 @@ export function TopHint({ isPinMode, isTeeMode }: TopHintProps) {
       >
         {isPinMode
           ? 'Pin mode — tap to place flag'
-          : isTeeMode
-            ? 'Tee mode — tap to place tee box'
-            : 'Drag the ball to refine, then tap Mark ball here'}
+          : 'Drag the ball to refine, then tap Mark ball here'}
       </Text>
     </View>
   )
@@ -223,18 +220,14 @@ interface LeftToolbarProps {
   dotsVisible: boolean
   onToggleDots: () => void
   onPlacePin: () => void
-  onPlaceTee: () => void
   pinMode: boolean
-  teeMode: boolean
 }
 
 export function LeftToolbar({
   dotsVisible,
   onToggleDots,
   onPlacePin,
-  onPlaceTee,
   pinMode,
-  teeMode,
 }: LeftToolbarProps) {
   return (
     <View
@@ -273,12 +266,6 @@ export function LeftToolbar({
           label="Place pin"
           active={pinMode}
           onPress={onPlacePin}
-        />
-        <ToolbarButton
-          icon="golf-tee"
-          label="Place tee box"
-          active={teeMode}
-          onPress={onPlaceTee}
         />
       </View>
     </View>

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -79,7 +79,6 @@ export default function LiveRoundSession({
   // a modal left open on hole 5 doesn't reappear on hole 6.
   const [loggerOpen, setLoggerOpen] = useState(false)
   const [pinPlacementOpen, setPinPlacementOpen] = useState(false)
-  const [teePlacementOpen, setTeePlacementOpen] = useState(false)
   const [scorecardOpen, setScorecardOpen] = useState(false)
   // One mutually-exclusive confirm dialog at a time. See ActiveDialog
   // in ./hole/types for the full union + rationale (#293).
@@ -108,7 +107,6 @@ export default function LiveRoundSession({
   useEffect(() => {
     setLoggerOpen(false)
     setPinPlacementOpen(false)
-    setTeePlacementOpen(false)
     setLoggerInitial({})
     // Clear only hole-scoped dialogs (onGreen / aim). Session-scoped
     // confirms (delete / leave / end / exit) stay open across hole
@@ -161,13 +159,14 @@ export default function LiveRoundSession({
     finalState.ball?.lng,
   ])
 
-  // Two-dot tee box at the tee, oriented down the line of play (toward the aim,
-  // else the pin) — same visual as past-round (PastRoundMap). Hidden while the
-  // tee-placement flow is open so that flow keeps its own marker; HoleMap falls
-  // back to the single TeeBadge whenever teeBox is null.
+  // Two-dot tee box flanking the tee, oriented down the line of play (toward the
+  // aim, else the pin). The tee IS the first shot's start — like past-round
+  // (PastRoundMap): the course tee when known, otherwise the shot-1 ball as you
+  // place it (persisted as the hole tee on save, see useShotActions). After
+  // shot 1 it lives in data.tee, so the dots stay put on later shots.
   const teeBox = useMemo<[LatLng, LatLng] | null>(() => {
-    const origin = data.tee
-    if (!origin || teePlacementOpen) return null
+    const origin = data.tee ?? (data.shotNumber === 1 ? finalState.ball : null)
+    if (!origin) return null
     const toward = finalState.aim ?? data.roundPin ?? data.storedPin
     const heading = toward
       ? bearingDegrees(origin.lat, origin.lng, toward.lat, toward.lng)
@@ -179,7 +178,9 @@ export default function LiveRoundSession({
   }, [
     data.tee?.lat,
     data.tee?.lng,
-    teePlacementOpen,
+    data.shotNumber,
+    finalState.ball?.lat,
+    finalState.ball?.lng,
     finalState.aim?.lat,
     finalState.aim?.lng,
     data.roundPin?.lat,
@@ -264,7 +265,6 @@ export default function LiveRoundSession({
     setLoggerOpen,
     setLoggerInitial,
     setPinPlacementOpen,
-    setTeePlacementOpen,
     setActiveDialog,
     // URL sync fires here — only on user-driven navigation (Next /
     // Prev / Finish), not on every render. A reactive useEffect that
@@ -500,11 +500,9 @@ export default function LiveRoundSession({
           phase={
             pinPlacementOpen
               ? 'PIN'
-              : teePlacementOpen
-                ? 'TEE'
-                : finalState.roundState === 'SET_AIM'
-                  ? 'SET_AIM'
-                  : 'PLACE_BALL'
+              : finalState.roundState === 'SET_AIM'
+                ? 'SET_AIM'
+                : 'PLACE_BALL'
           }
           // A SET_AIM → SHOT_DETAIL/PUTTING transition is a real shot commit;
           // SET_AIM → bare PLACE_BALL ("Re-place ball") is a backout. The
@@ -540,7 +538,6 @@ export default function LiveRoundSession({
             finalState.setBall(loc)
           }}
           onPlacePin={actions.persistRoundPin}
-          onPlaceTee={actions.persistTee}
         />
         {finalState.aimHintVisible && (
           <Pressable
@@ -571,13 +568,11 @@ export default function LiveRoundSession({
           dotsVisible={dotsVisible}
           onToggleDots={() => setDotsVisible((v) => !v)}
           onPlacePin={() => setPinPlacementOpen(true)}
-          onPlaceTee={() => setTeePlacementOpen(true)}
           pinMode={pinPlacementOpen}
-          teeMode={teePlacementOpen}
         />
         {/* Tee/Appr + distance rail — appears once an aim exists, hidden
-            during pin/tee placement so it doesn't fight those flows. */}
-        {finalState.aim && !pinPlacementOpen && !teePlacementOpen && (
+            during pin placement so it doesn't fight that flow. */}
+        {finalState.aim && !pinPlacementOpen && (
           <RightRail
             mode={overlayMode}
             onSetMode={setOverlayMode}
@@ -589,7 +584,6 @@ export default function LiveRoundSession({
         <MapBottomChrome
           roundState={finalState.roundState}
           pinPlacementOpen={pinPlacementOpen}
-          teePlacementOpen={teePlacementOpen}
           ball={finalState.ball}
           aim={finalState.aim}
           saving={actions.saving}
@@ -600,7 +594,6 @@ export default function LiveRoundSession({
           par={data.currentHole.par}
           yardsLabel={data.currentHole.yards ? toDisplay(data.currentHole.yards) : null}
           onCancelPinPlacement={() => setPinPlacementOpen(false)}
-          onCancelTeePlacement={() => setTeePlacementOpen(false)}
           onClearRoundPin={actions.clearRoundPin}
           onConfirmAim={actions.confirmAim}
           onRePlaceBall={() => {

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -10,7 +10,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { HoleMap, type LatLng } from './HoleMap'
 import type { ShotLoggerValue } from './ShotLogger'
-import { DEFAULT_HANDICAP } from '@oga/core'
+import { DEFAULT_HANDICAP, bearingDegrees, destinationYards } from '@oga/core'
 import { getProfile } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { distanceYards } from '../../lib/maps'
@@ -40,6 +40,10 @@ import { LeftToolbar, RightRail } from './HoleMapOverlays'
 const TEE_RAIL_YARDS = [95, 85, 75, 65] as const
 const APPR_RAIL_FEET = [50, 36, 30, 24] as const
 const FEET_PER_YARD = 3
+
+// Half-width of the two-dot tee box, each side of the line of play (matches
+// PastRoundMap's dual-dot tee). Place the drive between the dots.
+const TEE_BOX_HALF_YARDS = 4
 
 interface LiveRoundSessionProps {
   roundId: string | undefined
@@ -155,6 +159,33 @@ export default function LiveRoundSession({
     data.courseCenter?.lng,
     finalState.ball?.lat,
     finalState.ball?.lng,
+  ])
+
+  // Two-dot tee box at the tee, oriented down the line of play (toward the aim,
+  // else the pin) — same visual as past-round (PastRoundMap). Hidden while the
+  // tee-placement flow is open so that flow keeps its own marker; HoleMap falls
+  // back to the single TeeBadge whenever teeBox is null.
+  const teeBox = useMemo<[LatLng, LatLng] | null>(() => {
+    const origin = data.tee
+    if (!origin || teePlacementOpen) return null
+    const toward = finalState.aim ?? data.roundPin ?? data.storedPin
+    const heading = toward
+      ? bearingDegrees(origin.lat, origin.lng, toward.lat, toward.lng)
+      : 0
+    return [
+      destinationYards(origin, heading - 90, TEE_BOX_HALF_YARDS),
+      destinationYards(origin, heading + 90, TEE_BOX_HALF_YARDS),
+    ]
+  }, [
+    data.tee?.lat,
+    data.tee?.lng,
+    teePlacementOpen,
+    finalState.aim?.lat,
+    finalState.aim?.lng,
+    data.roundPin?.lat,
+    data.roundPin?.lng,
+    data.storedPin?.lat,
+    data.storedPin?.lng,
   ])
 
   // Per-club dispersion from the player's whole history (one query/session).
@@ -452,6 +483,7 @@ export default function LiveRoundSession({
           pin={data.storedPin}
           roundPin={data.roundPin}
           tee={data.tee}
+          teeBox={teeBox}
           aim={finalState.aim}
           ball={finalState.ball}
           overlayMode={overlayMode}

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -7,8 +7,8 @@ import { KICKER, type RoundState } from './hole/types'
 // Floating bottom chrome that replaces the old cream HoleStrip panel so the
 // satellite map runs nearly full-bleed (Shot Pattern refs: contextual CTA over
 // a thin hole-nav). All action wiring is the HoleStrip wiring verbatim — only
-// the presentation moved from a solid panel to map-floating pills. Pin/tee
-// placement + recenter live in the left toolbar now, so they're gone here.
+// the presentation moved from a solid panel to map-floating pills. Pin
+// placement lives in the left toolbar now, so it's gone here.
 //
 // The nav pill is kept narrow + centered so the Mapbox logo/attribution at the
 // bottom corners stays unobstructed (ToS).
@@ -18,7 +18,6 @@ const CREAM = '#F2EEE5'
 interface MapBottomChromeProps {
   roundState: RoundState
   pinPlacementOpen: boolean
-  teePlacementOpen: boolean
   ball: { lat: number; lng: number } | null
   aim: { lat: number; lng: number } | null
   saving: boolean
@@ -29,7 +28,6 @@ interface MapBottomChromeProps {
   par: number
   yardsLabel: string | null
   onCancelPinPlacement: () => void
-  onCancelTeePlacement: () => void
   onClearRoundPin: () => void
   onConfirmAim: () => void
   onRePlaceBall: () => void
@@ -69,9 +67,6 @@ function ContextualActions(p: MapBottomChromeProps) {
         {p.roundPin && <SecondaryPill label="Clear flag" danger onPress={p.onClearRoundPin} />}
       </View>
     )
-  }
-  if (p.teePlacementOpen) {
-    return <SecondaryPill label="Cancel" onPress={p.onCancelTeePlacement} />
   }
   if (p.roundState === 'SET_AIM') {
     return (

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -34,7 +34,6 @@ interface UseShotActionsInput {
   setLoggerOpen: Dispatch<SetStateAction<boolean>>
   setLoggerInitial: Dispatch<SetStateAction<ShotLoggerValue>>
   setPinPlacementOpen: Dispatch<SetStateAction<boolean>>
-  setTeePlacementOpen: Dispatch<SetStateAction<boolean>>
   setActiveDialog: Dispatch<SetStateAction<ActiveDialog>>
   // Hole navigation is callback-driven so the parent (LiveRoundSession)
   // can keep the MapView resident across hole changes. Direct router.replace
@@ -56,7 +55,6 @@ export interface UseShotActionsResult {
   persistPutt: (v: PuttingValue) => Promise<void>
   persistRoundPin: (loc: LatLng) => Promise<void>
   clearRoundPin: () => Promise<void>
-  persistTee: (loc: LatLng) => Promise<void>
   markBallHere: () => Promise<void>
   handleOnGreenYes: () => void
   handleOnGreenNo: () => void
@@ -84,7 +82,6 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     setLoggerOpen,
     setLoggerInitial,
     setPinPlacementOpen,
-    setTeePlacementOpen,
     setActiveDialog,
     onHoleChange,
   } = input
@@ -222,6 +219,19 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       // Bump only on success — a failed save (caught below) shouldn't
       // remount the form and wipe the player's entry.
       setShotEntrySeq((s) => s + 1)
+
+      // First shot on a hole with no course tee → the drive's start IS the
+      // tee. Persist it so the tee box, camera, and distances have an anchor
+      // (mapped holes keep their stored course tee). Background, not awaited.
+      if (
+        shotNumber === 1 &&
+        currentHole &&
+        currentHole.tee_lat == null &&
+        payload.start_lat != null &&
+        payload.start_lng != null
+      ) {
+        void writeTee({ lat: payload.start_lat, lng: payload.start_lng })
+      }
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('shot save failed', err, payload)
@@ -289,7 +299,13 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     }
   }
 
-  async function persistTee(loc: LatLng) {
+  // Auto-persist the tee = the first shot's start (the drive's starting point),
+  // the live analogue of past-round deriving the tee from placed[0].start.
+  // Called from persistShot on shot 1 only when the hole has no course tee, so
+  // the dual-dot tee box + camera + distances (all keyed on holes.tee_lat/lng)
+  // light up without a manual placement step. Background + non-blocking: the
+  // shot already saved, so a failure warns rather than alerting.
+  async function writeTee(loc: LatLng) {
     if (!currentHole) return
     if (!Number.isFinite(loc.lat) || !Number.isFinite(loc.lng)) return
     setHoles((prev) =>
@@ -299,13 +315,13 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
           : h,
       ),
     )
-    setTeePlacementOpen(false)
     const { error: updateErr } = await supabase
       .from('holes')
       .update({ tee_lat: loc.lat, tee_lng: loc.lng })
       .eq('id', currentHole.id)
     if (updateErr) {
-      Alert.alert('Tee save failed', updateErr.message)
+      // eslint-disable-next-line no-console
+      console.warn('[hole/tee-auto-persist]', updateErr.message)
     }
   }
 
@@ -533,7 +549,6 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     persistPutt,
     persistRoundPin,
     clearRoundPin,
-    persistTee,
     markBallHere,
     handleOnGreenYes,
     handleOnGreenNo,

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -186,8 +186,7 @@ export function useHoleCamera({
     if (
       phase === 'PLACE_BALL' &&
       prevPhaseRef.current !== 'PLACE_BALL' &&
-      prevPhaseRef.current !== 'PIN' &&
-      prevPhaseRef.current !== 'TEE'
+      prevPhaseRef.current !== 'PIN'
     ) {
       reframePlaceBallRef.current = true
     }

--- a/apps/mobile/hooks/usePracticePlan.ts
+++ b/apps/mobile/hooks/usePracticePlan.ts
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  getDrillsByIds,
+  getLatestPracticePlan,
+  saveFeedback,
+  updatePlanProgress,
+} from '@oga/supabase'
+import type { Database } from '@oga/supabase'
+import { supabase } from '../lib/supabase'
+import { useAuth } from './useAuth'
+
+export type PracticePlan = Database['public']['Tables']['practice_plans']['Row']
+
+// Mirrors getDrillsByIds' select shape (the drill fields the plan view needs).
+export type DrillCard = {
+  id: string
+  name: string
+  description: string | null
+  instructions: string | null
+  facility: string[] | null
+  duration_min: number | null
+  drill_type: string
+  category: string | null
+  source: string | null
+  source_url: string | null
+}
+
+// Mobile counterpart of web's useDrills.ts hooks (useLatestPracticePlan /
+// useGeneratePlan / useDrillsByIds / useUpdatePlanProgress / useSaveFeedback).
+// No react-query on mobile — manual fetch + optimistic local state, matching
+// the round screen. The plan view computes the drill ids from the plan blocks
+// and calls loadDrills(ids); generation invokes the Claude edge fn then
+// refetches (the fn writes the plan before returning, like web's invalidate).
+export function usePracticePlan() {
+  const { user } = useAuth()
+  const [plan, setPlan] = useState<PracticePlan | null>(null)
+  const [drillsById, setDrillsById] = useState<Record<string, DrillCard>>({})
+  const [loading, setLoading] = useState(true)
+  const [generating, setGenerating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    if (!user) return
+    setLoading(true)
+    setError(null)
+    const { data, error: pErr } = await getLatestPracticePlan(supabase, user.id)
+    if (pErr) {
+      setError(pErr.message)
+      setLoading(false)
+      return
+    }
+    setPlan((data as PracticePlan | null) ?? null)
+    setLoading(false)
+  }, [user])
+
+  useEffect(() => {
+    reload()
+  }, [reload])
+
+  const loadDrills = useCallback(async (ids: string[]) => {
+    if (ids.length === 0) {
+      setDrillsById({})
+      return
+    }
+    const { data, error: dErr } = await getDrillsByIds(supabase, ids)
+    if (dErr) return
+    const byId: Record<string, DrillCard> = {}
+    for (const d of (data ?? []) as DrillCard[]) byId[d.id] = d
+    setDrillsById(byId)
+  }, [])
+
+  const generate = useCallback(async () => {
+    setGenerating(true)
+    setError(null)
+    const { error: gErr } = await supabase.functions.invoke('generate-practice-plan', {
+      body: {},
+    })
+    if (gErr) {
+      setError(gErr.message)
+      setGenerating(false)
+      return
+    }
+    await reload()
+    setGenerating(false)
+  }, [reload])
+
+  // Completion keys off the block id (StoredBlock.id), not the drill id —
+  // matches web's onToggleComplete(blockId) → completed_drill_ids.
+  const toggleCompletion = useCallback(
+    async (blockId: string) => {
+      if (!plan) return
+      const current = plan.completed_drill_ids ?? []
+      const next = current.includes(blockId)
+        ? current.filter((id) => id !== blockId)
+        : [...current, blockId]
+      // Optimistic — revert on failure (mirrors web's onMutate/onError).
+      setPlan((prev) => (prev ? { ...prev, completed_drill_ids: next } : prev))
+      const { error: uErr } = await updatePlanProgress(supabase, plan.id, next)
+      if (uErr) {
+        setPlan((prev) => (prev ? { ...prev, completed_drill_ids: current } : prev))
+        setError(uErr.message)
+      }
+    },
+    [plan],
+  )
+
+  const submitFeedback = useCallback(
+    async (feedback: string) => {
+      if (!plan) return
+      const { error: fErr } = await saveFeedback(supabase, plan.id, feedback)
+      if (fErr) {
+        setError(fErr.message)
+        return
+      }
+      setPlan((prev) => (prev ? { ...prev, feedback } : prev))
+    },
+    [plan],
+  )
+
+  return {
+    plan,
+    drillsById,
+    loading,
+    generating,
+    error,
+    reload,
+    loadDrills,
+    generate,
+    toggleCompletion,
+    submitFeedback,
+  }
+}

--- a/apps/mobile/hooks/usePracticePlan.ts
+++ b/apps/mobile/hooks/usePracticePlan.ts
@@ -63,7 +63,12 @@ export function usePracticePlan() {
       return
     }
     const { data, error: dErr } = await getDrillsByIds(supabase, ids)
-    if (dErr) return
+    if (dErr) {
+      // Surface it — otherwise the plan renders with every drill row stuck on
+      // the bare "Drill" fallback and no indication anything failed.
+      setError(dErr.message)
+      return
+    }
     const byId: Record<string, DrillCard> = {}
     for (const d of (data ?? []) as DrillCard[]) byId[d.id] = d
     setDrillsById(byId)

--- a/apps/web/src/pages/practice/DrillLibraryPage.tsx
+++ b/apps/web/src/pages/practice/DrillLibraryPage.tsx
@@ -1,72 +1,264 @@
+import { useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
+import type { BlockType, PlanCategory } from '@oga/core'
+import type { Database } from '@oga/supabase'
+import { useDrills } from '../../hooks/useDrills'
+import { toUserMessage } from '../../lib/errors'
+import { BLOCK_TYPE_LABEL, CATEGORY_LABEL, FACILITY_LABEL, renderInstructions } from './drillDisplay'
+
+type Drill = Database['public']['Tables']['drills']['Row']
+
+const LINE = '#D9D2BF'
+
+// Filter vocab: 'all' sentinel + the @oga/core enums. Category order mirrors a
+// round — off the tee through the green — so the chips read as a shot progression.
+const CATEGORIES: PlanCategory[] = ['off_tee', 'approach', 'around_green', 'putting']
+const MODES: BlockType[] = ['warmup', 'blocked', 'random', 'skill_game', 'pressure_game', 'on_course']
 
 export function DrillLibraryPage() {
+  const drillsQuery = useDrills()
+  const [category, setCategory] = useState<PlanCategory | 'all'>('all')
+  const [mode, setMode] = useState<BlockType | 'all'>('all')
+
+  const drills = useMemo(() => drillsQuery.data ?? [], [drillsQuery.data])
+  const filtered = useMemo(
+    () =>
+      drills.filter(
+        (d) =>
+          (category === 'all' || d.category === category) &&
+          (mode === 'all' || d.drill_type === mode),
+      ),
+    [drills, category, mode],
+  )
+
   return (
     <div>
       <Link
         to="/practice"
         className="font-mono uppercase text-caddie-ink-mute hover:text-caddie-ink"
-        style={{
-          fontSize: 10,
-          letterSpacing: '0.14em',
-          marginBottom: 18,
-          display: 'inline-block',
-        }}
+        style={{ fontSize: 10, letterSpacing: '0.14em', marginBottom: 18, display: 'inline-block' }}
       >
         ← Practice plan
       </Link>
 
-      <div style={{ marginBottom: 28 }}>
+      <div style={{ marginBottom: 24 }}>
         <div className="kicker" style={{ marginBottom: 8 }}>
           Drill library
         </div>
-        <h1
-          className="font-serif text-caddie-ink"
-          style={{ fontSize: 28, fontWeight: 500, lineHeight: 1.15 }}
-        >
+        <h1 className="font-serif text-caddie-ink" style={{ fontSize: 28, fontWeight: 500, lineHeight: 1.15 }}>
           The full set
         </h1>
-        <p
-          className="text-caddie-ink-dim"
-          style={{ fontSize: 15, marginTop: 6, maxWidth: 560 }}
-        >
-          The drill library is seeded in Supabase and surfaces here once
-          Phase 5 ships.
+        <p className="text-caddie-ink-dim" style={{ fontSize: 15, marginTop: 6, maxWidth: 560 }}>
+          Every drill the plan generator can draw from. Each one explains the why,
+          the how, and the rep target — no gimmicks.
         </p>
       </div>
 
-      <div
-        className="bg-caddie-surface"
-        style={{
-          border: '1px solid #D9D2BF',
-          borderRadius: 4,
-          padding: '40px 32px',
-          maxWidth: 640,
-        }}
-      >
-        <div className="kicker" style={{ marginBottom: 12 }}>
-          Coming in phase 5
+      {/* Filters — category (the part of the game) then practice mode. */}
+      <FilterRow
+        label="Part of the game"
+        active={category}
+        all="all"
+        options={CATEGORIES}
+        labelFor={(c) => CATEGORY_LABEL[c]}
+        onPick={setCategory}
+      />
+      <FilterRow
+        label="Practice mode"
+        active={mode}
+        all="all"
+        options={MODES}
+        labelFor={(m) => BLOCK_TYPE_LABEL[m]}
+        onPick={setMode}
+      />
+
+      {drillsQuery.isLoading ? (
+        <div className="font-mono text-caddie-ink-dim" style={{ fontSize: 13, paddingTop: 24 }}>
+          Loading drills…
         </div>
-        <h2
-          className="font-serif text-caddie-ink"
-          style={{
-            fontSize: 22,
-            fontWeight: 500,
-            fontStyle: 'italic',
-            lineHeight: 1.2,
-          }}
+      ) : drillsQuery.error ? (
+        <div
+          className="text-caddie-neg"
+          style={{ marginTop: 24, border: `1px solid ${LINE}`, borderRadius: 4, padding: '12px 14px', fontSize: 13 }}
         >
-          Drills with intent.
-        </h2>
-        <p
-          className="font-serif text-caddie-ink"
-          style={{ fontSize: 17, lineHeight: 1.55, marginTop: 14 }}
-        >
-          Filter by <em>category</em>, facility, and skill level. Each
-          drill explains the why, the how, and the rep target — no
-          gimmicks.
-        </p>
+          {toUserMessage(drillsQuery.error)}
+        </div>
+      ) : (
+        <>
+          <div
+            className="font-mono text-caddie-ink-mute"
+            style={{ fontSize: 10, letterSpacing: '0.1em', textTransform: 'uppercase', margin: '24px 0 4px' }}
+          >
+            {filtered.length} drill{filtered.length === 1 ? '' : 's'}
+          </div>
+          {filtered.length === 0 ? (
+            <p className="font-serif text-caddie-ink-dim" style={{ fontSize: 17, fontStyle: 'italic', paddingTop: 16 }}>
+              No drills match those filters.
+            </p>
+          ) : (
+            <div style={{ maxWidth: 720 }}>
+              {filtered.map((drill) => (
+                <DrillCard key={drill.id} drill={drill} />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function FilterRow<T extends string>({
+  label,
+  active,
+  all,
+  options,
+  labelFor,
+  onPick,
+}: {
+  label: string
+  active: T | 'all'
+  all: 'all'
+  options: T[]
+  labelFor: (value: T) => string
+  onPick: (value: T | 'all') => void
+}) {
+  const chips: Array<{ value: T | 'all'; label: string }> = [
+    { value: all, label: 'All' },
+    ...options.map((o) => ({ value: o, label: labelFor(o) })),
+  ]
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <div className="kicker" style={{ marginBottom: 8 }}>
+        {label}
       </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        {chips.map((chip) => {
+          const selected = chip.value === active
+          return (
+            <button
+              key={chip.value}
+              type="button"
+              onClick={() => onPick(chip.value)}
+              aria-pressed={selected}
+              className={
+                selected ? 'bg-caddie-accent text-caddie-accent-ink' : 'bg-caddie-surface text-caddie-ink-dim hover:text-caddie-ink'
+              }
+              style={{
+                fontSize: 12,
+                fontWeight: 600,
+                letterSpacing: '0.02em',
+                padding: '6px 12px',
+                borderRadius: 2,
+                border: selected ? 'none' : `1px solid ${LINE}`,
+                cursor: 'pointer',
+              }}
+            >
+              {chip.label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function DrillCard({ drill }: { drill: Drill }) {
+  const [open, setOpen] = useState(false)
+  const facilities = drill.facility ?? []
+  const instructions = drill.instructions?.trim() || drill.description?.trim() || ''
+  const canExpand = instructions.length > 0
+
+  return (
+    <div style={{ borderBottom: `1px solid ${LINE}`, padding: '18px 0' }}>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 14, alignItems: 'start' }}>
+        <div>
+          {canExpand ? (
+            <button
+              type="button"
+              onClick={() => setOpen((o) => !o)}
+              aria-expanded={open}
+              aria-controls={`drill-detail-${drill.id}`}
+              className="font-serif text-caddie-ink hover:opacity-80"
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                gap: 8,
+                fontSize: 19,
+                fontStyle: 'italic',
+                lineHeight: 1.2,
+                textAlign: 'left',
+                cursor: 'pointer',
+                background: 'none',
+                border: 'none',
+                padding: 0,
+              }}
+            >
+              <span>{drill.name}</span>
+              <span
+                className="font-mono text-caddie-ink-mute"
+                aria-hidden="true"
+                style={{ fontSize: 15, fontStyle: 'normal', lineHeight: 1 }}
+              >
+                {open ? '−' : '+'}
+              </span>
+            </button>
+          ) : (
+            <div className="font-serif text-caddie-ink" style={{ fontSize: 19, fontStyle: 'italic', lineHeight: 1.2 }}>
+              {drill.name}
+            </div>
+          )}
+          {facilities.length > 0 ? (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 10 }}>
+              {facilities.map((f) => (
+                <span
+                  key={f}
+                  className="font-mono bg-caddie-surface-2 text-caddie-ink-dim"
+                  style={{ fontSize: 10, letterSpacing: '0.04em', textTransform: 'uppercase', padding: '3px 8px', borderRadius: 2 }}
+                >
+                  {FACILITY_LABEL[f] ?? f}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </div>
+
+        {/* Right — duration + mode tag */}
+        <div style={{ textAlign: 'right', minWidth: 72 }}>
+          {drill.duration_min != null ? (
+            <div className="font-serif text-caddie-ink" style={{ fontSize: 22, fontStyle: 'italic', lineHeight: 1 }}>
+              {drill.duration_min} min
+            </div>
+          ) : null}
+          <div
+            className="font-mono text-caddie-accent"
+            style={{ fontSize: 9, letterSpacing: '0.12em', textTransform: 'uppercase', marginTop: drill.duration_min != null ? 6 : 0 }}
+          >
+            {BLOCK_TYPE_LABEL[drill.drill_type as BlockType] ?? drill.drill_type}
+          </div>
+        </div>
+      </div>
+
+      {canExpand && open ? (
+        <div id={`drill-detail-${drill.id}`} style={{ borderTop: `1px solid ${LINE}`, marginTop: 16, paddingTop: 16, maxWidth: 660 }}>
+          {renderInstructions(instructions)}
+          {drill.source ? (
+            <div
+              className="font-mono text-caddie-ink-mute"
+              style={{ fontSize: 10, letterSpacing: '0.04em', textTransform: 'uppercase', marginTop: 14 }}
+            >
+              via{' '}
+              {drill.source_url ? (
+                <a href={drill.source_url} target="_blank" rel="noopener noreferrer" className="text-caddie-accent hover:opacity-80">
+                  {drill.source}
+                </a>
+              ) : (
+                drill.source
+              )}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import type { PlanCategory, BlockType, StoredBlock, StoredSession, StoredFocusArea } from '@oga/core'
+import type { StoredBlock, StoredSession, StoredFocusArea } from '@oga/core'
 import {
   useDrillsByIds,
   useGeneratePlan,
@@ -9,6 +9,7 @@ import {
   useUpdatePlanProgress,
 } from '../../hooks/useDrills'
 import { toUserMessage } from '../../lib/errors'
+import { BLOCK_TYPE_LABEL, CATEGORY_LABEL, FACILITY_LABEL, renderInstructions } from './drillDisplay'
 
 // Resolved drill row from useDrillsByIds (shape mirrors getDrillsByIds' select).
 type ResolvedDrill = {
@@ -29,29 +30,6 @@ type ResolvedDrill = {
 // ---------------------------------------------------------------------------
 
 type PlanDrills = { sessions: StoredSession[] }
-
-const CATEGORY_LABEL: Record<PlanCategory, string> = {
-  off_tee: 'Off the tee',
-  approach: 'Approach',
-  around_green: 'Around the green',
-  putting: 'Putting',
-}
-
-const BLOCK_TYPE_LABEL: Record<BlockType, string> = {
-  warmup: 'Warm-up',
-  blocked: 'Blocked',
-  random: 'Random',
-  skill_game: 'Skill game',
-  pressure_game: 'Pressure game',
-  on_course: 'On course',
-}
-
-const FACILITY_LABEL: Record<string, string> = {
-  range: 'Range',
-  short_game: 'Short game',
-  putting: 'Putting green',
-  sim: 'Simulator',
-}
 
 const LINE = '#D9D2BF'
 
@@ -94,57 +72,6 @@ function normalizeCategoryProse(text: string): string {
   return text
     .replace(/\boff_tee\b/gi, 'off the tee')
     .replace(/\baround_green\b/gi, 'around the green')
-}
-
-// Tiny markdown-ish renderer scoped to the drill `instructions` format.
-// Tokenizes left-to-right into complete tokens (**bold** | *italic* | plain)
-// then groups: each **bold** header starts a new paragraph, following
-// plain/italic text belongs to that section.
-// The continuous seed format `**Why.** prose **Setup.** prose` produces one
-// paragraph per section. Complete-token matching (not a lookahead) avoids the
-// closing-**+body+opening-** ambiguity of the prior split approach.
-// No dangerouslySetInnerHTML — all text nodes + React elements only.
-function renderInstructions(text: string): React.ReactNode {
-  // Tokenize left-to-right into complete tokens: **bold** | *italic* | plain.
-  // Matching complete tokens (not a lookahead) avoids the closing-**+body+opening-**
-  // ambiguity. The seed uses **…** only for section headers and *…* for emphasis.
-  const tokens = text.match(/\*\*[^*]+\*\*|\*[^*]+\*|[^*]+/g) ?? []
-  // Group into paragraphs: each **bold** header starts a new paragraph; the
-  // following plain/italic text belongs to that section.
-  type Seg = { kind: 'b' | 'i' | 't'; text: string }
-  const paras: Seg[][] = []
-  let cur: Seg[] = []
-  for (const tok of tokens) {
-    if (tok.startsWith('**')) {
-      if (cur.length) paras.push(cur)
-      cur = [{ kind: 'b', text: tok.slice(2, -2) }]
-    } else if (tok.startsWith('*')) {
-      cur.push({ kind: 'i', text: tok.slice(1, -1) })
-    } else {
-      cur.push({ kind: 't', text: tok })
-    }
-  }
-  if (cur.length) paras.push(cur)
-
-  return paras.map((para, pi) => (
-    <p
-      key={pi}
-      className="font-serif text-caddie-ink-dim"
-      style={{ fontSize: 15, lineHeight: 1.6, marginTop: pi === 0 ? 0 : 12 }}
-    >
-      {para.map((seg, si) =>
-        seg.kind === 'b' ? (
-          <strong key={si} className="text-caddie-ink" style={{ fontWeight: 600 }}>
-            {seg.text}
-          </strong>
-        ) : seg.kind === 'i' ? (
-          <em key={si}>{seg.text}</em>
-        ) : (
-          <span key={si}>{seg.text}</span>
-        ),
-      )}
-    </p>
-  ))
 }
 
 // ---------------------------------------------------------------------------
@@ -334,12 +261,19 @@ function NoPlanState({
           Generate a week of practice sized to your strokes gained — which drills,
           in what order, with the reasoning behind each one.
         </p>
-        <div style={{ marginTop: 22 }}>
+        <div style={{ marginTop: 22, display: 'flex', alignItems: 'center', gap: 20, flexWrap: 'wrap' }}>
           <GenerateButton
             label="Generate this week's plan"
             onGenerate={onGenerate}
             isPending={isPending}
           />
+          <Link
+            to="/practice/drills"
+            className="font-serif text-caddie-accent hover:opacity-80"
+            style={{ fontSize: 16, fontStyle: 'italic', fontWeight: 500 }}
+          >
+            Browse all drills →
+          </Link>
         </div>
         {errorNotice}
       </div>
@@ -923,6 +857,17 @@ export function PracticePlanPage() {
           Based on your last {plan.based_on_rounds} round{plan.based_on_rounds === 1 ? '' : 's'}
         </div>
       ) : null}
+
+      <div style={{ borderTop: `1px solid ${LINE}`, marginTop: 28, paddingTop: 18 }}>
+        <Link
+          to="/practice/drills"
+          className="font-serif text-caddie-accent hover:opacity-80"
+          style={{ fontSize: 17, fontStyle: 'italic', fontWeight: 500 }}
+        >
+          Browse all drills{' '}
+          <span style={{ fontStyle: 'italic' }}>→</span>
+        </Link>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/pages/practice/drillDisplay.tsx
+++ b/apps/web/src/pages/practice/drillDisplay.tsx
@@ -1,0 +1,75 @@
+import type { BlockType, PlanCategory } from '@oga/core'
+
+// Shared drill-display vocabulary + the instructions renderer, used by both
+// PracticePlanPage (plan blocks) and DrillLibraryPage (browse-all). Extracted
+// because renderInstructions is substantial and must stay identical across the
+// two surfaces — the human-readable face of the @oga/core enums lives here.
+
+export const CATEGORY_LABEL: Record<PlanCategory, string> = {
+  off_tee: 'Off the tee',
+  approach: 'Approach',
+  around_green: 'Around the green',
+  putting: 'Putting',
+}
+
+export const BLOCK_TYPE_LABEL: Record<BlockType, string> = {
+  warmup: 'Warm-up',
+  blocked: 'Blocked',
+  random: 'Random',
+  skill_game: 'Skill game',
+  pressure_game: 'Pressure game',
+  on_course: 'On course',
+}
+
+export const FACILITY_LABEL: Record<string, string> = {
+  range: 'Range',
+  short_game: 'Short game',
+  putting: 'Putting green',
+  sim: 'Simulator',
+}
+
+// Tiny markdown-ish renderer scoped to the drill `instructions` format.
+// Tokenizes left-to-right into complete tokens (**bold** | *italic* | plain)
+// then groups: each **bold** header starts a new paragraph, following
+// plain/italic text belongs to that section.
+// The continuous seed format `**Why.** prose **Setup.** prose` produces one
+// paragraph per section. Complete-token matching (not a lookahead) avoids the
+// closing-**+body+opening-** ambiguity of the prior split approach.
+// No dangerouslySetInnerHTML — all text nodes + React elements only.
+export function renderInstructions(text: string): React.ReactNode {
+  const tokens = text.match(/\*\*[^*]+\*\*|\*[^*]+\*|[^*]+/g) ?? []
+  type Seg = { kind: 'b' | 'i' | 't'; text: string }
+  const paras: Seg[][] = []
+  let cur: Seg[] = []
+  for (const tok of tokens) {
+    if (tok.startsWith('**')) {
+      if (cur.length) paras.push(cur)
+      cur = [{ kind: 'b', text: tok.slice(2, -2) }]
+    } else if (tok.startsWith('*')) {
+      cur.push({ kind: 'i', text: tok.slice(1, -1) })
+    } else {
+      cur.push({ kind: 't', text: tok })
+    }
+  }
+  if (cur.length) paras.push(cur)
+
+  return paras.map((para, pi) => (
+    <p
+      key={pi}
+      className="font-serif text-caddie-ink-dim"
+      style={{ fontSize: 15, lineHeight: 1.6, marginTop: pi === 0 ? 0 : 12 }}
+    >
+      {para.map((seg, si) =>
+        seg.kind === 'b' ? (
+          <strong key={si} className="text-caddie-ink" style={{ fontWeight: 600 }}>
+            {seg.text}
+          </strong>
+        ) : seg.kind === 'i' ? (
+          <em key={si}>{seg.text}</em>
+        ) : (
+          <span key={si}>{seg.text}</span>
+        ),
+      )}
+    </p>
+  ))
+}


### PR DESCRIPTION
**Draft — phases 1-2 of the mobile Practice port (#511, v1.0).**

Ports the shipped web practice-plan generator to React Native.

## Done
- **Phase 1** `usePracticePlan` hook — mobile counterpart of web's `useDrills` (manual fetch, no react-query): latest plan · generate (Claude edge fn) · drills-by-ids · optimistic completion toggle · feedback. Reuses `@oga/supabase` practice queries + `@oga/core` plan types unchanged.
- **Phase 2** `practice.tsx` — loading / no-plan + Generate (with progress) / plan view: insight, coach-note reasoning, focus areas, sessions → drill cards (completion toggle + expandable instructions), based-on-rounds footer.

## Deferred (phase 3+)
- Feedback textarea (save-on-blur)
- Expiry / regenerate-when-stale gating (web uses `valid_until`)
- Drill library — **note: not surfaced on web yet either**, so it needs its own surfacing decision (no web nav precedent to mirror).

Typecheck green. On-device QA pending. Refs #511.