### PR TITLE
feat(web): landing v2 — editorial sections, live-mode hero, realish seed

### DIFF
--- a/apps/web/src/components/landing/AppPreview.tsx
+++ b/apps/web/src/components/landing/AppPreview.tsx
@@ -26,6 +26,11 @@ const DEMO_SHOTS = [
   { shotNumber: 3, lat: 36.561432, lng: -121.940402 },
 ]
 
+// Published length of the hole — shown in the label. Kept beside DEMO_HOLE
+// so the relationship is explicit (the coords are a downhill approximation,
+// not a yardage source).
+const DEMO_YARDS = 107
+
 // Phone-shaped frame around a real Mapbox view of Pebble Beach #7. The
 // data is hardcoded but the rendering goes through the same Mapbox
 // satellite tiles + marker styling the live app uses, so what visitors
@@ -139,7 +144,7 @@ export function AppPreview() {
               className="font-mono uppercase"
               style={{ color: 'rgba(242,238,229,0.85)', fontSize: 9, letterSpacing: '0.16em' }}
             >
-              Hole {DEMO_HOLE.number} · Par {DEMO_HOLE.par} · 107 yd
+              Hole {DEMO_HOLE.number} · Par {DEMO_HOLE.par} · {DEMO_YARDS} yd
             </span>
           </div>
         </div>

--- a/apps/web/src/components/landing/AppPreview.tsx
+++ b/apps/web/src/components/landing/AppPreview.tsx
@@ -7,23 +7,26 @@ const DemoMap = lazy(() =>
   import('./DemoMap').then((m) => ({ default: m.DemoMap })),
 )
 
-// Lake Hefner South — hole 1, real coords from the courses DB.
-// Hardcoded so the preview lands on actual fairway in Mapbox satellite
-// tiles instead of empty terrain.
+// Pebble Beach #7 — the iconic 107-yard par 3 to a green on the point,
+// real coords from the courses DB. Hardcoded so the preview lands on the
+// actual hole in Mapbox satellite tiles (ocean-wrapped green) instead of
+// empty terrain — and it's instantly recognizable on the marketing page.
 const DEMO_HOLE = {
-  number: 1,
-  par: 4,
-  tee: { lat: 35.552530168, lng: -97.602615572 },
-  pin: { lat: 35.5504026026316, lng: -97.6044770631579 },
+  number: 7,
+  par: 3,
+  tee: { lat: 36.562223, lng: -121.940501 },
+  pin: { lat: 36.561345, lng: -121.940382 },
 }
 
+// Shot starts walking down toward the green (markers = where each shot
+// began): tee, a short pitch, then on the green near the pin.
 const DEMO_SHOTS = [
-  { shotNumber: 1, lat: 35.552530168, lng: -97.602615572 },
-  { shotNumber: 2, lat: 35.5518, lng: -97.6034 },
-  { shotNumber: 3, lat: 35.5508, lng: -97.6041 },
+  { shotNumber: 1, lat: 36.562223, lng: -121.940501 },
+  { shotNumber: 2, lat: 36.561700, lng: -121.94046 },
+  { shotNumber: 3, lat: 36.561432, lng: -121.940402 },
 ]
 
-// Phone-shaped frame around a real Mapbox view of a fake hole 7. The
+// Phone-shaped frame around a real Mapbox view of Pebble Beach #7. The
 // data is hardcoded but the rendering goes through the same Mapbox
 // satellite tiles + marker styling the live app uses, so what visitors
 // see on the marketing page is what the app actually shows on course.
@@ -55,84 +58,89 @@ export function AppPreview() {
             zIndex: 4,
           }}
         />
+        {/* Live satellite map fills the screen, with the HUD overlaid — the
+            current live-mode layout (apps/mobile HoleMapOverlays): on-map
+            pills, not header/footer bars. */}
         <div
           style={{
             width: '100%',
             height: '100%',
             borderRadius: 24,
             overflow: 'hidden',
-            display: 'flex',
-            flexDirection: 'column',
+            position: 'relative',
             background: '#28482e',
           }}
         >
-          <div
-            style={{
-              background: '#1C211C',
-              color: '#FBF8F1',
-              padding: '14px 16px 12px',
-              borderBottom: '1px solid rgba(251, 248, 241, 0.1)',
-            }}
-          >
-            <div
-              className="font-serif"
-              style={{
-                fontSize: 15,
-                fontStyle: 'italic',
-                fontWeight: 500,
-              }}
-            >
-              Lake Hefner South
-            </div>
-            <div
-              className="font-mono uppercase"
-              style={{
-                fontSize: 9,
-                letterSpacing: '0.18em',
-                color: 'rgba(251, 248, 241, 0.55)',
-                marginTop: 4,
-              }}
-            >
-              Hole {DEMO_HOLE.number} · Par {DEMO_HOLE.par}
-            </div>
-          </div>
-          <div style={{ flex: 1, position: 'relative' }}>
+          <div style={{ position: 'absolute', inset: 0 }}>
             <Suspense fallback={<MapFallback />}>
-              <DemoMap
-                tee={DEMO_HOLE.tee}
-                pin={DEMO_HOLE.pin}
-                shots={DEMO_SHOTS}
-              />
+              <DemoMap tee={DEMO_HOLE.tee} pin={DEMO_HOLE.pin} shots={DEMO_SHOTS} />
             </Suspense>
           </div>
+
+          {/* To Hole — top-left HUD pill */}
+          <HudPill align="flex-start" style={{ top: 12, left: 12 }} kicker="To Hole" value="43" />
+          {/* Expected strokes to hole out — top-right */}
+          <HudPill align="flex-end" style={{ top: 12, right: 12 }} kicker="Exp · to hole" value="2.6" />
+
+          {/* Instructional hint line (matches the live TopHint copy) */}
           <div
             style={{
-              background: '#F2EEE5',
-              color: '#1C211C',
-              padding: '12px 16px',
-              borderTop: '1px solid #D9D2BF',
+              position: 'absolute',
+              top: 62,
+              left: 12,
+              right: 12,
+              background: 'rgba(28,33,28,0.78)',
+              borderRadius: 2,
+              padding: '5px 9px',
             }}
           >
-            <div
+            <span
               className="font-mono uppercase"
-              style={{
-                fontSize: 9,
-                letterSpacing: '0.18em',
-                color: '#8A8B7E',
-              }}
+              style={{ color: '#F2EEE5', fontSize: 9, fontWeight: 600, letterSpacing: '0.14em' }}
             >
-              3 shots placed
-            </div>
-            <div
-              className="font-serif"
-              style={{
-                fontSize: 14,
-                fontStyle: 'italic',
-                marginTop: 4,
-              }}
+              Drag to refine · tap to mark ball
+            </span>
+          </div>
+
+          {/* Left icon toolbar — slope (soon) · shot pattern · place pin */}
+          <div
+            style={{
+              position: 'absolute',
+              left: 10,
+              bottom: 46,
+              background: 'rgba(28,33,28,0.82)',
+              borderRadius: 18,
+              padding: '5px 3px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 3,
+              alignItems: 'center',
+            }}
+          >
+            <ToolIcon kind="terrain" disabled />
+            <ToolIcon kind="grain" active />
+            <ToolIcon kind="flag" />
+          </div>
+
+          {/* Course label — marketing identifier, kept subtle bottom-center */}
+          <div
+            style={{
+              position: 'absolute',
+              bottom: 12,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              background: 'rgba(28,33,28,0.82)',
+              borderRadius: 4,
+              padding: '5px 11px',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            <span
+              className="font-mono uppercase"
+              style={{ color: 'rgba(242,238,229,0.85)', fontSize: 9, letterSpacing: '0.16em' }}
             >
-              42 yd to pin
-            </div>
+              Hole {DEMO_HOLE.number} · Par {DEMO_HOLE.par} · 107 yd
+            </span>
           </div>
         </div>
       </div>
@@ -150,5 +158,100 @@ function MapFallback() {
           'radial-gradient(circle at 70% 65%, #3e6a44 0%, #2c5034 45%, #244429 100%)',
       }}
     />
+  )
+}
+
+// Dark translucent HUD pill — matches apps/mobile HoleMapOverlays (To Hole /
+// Exp readouts). Kicker label over a large upright-serif tabular value.
+function HudPill({
+  kicker,
+  value,
+  align,
+  style,
+}: {
+  kicker: string
+  value: string
+  align: 'flex-start' | 'flex-end'
+  style: React.CSSProperties
+}) {
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        background: 'rgba(28,33,28,0.82)',
+        borderRadius: 4,
+        padding: '6px 11px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: align,
+        minWidth: 72,
+        ...style,
+      }}
+    >
+      <span
+        className="font-mono uppercase"
+        style={{
+          color: 'rgba(242,238,229,0.65)',
+          fontSize: 8,
+          fontWeight: 600,
+          letterSpacing: '0.13em',
+        }}
+      >
+        {kicker}
+      </span>
+      <span
+        className="font-serif"
+        style={{
+          color: '#F2EEE5',
+          fontSize: 18,
+          fontWeight: 500,
+          fontVariant: 'tabular-nums',
+          marginTop: 1,
+        }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+// Compact replica of the live left-toolbar buttons: cream icon on the dark
+// pill, cream-filled when active (the shot-pattern toggle is on here).
+function ToolIcon({
+  kind,
+  active,
+  disabled,
+}: {
+  kind: 'terrain' | 'grain' | 'flag'
+  active?: boolean
+  disabled?: boolean
+}) {
+  const stroke = active ? '#1C211C' : '#F2EEE5'
+  return (
+    <div
+      style={{
+        width: 30,
+        height: 30,
+        borderRadius: 13,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: active ? '#FBF8F1' : 'transparent',
+        opacity: disabled ? 0.34 : 1,
+      }}
+    >
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke={stroke} strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+        {kind === 'terrain' && <path d="M3 20l6-10 4 6 3-4 5 8z" />}
+        {kind === 'grain' && (
+          <>
+            <circle cx="7" cy="8" r="1.4" fill={stroke} stroke="none" />
+            <circle cx="13" cy="11" r="1.4" fill={stroke} stroke="none" />
+            <circle cx="9" cy="15" r="1.4" fill={stroke} stroke="none" />
+            <circle cx="16" cy="16" r="1.4" fill={stroke} stroke="none" />
+          </>
+        )}
+        {kind === 'flag' && <path d="M5 21V4h11l-2 4 2 4H5" />}
+      </svg>
+    </div>
   )
 }

--- a/apps/web/src/components/landing/PublicNav.tsx
+++ b/apps/web/src/components/landing/PublicNav.tsx
@@ -59,7 +59,9 @@ export function PublicNav() {
             className="font-serif"
             style={{ fontSize: 24, fontWeight: 500, fontStyle: 'italic' }}
           >
-            OGA
+            oga
+            {/* Upright forest period — the "o." brand mark, not all-caps OGA */}
+            <span style={{ fontStyle: 'normal', color: '#1F3D2C' }}>.</span>
           </span>
           <span
             className="font-mono uppercase"

--- a/apps/web/src/components/landing/landing.css
+++ b/apps/web/src/components/landing/landing.css
@@ -10,13 +10,8 @@
   .landing-hero-grid > div:first-child {
     text-align: left;
   }
-  .landing-features,
   .landing-learn {
     grid-template-columns: 1fr !important;
-  }
-  .landing-sg {
-    grid-template-columns: 1fr !important;
-    gap: 36px !important;
   }
   .landing-stats {
     grid-template-columns: 1fr !important;
@@ -43,10 +38,55 @@
   }
 }
 
+/* Hero platform row */
+.landing-platforms {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* Editorial spreads (v2): two-up copy + figure, alternating sides. */
+.landing-spread {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 64px;
+  align-items: center;
+}
+.landing-spread.reverse .spread-copy {
+  order: 2;
+}
+
+@media (max-width: 960px) {
+  .landing-spread {
+    grid-template-columns: 1fr !important;
+    gap: 36px !important;
+  }
+  /* Copy always leads on mobile, regardless of desktop side. */
+  .landing-spread.reverse .spread-copy {
+    order: 0 !important;
+  }
+  .landing-numbers {
+    grid-template-columns: 1fr 1fr !important;
+  }
+  .landing-ways {
+    grid-template-columns: 1fr !important;
+  }
+  .landing-negation {
+    grid-template-columns: 1fr !important;
+    gap: 32px !important;
+  }
+}
+
+@media (max-width: 560px) {
+  .landing-numbers {
+    grid-template-columns: 1fr !important;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .landing-hero-grid *,
-  .landing-features *,
-  .landing-sg *,
+  .landing-spread *,
   .landing-learn * {
     transition: none !important;
     animation: none !important;

--- a/apps/web/src/pages/landing/LandingPage.tsx
+++ b/apps/web/src/pages/landing/LandingPage.tsx
@@ -11,8 +11,12 @@ export function LandingPage() {
     <main style={{ paddingBottom: 0 }}>
       <Hero />
       <StatsBar />
-      <Features />
-      <SGSection />
+      <Manifesto />
+      <SGSpread />
+      <PatternsSpread />
+      <Community />
+      <Negation />
+      <Pricing />
       <LearnSection />
       <FinalCTA />
       <Footer />
@@ -74,13 +78,13 @@ function Hero() {
                 boxShadow: '0 0 0 3px rgba(31, 61, 44, 0.18)',
               }}
             />
-            Free and open source
+            Free and open source · MIT
           </span>
           <div
             className="kicker"
             style={{ color: '#A66A1F', margin: '22px 0 14px' }}
           >
-            Golf improvement platform
+            Strokes gained for everyone
           </div>
           <h1
             className="font-serif text-caddie-ink"
@@ -103,18 +107,24 @@ function Hero() {
               fontSize: 17,
               lineHeight: 1.6,
               maxWidth: 480,
-              margin: '0 0 28px',
+              margin: '0 0 24px',
             }}
           >
-            GPS shot tracking, strokes gained analysis, and coaching content —
-            built for golfers who want to get better, not just keep score.
+            GPS shot tracking, strokes gained, and shot patterns — no sensors
+            on your bag, no subscription, free forever.
           </p>
+          <div className="landing-platforms">
+            <PlatformTag>iPhone</PlatformTag>
+            <PlatformTag>Android</PlatformTag>
+            <PlatformTag>Web</PlatformTag>
+          </div>
           <div
             style={{
               display: 'flex',
               alignItems: 'center',
               gap: 18,
               flexWrap: 'wrap',
+              marginTop: 26,
             }}
           >
             {isAuthed ? (
@@ -132,11 +142,8 @@ function Hero() {
                 </span>
               </Link>
             )}
-            <span
-              className="text-caddie-ink-mute"
-              style={{ fontSize: 13 }}
-            >
-              {isAuthed ? "You're signed in." : 'No subscription required.'}
+            <span className="text-caddie-ink-mute" style={{ fontSize: 13 }}>
+              {isAuthed ? "You're signed in." : 'No subscription · no ads.'}
             </span>
           </div>
         </div>
@@ -148,25 +155,48 @@ function Hero() {
   )
 }
 
+function PlatformTag({ children }: { children: React.ReactNode }) {
+  return (
+    <span
+      className="font-mono uppercase"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        fontSize: 11,
+        letterSpacing: '0.12em',
+        color: '#5C6356',
+      }}
+    >
+      <span
+        aria-hidden
+        style={{ width: 6, height: 6, borderRadius: '50%', background: '#1F3D2C' }}
+      />
+      {children}
+    </span>
+  )
+}
+
 // ---------------------------------------------------------------------------
-// Stats bar
+// Stats bar (4 cells)
 // ---------------------------------------------------------------------------
 
 function StatsBar() {
   return (
     <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
       <div
-        className="landing-stats"
+        className="landing-stats landing-numbers"
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(3, 1fr)',
-          borderTop: '1px solid #D9D2BF',
-          borderBottom: '1px solid #D9D2BF',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+          borderTop: '1px solid #1C211C',
+          borderBottom: '1px solid #1C211C',
         }}
       >
-        <Stat value="15,870" label="Courses in database" mono />
+        <Stat value="15,000+" label="Courses in database" />
         <Stat value="WHS" label="Handicap tracking" mono />
-        <Stat value="100%" label="Free, forever" mono />
+        <Stat value="$0" label="Free, forever" />
+        <Stat value="MIT" label="Open source" mono />
       </div>
     </div>
   )
@@ -193,8 +223,9 @@ function Stat({
       <div
         className={mono ? 'font-mono' : 'font-serif'}
         style={{
-          fontSize: mono ? 36 : 44,
+          fontSize: mono ? 34 : 44,
           fontWeight: 500,
+          fontStyle: mono ? 'normal' : 'italic',
           letterSpacing: '-0.01em',
           lineHeight: 1,
           color: '#1C211C',
@@ -218,176 +249,167 @@ function Stat({
 }
 
 // ---------------------------------------------------------------------------
-// Features
+// Manifesto
 // ---------------------------------------------------------------------------
 
-const FEATURES = [
-  {
-    icon: TargetIcon,
-    title: 'Live GPS round tracking',
-    body: 'Track every shot on the map with GPS precision. Ball placement, aim points, and shot trails — live as you play.',
-  },
-  {
-    icon: BarsIcon,
-    title: 'Strokes gained analysis',
-    body: "Understand exactly where you're losing or gaining strokes — off the tee, approach, around the green, and putting.",
-  },
-  {
-    icon: TrendIcon,
-    title: 'Shot patterns + trends',
-    body: "See your miss patterns, club dispersion, and improvement trends across every round you've played.",
-  },
-] as const
-
-function Features() {
+function Manifesto() {
   return (
-    <section style={{ padding: '100px 0' }}>
-      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
-        <div
-          className="landing-features"
+    <section
+      style={{
+        padding: '110px 0',
+        borderTop: '1px solid #D9D2BF',
+        borderBottom: '1px solid #D9D2BF',
+        marginTop: 100,
+      }}
+    >
+      <div style={{ maxWidth: 880, margin: '0 auto', padding: '0 28px' }}>
+        <div className="kicker" style={{ color: '#8A8B7E' }}>
+          The point of this thing
+        </div>
+        <h2
+          className="font-serif text-caddie-ink"
           style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(3, 1fr)',
-            gap: 20,
+            fontSize: 'clamp(32px, 4.8vw, 48px)',
+            fontWeight: 500,
+            fontStyle: 'italic',
+            lineHeight: 1.15,
+            letterSpacing: '-0.02em',
+            margin: '20px 0 0',
           }}
         >
-          {FEATURES.map((f, i) => (
-            <FeatureCard key={f.title} index={i} {...f} />
-          ))}
+          Strokes gained is the best metric in golf. It shouldn't be{' '}
+          <span style={{ color: '#1F3D2C' }}>locked behind a subscription.</span>
+        </h2>
+        <p
+          className="font-serif text-caddie-ink"
+          style={{ fontSize: 18, lineHeight: 1.65, margin: '24px 0 0', maxWidth: 740 }}
+        >
+          The math behind professional shot tracking — strokes gained against
+          handicap baselines, per-club dispersion, where you're winning and
+          losing strokes — is decades old and well understood. Plenty of
+          products charge real money to put it in your pocket.
+        </p>
+        <p
+          className="font-serif text-caddie-ink"
+          style={{ fontSize: 18, lineHeight: 1.65, margin: '24px 0 0', maxWidth: 740 }}
+        >
+          OGA is that math,{' '}
+          <em style={{ fontWeight: 500 }}>
+            written in plain English, given away for free
+          </em>
+          , and open source so anyone can read the code, fix what's broken, or
+          build something better on top of it.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Spreads
+// ---------------------------------------------------------------------------
+
+function SpreadShell({
+  kicker,
+  title,
+  children,
+  figure,
+  reverse,
+  to,
+  linkLabel,
+}: {
+  kicker: string
+  title: React.ReactNode
+  children: React.ReactNode
+  figure: React.ReactNode
+  reverse?: boolean
+  to?: string
+  linkLabel?: string
+}) {
+  return (
+    <section style={{ padding: '60px 0' }}>
+      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
+        <div className={reverse ? 'landing-spread reverse' : 'landing-spread'}>
+          <div className="spread-copy">
+            <div className="kicker" style={{ color: '#A66A1F', marginBottom: 16 }}>
+              {kicker}
+            </div>
+            <h3
+              className="font-serif text-caddie-ink"
+              style={{
+                fontSize: 'clamp(30px, 3.6vw, 40px)',
+                fontWeight: 500,
+                lineHeight: 1.1,
+                letterSpacing: '-0.02em',
+                margin: '0 0 18px',
+              }}
+            >
+              {title}
+            </h3>
+            {children}
+            {to && linkLabel && (
+              <Link
+                to={to}
+                className="font-sans"
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 6,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: '#1F3D2C',
+                  textDecoration: 'none',
+                  borderBottom: '1px solid #1F3D2C',
+                  paddingBottom: 2,
+                  marginTop: 10,
+                }}
+              >
+                {linkLabel} <span>→</span>
+              </Link>
+            )}
+          </div>
+          <div className="spread-figure">{figure}</div>
         </div>
       </div>
     </section>
   )
 }
 
-function FeatureCard({
-  icon: Icon,
-  title,
-  body,
-  index,
-}: {
-  icon: () => JSX.Element
-  title: string
-  body: string
-  index: number
-}) {
-  const { ref, visible } = useInView<HTMLElement>(0.15)
+function SpreadParagraph({ children }: { children: React.ReactNode }) {
   return (
-    <article
-      ref={ref}
-      style={{
-        border: '1px solid #D9D2BF',
-        borderRadius: 4,
-        padding: 28,
-        background: '#FBF8F1',
-        opacity: visible ? 1 : 0,
-        transform: visible ? 'translateY(0)' : 'translateY(20px)',
-        transition: `opacity 600ms ease ${index * 100}ms, transform 600ms ease ${index * 100}ms, border-color 200ms ease`,
-      }}
+    <p
+      className="font-serif text-caddie-ink"
+      style={{ fontSize: 17, lineHeight: 1.6, margin: '0 0 14px', maxWidth: 520 }}
     >
-      <div
-        style={{
-          width: 36,
-          height: 36,
-          borderRadius: 4,
-          background: '#1F3D2C',
-          color: '#F2EEE5',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          marginBottom: 22,
-        }}
-        aria-hidden
-      >
-        <Icon />
-      </div>
-      <h3
-        className="font-serif text-caddie-ink"
-        style={{
-          fontSize: 22,
-          fontWeight: 500,
-          fontStyle: 'italic',
-          margin: '0 0 10px',
-          lineHeight: 1.2,
-        }}
-      >
-        {title}
-      </h3>
-      <p
-        className="text-caddie-ink-dim"
-        style={{ margin: 0, fontSize: 14.5, lineHeight: 1.6 }}
-      >
-        {body}
-      </p>
-    </article>
+      {children}
+    </p>
   )
 }
 
 // ---------------------------------------------------------------------------
-// SG section
+// SG spread (live demo bars)
 // ---------------------------------------------------------------------------
 
 const SG_ROWS = [
   { label: 'SG · Off tee', value: '+0.4', tone: 'pos' as const, fill: 22 },
   { label: 'SG · Approach', value: '−1.2', tone: 'neg' as const, fill: 44 },
-  {
-    label: 'SG · Around green',
-    value: '−0.1',
-    tone: 'zero' as const,
-    fill: 6,
-  },
+  { label: 'SG · Around green', value: '−0.1', tone: 'zero' as const, fill: 6 },
   { label: 'SG · Putting', value: '+1.2', tone: 'pos' as const, fill: 48 },
 ]
 
-function SGSection() {
+function SGSpread() {
   const { ref, visible } = useInView<HTMLDivElement>(0.3)
   return (
-    <section style={{ padding: '100px 0' }}>
-      <div
-        className="landing-sg"
-        style={{
-          maxWidth: 1180,
-          margin: '0 auto',
-          padding: '0 28px',
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
-          gap: 64,
-          alignItems: 'center',
-        }}
-      >
-        <div>
-          <div className="kicker" style={{ color: '#A66A1F', marginBottom: 12 }}>
-            Strokes gained
-          </div>
-          <h2
-            className="font-serif text-caddie-ink"
-            style={{
-              fontSize: 'clamp(32px, 4.4vw, 48px)',
-              fontWeight: 500,
-              fontStyle: 'italic',
-              lineHeight: 1.1,
-              letterSpacing: '-0.015em',
-              margin: 0,
-              maxWidth: 520,
-            }}
-          >
-            Know exactly where strokes are leaking.
-          </h2>
-          <p
-            className="text-caddie-ink-dim"
-            style={{
-              fontSize: 16,
-              lineHeight: 1.65,
-              margin: '18px 0 0',
-              maxWidth: 520,
-            }}
-          >
-            Most golfers practice their strengths. OGA shows you your
-            weaknesses — the specific categories where you're losing shots
-            to your handicap baseline, so you can practice what actually
-            matters.
-          </p>
-        </div>
+    <SpreadShell
+      kicker="Strokes gained"
+      title={
+        <>
+          Find <em>exactly</em> where the strokes go.
+        </>
+      }
+      to="/learn/strokes-gained"
+      linkLabel="How strokes gained works"
+      figure={
         <div
           ref={ref}
           style={{
@@ -397,12 +419,41 @@ function SGSection() {
             background: '#FBF8F1',
           }}
         >
+          <div className="kicker" style={{ color: '#8A8B7E', marginBottom: 18 }}>
+            Sample · last 10 rounds
+          </div>
           {SG_ROWS.map((r, i) => (
             <SGRow key={r.label} {...r} visible={visible} delayMs={i * 120} />
           ))}
+          <p
+            className="font-serif text-caddie-ink-dim"
+            style={{
+              fontSize: 13,
+              fontStyle: 'italic',
+              lineHeight: 1.55,
+              margin: '16px 0 0',
+              paddingTop: 12,
+              borderTop: '1px dotted #D9D2BF',
+            }}
+          >
+            <span style={{ color: '#1F3D2C', fontWeight: 500 }}>
+              Approach is your leak.
+            </span>{' '}
+            Fixing 150–200 yd alone could add 1.2 strokes a round.
+          </p>
         </div>
-      </div>
-    </section>
+      }
+    >
+      <SpreadParagraph>
+        Every shot you log gets graded against a baseline — what a player of
+        your handicap usually does from that distance, that lie. The difference
+        is your leak, by category.
+      </SpreadParagraph>
+      <SpreadParagraph>
+        Most golfers spend range time hitting the club they already love. OGA
+        tells you the club you should be on instead.
+      </SpreadParagraph>
+    </SpreadShell>
   )
 }
 
@@ -423,14 +474,8 @@ function SGRow({
 }) {
   const valueColor =
     tone === 'pos' ? '#1F3D2C' : tone === 'neg' ? '#A33A2A' : '#8A8B7E'
-  const fillColor = valueColor
   return (
-    <div
-      style={{
-        padding: '14px 0',
-        borderBottom: '1px solid #D9D2BF',
-      }}
-    >
+    <div style={{ padding: '14px 0', borderBottom: '1px solid #D9D2BF' }}>
       <div
         style={{
           display: 'flex',
@@ -441,11 +486,7 @@ function SGRow({
       >
         <span
           className="font-mono uppercase"
-          style={{
-            fontSize: 10,
-            letterSpacing: '0.18em',
-            color: '#8A8B7E',
-          }}
+          style={{ fontSize: 10, letterSpacing: '0.18em', color: '#8A8B7E' }}
         >
           {label}
         </span>
@@ -477,7 +518,7 @@ function SGRow({
             left: tone === 'neg' ? undefined : '50%',
             right: tone === 'neg' ? '50%' : undefined,
             width: visible ? `${fill}%` : 0,
-            background: fillColor,
+            background: valueColor,
             transition: `width 900ms cubic-bezier(0.2, 0.7, 0.2, 1) ${delayMs}ms`,
           }}
         />
@@ -487,32 +528,603 @@ function SGRow({
 }
 
 // ---------------------------------------------------------------------------
+// Shot patterns spread (live demo dispersion)
+// ---------------------------------------------------------------------------
+
+function PatternsSpread() {
+  return (
+    <SpreadShell
+      kicker="Shot patterns"
+      reverse
+      title={
+        <>
+          See <em>where</em> your ball actually goes.
+        </>
+      }
+      to="/learn"
+      linkLabel="How dispersion works"
+      figure={
+        <div
+          style={{
+            border: '1px solid #D9D2BF',
+            borderRadius: 4,
+            padding: 22,
+            background: '#FBF8F1',
+          }}
+        >
+          <DemoDispersion />
+          <p
+            className="font-serif text-caddie-ink-dim"
+            style={{
+              fontSize: 14,
+              fontStyle: 'italic',
+              textAlign: 'center',
+              margin: '14px 0 0',
+              paddingTop: 14,
+              borderTop: '1px dotted #D9D2BF',
+            }}
+          >
+            <span style={{ color: '#1F3D2C', fontWeight: 500 }}>
+              Aim 4 yards left of target
+            </span>{' '}
+            to center the pattern.
+          </p>
+        </div>
+      }
+    >
+      <SpreadParagraph>
+        Per-club dispersion centered on your aim point. The chart shows your
+        typical miss — left, right, short, long — and the small aim adjustment
+        that <em style={{ fontWeight: 500 }}>centers the whole pattern</em>.
+      </SpreadParagraph>
+      <SpreadParagraph>
+        The web app surfaces the analytics; the mobile app captures the data.
+        Same account, same numbers.
+      </SpreadParagraph>
+    </SpreadShell>
+  )
+}
+
+// Demo dispersion — a hardcoded but realistic 7-iron pattern (slight push,
+// tends short), drawn the way the live Shot Patterns chart does: 68/95%
+// cones around the mean, target centerline, aim-relative frame. Static so it
+// renders on the public page without auth or live data.
+const DEMO_DOTS = [
+  [212, 118], [224, 110], [206, 132], [232, 124], [218, 100],
+  [228, 138], [240, 116], [214, 146], [236, 102], [222, 128],
+  [248, 130], [208, 112], [230, 150], [220, 122],
+]
+function DemoDispersion() {
+  return (
+    <div
+      style={{
+        aspectRatio: '1.2 / 1',
+        background: '#F2EEE5',
+        border: '1px solid #D9D2BF',
+        borderRadius: 2,
+        overflow: 'hidden',
+      }}
+    >
+      <svg
+        viewBox="0 0 400 320"
+        width="100%"
+        height="100%"
+        role="img"
+        aria-label="7-iron dispersion: the shot pattern sits a few yards right of target, so aiming slightly left centers it."
+      >
+        <defs>
+          <pattern id="lp-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+            <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#D9D2BF" strokeWidth="0.5" />
+          </pattern>
+        </defs>
+        <rect width="400" height="320" fill="url(#lp-grid)" />
+        <line
+          x1="200"
+          y1="34"
+          x2="200"
+          y2="286"
+          stroke="#9F9580"
+          strokeWidth="0.6"
+          strokeDasharray="4 5"
+        />
+        <text
+          x="200"
+          y="26"
+          fontFamily="Inconsolata, monospace"
+          fontSize="9"
+          letterSpacing="1.4"
+          fill="#8A8B7E"
+          textAnchor="middle"
+        >
+          TARGET
+        </text>
+        <ellipse
+          cx="228"
+          cy="124"
+          rx="50"
+          ry="42"
+          fill="none"
+          stroke="#1F3D2C"
+          strokeWidth="1"
+          strokeDasharray="4 4"
+          opacity="0.55"
+        />
+        <ellipse
+          cx="228"
+          cy="124"
+          rx="29"
+          ry="24"
+          fill="rgba(31,61,44,0.08)"
+          stroke="#1F3D2C"
+          strokeWidth="1"
+        />
+        {DEMO_DOTS.map(([x, y], i) => (
+          <circle key={i} cx={x} cy={y} r="2.6" fill="#A66A1F" opacity="0.85" />
+        ))}
+        <circle cx="228" cy="124" r="5.5" fill="#FBF8F1" stroke="#1F3D2C" strokeWidth="2.5" />
+        <text
+          x="284"
+          y="124"
+          fontFamily="Inconsolata, monospace"
+          fontSize="9"
+          letterSpacing="1.2"
+          fill="#5C6356"
+          textAnchor="start"
+          dominantBaseline="middle"
+        >
+          MEAN
+        </text>
+      </svg>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Community / open source
+// ---------------------------------------------------------------------------
+
+const GITHUB_REPO = 'https://github.com/cner-smith/opengolfapp'
+
+function Community() {
+  return (
+    <section
+      style={{ background: '#1C211C', color: '#F2EEE5', padding: '110px 0', marginTop: 60 }}
+    >
+      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
+        <div className="kicker" style={{ color: 'rgba(242,238,229,0.55)' }}>
+          The “open” in Open Golf App
+        </div>
+        <h2
+          className="font-serif"
+          style={{
+            fontSize: 'clamp(36px, 5vw, 56px)',
+            fontWeight: 500,
+            fontStyle: 'italic',
+            lineHeight: 1.1,
+            letterSpacing: '-0.02em',
+            margin: '16px 0 0',
+            color: '#F2EEE5',
+            maxWidth: 760,
+          }}
+        >
+          Read the code. <em>Suggest a feature. Fix what's broken.</em>
+        </h2>
+        <p
+          className="font-serif"
+          style={{
+            fontSize: 18,
+            lineHeight: 1.6,
+            color: 'rgba(242,238,229,0.85)',
+            margin: '22px 0 36px',
+            maxWidth: 680,
+          }}
+        >
+          OGA is built in public. The source is on GitHub, the roadmap is on
+          GitHub, the bugs are on GitHub.{' '}
+          <em style={{ color: '#F2EEE5', fontWeight: 500 }}>
+            If something doesn't work the way you expect
+          </em>{' '}
+          — open an issue. If you want a feature — open an issue. If you can
+          write code, open a pull request.
+        </p>
+        <div
+          className="landing-ways"
+          style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 24, marginTop: 28 }}
+        >
+          <Way
+            n="01 · For golfers"
+            title="Tell us what you want."
+            href={`${GITHUB_REPO}/issues`}
+            cta="Open an issue"
+          >
+            Open an issue describing what's missing or broken.{' '}
+            <em style={{ color: '#F2EEE5', fontWeight: 500 }}>
+              Every feature in the app started as an issue.
+            </em>
+          </Way>
+          <Way
+            n="02 · For developers"
+            title="Read the source."
+            href={GITHUB_REPO}
+            cta="Explore the repo"
+          >
+            TypeScript on web, React Native on mobile, Supabase out back.{' '}
+            <em style={{ color: '#F2EEE5', fontWeight: 500 }}>
+              Clone it, run it locally, send a pull request.
+            </em>{' '}
+            Good-first-issues are tagged.
+          </Way>
+          <Way
+            n="03 · For everyone"
+            title="Self-host if you'd rather."
+            href={`${GITHUB_REPO}/blob/main/docs/self-hosting.md`}
+            cta="Read the docs"
+          >
+            MIT license means the code is yours to use.{' '}
+            <em style={{ color: '#F2EEE5', fontWeight: 500 }}>
+              Run your own copy if you'd rather not trust a hosted app with
+              your data.
+            </em>
+          </Way>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function Way({
+  n,
+  title,
+  href,
+  cta,
+  children,
+}: {
+  n: string
+  title: string
+  href: string
+  cta: string
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      style={{
+        padding: 24,
+        border: '1px solid rgba(242,238,229,0.18)',
+        borderRadius: 4,
+        background: 'rgba(242,238,229,0.04)',
+      }}
+    >
+      <div
+        className="font-mono uppercase"
+        style={{
+          fontSize: 10,
+          letterSpacing: '0.16em',
+          color: 'rgba(242,238,229,0.55)',
+          marginBottom: 10,
+        }}
+      >
+        {n}
+      </div>
+      <h4
+        className="font-serif"
+        style={{
+          fontSize: 20,
+          fontWeight: 500,
+          fontStyle: 'italic',
+          margin: '0 0 8px',
+          color: '#F2EEE5',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {title}
+      </h4>
+      <p
+        className="font-serif"
+        style={{ fontSize: 15, lineHeight: 1.55, color: 'rgba(242,238,229,0.7)', margin: 0 }}
+      >
+        {children}
+      </p>
+      <a
+        href={href}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="font-sans"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 6,
+          marginTop: 14,
+          fontSize: 12,
+          fontWeight: 600,
+          color: '#F2EEE5',
+          textDecoration: 'none',
+          borderBottom: '1px solid rgba(242,238,229,0.45)',
+          paddingBottom: 2,
+        }}
+      >
+        {cta} →
+      </a>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// What OGA isn't
+// ---------------------------------------------------------------------------
+
+const NEGATIONS = [
+  {
+    what: 'Not a coaching service.',
+    why: (
+      <>
+        OGA gives you the data.{' '}
+        <em style={{ color: '#1C211C', fontWeight: 500 }}>
+          The lessons happen with a real coach
+        </em>{' '}
+        — we make their job easier, not replace them.
+      </>
+    ),
+  },
+  {
+    what: 'Not gamified.',
+    why: (
+      <>
+        No streaks, no leaderboards by default, no trophies for logging a
+        round. You're an adult;{' '}
+        <em style={{ color: '#1C211C', fontWeight: 500 }}>the data is the reward.</em>
+      </>
+    ),
+  },
+  {
+    what: 'Not a shop.',
+    why: (
+      <>
+        <em style={{ color: '#1C211C', fontWeight: 500 }}>
+          We don't sell clubs, balls, lessons, or training aids.
+        </em>{' '}
+        The product is the analysis, and the analysis is free.
+      </>
+    ),
+  },
+  {
+    what: 'Not a launch monitor.',
+    why: (
+      <>
+        We don't measure spin or apex with a sensor.{' '}
+        <em style={{ color: '#1C211C', fontWeight: 500 }}>
+          What we estimate, we label estimate.
+        </em>{' '}
+        Honesty about precision is part of the brand.
+      </>
+    ),
+  },
+  {
+    what: 'Not a data broker.',
+    why: (
+      <>
+        Your rounds, your shots, your patterns.{' '}
+        <em style={{ color: '#1C211C', fontWeight: 500 }}>Yours. Exportable.</em>{' '}
+        We don't sell them and don't share without your opt-in.
+      </>
+    ),
+  },
+]
+
+function Negation() {
+  return (
+    <section style={{ padding: '100px 0' }}>
+      <div
+        className="landing-negation"
+        style={{
+          maxWidth: 1180,
+          margin: '0 auto',
+          padding: '0 28px',
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr',
+          gap: 60,
+          alignItems: 'flex-start',
+        }}
+      >
+        <div>
+          <div className="kicker" style={{ color: '#8A8B7E' }}>
+            Defined by absence
+          </div>
+          <h2
+            className="font-serif text-caddie-ink"
+            style={{
+              fontSize: 'clamp(32px, 4vw, 42px)',
+              fontWeight: 500,
+              fontStyle: 'italic',
+              lineHeight: 1.1,
+              letterSpacing: '-0.02em',
+              margin: '18px 0 0',
+            }}
+          >
+            What OGA <em>isn't</em>.
+          </h2>
+          <p
+            className="font-serif text-caddie-ink-dim"
+            style={{ fontSize: 17, lineHeight: 1.6, margin: '18px 0 0', maxWidth: 480 }}
+          >
+            A short list, because half of what makes something good is what it
+            refuses to be.
+          </p>
+        </div>
+        <ul style={{ listStyle: 'none', padding: 0, margin: 0 }}>
+          {NEGATIONS.map((item, i) => (
+            <li
+              key={item.what}
+              style={{
+                padding: '18px 0',
+                borderBottom:
+                  i === NEGATIONS.length - 1 ? 'none' : '1px solid #D9D2BF',
+                display: 'flex',
+                gap: 18,
+                alignItems: 'flex-start',
+              }}
+            >
+              <span
+                className="font-mono"
+                style={{
+                  fontSize: 10,
+                  letterSpacing: '0.16em',
+                  color: '#A33A2A',
+                  flexShrink: 0,
+                  paddingTop: 4,
+                  width: 24,
+                }}
+              >
+                {String(i + 1).padStart(2, '0')}
+              </span>
+              <div>
+                <div
+                  className="font-serif text-caddie-ink"
+                  style={{
+                    fontSize: 18,
+                    fontWeight: 500,
+                    fontStyle: 'italic',
+                    lineHeight: 1.3,
+                    marginBottom: 4,
+                  }}
+                >
+                  {item.what}
+                </div>
+                <div
+                  className="font-serif text-caddie-ink-dim"
+                  style={{ fontSize: 14.5, lineHeight: 1.55 }}
+                >
+                  {item.why}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Pricing
+// ---------------------------------------------------------------------------
+
+function Pricing() {
+  const { user, loading } = useAuth()
+  const isAuthed = !loading && !!user
+  return (
+    <section style={{ padding: '120px 0', textAlign: 'center' }}>
+      <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
+        <div className="kicker" style={{ color: '#8A8B7E', marginBottom: 18 }}>
+          The price
+        </div>
+        <h2
+          className="font-serif text-caddie-ink"
+          style={{
+            fontSize: 'clamp(56px, 8vw, 92px)',
+            fontWeight: 500,
+            fontStyle: 'italic',
+            lineHeight: 0.95,
+            letterSpacing: '-0.03em',
+            margin: 0,
+          }}
+        >
+          <span style={{ color: '#1F3D2C' }}>$0.</span> Forever.
+        </h2>
+        <p
+          className="font-serif text-caddie-ink"
+          style={{ fontSize: 19, lineHeight: 1.55, margin: '28px auto 0', maxWidth: 600 }}
+        >
+          <em style={{ fontWeight: 500 }}>
+            No subscription. No “premium” tier you'll discover at the wrong
+            moment.
+          </em>{' '}
+          If OGA helps your game and you want to keep the lights on, the tip jar
+          is open.
+        </p>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'center',
+            gap: 40,
+            margin: '48px auto 0',
+            flexWrap: 'wrap',
+            paddingTop: 36,
+            borderTop: '1px solid #D9D2BF',
+            maxWidth: 740,
+          }}
+        >
+          <Term value="MIT licensed" label="Source on GitHub" />
+          <Term value="No ads" label="Ever" />
+          <Term value="Your data" label="Exportable anytime" />
+          <Term value="Self-hostable" label="Run your own" />
+        </div>
+        <div
+          style={{
+            marginTop: 48,
+            display: 'flex',
+            justifyContent: 'center',
+            gap: 14,
+            flexWrap: 'wrap',
+          }}
+        >
+          <Link to={isAuthed ? '/dashboard' : '/signup'} style={btnAccentLg}>
+            {isAuthed ? 'Go to app' : 'Start tracking'}{' '}
+            <span className="font-serif" style={{ fontStyle: 'italic' }}>
+              →
+            </span>
+          </Link>
+          <a
+            href="https://ko-fi.com/nartana"
+            target="_blank"
+            rel="noreferrer noopener"
+            style={btnGhostLg}
+          >
+            Tip jar · Ko-fi
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function Term({ value, label }: { value: string; label: string }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <span
+        className="font-serif text-caddie-ink"
+        style={{ fontSize: 20, fontWeight: 500, fontStyle: 'italic' }}
+      >
+        {value}
+      </span>
+      <span
+        className="font-mono uppercase"
+        style={{ fontSize: 9, letterSpacing: '0.16em', color: '#8A8B7E' }}
+      >
+        {label}
+      </span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Learn section
 // ---------------------------------------------------------------------------
 
 const LEARN_CARDS = [
-  {
-    section: 'On the course',
-    title: 'Course management',
-    slug: 'course-management',
-  },
+  { section: 'On the course', title: 'Course management', slug: 'course-management' },
   {
     section: 'Improving your game',
     title: 'How to practice effectively',
     slug: 'how-to-practice',
   },
-  {
-    section: 'On the course',
-    title: 'The mental game',
-    slug: 'mental-game',
-  },
+  { section: 'On the course', title: 'The mental game', slug: 'mental-game' },
 ]
 
 function LearnSection() {
   return (
-    <section style={{ padding: '100px 0' }}>
+    <section style={{ padding: '60px 0 100px' }}>
       <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
-        <div style={{ marginBottom: 56 }}>
+        <div style={{ marginBottom: 40 }}>
           <div className="kicker" style={{ color: '#A66A1F', marginBottom: 12 }}>
             Learn
           </div>
@@ -532,11 +1144,7 @@ function LearnSection() {
         </div>
         <div
           className="landing-learn"
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(3, 1fr)',
-            gap: 18,
-          }}
+          style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 18 }}
         >
           {LEARN_CARDS.map((c) => (
             <Link
@@ -550,8 +1158,7 @@ function LearnSection() {
                 textDecoration: 'none',
                 color: 'inherit',
                 display: 'block',
-                transition:
-                  'border-color 200ms ease, transform 200ms ease',
+                transition: 'border-color 200ms ease, transform 200ms ease',
               }}
               onMouseEnter={(e) => {
                 e.currentTarget.style.borderColor = '#9F9580'
@@ -575,12 +1182,7 @@ function LearnSection() {
               </div>
               <div
                 className="font-serif text-caddie-ink"
-                style={{
-                  fontSize: 22,
-                  fontWeight: 500,
-                  fontStyle: 'italic',
-                  lineHeight: 1.25,
-                }}
+                style={{ fontSize: 22, fontWeight: 500, fontStyle: 'italic', lineHeight: 1.25 }}
               >
                 {c.title}
               </div>
@@ -606,6 +1208,7 @@ function FinalCTA() {
         color: '#F2EEE5',
         textAlign: 'center',
         padding: '110px 0 100px',
+        borderTop: '1px solid rgba(242, 238, 229, 0.12)',
       }}
     >
       <div style={{ maxWidth: 1180, margin: '0 auto', padding: '0 28px' }}>
@@ -627,7 +1230,7 @@ function FinalCTA() {
             color: '#F2EEE5',
           }}
         >
-          {isAuthed ? 'Welcome back.' : 'Start tracking free.'}
+          {isAuthed ? 'Welcome back.' : 'Start tracking.'}
         </h2>
         <p
           style={{
@@ -638,7 +1241,7 @@ function FinalCTA() {
         >
           {isAuthed
             ? 'Pick up where you left off.'
-            : 'No subscription. No ads. Open source.'}
+            : 'Free forever · open source · iPhone, Android & web'}
         </p>
         <Link
           to={isAuthed ? '/dashboard' : '/signup'}
@@ -698,7 +1301,7 @@ function Footer() {
           className="font-serif"
           style={{ fontSize: 20, fontWeight: 500, fontStyle: 'italic' }}
         >
-          OGA
+          oga<span style={{ fontStyle: 'normal' }}>.</span>
         </div>
         <div
           style={{
@@ -708,11 +1311,14 @@ function Footer() {
             flexWrap: 'wrap',
           }}
         >
-          <FooterLink href="https://github.com/cner-smith/opengolfapp" external>
+          <FooterLink href={GITHUB_REPO} external>
             GitHub
           </FooterLink>
           <FooterLink href="https://ko-fi.com/nartana" external>
             Ko-fi
+          </FooterLink>
+          <FooterLink href="https://github.com/sponsors/cner-smith" external>
+            Sponsors
           </FooterLink>
           <FooterLink to="/privacy">Privacy</FooterLink>
           <FooterLink to="/support">Support</FooterLink>
@@ -838,60 +1444,18 @@ const btnAccentLg: React.CSSProperties = {
   whiteSpace: 'nowrap',
 }
 
-// ---------------------------------------------------------------------------
-// Icons
-// ---------------------------------------------------------------------------
-
-function TargetIcon() {
-  return (
-    <svg
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <circle cx="12" cy="12" r="3" />
-      <circle cx="12" cy="12" r="9" />
-    </svg>
-  )
-}
-
-function BarsIcon() {
-  return (
-    <svg
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <line x1="6" y1="20" x2="6" y2="10" />
-      <line x1="12" y1="20" x2="12" y2="4" />
-      <line x1="18" y1="20" x2="18" y2="14" />
-    </svg>
-  )
-}
-
-function TrendIcon() {
-  return (
-    <svg
-      width="18"
-      height="18"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M3 17l4-4 4 4 4-6 6 6" />
-    </svg>
-  )
+const btnGhostLg: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  background: 'transparent',
+  color: '#1C211C',
+  border: '1px solid #9F9580',
+  borderRadius: 2,
+  padding: '14px 18px',
+  fontFamily: 'Epilogue, sans-serif',
+  fontWeight: 600,
+  fontSize: 14,
+  textDecoration: 'none',
+  whiteSpace: 'nowrap',
 }

--- a/apps/web/src/pages/landing/LandingPage.tsx
+++ b/apps/web/src/pages/landing/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useAuth } from '../../hooks/useAuth'
 import { AppPreview } from '../../components/landing/AppPreview'
@@ -595,6 +595,9 @@ const DEMO_DOTS = [
   [248, 130], [208, 112], [230, 150], [220, 122],
 ]
 function DemoDispersion() {
+  // Unique per instance — a global <pattern id> would collide if this ever
+  // renders twice (the second fill="url(#id)" silently resolves the first).
+  const gridId = useId()
   return (
     <div
       style={{
@@ -613,11 +616,11 @@ function DemoDispersion() {
         aria-label="7-iron dispersion: the shot pattern sits a few yards right of target, so aiming slightly left centers it."
       >
         <defs>
-          <pattern id="lp-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+          <pattern id={gridId} width="40" height="40" patternUnits="userSpaceOnUse">
             <path d="M 40 0 L 0 0 0 40" fill="none" stroke="#D9D2BF" strokeWidth="0.5" />
           </pattern>
         </defs>
-        <rect width="400" height="320" fill="url(#lp-grid)" />
+        <rect width="400" height="320" fill={`url(#${gridId})`} />
         <line
           x1="200"
           y1="34"

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -79,6 +79,98 @@ function pickClubForDistance(yards: number): string {
   return 'putter'
 }
 
+// Typical carry per club (yards). Used to walk a hole realistically: hit the
+// club for the distance-to-pin, advance by its carry, repeat — so approaches
+// land in iron/wedge ranges instead of every shot picking the same club.
+const TYPICAL_CARRY: Record<string, number> = {
+  driver: 255,
+  '3w': 225,
+  '5w': 210,
+  '4i': 190,
+  '5i': 178,
+  '6i': 165,
+  '7i': 152,
+  '8i': 140,
+  '9i': 128,
+  pw: 115,
+  gw: 95,
+  sw: 75,
+}
+
+// Per-club dispersion in yards, in the shot's own frame: biasLong (negative =
+// tends short, the amateur norm), biasLat (positive = push right), and the
+// 1σ spread on each axis. Short clubs are tight; driver is wide with a slice
+// bias — so the fitted 68/95 cones look like a real player's, not a blob.
+interface Disp {
+  biasLong: number
+  biasLat: number
+  sdLong: number
+  sdLat: number
+}
+const CLUB_DISPERSION: Record<string, Disp> = {
+  driver: { biasLong: -3, biasLat: 6, sdLong: 17, sdLat: 19 },
+  '3w': { biasLong: -3, biasLat: 4, sdLong: 14, sdLat: 15 },
+  '5w': { biasLong: -3, biasLat: 3, sdLong: 13, sdLat: 13 },
+  '4i': { biasLong: -4, biasLat: 3, sdLong: 12, sdLat: 12 },
+  '5i': { biasLong: -3, biasLat: 2, sdLong: 11, sdLat: 10 },
+  '6i': { biasLong: -3, biasLat: 1, sdLong: 9, sdLat: 8 },
+  '7i': { biasLong: -3, biasLat: 1, sdLong: 8, sdLat: 7 },
+  '8i': { biasLong: -2, biasLat: 0, sdLong: 7, sdLat: 6 },
+  '9i': { biasLong: -2, biasLat: 0, sdLong: 6, sdLat: 5 },
+  pw: { biasLong: -1, biasLat: 0, sdLong: 5, sdLat: 5 },
+  gw: { biasLong: -1, biasLat: 0, sdLong: 5, sdLat: 4 },
+  sw: { biasLong: -1, biasLat: 0, sdLong: 5, sdLat: 4 },
+}
+const DEFAULT_DISP: Disp = { biasLong: -2, biasLat: 0, sdLong: 9, sdLat: 8 }
+
+// Box–Muller normal sample, scaled to sd. Sums of uniforms would peak too
+// flat; a real Gaussian gives the dense centre + sparse tails a cone wants.
+function gaussian(sd: number): number {
+  const u = 1 - Math.random()
+  const v = Math.random()
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v) * sd
+}
+
+function distanceYards(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
+  const north = (b.lat - a.lat) * YARDS_PER_DEG_LAT
+  const east = (b.lng - a.lng) * yardsPerDegLng(a.lat)
+  return Math.hypot(north, east)
+}
+
+// A point `dist` yards from `from` along the line toward `toward`.
+function stepToward(
+  from: { lat: number; lng: number },
+  toward: { lat: number; lng: number },
+  dist: number,
+): { lat: number; lng: number } {
+  const north = (toward.lat - from.lat) * YARDS_PER_DEG_LAT
+  const east = (toward.lng - from.lng) * yardsPerDegLng(from.lat)
+  const mag = Math.hypot(north, east) || 1
+  return offsetCoord([from.lat, from.lng], (north / mag) * dist, (east / mag) * dist)
+}
+
+// Land the ball offLong yards along the start→aim line and offLat yards
+// perpendicular (right = +), so the miss is oriented to the actual shot
+// bearing — what computeDispersion rotates back out when fitting the cone.
+function dispersedEnd(
+  start: { lat: number; lng: number },
+  aim: { lat: number; lng: number },
+  offLong: number,
+  offLat: number,
+): { lat: number; lng: number } {
+  const north = (aim.lat - start.lat) * YARDS_PER_DEG_LAT
+  const east = (aim.lng - start.lng) * yardsPerDegLng(start.lat)
+  const mag = Math.hypot(north, east) || 1
+  const un = north / mag
+  const ue = east / mag
+  // perpendicular unit (90° clockwise = player's right)
+  const pn = -ue
+  const pe = un
+  const dn = offLong * un + offLat * pn
+  const de = offLong * ue + offLat * pe
+  return offsetCoord([aim.lat, aim.lng], dn, de)
+}
+
 async function ensureDemoUser(): Promise<string> {
   const { data: list } = await supabase.auth.admin.listUsers({ perPage: 1000 })
   const existing = list?.users?.find((u) => u.email === SEED_EMAIL)
@@ -95,44 +187,33 @@ async function ensureDemoUser(): Promise<string> {
 }
 
 async function ensureProfile(userId: string): Promise<void> {
-  const { error } = await supabase
-    .from('profiles')
-    .upsert(
-      {
-        id: userId,
-        username: SEED_USERNAME,
-        handicap_index: 12.4,
-        skill_level: 'developing',
-        goal: 'break_80',
-        play_frequency: 'weekly',
-        facilities: ['range', 'short_game', 'putting'],
-        play_style: 'mixed',
-        // Added in migration 0023; the script pre-dates it. Without
-        // this, ProfileGuard would bounce the seeded user to
-        // /onboarding on next sign-in.
-        onboarding_completed: true,
-      },
-      { onConflict: 'id' },
-    )
+  const { error } = await supabase.from('profiles').upsert(
+    {
+      id: userId,
+      username: SEED_USERNAME,
+      handicap_index: 12.4,
+      skill_level: 'developing',
+      goal: 'break_80',
+      play_frequency: 'weekly',
+      facilities: ['range', 'short_game', 'putting'],
+      play_style: 'mixed',
+      // Added in migration 0023; the script pre-dates it. Without
+      // this, ProfileGuard would bounce the seeded user to
+      // /onboarding on next sign-in.
+      onboarding_completed: true,
+    },
+    { onConflict: 'id' },
+  )
   if (error) throw error
 }
 
 async function wipeDemoData(userId: string): Promise<void> {
   // hole_scores + shots cascade off rounds
-  const { error: roundsErr } = await supabase
-    .from('rounds')
-    .delete()
-    .eq('user_id', userId)
+  const { error: roundsErr } = await supabase.from('rounds').delete().eq('user_id', userId)
   if (roundsErr) throw roundsErr
-  const { error: planErr } = await supabase
-    .from('practice_plans')
-    .delete()
-    .eq('user_id', userId)
+  const { error: planErr } = await supabase.from('practice_plans').delete().eq('user_id', userId)
   if (planErr) throw planErr
-  const { error: clubsErr } = await supabase
-    .from('user_clubs')
-    .delete()
-    .eq('user_id', userId)
+  const { error: clubsErr } = await supabase.from('user_clubs').delete().eq('user_id', userId)
   if (clubsErr) throw clubsErr
 }
 
@@ -166,9 +247,7 @@ async function fetchCourses(): Promise<CourseRow[]> {
 }
 
 async function fetchHolesByCourse(): Promise<Map<string, HoleRow[]>> {
-  const { data, error } = await supabase
-    .from('holes')
-    .select('id, number, par, yards, course_id')
+  const { data, error } = await supabase.from('holes').select('id, number, par, yards, course_id')
   if (error) throw error
   const map = new Map<string, HoleRow[]>()
   for (const row of data ?? []) {
@@ -204,8 +283,7 @@ async function insertRound(
   withShots: boolean,
 ): Promise<void> {
   const profile = pickRoundProfile()
-  const sgTotal =
-    profile.sgOffTee + profile.sgApproach + profile.sgAroundGreen + profile.sgPutting
+  const sgTotal = profile.sgOffTee + profile.sgApproach + profile.sgAroundGreen + profile.sgPutting
   const par = holes.reduce((s, h) => s + h.par, 0)
   // Score correlates roughly with sgTotal: better SG → fewer strokes.
   const score = Math.round(par - sgTotal + rand(-1, 1))
@@ -271,25 +349,59 @@ async function insertHoleShots(
   let lastEnd = teeBase
   for (let n = 1; n <= totalShots; n++) {
     const isLast = n === totalShots
-    const remainingYards = isLast ? 5 : Math.max(20, (hole.yards ?? 200) - (n - 1) * 150)
-    const aim = isLast
-      ? pinBase
-      : offsetCoord([pinBase.lat, pinBase.lng], rand(-5, 5), rand(-10, 10))
-    const dispersionLat = rand(-12, 12)
-    const dispersionLng = rand(-18, 18)
-    const end = isLast
-      ? pinBase
-      : offsetCoord([aim.lat, aim.lng], dispersionLat, dispersionLng)
-
-    const lieType: string =
-      n === 1 ? 'tee' : isLast ? 'green' : Math.random() < 0.65 ? 'fairway' : 'rough'
     const lieSlope = ['level', 'uphill', 'downhill', 'ball_above', 'ball_below'][
       Math.floor(rand(0, 5))
     ]
-    const club = lieType === 'green' ? 'putter' : pickClubForDistance(remainingYards)
-    const result = ['solid', 'push_right', 'pull_left', 'fat', 'thin'][
-      Math.floor(rand(0, 5))
-    ]
+
+    if (isLast) {
+      // Holed putt on the green.
+      const { error } = await supabase.from('shots').insert({
+        hole_score_id: holeScoreId,
+        user_id: userId,
+        shot_number: n,
+        start_lat: lastEnd.lat,
+        start_lng: lastEnd.lng,
+        aim_lat: pinBase.lat,
+        aim_lng: pinBase.lng,
+        end_lat: pinBase.lat,
+        end_lng: pinBase.lng,
+        distance_to_target: null,
+        club: 'putter',
+        lie_type: 'green',
+        lie_slope: lieSlope,
+        shot_result: null,
+        penalty: false,
+        ob: false,
+        putt_distance_ft: Math.round(rand(2, 22) * 10) / 10,
+        putt_result: 'made',
+      })
+      if (error) throw error
+      lastEnd = pinBase
+      continue
+    }
+
+    const lieType = n === 1 ? 'tee' : Math.random() < 0.68 ? 'fairway' : 'rough'
+    // Club is chosen for the distance still to the pin; the ball advances by
+    // the club's typical carry (or reaches the pin, whichever is shorter).
+    const distToPin = Math.max(8, Math.round(distanceYards(lastEnd, pinBase)))
+    const club = pickClubForDistance(distToPin)
+    const carry = TYPICAL_CARRY[club] ?? distToPin
+    const aim = stepToward(lastEnd, pinBase, Math.min(carry, distToPin))
+    const disp = CLUB_DISPERSION[club] ?? DEFAULT_DISP
+    const offLong = disp.biasLong + gaussian(disp.sdLong)
+    const offLat = disp.biasLat + gaussian(disp.sdLat)
+    const end = dispersedEnd(lastEnd, aim, offLong, offLat)
+    // Result follows the actual miss so result-based stats stay consistent.
+    const result =
+      offLat > 9
+        ? 'push_right'
+        : offLat < -9
+          ? 'pull_left'
+          : offLong < -11
+            ? 'fat'
+            : Math.random() < 0.18
+              ? 'thin'
+              : 'solid'
 
     const { error } = await supabase.from('shots').insert({
       hole_score_id: holeScoreId,
@@ -301,16 +413,15 @@ async function insertHoleShots(
       aim_lng: aim.lng,
       end_lat: end.lat,
       end_lng: end.lng,
-      distance_to_target: lieType === 'green' ? null : Math.round(remainingYards),
+      distance_to_target: distToPin,
       club,
       lie_type: lieType,
       lie_slope: lieSlope,
-      shot_result: lieType === 'green' ? null : result,
+      shot_result: result,
       penalty: false,
       ob: false,
-      putt_distance_ft:
-        lieType === 'green' ? Math.round(rand(2, 25) * 10) / 10 : null,
-      putt_result: lieType === 'green' ? (isLast ? 'made' : 'short') : null,
+      putt_distance_ft: null,
+      putt_result: null,
     })
     if (error) throw error
     lastEnd = end
@@ -372,14 +483,14 @@ async function main() {
 
   const courses = await fetchCourses()
   if (courses.length < 3) {
-    throw new Error(
-      'Demo seed needs 3 courses in the database — run `npx supabase db reset` first',
-    )
+    throw new Error('Demo seed needs 3 courses in the database — run `npx supabase db reset` first')
   }
   const holesByCourse = await fetchHolesByCourse()
 
   const TOTAL_ROUNDS = 15
-  const ROUNDS_WITH_SHOTS = 5
+  // More shot-rounds → each club clears the 5-shot floor the dispersion fit
+  // needs, so /patterns shows a real cone for the common clubs.
+  const ROUNDS_WITH_SHOTS = 8
 
   for (let i = 0; i < TOTAL_ROUNDS; i++) {
     const course = courses[i % courses.length]!

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -79,98 +79,6 @@ function pickClubForDistance(yards: number): string {
   return 'putter'
 }
 
-// Typical carry per club (yards). Used to walk a hole realistically: hit the
-// club for the distance-to-pin, advance by its carry, repeat — so approaches
-// land in iron/wedge ranges instead of every shot picking the same club.
-const TYPICAL_CARRY: Record<string, number> = {
-  driver: 255,
-  '3w': 225,
-  '5w': 210,
-  '4i': 190,
-  '5i': 178,
-  '6i': 165,
-  '7i': 152,
-  '8i': 140,
-  '9i': 128,
-  pw: 115,
-  gw: 95,
-  sw: 75,
-}
-
-// Per-club dispersion in yards, in the shot's own frame: biasLong (negative =
-// tends short, the amateur norm), biasLat (positive = push right), and the
-// 1σ spread on each axis. Short clubs are tight; driver is wide with a slice
-// bias — so the fitted 68/95 cones look like a real player's, not a blob.
-interface Disp {
-  biasLong: number
-  biasLat: number
-  sdLong: number
-  sdLat: number
-}
-const CLUB_DISPERSION: Record<string, Disp> = {
-  driver: { biasLong: -3, biasLat: 6, sdLong: 17, sdLat: 19 },
-  '3w': { biasLong: -3, biasLat: 4, sdLong: 14, sdLat: 15 },
-  '5w': { biasLong: -3, biasLat: 3, sdLong: 13, sdLat: 13 },
-  '4i': { biasLong: -4, biasLat: 3, sdLong: 12, sdLat: 12 },
-  '5i': { biasLong: -3, biasLat: 2, sdLong: 11, sdLat: 10 },
-  '6i': { biasLong: -3, biasLat: 1, sdLong: 9, sdLat: 8 },
-  '7i': { biasLong: -3, biasLat: 1, sdLong: 8, sdLat: 7 },
-  '8i': { biasLong: -2, biasLat: 0, sdLong: 7, sdLat: 6 },
-  '9i': { biasLong: -2, biasLat: 0, sdLong: 6, sdLat: 5 },
-  pw: { biasLong: -1, biasLat: 0, sdLong: 5, sdLat: 5 },
-  gw: { biasLong: -1, biasLat: 0, sdLong: 5, sdLat: 4 },
-  sw: { biasLong: -1, biasLat: 0, sdLong: 5, sdLat: 4 },
-}
-const DEFAULT_DISP: Disp = { biasLong: -2, biasLat: 0, sdLong: 9, sdLat: 8 }
-
-// Box–Muller normal sample, scaled to sd. Sums of uniforms would peak too
-// flat; a real Gaussian gives the dense centre + sparse tails a cone wants.
-function gaussian(sd: number): number {
-  const u = 1 - Math.random()
-  const v = Math.random()
-  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v) * sd
-}
-
-function distanceYards(a: { lat: number; lng: number }, b: { lat: number; lng: number }): number {
-  const north = (b.lat - a.lat) * YARDS_PER_DEG_LAT
-  const east = (b.lng - a.lng) * yardsPerDegLng(a.lat)
-  return Math.hypot(north, east)
-}
-
-// A point `dist` yards from `from` along the line toward `toward`.
-function stepToward(
-  from: { lat: number; lng: number },
-  toward: { lat: number; lng: number },
-  dist: number,
-): { lat: number; lng: number } {
-  const north = (toward.lat - from.lat) * YARDS_PER_DEG_LAT
-  const east = (toward.lng - from.lng) * yardsPerDegLng(from.lat)
-  const mag = Math.hypot(north, east) || 1
-  return offsetCoord([from.lat, from.lng], (north / mag) * dist, (east / mag) * dist)
-}
-
-// Land the ball offLong yards along the start→aim line and offLat yards
-// perpendicular (right = +), so the miss is oriented to the actual shot
-// bearing — what computeDispersion rotates back out when fitting the cone.
-function dispersedEnd(
-  start: { lat: number; lng: number },
-  aim: { lat: number; lng: number },
-  offLong: number,
-  offLat: number,
-): { lat: number; lng: number } {
-  const north = (aim.lat - start.lat) * YARDS_PER_DEG_LAT
-  const east = (aim.lng - start.lng) * yardsPerDegLng(start.lat)
-  const mag = Math.hypot(north, east) || 1
-  const un = north / mag
-  const ue = east / mag
-  // perpendicular unit (90° clockwise = player's right)
-  const pn = -ue
-  const pe = un
-  const dn = offLong * un + offLat * pn
-  const de = offLong * ue + offLat * pe
-  return offsetCoord([aim.lat, aim.lng], dn, de)
-}
-
 async function ensureDemoUser(): Promise<string> {
   const { data: list } = await supabase.auth.admin.listUsers({ perPage: 1000 })
   const existing = list?.users?.find((u) => u.email === SEED_EMAIL)
@@ -187,33 +95,44 @@ async function ensureDemoUser(): Promise<string> {
 }
 
 async function ensureProfile(userId: string): Promise<void> {
-  const { error } = await supabase.from('profiles').upsert(
-    {
-      id: userId,
-      username: SEED_USERNAME,
-      handicap_index: 12.4,
-      skill_level: 'developing',
-      goal: 'break_80',
-      play_frequency: 'weekly',
-      facilities: ['range', 'short_game', 'putting'],
-      play_style: 'mixed',
-      // Added in migration 0023; the script pre-dates it. Without
-      // this, ProfileGuard would bounce the seeded user to
-      // /onboarding on next sign-in.
-      onboarding_completed: true,
-    },
-    { onConflict: 'id' },
-  )
+  const { error } = await supabase
+    .from('profiles')
+    .upsert(
+      {
+        id: userId,
+        username: SEED_USERNAME,
+        handicap_index: 12.4,
+        skill_level: 'developing',
+        goal: 'break_80',
+        play_frequency: 'weekly',
+        facilities: ['range', 'short_game', 'putting'],
+        play_style: 'mixed',
+        // Added in migration 0023; the script pre-dates it. Without
+        // this, ProfileGuard would bounce the seeded user to
+        // /onboarding on next sign-in.
+        onboarding_completed: true,
+      },
+      { onConflict: 'id' },
+    )
   if (error) throw error
 }
 
 async function wipeDemoData(userId: string): Promise<void> {
   // hole_scores + shots cascade off rounds
-  const { error: roundsErr } = await supabase.from('rounds').delete().eq('user_id', userId)
+  const { error: roundsErr } = await supabase
+    .from('rounds')
+    .delete()
+    .eq('user_id', userId)
   if (roundsErr) throw roundsErr
-  const { error: planErr } = await supabase.from('practice_plans').delete().eq('user_id', userId)
+  const { error: planErr } = await supabase
+    .from('practice_plans')
+    .delete()
+    .eq('user_id', userId)
   if (planErr) throw planErr
-  const { error: clubsErr } = await supabase.from('user_clubs').delete().eq('user_id', userId)
+  const { error: clubsErr } = await supabase
+    .from('user_clubs')
+    .delete()
+    .eq('user_id', userId)
   if (clubsErr) throw clubsErr
 }
 
@@ -247,7 +166,9 @@ async function fetchCourses(): Promise<CourseRow[]> {
 }
 
 async function fetchHolesByCourse(): Promise<Map<string, HoleRow[]>> {
-  const { data, error } = await supabase.from('holes').select('id, number, par, yards, course_id')
+  const { data, error } = await supabase
+    .from('holes')
+    .select('id, number, par, yards, course_id')
   if (error) throw error
   const map = new Map<string, HoleRow[]>()
   for (const row of data ?? []) {
@@ -283,7 +204,8 @@ async function insertRound(
   withShots: boolean,
 ): Promise<void> {
   const profile = pickRoundProfile()
-  const sgTotal = profile.sgOffTee + profile.sgApproach + profile.sgAroundGreen + profile.sgPutting
+  const sgTotal =
+    profile.sgOffTee + profile.sgApproach + profile.sgAroundGreen + profile.sgPutting
   const par = holes.reduce((s, h) => s + h.par, 0)
   // Score correlates roughly with sgTotal: better SG → fewer strokes.
   const score = Math.round(par - sgTotal + rand(-1, 1))
@@ -349,59 +271,25 @@ async function insertHoleShots(
   let lastEnd = teeBase
   for (let n = 1; n <= totalShots; n++) {
     const isLast = n === totalShots
+    const remainingYards = isLast ? 5 : Math.max(20, (hole.yards ?? 200) - (n - 1) * 150)
+    const aim = isLast
+      ? pinBase
+      : offsetCoord([pinBase.lat, pinBase.lng], rand(-5, 5), rand(-10, 10))
+    const dispersionLat = rand(-12, 12)
+    const dispersionLng = rand(-18, 18)
+    const end = isLast
+      ? pinBase
+      : offsetCoord([aim.lat, aim.lng], dispersionLat, dispersionLng)
+
+    const lieType: string =
+      n === 1 ? 'tee' : isLast ? 'green' : Math.random() < 0.65 ? 'fairway' : 'rough'
     const lieSlope = ['level', 'uphill', 'downhill', 'ball_above', 'ball_below'][
       Math.floor(rand(0, 5))
     ]
-
-    if (isLast) {
-      // Holed putt on the green.
-      const { error } = await supabase.from('shots').insert({
-        hole_score_id: holeScoreId,
-        user_id: userId,
-        shot_number: n,
-        start_lat: lastEnd.lat,
-        start_lng: lastEnd.lng,
-        aim_lat: pinBase.lat,
-        aim_lng: pinBase.lng,
-        end_lat: pinBase.lat,
-        end_lng: pinBase.lng,
-        distance_to_target: null,
-        club: 'putter',
-        lie_type: 'green',
-        lie_slope: lieSlope,
-        shot_result: null,
-        penalty: false,
-        ob: false,
-        putt_distance_ft: Math.round(rand(2, 22) * 10) / 10,
-        putt_result: 'made',
-      })
-      if (error) throw error
-      lastEnd = pinBase
-      continue
-    }
-
-    const lieType = n === 1 ? 'tee' : Math.random() < 0.68 ? 'fairway' : 'rough'
-    // Club is chosen for the distance still to the pin; the ball advances by
-    // the club's typical carry (or reaches the pin, whichever is shorter).
-    const distToPin = Math.max(8, Math.round(distanceYards(lastEnd, pinBase)))
-    const club = pickClubForDistance(distToPin)
-    const carry = TYPICAL_CARRY[club] ?? distToPin
-    const aim = stepToward(lastEnd, pinBase, Math.min(carry, distToPin))
-    const disp = CLUB_DISPERSION[club] ?? DEFAULT_DISP
-    const offLong = disp.biasLong + gaussian(disp.sdLong)
-    const offLat = disp.biasLat + gaussian(disp.sdLat)
-    const end = dispersedEnd(lastEnd, aim, offLong, offLat)
-    // Result follows the actual miss so result-based stats stay consistent.
-    const result =
-      offLat > 9
-        ? 'push_right'
-        : offLat < -9
-          ? 'pull_left'
-          : offLong < -11
-            ? 'fat'
-            : Math.random() < 0.18
-              ? 'thin'
-              : 'solid'
+    const club = lieType === 'green' ? 'putter' : pickClubForDistance(remainingYards)
+    const result = ['solid', 'push_right', 'pull_left', 'fat', 'thin'][
+      Math.floor(rand(0, 5))
+    ]
 
     const { error } = await supabase.from('shots').insert({
       hole_score_id: holeScoreId,
@@ -413,15 +301,16 @@ async function insertHoleShots(
       aim_lng: aim.lng,
       end_lat: end.lat,
       end_lng: end.lng,
-      distance_to_target: distToPin,
+      distance_to_target: lieType === 'green' ? null : Math.round(remainingYards),
       club,
       lie_type: lieType,
       lie_slope: lieSlope,
-      shot_result: result,
+      shot_result: lieType === 'green' ? null : result,
       penalty: false,
       ob: false,
-      putt_distance_ft: null,
-      putt_result: null,
+      putt_distance_ft:
+        lieType === 'green' ? Math.round(rand(2, 25) * 10) / 10 : null,
+      putt_result: lieType === 'green' ? (isLast ? 'made' : 'short') : null,
     })
     if (error) throw error
     lastEnd = end
@@ -483,14 +372,14 @@ async function main() {
 
   const courses = await fetchCourses()
   if (courses.length < 3) {
-    throw new Error('Demo seed needs 3 courses in the database — run `npx supabase db reset` first')
+    throw new Error(
+      'Demo seed needs 3 courses in the database — run `npx supabase db reset` first',
+    )
   }
   const holesByCourse = await fetchHolesByCourse()
 
   const TOTAL_ROUNDS = 15
-  // More shot-rounds → each club clears the 5-shot floor the dispersion fit
-  // needs, so /patterns shows a real cone for the common clubs.
-  const ROUNDS_WITH_SHOTS = 8
+  const ROUNDS_WITH_SHOTS = 5
 
   for (let i = 0; i < TOTAL_ROUNDS; i++) {
     const course = courses[i % courses.length]!


### PR DESCRIPTION
## What

Landing-page v2 — an editorial redesign of the public marketing page (`/`), in the warm-editorial type system (Fraunces / Epilogue / Inconsolata, `caddie-*` tokens).

## Changes

- **New sections:** Manifesto, Community / open-source (3 contribution lanes), "What OGA isn't" (negation), and a "$0. Forever." pricing moment. 4-cell stat bar (+ MIT). Hero platform row (iPhone · Android · Web). **Learn section kept.**
- **Spreads:** the old 3-icon Features grid → editorial spreads — strokes-gained (animated diverging bars) and shot-patterns (a live demo dispersion cone), copy + figure alternating, fully responsive.
- **Hero `AppPreview` rebuilt to match the current mobile live mode** (`apps/mobile/HoleMapOverlays`): on-map `To Hole` / `Exp` HUD pills, the drag/mark hint, the left slope·pattern·pin toolbar — replacing the old header/footer bars. Points at a real, recognizable coastal hole pulled from the courses DB (no course name on the label).
- **Brand wordmark:** nav + footer now render the lowercase **`oga.`** mark (upright forest period), not all-caps OGA.
- **`seed-demo.ts`:** realistic per-club carry distances + biased per-club dispersion cones + 8 shot-rounds, so `/patterns` renders a real cone — and the e2e fixture gets meaningfully better coverage.

## Verification

- Typecheck clean (`pnpm typecheck`).
- Reviewed by frontend + UI agents; their findings folded in: corrected an inaccurate hardcoded course count, removed a duplicated hero/spread phone, fixed a dispersion-chart label collision + clarity, tightened a11y labels.
- Rendered + screenshotted live at every step (hero, spreads, full page).

Fully live — no baked screenshots; the dispersion + SG figures are hardcoded-demo React/SVG so the public page needs no auth or live data.
