### PR TITLE
chore(mobile): lock to iPhone-only for v1 (supportsTablet: false)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -43,7 +43,9 @@ const config: ExpoConfig = {
     // appVersionSource: 'remote' in eas.json, no seed = first build errors
     // because there's no remote value to increment.
     buildNumber: '1',
-    supportsTablet: true,
+    // iPhone-only for v1: drops the App Store's 12.9" iPad screenshot
+    // requirement and iPad-layout QA. Revisit when an iPad layout is on the roadmap.
+    supportsTablet: false,
     infoPlist: {
       // Foreground-only: OGA calls requestForegroundPermissionsAsync during a
       // round and never requests background/Always location. The expo-location


### PR DESCRIPTION
Locks the v1 dual-store launch to **iPhone-only** by setting `ios.supportsTablet: false` in `app.config.ts`.

## Why
Drops the App Store's 12.9" iPad screenshot requirement (2048×2732) and iPad-layout QA from the v1 critical path. The app still installs on iPad in iPhone-compatibility mode. iPad support can be added in a later release.

## Scope
- One field flip + an explanatory comment. No code paths affected (`supportsTablet` is consumed only at native prebuild to set the iOS device-family capability).
- Part of the broader store-listing prep tracked in `docs/internal/store-submission.md`; closes the iPad portion of #309.

## Test plan
- Typecheck only — config-only change. iPad device-family behavior validates on the #376 device build.

Refs #309