### PR TITLE
feat(mobile): handicap differential + index recompute (rated tees)

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -30,6 +30,7 @@ import type { Database } from '@oga/supabase'
 import { supabase } from '../../../../lib/supabase'
 import { completeRound } from '../../../../lib/completeRound'
 import { ShareableScorecardCard } from '../../../../components/round/ShareableScorecardCard'
+import { RoundTeeSelector } from '../../../../components/round/RoundTeeSelector'
 import { PastHoleShotsSheet } from '../../../../components/round/PastHoleShotsSheet'
 import { PastRoundMap } from '../../../../components/round/PastRoundMap'
 import { ScoreCell, TabSwitcher } from '../../../../components/round/PastScorecardParts'
@@ -816,6 +817,20 @@ export default function RoundIndex() {
             )
           })}
         </View>
+
+        {user && (
+          <RoundTeeSelector
+            courseId={round.course_id}
+            roundId={round.id}
+            userId={user.id}
+            currentTeeId={round.course_tee_id}
+            onChange={(tee) =>
+              setRound((r) =>
+                r ? { ...r, course_tee_id: tee.id, tee_color: tee.color } : r,
+              )
+            }
+          />
+        )}
 
         <Pressable
           accessibilityRole="button"

--- a/apps/mobile/components/round/RoundTeeSelector.tsx
+++ b/apps/mobile/components/round/RoundTeeSelector.tsx
@@ -40,21 +40,22 @@ export function RoundTeeSelector({
 
   useEffect(() => {
     let active = true
-    getCourseTees(supabase, courseId)
-      .then(({ data }) => {
+    ;(async () => {
+      try {
+        const { data } = await getCourseTees(supabase, courseId)
         if (active) {
           setTees(data ?? [])
           setLoading(false)
         }
-      })
-      .catch(() => {
+      } catch {
         // Network failure: drop to an empty list rather than stranding the
         // component on "Loading tees…" with an unhandled rejection.
         if (active) {
           setTees([])
           setLoading(false)
         }
-      })
+      }
+    })()
     return () => {
       active = false
     }

--- a/apps/mobile/components/round/RoundTeeSelector.tsx
+++ b/apps/mobile/components/round/RoundTeeSelector.tsx
@@ -40,12 +40,21 @@ export function RoundTeeSelector({
 
   useEffect(() => {
     let active = true
-    getCourseTees(supabase, courseId).then(({ data }) => {
-      if (active) {
-        setTees(data ?? [])
-        setLoading(false)
-      }
-    })
+    getCourseTees(supabase, courseId)
+      .then(({ data }) => {
+        if (active) {
+          setTees(data ?? [])
+          setLoading(false)
+        }
+      })
+      .catch(() => {
+        // Network failure: drop to an empty list rather than stranding the
+        // component on "Loading tees…" with an unhandled rejection.
+        if (active) {
+          setTees([])
+          setLoading(false)
+        }
+      })
     return () => {
       active = false
     }
@@ -274,10 +283,10 @@ function TeeField({
   ...input
 }: {
   label: string
-  width: string
+  width: import('react-native').DimensionValue
 } & React.ComponentProps<typeof TextInput>) {
   return (
-    <View style={{ width: width as `${number}%`, gap: 4 }}>
+    <View style={{ width, gap: 4 }}>
       <Text style={{ ...KICKER, fontSize: 9 }}>{label}</Text>
       <TextInput
         {...input}

--- a/apps/mobile/components/round/RoundTeeSelector.tsx
+++ b/apps/mobile/components/round/RoundTeeSelector.tsx
@@ -1,0 +1,297 @@
+import { useEffect, useState } from 'react'
+import { Alert, Pressable, Text, TextInput, View } from 'react-native'
+import { getCourseTees, updateRound, upsertCourseTees } from '@oga/supabase'
+import type { Database } from '@oga/supabase'
+import { supabase } from '../../lib/supabase'
+import { FONT, TYPE } from '../../lib/typography'
+
+type CourseTeeRow = Database['public']['Tables']['course_tees']['Row']
+
+const KICKER: import('react-native').TextStyle = {
+  fontFamily: FONT.mono,
+  color: '#8A8B7E',
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+// Picks (or adds) the tee played so the finalize pass can compute a WHS
+// score differential — a tee with course rating + slope is the one input
+// the crawler can't supply, so the player records it here. Mirrors the web
+// TeeSelector; persists course_tee_id + tee_color onto the round itself.
+export function RoundTeeSelector({
+  courseId,
+  roundId,
+  userId,
+  currentTeeId,
+  onChange,
+}: {
+  courseId: string
+  roundId: string
+  userId: string
+  currentTeeId: string | null
+  onChange: (tee: { id: string; color: string }) => void
+}) {
+  const [tees, setTees] = useState<CourseTeeRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [adding, setAdding] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    let active = true
+    getCourseTees(supabase, courseId).then(({ data }) => {
+      if (active) {
+        setTees(data ?? [])
+        setLoading(false)
+      }
+    })
+    return () => {
+      active = false
+    }
+  }, [courseId])
+
+  async function selectTee(tee: { id: string; tee_color: string }) {
+    setBusy(true)
+    try {
+      const { error } = await updateRound(
+        supabase,
+        roundId,
+        { course_tee_id: tee.id, tee_color: tee.tee_color },
+        userId,
+      )
+      if (error) throw error
+      onChange({ id: tee.id, color: tee.tee_color })
+    } catch (e) {
+      Alert.alert('Could not set tee', (e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function addTee(vals: {
+    color: string
+    rating: number | null
+    slope: number | null
+    yards: number | null
+  }) {
+    setBusy(true)
+    try {
+      const { data, error } = await upsertCourseTees(supabase, [
+        {
+          course_id: courseId,
+          tee_color: vals.color.toLowerCase(),
+          course_rating: vals.rating,
+          slope_rating: vals.slope,
+          total_yards: vals.yards,
+        },
+      ])
+      if (error) throw error
+      const created = (data ?? [])[0] as CourseTeeRow | undefined
+      if (!created) throw new Error('Tee not created')
+      setTees((prev) => {
+        const without = prev.filter((t) => t.id !== created.id)
+        return [...without, created]
+      })
+      setAdding(false)
+      await selectTee(created)
+    } catch (e) {
+      Alert.alert('Could not add tee', (e as Error).message)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <View
+      style={{
+        borderTopWidth: 1,
+        borderColor: '#D9D2BF',
+        paddingTop: 14,
+        marginTop: 8,
+      }}
+    >
+      <Text style={{ ...KICKER, marginBottom: 4 }}>Tee played</Text>
+      <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 12, marginBottom: 12 }]}>
+        Add the tee's rating and slope to get a handicap differential.
+      </Text>
+
+      {loading ? (
+        <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 13 }]}>Loading tees…</Text>
+      ) : (
+        <View style={{ gap: 8 }}>
+          {tees.map((t) => {
+            const active = currentTeeId === t.id
+            const hasRating = t.course_rating != null && t.slope_rating != null
+            return (
+              <Pressable
+                key={t.id}
+                onPress={() => selectTee(t)}
+                disabled={busy}
+                style={{
+                  flexDirection: 'row',
+                  alignItems: 'baseline',
+                  justifyContent: 'space-between',
+                  backgroundColor: active ? '#1F3D2C' : '#FBF8F1',
+                  borderWidth: 1,
+                  borderColor: active ? '#1F3D2C' : '#D9D2BF',
+                  borderRadius: 2,
+                  paddingVertical: 12,
+                  paddingHorizontal: 14,
+                  opacity: busy ? 0.5 : 1,
+                }}
+              >
+                <Text
+                  style={[TYPE.serif, {
+                    color: active ? '#F2EEE5' : '#1C211C',
+                    fontSize: 16,
+                    fontStyle: 'italic',
+                    fontWeight: '500',
+                    textTransform: 'capitalize',
+                  }]}
+                >
+                  {t.tee_color}
+                </Text>
+                <Text
+                  style={{
+                    ...KICKER,
+                    color: active ? 'rgba(242,238,229,0.75)' : '#5C6356',
+                  }}
+                >
+                  {hasRating ? `${t.course_rating?.toFixed(1)} / ${t.slope_rating}` : 'No rating'}
+                </Text>
+              </Pressable>
+            )
+          })}
+
+          {adding ? (
+            <AddTeeForm busy={busy} onCancel={() => setAdding(false)} onSubmit={addTee} />
+          ) : (
+            <Pressable
+              onPress={() => setAdding(true)}
+              disabled={busy}
+              style={{
+                borderWidth: 1,
+                borderColor: '#D9D2BF',
+                borderStyle: 'dashed',
+                borderRadius: 2,
+                paddingVertical: 11,
+                alignItems: 'center',
+              }}
+            >
+              <Text style={{ ...KICKER, color: '#5C6356' }}>+ Add tee</Text>
+            </Pressable>
+          )}
+        </View>
+      )}
+    </View>
+  )
+}
+
+function AddTeeForm({
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  busy: boolean
+  onCancel: () => void
+  onSubmit: (vals: {
+    color: string
+    rating: number | null
+    slope: number | null
+    yards: number | null
+  }) => void
+}) {
+  const [color, setColor] = useState('white')
+  const [rating, setRating] = useState('')
+  const [slope, setSlope] = useState('')
+  const [yards, setYards] = useState('')
+
+  // Postgres numeric accepts 'NaN'; filter to finite to avoid poisoning the
+  // differential math (mirrors the bag form's parseNumOrNull).
+  function num(s: string): number | null {
+    if (!s.trim()) return null
+    const n = Number(s)
+    return Number.isFinite(n) ? n : null
+  }
+
+  return (
+    <View
+      style={{
+        backgroundColor: '#FBF8F1',
+        borderWidth: 1,
+        borderColor: '#D9D2BF',
+        borderRadius: 2,
+        padding: 14,
+        gap: 10,
+      }}
+    >
+      <Text style={{ ...KICKER }}>Add tee</Text>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 8 }}>
+        <TeeField label="Color" value={color} onChangeText={setColor} width="100%" autoCapitalize="none" />
+        <TeeField label="Rating" value={rating} onChangeText={setRating} placeholder="71.2" keyboardType="decimal-pad" width="31%" />
+        <TeeField label="Slope" value={slope} onChangeText={setSlope} placeholder="124" keyboardType="number-pad" width="31%" />
+        <TeeField label="Yards" value={yards} onChangeText={setYards} placeholder="6450" keyboardType="number-pad" width="31%" />
+      </View>
+      <View style={{ flexDirection: 'row', justifyContent: 'flex-end', gap: 8 }}>
+        <Pressable
+          onPress={onCancel}
+          style={{
+            borderWidth: 1,
+            borderColor: '#D9D2BF',
+            borderRadius: 2,
+            paddingVertical: 9,
+            paddingHorizontal: 14,
+          }}
+        >
+          <Text style={[TYPE.body, { color: '#5C6356', fontSize: 13 }]}>Cancel</Text>
+        </Pressable>
+        <Pressable
+          onPress={() =>
+            color.trim() &&
+            onSubmit({ color, rating: num(rating), slope: num(slope), yards: num(yards) })
+          }
+          disabled={busy || !color.trim()}
+          style={{
+            backgroundColor: busy || !color.trim() ? '#9F9580' : '#1F3D2C',
+            borderRadius: 2,
+            paddingVertical: 9,
+            paddingHorizontal: 16,
+          }}
+        >
+          <Text style={[TYPE.bodyBold, { color: '#F2EEE5', fontSize: 13, fontWeight: '600' }]}>
+            {busy ? 'Saving…' : 'Add tee'}
+          </Text>
+        </Pressable>
+      </View>
+    </View>
+  )
+}
+
+function TeeField({
+  label,
+  width,
+  ...input
+}: {
+  label: string
+  width: string
+} & React.ComponentProps<typeof TextInput>) {
+  return (
+    <View style={{ width: width as `${number}%`, gap: 4 }}>
+      <Text style={{ ...KICKER, fontSize: 9 }}>{label}</Text>
+      <TextInput
+        {...input}
+        style={[TYPE.body, {
+          backgroundColor: '#FFFFFF',
+          borderWidth: 1,
+          borderColor: '#D9D2BF',
+          borderRadius: 2,
+          paddingHorizontal: 10,
+          paddingVertical: 8,
+          fontSize: 14,
+          color: '#1C211C',
+        }]}
+      />
+    </View>
+  )
+}

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -1,8 +1,16 @@
-import { computeRoundSG, inferHoleStats } from '@oga/core'
 import {
+  adjustedScore,
+  calculateDifferential,
+  calculateHandicapIndex,
+  computeRoundSG,
+  inferHoleStats,
+} from '@oga/core'
+import {
+  getCourseTees,
   getHoleScoresForRound,
   getHolesForCourse,
   getShotsForRound,
+  updateProfile,
   updateRound,
 } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
@@ -12,6 +20,7 @@ import { syncPendingShots } from './sync'
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
 type ShotRow = Database['public']['Tables']['shots']['Row']
 type HoleRow = Database['public']['Tables']['holes']['Row']
+type CourseTeeRow = Database['public']['Tables']['course_tees']['Row']
 
 interface CompleteArgs {
   roundId: string
@@ -33,10 +42,16 @@ export async function completeRound({
 }: CompleteArgs): Promise<void> {
   await syncPendingShots().catch(() => undefined)
 
-  const [holesRes, holeScoresRes, shotsRes] = await Promise.all([
+  const [holesRes, holeScoresRes, shotsRes, teesRes, roundRes] = await Promise.all([
     getHolesForCourse(supabase, courseId),
     getHoleScoresForRound(supabase, roundId),
     getShotsForRound(supabase, roundId, userId),
+    getCourseTees(supabase, courseId),
+    supabase
+      .from('rounds')
+      .select('course_tee_id, tee_color')
+      .eq('id', roundId)
+      .single(),
   ])
   if (holesRes.error) throw holesRes.error
   if (holeScoresRes.error) throw holeScoresRes.error
@@ -51,6 +66,8 @@ export async function completeRound({
     return rest
   })
   const shots = (shotsRes.data ?? []) as unknown as ShotRow[]
+  const tees: CourseTeeRow[] = teesRes.data ?? []
+  const roundTee = roundRes.data ?? null
 
   // Infer fairway_hit + gir for any hole where the player didn't set
   // them manually. Mobile live mode never writes those columns
@@ -135,6 +152,41 @@ export async function completeRound({
     if (sgError) throw sgError
   }
 
+  // ---- Handicap differential ------------------------------------------
+  // Mirrors web's useCompleteRound: resolve the played tee (by id, else by
+  // colour), and if it carries a course rating + slope, compute the WHS
+  // score differential from the ESC-adjusted gross. Null when no rated tee
+  // is on the round — common, since most crawled courses have no tee data.
+  const tee =
+    (roundTee?.course_tee_id
+      ? tees.find((t) => t.id === roundTee.course_tee_id)
+      : null) ??
+    (roundTee?.tee_color
+      ? tees.find((t) => t.tee_color === roundTee.tee_color!.toLowerCase())
+      : null) ??
+    null
+  let differential: number | null = null
+  if (
+    tee &&
+    tee.course_rating != null &&
+    tee.slope_rating != null &&
+    tee.slope_rating > 0
+  ) {
+    const holeRows = holeScores
+      .map((hs) => {
+        const h = holesById.get(hs.hole_id)
+        if (!h) return null
+        return { score: hs.score, par: h.par }
+      })
+      .filter((x): x is { score: number; par: number } => !!x)
+    if (holeRows.length > 0) {
+      const adjusted = adjustedScore(holeRows, handicap ?? 18)
+      differential = round2(
+        calculateDifferential(adjusted, tee.course_rating, tee.slope_rating),
+      )
+    }
+  }
+
   const { error: roundError } = await updateRound(
     supabase,
     roundId,
@@ -151,10 +203,39 @@ export async function completeRound({
         result.totals.fairwaysTotal > 0 ? result.totals.fairwaysHit : null,
       fairways_total: result.totals.fairwaysTotal || null,
       gir: result.totals.gir,
+      course_tee_id: tee?.id ?? roundTee?.course_tee_id ?? null,
+      score_differential: differential,
     },
     userId,
   )
   if (roundError) throw roundError
+
+  // ---- Handicap index recompute --------------------------------------
+  // Once this round contributes a differential, re-derive the WHS index
+  // from the most recent 20 and write it to the profile. Below 3 total
+  // differentials calculateHandicapIndex returns null and the entered
+  // value stands. Mirrors web; this is what makes a mobile player's index
+  // become a calculated "WHS index" rather than staying "Provisional".
+  if (differential != null) {
+    const { data: recentDiffs, error: diffsError } = await supabase
+      .from('rounds')
+      .select('score_differential')
+      .eq('user_id', userId)
+      .not('score_differential', 'is', null)
+      .order('played_at', { ascending: false })
+      .limit(20)
+    if (diffsError) throw diffsError
+    const diffs = (recentDiffs ?? [])
+      .map((r) => r.score_differential)
+      .filter((d): d is number => d != null)
+    const newIndex = calculateHandicapIndex(diffs)
+    if (newIndex != null) {
+      const { error: profileError } = await updateProfile(supabase, userId, {
+        handicap_index: newIndex,
+      })
+      if (profileError) throw profileError
+    }
+  }
 }
 
 function round2(n: number): number {


### PR DESCRIPTION
Builds on #536 (#521). Surfaced there: **mobile never recomputes a handicap** — it records no played tee and never computes a `score_differential`, so a mobile player's `handicap_index` stays the entered value forever ("Provisional"). All WHS calculation was web-only. Data confirms it's dormant app-wide: 0 of 11 prod rounds have a differential, and only 1 of 15,297 courses has a rated tee.

## Root cause
A WHS differential needs the played tee's **course rating + slope**, which the crawler (OpenGolfAPI/OSM) doesn't carry. Web has a `TeeSelector` to record one; mobile had nothing.

## Fix
**Capture** (`RoundTeeSelector`, new) — on the round detail screen, pick an existing `course_tees` row or add one (colour / rating / slope / yards), persisting `course_tee_id` + `tee_color` on the round. Mirrors web's `TeeSelector`; the 0037 RLS allows the insert (`created_by` defaults to `auth.uid()`).

**Compute** (`lib/completeRound.ts`) — both finalize paths (live end-round + past Save-SG) funnel through `completeRound()`, so the recompute lives there once, mirroring web's `useCompleteRound`:
1. Resolve the round's tee (by id, else colour).
2. If it has rating + slope, compute the WHS differential from the ESC-adjusted gross; stamp `score_differential` + `course_tee_id` on the round.
3. Recompute the index from the most recent 20 differentials; write the profile.

Reuses `@oga/core` math (`adjustedScore` / `calculateDifferential` / `calculateHandicapIndex`) — no new core logic. Differential stays `null` when no rated tee is recorded (the common case), so behavior is unchanged for courses without tee data; the index only becomes a calculated "WHS index" once ≥3 rated rounds exist.

## Verification
- `cd apps/mobile && npm run typecheck` ✅
- On-device validation needed (tee add/select → Save SG → differential written → profile index flips from "Provisional" to "WHS index" at the 3rd rated round). Rides the next QA build.

## Note
Pairs with #536's provenance label. With this merged, a mobile-primary player can finally reach a calculated index — closing the gap that PR flagged.