### PR TITLE
fix(mobile): My Bag button clipped by home indicator (#528)

### DIFF
--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -9,6 +9,7 @@ import {
   View,
 } from 'react-native'
 import { useRouter } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import {
   CANONICAL_CLUBS_BY_CATEGORY,
   CLUB_CATEGORIES,
@@ -60,6 +61,7 @@ const EMPTY_DRAFT: AddDraft = {
 
 export default function BagScreen() {
   const router = useRouter()
+  const insets = useSafeAreaInsets()
   const { user } = useAuth()
   const { bag, isLoading, error, refetch } = useUserBag({
     includeBenched: true,
@@ -261,7 +263,7 @@ export default function BagScreen() {
           data={bag}
           keyExtractor={(c) => c.id}
           onDragEnd={({ data }) => onDragEnd(data)}
-          contentContainerStyle={{ padding: 18, paddingBottom: 40 }}
+          contentContainerStyle={{ padding: 18, paddingBottom: insets.bottom + 24 }}
           ListHeaderComponent={
             <View style={{ marginBottom: 18 }}>
               <Text style={[TYPE.body, { color: '#5C6356', fontSize: 14, marginBottom: 6 }]}>
@@ -347,7 +349,7 @@ export default function BagScreen() {
               borderTopLeftRadius: 12,
               borderTopRightRadius: 12,
             }}
-            contentContainerStyle={{ padding: 18, paddingBottom: 28 }}
+            contentContainerStyle={{ padding: 18, paddingBottom: insets.bottom + 28 }}
           >
             <View
               style={{


### PR DESCRIPTION
Closes #528.

## Problem
On the My Bag screen, the **"Add club →"** footer button and the **"Add to bag → / Save changes →"** button in the add/edit-club bottom sheet were clipped by the iOS home indicator. `bag.tsx` hardcoded bottom padding (`paddingBottom: 40` on the list, `28` on the `flex-end` modal sheet) with no safe-area inset.

## Fix
Add `useSafeAreaInsets()` and fold `insets.bottom` into both paddings, per the CLAUDE.md safe-area convention (`AppBar.tsx` `insets.top + 14` is the reference):
- `DraggableFlatList` footer → `paddingBottom: insets.bottom + 24`
- add/edit-club modal `ScrollView` → `paddingBottom: insets.bottom + 28`

## Verification
- `cd apps/mobile && npm run typecheck` ✅
- On-device confirmation rides the next QA build.

Pure safe-area fix, no logic change. `merged-to-dev` on merge; closes on the `dev→main` release.