### PR TITLE
feat: call out the standout SG category on stats pages (#522)

### DIFF
--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -194,45 +194,7 @@ export default function Stats() {
           </View>
         ) : (
           <>
-            {stats &&
-              (() => {
-                const { weakest, strongest } = sgStandouts(stats.sg)
-                if (!weakest) return null
-                const showStrength =
-                  strongest != null &&
-                  strongest.key !== weakest.key &&
-                  strongest.value > 0
-                const leak =
-                  weakest.value < 0
-                    ? `Your biggest leak is ${SG_STANDOUT_LABEL[weakest.key]} — ${formatSG(weakest.value)} a round.`
-                    : `Your softest area is ${SG_STANDOUT_LABEL[weakest.key]} (${formatSG(weakest.value)} a round).`
-                const strength = showStrength
-                  ? ` ${SG_STANDOUT_LABEL[strongest.key]} is a strength, ${formatSG(strongest.value)} a round.`
-                  : ''
-                return (
-                  <View
-                    style={{
-                      borderLeftWidth: 2,
-                      borderColor: '#1F3D2C',
-                      paddingLeft: 14,
-                      marginBottom: 22,
-                    }}
-                  >
-                    <Text
-                      style={[TYPE.serif, {
-                        color: '#1C211C',
-                        fontSize: 17,
-                        fontStyle: 'italic',
-                        fontWeight: '500',
-                        lineHeight: 24,
-                      }]}
-                    >
-                      {leak}
-                      {strength}
-                    </Text>
-                  </View>
-                )
-              })()}
+            {stats && <StandoutCallout sg={stats.sg} />}
 
             <Section kicker={`Avg — last ${rounds.length} rounds`}>
               <View
@@ -731,4 +693,36 @@ function fmtInt(v: number | null): string {
 
 function fmtPct(v: number | null): string {
   return v != null ? `${v.toFixed(1)}%` : '—'
+}
+
+// Prose callout naming the leak (worst SG category) and, when distinct and
+// positive, the strength. Co-located: single caller, no closure-per-render.
+function StandoutCallout({ sg }: { sg: SGAverages }) {
+  const { weakest, strongest } = sgStandouts(sg)
+  if (!weakest) return null
+  const showStrength =
+    strongest != null && strongest.key !== weakest.key && strongest.value > 0
+  const leak =
+    weakest.value < 0
+      ? `Your biggest leak is ${SG_STANDOUT_LABEL[weakest.key]} — ${formatSG(weakest.value)} a round.`
+      : `Your softest area is ${SG_STANDOUT_LABEL[weakest.key]} (${formatSG(weakest.value)} a round).`
+  const strength = showStrength
+    ? ` ${SG_STANDOUT_LABEL[strongest.key]} is a strength, ${formatSG(strongest.value)} a round.`
+    : ''
+  return (
+    <View style={{ borderLeftWidth: 2, borderColor: '#1F3D2C', paddingLeft: 14, marginBottom: 22 }}>
+      <Text
+        style={[TYPE.serif, {
+          color: '#1C211C',
+          fontSize: 17,
+          fontStyle: 'italic',
+          fontWeight: '500',
+          lineHeight: 24,
+        }]}
+      >
+        {leak}
+        {strength}
+      </Text>
+    </View>
+  )
 }

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -6,10 +6,12 @@ import {
   computeDetailedStats,
   DEFAULT_HANDICAP,
   formatSG,
+  sgStandouts,
   YARDS_TO_METERS,
   type ApproachBandStat,
   type DetailedRound,
   type DetailedStats,
+  type SGAverages,
 } from '@oga/core'
 import { getRoundsWithDetails } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
@@ -19,6 +21,14 @@ import { AppBar } from '../../components/ui/AppBar'
 import { TYPE } from '../../lib/typography'
 
 const N_OPTIONS = [5, 10, 20] as const
+// Short labels for the standout callout, keyed to SGAverages (camelCase);
+// kept identical to the web stats page so the prose reads the same. #522
+const SG_STANDOUT_LABEL: Record<keyof SGAverages, string> = {
+  offTee: 'Off tee',
+  approach: 'Approach',
+  aroundGreen: 'Around green',
+  putting: 'Putting',
+}
 // Pin x-axis to chart bottom regardless of where y=0 falls in domain.
 const CHART_HEIGHT = 260
 const CHART_BOTTOM = 28
@@ -184,6 +194,46 @@ export default function Stats() {
           </View>
         ) : (
           <>
+            {stats &&
+              (() => {
+                const { weakest, strongest } = sgStandouts(stats.sg)
+                if (!weakest) return null
+                const showStrength =
+                  strongest != null &&
+                  strongest.key !== weakest.key &&
+                  strongest.value > 0
+                const leak =
+                  weakest.value < 0
+                    ? `Your biggest leak is ${SG_STANDOUT_LABEL[weakest.key]} — ${formatSG(weakest.value)} a round.`
+                    : `Your softest area is ${SG_STANDOUT_LABEL[weakest.key]} (${formatSG(weakest.value)} a round).`
+                const strength = showStrength
+                  ? ` ${SG_STANDOUT_LABEL[strongest.key]} is a strength, ${formatSG(strongest.value)} a round.`
+                  : ''
+                return (
+                  <View
+                    style={{
+                      borderLeftWidth: 2,
+                      borderColor: '#1F3D2C',
+                      paddingLeft: 14,
+                      marginBottom: 22,
+                    }}
+                  >
+                    <Text
+                      style={[TYPE.serif, {
+                        color: '#1C211C',
+                        fontSize: 17,
+                        fontStyle: 'italic',
+                        fontWeight: '500',
+                        lineHeight: 24,
+                      }]}
+                    >
+                      {leak}
+                      {strength}
+                    </Text>
+                  </View>
+                )
+              })()}
+
             <Section kicker={`Avg — last ${rounds.length} rounds`}>
               <View
                 style={{

--- a/apps/web/src/pages/stats/sections/StrokesGainedSection.tsx
+++ b/apps/web/src/pages/stats/sections/StrokesGainedSection.tsx
@@ -8,7 +8,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import type { DetailedStats } from '@oga/core'
+import { formatSG, sgStandouts, type DetailedStats, type SGAverages } from '@oga/core'
 import { Insufficient, Section, Subkicker } from '../components/Section'
 import { ApproachBandTile, SgTile } from '../components/StatTiles'
 
@@ -72,8 +72,45 @@ export function StrokesGainedSection({ data }: { data: DetailedStats }) {
     putting: t.putting,
   }))
 
+  const standouts = sgStandouts(data.sg)
+  const sgLabel = (key: keyof SGAverages) =>
+    SG_SERIES.find((s) => s.key === key)?.label ?? key
+
   return (
     <Section kicker="Strokes gained">
+      {standouts.weakest && (
+        <p
+          style={{
+            fontFamily: 'Fraunces, serif',
+            fontStyle: 'italic',
+            fontSize: 15,
+            lineHeight: 1.5,
+            color: '#1C211C',
+            borderLeft: '2px solid #1F3D2C',
+            paddingLeft: 14,
+            margin: '0 0 22px',
+          }}
+        >
+          {standouts.weakest.value < 0 ? (
+            <>
+              Your biggest leak is <strong>{sgLabel(standouts.weakest.key)}</strong> — {formatSG(standouts.weakest.value)} a round.
+            </>
+          ) : (
+            <>
+              Your softest area is <strong>{sgLabel(standouts.weakest.key)}</strong> ({formatSG(standouts.weakest.value)} a round).
+            </>
+          )}
+          {standouts.strongest &&
+            standouts.strongest.key !== standouts.weakest.key &&
+            standouts.strongest.value > 0 && (
+              <>
+                {' '}
+                <strong>{sgLabel(standouts.strongest.key)}</strong> is a strength, {formatSG(standouts.strongest.value)} a round.
+              </>
+            )}
+        </p>
+      )}
+
       <div className="grid grid-cols-2 sm:grid-cols-4" style={{ gap: 14, marginBottom: 22 }}>
         {series.map((s) => (
           <SgTile key={s.key} label={s.label} color={s.color} value={s.value} />

--- a/packages/core/src/__tests__/stats.test.ts
+++ b/packages/core/src/__tests__/stats.test.ts
@@ -4,6 +4,7 @@ import {
   getProximityYards,
   scoringDistribution,
   scoringStats,
+  sgStandouts,
   shortGameStats,
   type DetailedHoleScore,
   type DetailedRound,
@@ -448,5 +449,37 @@ describe('combinedPuttResult', () => {
     expect(combinedPuttResult({})).toBeNull()
     expect(combinedPuttResult({ made: false })).toBeNull()
     expect(combinedPuttResult({ made: false, distance: null, direction: null })).toBeNull()
+  })
+})
+
+describe('sgStandouts', () => {
+  it('returns nulls when no category has data', () => {
+    expect(
+      sgStandouts({ offTee: null, approach: null, aroundGreen: null, putting: null }),
+    ).toEqual({ weakest: null, strongest: null })
+  })
+
+  it('picks the lowest as weakest and highest as strongest', () => {
+    const s = sgStandouts({ offTee: 0.4, approach: -0.8, aroundGreen: 0.1, putting: -0.2 })
+    expect(s.weakest).toEqual({ key: 'approach', value: -0.8 })
+    expect(s.strongest).toEqual({ key: 'offTee', value: 0.4 })
+  })
+
+  it('ignores null categories when ranking', () => {
+    const s = sgStandouts({ offTee: null, approach: -0.3, aroundGreen: null, putting: 0.5 })
+    expect(s.weakest).toEqual({ key: 'approach', value: -0.3 })
+    expect(s.strongest).toEqual({ key: 'putting', value: 0.5 })
+  })
+
+  it('weakest and strongest are the same entry when only one category has data', () => {
+    const s = sgStandouts({ offTee: null, approach: 0.2, aroundGreen: null, putting: null })
+    expect(s.weakest).toEqual({ key: 'approach', value: 0.2 })
+    expect(s.strongest).toEqual({ key: 'approach', value: 0.2 })
+  })
+
+  it('all-positive: weakest is the smallest gain, not necessarily a loss', () => {
+    const s = sgStandouts({ offTee: 0.1, approach: 0.6, aroundGreen: 0.3, putting: 0.9 })
+    expect(s.weakest).toEqual({ key: 'offTee', value: 0.1 })
+    expect(s.strongest).toEqual({ key: 'putting', value: 0.9 })
   })
 })

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -126,6 +126,45 @@ export function sgAverages(rounds: DetailedRound[]): SGAverages {
   return out
 }
 
+export interface SGStandout {
+  key: keyof SGAverages
+  value: number
+}
+
+export interface SGStandouts {
+  /** Lowest-scoring category with data — the biggest leak when negative. */
+  weakest: SGStandout | null
+  /** Highest-scoring category with data — a strength when positive. */
+  strongest: SGStandout | null
+}
+
+// Picks the lowest (biggest leak) and highest (biggest strength) SG
+// category from the per-round averages, ignoring categories with no data.
+// weakest and strongest are the same entry when only one category has
+// data, and both null when none do. Sign is left to the caller: a negative
+// weakest reads as a leak, a positive strongest as a strength. #522
+export function sgStandouts(sg: SGAverages): SGStandouts {
+  const entries = (
+    [
+      ['offTee', sg.offTee],
+      ['approach', sg.approach],
+      ['aroundGreen', sg.aroundGreen],
+      ['putting', sg.putting],
+    ] as const
+  ).filter((e): e is [keyof SGAverages, number] => e[1] != null)
+  if (entries.length === 0) return { weakest: null, strongest: null }
+  let weakest = entries[0]!
+  let strongest = entries[0]!
+  for (const e of entries) {
+    if (e[1] < weakest[1]) weakest = e
+    if (e[1] > strongest[1]) strongest = e
+  }
+  return {
+    weakest: { key: weakest[0], value: weakest[1] },
+    strongest: { key: strongest[0], value: strongest[1] },
+  }
+}
+
 export type SGBreakdownKey =
   | 'sg_off_tee'
   | 'sg_approach'

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -138,11 +138,8 @@ export interface SGStandouts {
   strongest: SGStandout | null
 }
 
-// Picks the lowest (biggest leak) and highest (biggest strength) SG
-// category from the per-round averages, ignoring categories with no data.
 // weakest and strongest are the same entry when only one category has
-// data, and both null when none do. Sign is left to the caller: a negative
-// weakest reads as a leak, a positive strongest as a strength. #522
+// data, and both null when none do. Sign is left to the caller. #522
 export function sgStandouts(sg: SGAverages): SGStandouts {
   const entries = (
     [


### PR DESCRIPTION
Closes #522.

## Problem
The stats pages showed four strokes-gained category averages but never said which was the **leak** or the **strength** — the player had to eyeball four numbers.

## Fix
New `@oga/core` `sgStandouts(sg)` picks the lowest (biggest leak) and highest (biggest strength) category from the per-round SG averages — null-safe, sign left to the caller, weakest===strongest when only one category has data. Pure + tested (+5).

A one-line prose callout renders on both surfaces, calibrated to the same handicap-bracket SG the tiles already use:
- **Web** `StrokesGainedSection`: italic note above the SG tiles ("Your biggest leak is **Approach** — -0.8 a round. **Off tee** is a strength, +0.4 a round.").
- **Mobile** `stats.tsx`: same prose in a left-border note above the averages, using a label map kept identical to web's `SG_SERIES`.

Copy adapts to sign: "biggest leak" when the weakest category is negative, "softest area" when it's still positive; the strength clause only shows when it's a distinct, positive category.

## Verification
- `pnpm typecheck` (web + core + supabase) ✅
- `cd apps/mobile && npm run typecheck` ✅
- `pnpm test` — 531 core tests (+5 `sgStandouts`) ✅

`merged-to-dev` on merge; closes on the `dev→main` release.