### PR TITLE
docs(env): document web/mobile Mapbox token split (#115)

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -2,5 +2,9 @@
 # 127.0.0.1 for emulator. Hosted project URL for non-local builds.
 EXPO_PUBLIC_SUPABASE_URL=
 EXPO_PUBLIC_SUPABASE_ANON_KEY=
+# Mobile's OWN public Mapbox token — separate from web's, and NOT URL-restricted
+# (native apps send no referer, so a URL restriction would blank the map). The
+# build-time iOS SDK download uses the SECRET sk. token via the
+# MAPBOX_DOWNLOADS_TOKEN EAS secret, never here.
 EXPO_PUBLIC_MAPBOX_TOKEN=
 EXPO_PUBLIC_TURNSTILE_SITE_KEY=

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,6 @@
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
+# Public Mapbox token, URL-restricted to the web domains (it ships in the JS
+# bundle). Mobile uses its OWN, separate public token — don't share one.
 VITE_MAPBOX_TOKEN=
 VITE_TURNSTILE_SITE_KEY=


### PR DESCRIPTION
## What
Documents the now-split Mapbox tokens in both `.env.example` files.

- **Web** (`VITE_MAPBOX_TOKEN`): public token, URL-restricted to the web domains (ships in the JS bundle).
- **Mobile** (`EXPO_PUBLIC_MAPBOX_TOKEN`): its **own** public token, **not** URL-restricted — native apps send no `Referer`, so a URL restriction would blank the map.
- **Secret** `sk.` download token stays an EAS secret (`MAPBOX_DOWNLOADS_TOKEN`), never in env files.

## Why
Web and mobile previously shared one URL-restricted token. A native app's no-referer requests against a URL-restricted token are the ambiguous case (risk of blank maps), and a single token muddies rotation/usage attribution. Tokens have since been split in EAS + local `.env` files; this just records the intent so the two aren't re-merged or the mobile one URL-restricted by mistake.

Docs only — no code, no behavior change.

Refs #115.