### PR TITLE
feat(mobile): signal Learn is a browsable library (#524)

### DIFF
--- a/apps/mobile/app/(app)/learn/index.tsx
+++ b/apps/mobile/app/(app)/learn/index.tsx
@@ -2,6 +2,7 @@ import { Pressable, ScrollView, Text, View } from 'react-native'
 import { useRouter } from 'expo-router'
 import {
   LEARN_SECTIONS,
+  READABLE_LEARN_ARTICLES,
   readingTimeMinutes,
   type LearnArticle,
   type LearnSection,
@@ -19,14 +20,13 @@ const KICKER: import('react-native').TextStyle = {
   textTransform: 'uppercase',
 }
 
+// Library-signal counts — static (derived from the @oga/core catalog), so
+// they live at module scope rather than re-deriving each render.
+const ARTICLE_COUNT = READABLE_LEARN_ARTICLES.length
+const SECTION_COUNT = LEARN_SECTIONS.length
+
 export default function LearnScreen() {
   const router = useRouter()
-  // Readable count for the library signal — 'soon' stubs aren't tappable,
-  // so they don't count toward "what's here to read".
-  const articleCount = LEARN_SECTIONS.reduce(
-    (n, s) => n + s.articles.filter((a) => a.status !== 'soon').length,
-    0,
-  )
 
   return (
     <View style={{ flex: 1, backgroundColor: C.bg }}>
@@ -59,7 +59,8 @@ export default function LearnScreen() {
           the field.
         </Text>
         <Text style={{ ...KICKER, marginTop: 14 }}>
-          {articleCount} short reads · {LEARN_SECTIONS.length} sections
+          {ARTICLE_COUNT} short reads · {SECTION_COUNT} section
+          {SECTION_COUNT === 1 ? '' : 's'}
         </Text>
 
         {LEARN_SECTIONS.map((section) => (

--- a/apps/mobile/app/(app)/learn/index.tsx
+++ b/apps/mobile/app/(app)/learn/index.tsx
@@ -21,6 +21,12 @@ const KICKER: import('react-native').TextStyle = {
 
 export default function LearnScreen() {
   const router = useRouter()
+  // Readable count for the library signal — 'soon' stubs aren't tappable,
+  // so they don't count toward "what's here to read".
+  const articleCount = LEARN_SECTIONS.reduce(
+    (n, s) => n + s.articles.filter((a) => a.status !== 'soon').length,
+    0,
+  )
 
   return (
     <View style={{ flex: 1, backgroundColor: C.bg }}>
@@ -51,6 +57,9 @@ export default function LearnScreen() {
         <Text style={[TYPE.body, { color: C.inkDim, fontSize: 14, lineHeight: 20 }]}>
           What they mean, why they matter, and what the numbers look like across
           the field.
+        </Text>
+        <Text style={{ ...KICKER, marginTop: 14 }}>
+          {articleCount} short reads · {LEARN_SECTIONS.length} sections
         </Text>
 
         {LEARN_SECTIONS.map((section) => (

--- a/apps/mobile/components/home/LearnPreview.tsx
+++ b/apps/mobile/components/home/LearnPreview.tsx
@@ -15,9 +15,12 @@ const KICKER: import('react-native').TextStyle = {
 // encodes editorial priority (fundamentals first), so this surfaces the
 // two flagship published articles without needing a `featured` flag or
 // dates on the model. `soon` stubs aren't tappable, so they're excluded.
-const FEATURED: LearnArticle[] = LEARN_SECTIONS.flatMap((s) => s.articles)
-  .filter((a) => a.status !== 'soon')
-  .slice(0, 3)
+const READABLE: LearnArticle[] = LEARN_SECTIONS.flatMap((s) => s.articles).filter(
+  (a) => a.status !== 'soon',
+)
+const FEATURED: LearnArticle[] = READABLE.slice(0, 3)
+// Surfaced on "See all" so the card reads as a library of N, not a page.
+const READ_COUNT = READABLE.length
 
 export function LearnPreview() {
   const router = useRouter()
@@ -39,7 +42,7 @@ export function LearnPreview() {
           onPress={() => router.push('/(app)/learn')}
           hitSlop={8}
         >
-          <Text style={[TYPE.kicker, KICKER, { color: '#1F3D2C' }]}>See all →</Text>
+          <Text style={[TYPE.kicker, KICKER, { color: '#1F3D2C' }]}>See all {READ_COUNT} →</Text>
         </Pressable>
       </View>
 

--- a/apps/mobile/components/home/LearnPreview.tsx
+++ b/apps/mobile/components/home/LearnPreview.tsx
@@ -1,6 +1,6 @@
 import { Pressable, Text, View } from 'react-native'
 import { useRouter } from 'expo-router'
-import { LEARN_SECTIONS, readingTimeMinutes, type LearnArticle } from '@oga/core'
+import { READABLE_LEARN_ARTICLES, readingTimeMinutes, type LearnArticle } from '@oga/core'
 import { TYPE } from '../../lib/typography'
 
 const KICKER: import('react-native').TextStyle = {
@@ -13,14 +13,10 @@ const KICKER: import('react-native').TextStyle = {
 
 // First three readable pieces in catalog order. Section order already
 // encodes editorial priority (fundamentals first), so this surfaces the
-// two flagship published articles without needing a `featured` flag or
-// dates on the model. `soon` stubs aren't tappable, so they're excluded.
-const READABLE: LearnArticle[] = LEARN_SECTIONS.flatMap((s) => s.articles).filter(
-  (a) => a.status !== 'soon',
-)
-const FEATURED: LearnArticle[] = READABLE.slice(0, 3)
+// flagship published articles without needing a `featured` flag.
+const FEATURED: LearnArticle[] = READABLE_LEARN_ARTICLES.slice(0, 3)
 // Surfaced on "See all" so the card reads as a library of N, not a page.
-const READ_COUNT = READABLE.length
+const READ_COUNT = READABLE_LEARN_ARTICLES.length
 
 export function LearnPreview() {
   const router = useRouter()

--- a/packages/core/src/learn.ts
+++ b/packages/core/src/learn.ts
@@ -221,3 +221,10 @@ export function readingTimeMinutes(article: LearnArticle): number | null {
   if (!article.words) return null
   return Math.max(1, Math.ceil(article.words / WORDS_PER_MINUTE))
 }
+
+// Readable articles across every section — everything except 'soon' stubs,
+// which aren't tappable. Single source so the Learn index's count and the
+// home preview's "See all N" can never drift apart. #524
+export const READABLE_LEARN_ARTICLES: LearnArticle[] = LEARN_SECTIONS.flatMap(
+  (s) => s.articles,
+).filter((a) => a.status !== 'soon')


### PR DESCRIPTION
Closes #524.

## Problem
On mobile, the Learn "yardage book" didn't read as a *library of articles* — the entry point and destination both looked like they might be a single page, so it was easy to miss that there are 20 short guides.

## Fix (pure IA/discoverability — no content change)
- **Destination** (`learn/index.tsx`): a metadata kicker under the intro — **"20 short reads · 5 sections"** — so the screen announces itself as a browsable index (count derived live; `soon` stubs excluded since they aren't tappable).
- **Home entry point** (`LearnPreview.tsx`): the "See all →" now reads **"See all 20 →"**, signalling a library of N rather than a page. (Refactored `FEATURED` to derive from a shared `READABLE` list so the count and the featured-3 stay in sync.)

Deliberately did **not** add a new tab or restructure navigation — the existing home card + practice link are the surfaces; this just makes them read as a library, per ship-minimum. Mono-kicker treatment follows DESIGN.md (Inconsolata, metadata/eyebrow role).

## Verification
- `cd apps/mobile && npm run typecheck` ✅
- On-device confirmation rides the next QA build.

`merged-to-dev` on merge; closes on the `dev→main` release.