### PR TITLE
fix(mobile): partial-course holes can't log shots (#525)

### DIFF
--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -13,6 +13,7 @@ import * as Location from 'expo-location'
 import {
   formatLocation,
   getOpenGolfApiCourse,
+  inferHoleCount,
   searchOpenGolfApi,
   todayLocalDate,
   type OpenGolfApiSearchResult,
@@ -188,26 +189,37 @@ export default function NewRound() {
         .order('number')
       if (holesError) throw holesError
 
-      // Most courses (private clubs, anything not OSM-mapped) have zero
-      // rows in `holes`. Without holes there are no FK targets for
-      // hole_scores, the hole screen hits "Hole not found", and the
-      // resume banner traps the user. Materialize 18 par-4 placeholders
-      // for the course on the first round there — subsequent rounds at
-      // the same course inherit them, and any later enrichment / shot
-      // logging upgrades the rows in place via tee_lat / pin_lat fills.
-      let holes = existingHoles ?? []
-      if (holes.length === 0) {
+      // Courses range from fully unmapped (most private clubs — zero
+      // `holes` rows) to partially mapped (the crawler averages ~14 of 18
+      // from OSM). Either way, every hole the round needs an FK target for
+      // must have a real `holes` row, or hole_scores can't be created for
+      // it and persistShot silently no-ops on the padded holes (#525).
+      // Materialize whichever hole numbers are missing. Hole count is
+      // inferred from the mapped numbers (course_tees.par is unpopulated in
+      // our data — see inferHoleCount); a genuine 9-hole course stays 9.
+      const existing = existingHoles ?? []
+      const expectedCount = inferHoleCount(existing.map((h) => h.number))
+      const byNumber = new Map<number, { id: string }>()
+      for (const h of existing) byNumber.set(h.number, { id: h.id })
+
+      const missing = Array.from(
+        { length: expectedCount },
+        (_, i) => i + 1,
+      ).filter((n) => !byNumber.has(n))
+      if (missing.length > 0) {
         // A direct holes insert is blocked by RLS (migration 0026) on any
         // course the user didn't create — which is every crawler/public
         // course. Materialize through the insert_synthetic_hole SECURITY
         // DEFINER RPC instead (it authorizes by round ownership), the same
-        // path the web uses via ensureRealHole. Returns the hole id; pairs
-        // with the number/par we passed in.
+        // path the web uses via ensureRealHole. The RPC is idempotent
+        // (ON CONFLICT (course_id, number) DO NOTHING → re-select), so a
+        // partial failure + retry self-heals. Par defaults to 4; later
+        // enrichment / shot logging upgrades the row in place.
         const created = await Promise.all(
-          Array.from({ length: 18 }, (_, i) =>
+          missing.map((n) =>
             supabase.rpc('insert_synthetic_hole', {
               p_course_id: courseId,
-              p_number: i + 1,
+              p_number: n,
               p_par: 4,
               p_round_id: round.id,
             }),
@@ -215,16 +227,14 @@ export default function NewRound() {
         )
         const failed = created.find((r) => r.error)
         if (failed?.error) throw failed.error
-        holes = created.map((r, i) => ({
-          id: r.data as string,
-          number: i + 1,
-          par: 4,
-        }))
+        created.forEach((r, i) => {
+          byNumber.set(missing[i]!, { id: r.data as string })
+        })
       }
 
-      // Single batch insert beats 18 sequential round-trips; round was just
+      // Single batch insert beats per-hole round-trips; round was just
       // created so there's nothing to conflict against.
-      const holeScoreRows = holes.map((h) => ({
+      const holeScoreRows = Array.from(byNumber.values()).map((h) => ({
         round_id: round.id,
         hole_id: h.id,
         score: 0,

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -591,6 +591,7 @@ export default function LiveRoundSession({
           hasGps={finalState.gpsPosition != null}
           totalShotsThisHole={totalShotsThisHole}
           holeNumber={holeNumber}
+          holeCount={data.holeCount}
           par={data.currentHole.par}
           yardsLabel={data.currentHole.yards ? toDisplay(data.currentHole.yards) : null}
           onCancelPinPlacement={() => setPinPlacementOpen(false)}

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -25,6 +25,7 @@ interface MapBottomChromeProps {
   hasGps: boolean
   totalShotsThisHole: number
   holeNumber: number
+  holeCount: number
   par: number
   yardsLabel: string | null
   onCancelPinPlacement: () => void
@@ -97,7 +98,7 @@ function ContextualActions(p: MapBottomChromeProps) {
       <PrimaryCta label={ballLabel} disabled={ballDisabled} onPress={p.onMarkBallHere} />
       {p.totalShotsThisHole > 0 && (
         <TextChip
-          label={p.holeNumber < 18 ? 'Finish hole · next →' : 'Finish round'}
+          label={p.holeNumber < p.holeCount ? 'Finish hole · next →' : 'Finish round'}
           onPress={p.onFinishHole}
           strong
         />
@@ -234,6 +235,7 @@ function TextChip({
 
 function HoleNavPill({
   holeNumber,
+  holeCount,
   par,
   yardsLabel,
   onPrev,
@@ -265,7 +267,7 @@ function HoleNavPill({
           Scorecard ▾
         </Text>
       </Pressable>
-      <NavChevron dir="next" disabled={holeNumber === 18} onPress={onNext} />
+      <NavChevron dir="next" disabled={holeNumber >= holeCount} onPress={onNext} />
     </View>
   )
 }

--- a/apps/mobile/components/round/ShareableScorecardCard.tsx
+++ b/apps/mobile/components/round/ShareableScorecardCard.tsx
@@ -1,5 +1,5 @@
 import { Text, View } from 'react-native'
-import { formatSG, formatToPar } from '@oga/core'
+import { formatSG, formatToPar, inferHoleCount } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import { FONT } from '../../lib/typography'
 
@@ -73,7 +73,10 @@ export function ShareableScorecardCard({
 
   const holesByNumber = new Map<number, HoleRow>()
   for (const h of holes) holesByNumber.set(h.number, h)
-  const holeNumbers = Array.from({ length: 18 }, (_, i) => i + 1)
+  // Match the round's actual size (#525) — a 9-hole round shows one grid,
+  // not nine empty "In" cells. Empty/old rounds fall back to 18.
+  const holeCount = inferHoleCount(holes.map((h) => h.number))
+  const holeNumbers = Array.from({ length: holeCount }, (_, i) => i + 1)
 
   const totalPar = holeNumbers.reduce((sum, n) => {
     const h = holesByNumber.get(n)
@@ -143,14 +146,18 @@ export function ShareableScorecardCard({
         colors={c}
         rangeLabel="Out"
       />
-      <View style={{ height: 8 }} />
-      <ScoreGrid
-        holeNumbers={holeNumbers.slice(9)}
-        holesByNumber={holesByNumber}
-        scoresByHoleId={scoresByHoleId}
-        colors={c}
-        rangeLabel="In"
-      />
+      {holeNumbers.length > 9 && (
+        <>
+          <View style={{ height: 8 }} />
+          <ScoreGrid
+            holeNumbers={holeNumbers.slice(9)}
+            holesByNumber={holesByNumber}
+            scoresByHoleId={scoresByHoleId}
+            colors={c}
+            rangeLabel="In"
+          />
+        </>
+      )}
 
       <View
         style={{

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { inferHoleCount } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import {
   pendingShotsForHoleScore,
@@ -22,6 +23,7 @@ export interface UseHoleDataResult {
   loading: boolean
   error: string | null
   loadAll: () => Promise<void>
+  holeCount: 9 | 18
   effectiveHoles: HoleRow[]
   currentHole: HoleRow | null
   currentHoleScore: HoleScoreRow | null
@@ -55,19 +57,27 @@ export function useHoleData(
   const [pendingForHole, setPendingForHole] = useState<PendingShot[]>([])
   const [remoteShotStarts, setRemoteShotStarts] = useState<LatLng[]>([])
 
+  // How many holes this round plays. course_tees.par is unpopulated in
+  // our crawled data, so infer from the mapped hole numbers — a genuine
+  // 9-hole course stays 9 instead of padding to 18 phantom holes (#525).
+  // Drives both the synthetic display padding below and the nav/finish
+  // bounds in useShotActions (consumed via the returned holeCount).
+  const holeCount = useMemo(
+    () => inferHoleCount(holes.map((h) => h.number)),
+    [holes],
+  )
+
   // Synthetic-holes fallback. Mirrors the web pattern documented in
   // CLAUDE.md: when the course has fewer real `holes` rows than the
-  // expected count (18 here — mobile doesn't query course_tees yet),
-  // pad with par-4 placeholders keyed `synthetic-${roundId}-hole-${n}`
-  // so the UI can render and the player isn't trapped on a "Hole not
-  // found" screen.
-  const expectedHoleCount = 18
+  // expected count, pad with par-4 placeholders keyed
+  // `synthetic-${roundId}-hole-${n}` so the UI can render and the player
+  // isn't trapped on a "Hole not found" screen.
   const effectiveHoles = useMemo<HoleRow[]>(() => {
     if (!round) return holes
-    if (holes.length >= expectedHoleCount) return holes
+    if (holes.length >= holeCount) return holes
     const realByNumber = new Map<number, HoleRow>()
     for (const h of holes) realByNumber.set(h.number, h)
-    return Array.from({ length: expectedHoleCount }, (_, i) => {
+    return Array.from({ length: holeCount }, (_, i) => {
       const num = i + 1
       const real = realByNumber.get(num)
       if (real) return real
@@ -84,7 +94,7 @@ export function useHoleData(
         pin_lng: null,
       } as HoleRow
     })
-  }, [holes, round])
+  }, [holes, round, holeCount])
 
   const currentHole = useMemo(
     () => effectiveHoles.find((h) => h.number === holeNumber) ?? null,
@@ -236,6 +246,7 @@ export function useHoleData(
     loading,
     error,
     loadAll,
+    holeCount,
     effectiveHoles,
     currentHole,
     currentHoleScore,

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -60,8 +60,6 @@ export function useHoleData(
   // How many holes this round plays. course_tees.par is unpopulated in
   // our crawled data, so infer from the mapped hole numbers — a genuine
   // 9-hole course stays 9 instead of padding to 18 phantom holes (#525).
-  // Drives both the synthetic display padding below and the nav/finish
-  // bounds in useShotActions (consumed via the returned holeCount).
   const holeCount = useMemo(
     () => inferHoleCount(holes.map((h) => h.number)),
     [holes],

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -108,6 +108,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     remotePuttCount,
     localPuttCount,
     shotNumber,
+    holeCount,
   } = data
   const {
     ball,
@@ -462,12 +463,15 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
 
   function navigateHole(delta: number) {
     const next = holeNumber + delta
-    if (next < 1 || next > 18) return
+    // Bound by the round's actual hole count, not a hardcoded 18 — a
+    // 9-hole course must stop at 9 or the player lands on padded holes
+    // with no hole_scores (#525).
+    if (next < 1 || next > holeCount) return
     onHoleChange(next)
   }
 
   function finishHole() {
-    if (holeNumber < 18) {
+    if (holeNumber < holeCount) {
       onHoleChange(holeNumber + 1)
     } else {
       router.replace('/(app)')

--- a/packages/core/src/__tests__/round.test.ts
+++ b/packages/core/src/__tests__/round.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildInitialRows,
+  inferHoleCount,
   legacySlopeToAxes,
   type PlacedPoint,
 } from '../round'
@@ -165,5 +166,39 @@ describe('legacySlopeToAxes', () => {
       const hasBoth = out.forward !== undefined && out.side !== undefined
       expect(hasBoth).toBe(false)
     }
+  })
+})
+
+describe('inferHoleCount', () => {
+  it('empty (unmapped course) defaults to 18', () => {
+    expect(inferHoleCount([])).toBe(18)
+  })
+
+  it('contiguous 1–9 → 9', () => {
+    expect(inferHoleCount([1, 2, 3, 4, 5, 6, 7, 8, 9])).toBe(9)
+  })
+
+  it('contiguous 1–18 → 18', () => {
+    expect(inferHoleCount(Array.from({ length: 18 }, (_, i) => i + 1))).toBe(18)
+  })
+
+  it('partial 18 missing trailing holes (1–14) → 18 by max', () => {
+    expect(inferHoleCount(Array.from({ length: 14 }, (_, i) => i + 1))).toBe(18)
+  })
+
+  it('interior gaps keyed on max, not count (1–4, 7–18) → 18', () => {
+    expect(inferHoleCount([1, 2, 3, 4, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18])).toBe(18)
+  })
+
+  it('back-nine-only mapping (10–18) → 18', () => {
+    expect(inferHoleCount([10, 11, 12, 13, 14, 15, 16, 17, 18])).toBe(18)
+  })
+
+  it('sparse sub-9 mapping (1–5) → 9', () => {
+    expect(inferHoleCount([1, 2, 3, 4, 5])).toBe(9)
+  })
+
+  it('a single mapped hole 10 already implies 18', () => {
+    expect(inferHoleCount([10])).toBe(18)
   })
 })

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -49,6 +49,21 @@ export interface ReviewedShotRow {
   puttDirectionResult?: PuttDirectionResult
 }
 
+// Infer how many holes a course actually has from the hole NUMBERS we
+// have rows for. Golf courses are 9 or 18; `course_tees.par` would be the
+// authoritative signal but it's ~0% populated in our crawled data, so the
+// hole numbers are all we have. Keyed on max (not count) because a course
+// can have interior gaps (holes 1–4, 7–18 → still an 18) or start above 1
+// (back-nine-only mapping). An empty set means an unmapped course — assume
+// 18, the common case. A max ≤ 9 means a 9-hole course; this deliberately
+// buckets a front-9-only mapping of an 18 as a 9 (data can't distinguish
+// them, and stranding a real 9-hole player on phantom holes 10–18 is the
+// worse failure). See #525.
+export function inferHoleCount(holeNumbers: number[]): 9 | 18 {
+  if (holeNumbers.length === 0) return 18
+  return Math.max(...holeNumbers) <= 9 ? 9 : 18
+}
+
 export function buildInitialRows(
   points: PlacedPoint[],
   par: number,


### PR DESCRIPTION
Closes #525.

## Problem
Round creation (`apps/mobile/app/(app)/round/new.tsx`) only materialized `holes` + `hole_scores` when a course had **zero** `holes` rows (`if (holes.length === 0)`). A **partially-mapped** course — the crawler averages ~14 of 18 holes from OSM — got `hole_scores` for only its real holes. The synthetic display-padded holes had no `hole_scores` row, so `persistShot` silently no-opped (`useShotActions.ts` `if (!currentHoleScore) return null`) and the player **could not log shots** on the unmapped holes. Pre-existing; surfaced during #519 review.

## Data that shaped the fix
Queried prod (15,297 courses):
- **`course_tees.par` is ~0% populated** for mapped courses (10,694 of ~10,695 have no tees row) — the web's hole-count heuristic is unusable here.
- No course exceeds 18 holes; 1,588 courses have interior gaps; 682 don't start at hole 1.
- The only usable signal is the hole **numbers** themselves.

## Fix
- New pure `@oga/core` helper **`inferHoleCount(numbers): 9 | 18`** — empty → 18; `max(numbers) ≤ 9` → 9; else 18. Keyed on `max` (gap-immune), with tests.
- **`new.tsx`** — materialize whichever hole numbers in `1..expectedCount` are missing via the idempotent `insert_synthetic_hole` RPC (zero-case folds in), merge existing+created by number, create `hole_scores` for the full set.
- **`useHoleData.ts`** — replace hardcoded `expectedHoleCount = 18` with `inferHoleCount(...)`; expose `holeCount` so display padding matches creation.
- **`useShotActions.ts` + `MapBottomChrome.tsx`** — nav bounds, "Finish round" label, and Next-chevron disabled state now use `holeCount` instead of a hardcoded 18, so a 9-hole round navigates within bounds and finishes at 9.

Per the user requirement, genuine 9-hole courses are saved as 9, not coerced to 18.

## Verification
- `pnpm typecheck` (web + core + supabase) ✅
- `cd apps/mobile && npm run typecheck` ✅
- `pnpm test` — 529 core tests pass (+8 new for `inferHoleCount`) ✅
- On-device validation pending (next iOS/Android QA build).

## Known limitations (deliberate)
- **No backfill** — this is a creation-time fix; rounds already created on a partial course keep their incomplete `hole_scores`. Small population; self-corrects on new rounds.
- **Ambiguous contiguous-9 courses** (2,045 in prod) are bucketed as 9-hole. A true front-9-of-18 mapping caps at 9 — but the inverse (coercing a real 9-hole to 18 phantom holes) is worse, so bias-to-9 is intentional.
- **`ShareableScorecardCard.tsx`** still renders 18 cells on the post-round **share image** (cosmetic, non-logging surface) — left as a follow-up.