### PR TITLE
feat: label handicap provenance — calculated vs entered (#521)

### DIFF
--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -145,7 +145,11 @@ export default function ProfileTab() {
       .select('id', { count: 'exact', head: true })
       .eq('user_id', user.id)
       .not('score_differential', 'is', null)
-      .then(({ count }) => {
+      .then(({ count, error }) => {
+        if (error) {
+          // eslint-disable-next-line no-console
+          console.warn('[profile/differentials-count]', error.message)
+        }
         if (active) setDifferentialsCount(count ?? 0)
       })
     return () => {
@@ -196,6 +200,9 @@ export default function ProfileTab() {
     )
   }
 
+  const provenance = handicapProvenance(differentialsCount)
+  const provenanceCalculated = provenance === 'calculated'
+
   return (
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
       <AppBar
@@ -226,34 +233,29 @@ export default function ProfileTab() {
           >
             {profile?.handicap_index ?? '—'}
           </Text>
-          {profile?.handicap_index != null &&
-            (() => {
-              const provenance = handicapProvenance(differentialsCount)
-              const calculated = provenance === 'calculated'
-              return (
-                <View
-                  style={{
-                    marginTop: 8,
-                    paddingHorizontal: 8,
-                    paddingVertical: 3,
-                    borderRadius: 2,
-                    backgroundColor: calculated
-                      ? 'rgba(31,61,44,0.12)'
-                      : 'rgba(138,139,126,0.16)',
-                  }}
-                >
-                  <Text
-                    style={{
-                      ...KICKER,
-                      fontSize: 9,
-                      color: calculated ? '#1F3D2C' : '#8A8B7E',
-                    }}
-                  >
-                    {HANDICAP_PROVENANCE_LABEL[provenance]}
-                  </Text>
-                </View>
-              )
-            })()}
+          {profile?.handicap_index != null && (
+            <View
+              style={{
+                marginTop: 8,
+                paddingHorizontal: 8,
+                paddingVertical: 3,
+                borderRadius: 2,
+                backgroundColor: provenanceCalculated
+                  ? 'rgba(31,61,44,0.12)'
+                  : 'rgba(138,139,126,0.16)',
+              }}
+            >
+              <Text
+                style={{
+                  ...KICKER,
+                  fontSize: 9,
+                  color: provenanceCalculated ? '#1F3D2C' : '#8A8B7E',
+                }}
+              >
+                {HANDICAP_PROVENANCE_LABEL[provenance]}
+              </Text>
+            </View>
+          )}
           <Text
             style={[TYPE.body, {
               color: '#5C6356',

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -10,7 +10,13 @@ import {
   View,
 } from 'react-native'
 import { useRouter } from 'expo-router'
-import { FACILITIES, GOALS, SKILL_LEVELS } from '@oga/core'
+import {
+  FACILITIES,
+  GOALS,
+  HANDICAP_PROVENANCE_LABEL,
+  handicapProvenance,
+  SKILL_LEVELS,
+} from '@oga/core'
 import { getProfile, updateProfile } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
@@ -66,6 +72,11 @@ export default function ProfileTab() {
   const [facilities, setFacilities] = useState<string[]>([])
   const [unit, setUnit] = useState<'yards' | 'meters'>('yards')
   const [emailSummaries, setEmailSummaries] = useState(true)
+  // Count of rounds with a derived score_differential — the signal for
+  // whether the displayed index is a calculated WHS value or still the
+  // entered one (#521). Mobile doesn't compute differentials, so this is
+  // only ever non-zero for players who've also logged rated rounds on web.
+  const [differentialsCount, setDifferentialsCount] = useState(0)
   const [saving, setSaving] = useState(false)
   const [usernameTouched, setUsernameTouched] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -129,6 +140,14 @@ export default function ProfileTab() {
       setUnit(data.distance_unit === 'meters' ? 'meters' : 'yards')
       setEmailSummaries(data.email_round_summaries_enabled ?? true)
     })
+    supabase
+      .from('rounds')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', user.id)
+      .not('score_differential', 'is', null)
+      .then(({ count }) => {
+        if (active) setDifferentialsCount(count ?? 0)
+      })
     return () => {
       active = false
     }
@@ -207,6 +226,34 @@ export default function ProfileTab() {
           >
             {profile?.handicap_index ?? '—'}
           </Text>
+          {profile?.handicap_index != null &&
+            (() => {
+              const provenance = handicapProvenance(differentialsCount)
+              const calculated = provenance === 'calculated'
+              return (
+                <View
+                  style={{
+                    marginTop: 8,
+                    paddingHorizontal: 8,
+                    paddingVertical: 3,
+                    borderRadius: 2,
+                    backgroundColor: calculated
+                      ? 'rgba(31,61,44,0.12)'
+                      : 'rgba(138,139,126,0.16)',
+                  }}
+                >
+                  <Text
+                    style={{
+                      ...KICKER,
+                      fontSize: 9,
+                      color: calculated ? '#1F3D2C' : '#8A8B7E',
+                    }}
+                  >
+                    {HANDICAP_PROVENANCE_LABEL[provenance]}
+                  </Text>
+                </View>
+              )
+            })()}
           <Text
             style={[TYPE.body, {
               color: '#5C6356',

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -207,7 +207,7 @@ export function Sidebar() {
                   }}
                   title={
                     handicapMeta.provenance === 'calculated'
-                      ? `Calculated from ${handicapMeta.differentialsCount} round${handicapMeta.differentialsCount === 1 ? '' : 's'} with rated tees`
+                      ? `Calculated from ${handicapMeta.differentialsCount} rounds with rated tees`
                       : 'Self-reported — play 3+ rated rounds for a calculated WHS index'
                   }
                 >

--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { NavLink } from 'react-router-dom'
+import { HANDICAP_PROVENANCE_LABEL } from '@oga/core'
 import { supabase } from '../../lib/supabase'
 import { useProfile } from '../../hooks/useProfile'
 import { useHandicapMeta } from '../../hooks/useHandicapMeta'
@@ -188,19 +189,29 @@ export function Sidebar() {
                   ? `HCP ${profile.handicap_index}`
                   : 'NO HCP'}
               </span>
-              {handicapMeta?.official && (
+              {profile?.handicap_index != null && handicapMeta && (
                 <span
                   style={{
-                    background: 'rgba(31,61,44,0.65)',
-                    color: '#F2EEE5',
+                    background:
+                      handicapMeta.provenance === 'calculated'
+                        ? 'rgba(31,61,44,0.65)'
+                        : 'rgba(138,139,126,0.3)',
+                    color:
+                      handicapMeta.provenance === 'calculated'
+                        ? '#F2EEE5'
+                        : 'rgba(242,238,229,0.85)',
                     padding: '1px 5px',
                     fontSize: 8,
                     letterSpacing: '0.14em',
                     borderRadius: 2,
                   }}
-                  title={`Calculated from ${handicapMeta.differentialsCount} round${handicapMeta.differentialsCount === 1 ? '' : 's'} with rated tees`}
+                  title={
+                    handicapMeta.provenance === 'calculated'
+                      ? `Calculated from ${handicapMeta.differentialsCount} round${handicapMeta.differentialsCount === 1 ? '' : 's'} with rated tees`
+                      : 'Self-reported — play 3+ rated rounds for a calculated WHS index'
+                  }
                 >
-                  OFFICIAL
+                  {HANDICAP_PROVENANCE_LABEL[handicapMeta.provenance].toUpperCase()}
                 </span>
               )}
             </div>

--- a/apps/web/src/hooks/useHandicapMeta.ts
+++ b/apps/web/src/hooks/useHandicapMeta.ts
@@ -1,10 +1,13 @@
 import { useQuery } from '@tanstack/react-query'
+import { handicapProvenance } from '@oga/core'
 import { supabase } from '../lib/supabase'
 import { useAuth } from './useAuth'
 
-// Returns whether the user's handicap was last set by the auto-recompute
-// path (i.e. at least one finalized round has a score_differential), so
-// the UI can stamp an "Official" badge instead of "Manually entered".
+// Returns the provenance of the user's stored handicap_index: 'calculated'
+// once enough rated rounds exist for the WHS index to have been derived,
+// 'provisional' while it's still the entered value. The count of rounds
+// with a non-null score_differential is the signal; the threshold lives in
+// @oga/core (handicapProvenance) so web + mobile agree. See #521.
 export function useHandicapMeta() {
   const { user } = useAuth()
   return useQuery({
@@ -17,9 +20,10 @@ export function useHandicapMeta() {
         .eq('user_id', user!.id)
         .not('score_differential', 'is', null)
       if (error) throw error
+      const differentialsCount = count ?? 0
       return {
-        differentialsCount: count ?? 0,
-        official: (count ?? 0) > 0,
+        differentialsCount,
+        provenance: handicapProvenance(differentialsCount),
       }
     },
   })

--- a/packages/core/src/handicap.test.ts
+++ b/packages/core/src/handicap.test.ts
@@ -3,6 +3,7 @@ import {
   adjustedScore,
   calculateDifferential,
   calculateHandicapIndex,
+  handicapProvenance,
 } from './handicap'
 
 describe('calculateDifferential', () => {
@@ -160,5 +161,35 @@ describe('adjustedScore (ESC)', () => {
   it('does not raise scores below the cap', () => {
     const easy = [{ score: 3, par: 4 }]
     expect(adjustedScore(easy, 8)).toBe(3)
+  })
+})
+
+describe('handicapProvenance', () => {
+  it('0 differentials → provisional (entered-only, e.g. mobile)', () => {
+    expect(handicapProvenance(0)).toBe('provisional')
+  })
+
+  it('1-2 differentials → provisional (below WHS minimum, index not yet derived)', () => {
+    expect(handicapProvenance(1)).toBe('provisional')
+    expect(handicapProvenance(2)).toBe('provisional')
+  })
+
+  it('exactly 3 differentials → calculated (WHS minimum)', () => {
+    expect(handicapProvenance(3)).toBe('calculated')
+  })
+
+  it('many differentials → calculated', () => {
+    expect(handicapProvenance(20)).toBe('calculated')
+  })
+
+  it('threshold matches calculateHandicapIndex returning non-null', () => {
+    // The provenance threshold and the calc minimum must agree: a count
+    // that yields a real index must be labelled calculated, and vice versa.
+    const twoDiffs = [10.1, 12.4]
+    const threeDiffs = [10.1, 12.4, 9.8]
+    expect(calculateHandicapIndex(twoDiffs)).toBeNull()
+    expect(handicapProvenance(twoDiffs.length)).toBe('provisional')
+    expect(calculateHandicapIndex(threeDiffs)).not.toBeNull()
+    expect(handicapProvenance(threeDiffs.length)).toBe('calculated')
   })
 })

--- a/packages/core/src/handicap.ts
+++ b/packages/core/src/handicap.ts
@@ -15,6 +15,11 @@
 const MAX_HANDICAP_INDEX = 54.0
 const RECENT_WINDOW = 20
 
+// WHS Rule 5.2a needs at least 3 acceptable score differentials before an
+// index can be computed. Below this, the stored handicap_index is whatever
+// the player entered, not a derived value — see handicapProvenance.
+export const MIN_ROUNDS_FOR_HANDICAP = 3
+
 export function calculateDifferential(
   adjustedScore: number,
   courseRating: number,
@@ -55,7 +60,7 @@ export function calculateHandicapIndex(
   differentials: number[],
 ): number | null {
   const valid = differentials.filter((d) => Number.isFinite(d))
-  if (valid.length < 3) return null
+  if (valid.length < MIN_ROUNDS_FOR_HANDICAP) return null
 
   const considered =
     valid.length >= RECENT_WINDOW ? valid.slice(0, RECENT_WINDOW) : valid
@@ -87,4 +92,25 @@ function capForHole(par: number, handicapIndex: number): number {
   if (handicapIndex <= 29) return 8
   if (handicapIndex <= 39) return 9
   return 10
+}
+
+// Provenance of a stored handicap_index: 'calculated' once the player has
+// enough rated rounds for the WHS index to have been derived (and the
+// finalize flow to have overwritten the entered value), 'provisional'
+// otherwise. The number of rounds with a non-null score_differential is
+// the signal — it's also 0 for any player who has only ever entered a
+// value (e.g. mobile, which doesn't yet compute differentials). See #521.
+export type HandicapProvenance = 'calculated' | 'provisional'
+
+export function handicapProvenance(
+  differentialsCount: number,
+): HandicapProvenance {
+  return differentialsCount >= MIN_ROUNDS_FOR_HANDICAP
+    ? 'calculated'
+    : 'provisional'
+}
+
+export const HANDICAP_PROVENANCE_LABEL: Record<HandicapProvenance, string> = {
+  calculated: 'WHS index',
+  provisional: 'Provisional',
 }


### PR DESCRIPTION
Closes #521.

## Problem
The displayed `handicap_index` could be either a value the player typed at onboarding/settings or one derived from their rounds — with no way to tell which. (Mobile had no signal at all; web had an "OFFICIAL" badge but on the wrong threshold.)

## Approach
The number of rounds with a non-null `score_differential` is the signal. `calculateHandicapIndex` needs **≥3** differentials to produce a value (below that, the stored index is still the entered one). New `@oga/core` `handicapProvenance(count)` centralizes that threshold so web + mobile agree.

- **`@oga/core`**: `handicapProvenance(differentialsCount) → 'calculated' | 'provisional'`, `HANDICAP_PROVENANCE_LABEL` (`{ calculated: 'WHS index', provisional: 'Provisional' }`), and `MIN_ROUNDS_FOR_HANDICAP = 3` (now also used inside `calculateHandicapIndex`, replacing a magic `< 3`). +5 tests, incl. a parity test pinning the provenance threshold to the calc minimum.
- **Web** (`useHandicapMeta` + `Sidebar`): the hook used `official: count > 0` — so a 1–2-round user got an "OFFICIAL" badge while their stored index was still entered. **Fixed to the core `≥3` helper** and relabelled to "WHS index" / "Provisional" (badge now shows in both states; tooltip explains each).
- **Mobile** (`profile.tsx`): adds the same badge under the index, fed by a `score_differential` count query (manual fetch — mobile has no react-query).

## Known / deliberate
- **Mobile never computes differentials** (only web's finalize flow writes `score_differential`), so a mobile-only player always reads "Provisional". That's accurate to current behavior; **mobile handicap recompute is a separate gap** worth its own ticket, not folded in here.
- Approach A (infer from count) over a new `handicap_source` column — chosen to avoid a migration; the only case it mislabels is a web user who manually re-enters *after* playing ≥3 rated rounds (narrow, low-harm).

## Verification
- `pnpm typecheck` (web + core + supabase) ✅
- `cd apps/mobile && npm run typecheck` ✅
- `pnpm test` — 526 core tests pass (+5) ✅
- On-device + browser confirmation rides the next QA pass.

`merged-to-dev` on merge; closes on the `dev→main` release.