### PR TITLE
fix(mobile): bound My Bag list height so footer is reachable (#528)

### DIFF
--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -263,6 +263,11 @@ export default function BagScreen() {
           data={bag}
           keyExtractor={(c) => c.id}
           onDragEnd={({ data }) => onDragEnd(data)}
+          // The list is the last child of a flex:1 root next to the AppBar.
+          // Without a bounded height it sizes to content and pushes the
+          // footer (Add club / Reset to default bag) off-screen with no
+          // scroll — react-native-draggable-flatlist needs flex:1 here (#528).
+          containerStyle={{ flex: 1 }}
           contentContainerStyle={{ padding: 18, paddingBottom: insets.bottom + 24 }}
           ListHeaderComponent={
             <View style={{ marginBottom: 18 }}>


### PR DESCRIPTION
## Problem (on-device, iPhone)

The My Bag screen still cuts off at the bottom — the **Reset to default bag** option isn't reachable. The #528 inset fix (`5351d9e`) added `paddingBottom: insets.bottom + 24` but that only pads the scroll *content*; it didn't address the real cause.

## Root cause

The `DraggableFlatList` had no bounded height (no `containerStyle`). As the last child of a `flex:1` root next to the `AppBar`, it sizes to its content, so when the bag is full the footer (Add club / Reset to default bag) is pushed past the viewport with no scroll. `react-native-draggable-flatlist` requires a bounded-height container.

## Fix

One line: `containerStyle={{ flex: 1 }}` on the list, so it fills the remaining space and scrolls to the footer.

## Test
- `npm run typecheck` clean.
- On-device QA pending (the symptom was found on iPhone).