### PR TITLE
feat(mobile): tee selection at round creation (#542)

### DIFF
--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -30,6 +30,7 @@ import type { Database } from '@oga/supabase'
 import { supabase } from '../../../lib/supabase'
 import { useAuth } from '../../../hooks/useAuth'
 import { FONT, TYPE } from '../../../lib/typography'
+import { TeePicker } from '../../../components/round/RoundTeeSelector'
 
 type CourseRow = Database['public']['Tables']['courses']['Row']
 type HoleInsert = Database['public']['Tables']['holes']['Insert']
@@ -66,6 +67,13 @@ export default function NewRound() {
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [showManualForm, setShowManualForm] = useState(false)
+  // Once a course is resolved we step to a lightweight setup view (tee pick)
+  // before creating the round — mirrors web's NewRoundPage, where tee is an
+  // up-front field. Null = still on the course-search screen.
+  const [pendingCourse, setPendingCourse] = useState<{
+    id: string
+    name: string
+  } | null>(null)
   const [gps, setGps] = useState<GpsState>({ status: 'idle' })
   const searchAbort = useRef<AbortController | null>(null)
   const insets = useSafeAreaInsets()
@@ -164,7 +172,10 @@ export default function NewRound() {
   // actually meant (#472). Mirrors web CourseSearch.
   const showAddNew = !searching && debouncedQuery.trim().length > 0
 
-  async function startWith(courseId: string) {
+  async function startWith(
+    courseId: string,
+    tee?: { courseTeeId: string | null; teeColor: string | null },
+  ) {
     if (!user) return
     setBusy(true)
     setError(null)
@@ -179,6 +190,11 @@ export default function NewRound() {
         // scorecard, never the live map state machine. Live rounds leave
         // total_score null — that's the in-progress signal. See #514.
         ...(mode === 'past' ? { total_score: 0 } : {}),
+        // Tee is optional; only record it when the player picked one in the
+        // setup step. A rated tee is the input WHS differentials need (#542).
+        ...(tee?.courseTeeId
+          ? { course_tee_id: tee.courseTeeId, tee_color: tee.teeColor }
+          : {}),
       })
       if (roundError || !round) throw roundError ?? new Error('Round insert failed')
 
@@ -263,7 +279,8 @@ export default function NewRound() {
     try {
       const { data: existing } = await getCourseByExternalId(supabase, r.id)
       if (existing) {
-        await startWith(existing.id)
+        setPendingCourse({ id: existing.id, name: existing.name })
+        setBusy(false)
         return
       }
       const detail = await getOpenGolfApiCourse(r.id)
@@ -317,7 +334,8 @@ export default function NewRound() {
           })),
         )
       }
-      await startWith(course.id)
+      setPendingCourse({ id: course.id, name: detail.name || r.name })
+      setBusy(false)
     } catch (err) {
       setError((err as Error).message)
       setBusy(false)
@@ -361,13 +379,29 @@ export default function NewRound() {
             }))
             const { error: holeErr } = await createHoles(supabase, holes)
             if (holeErr) throw holeErr
-            await startWith(course.id)
             setShowManualForm(false)
+            setPendingCourse({ id: course.id, name: name.trim() })
+            setBusy(false)
           } catch (err) {
             setError((err as Error).message)
             setBusy(false)
           }
         }}
+      />
+    )
+  }
+
+  if (pendingCourse) {
+    return (
+      <RoundSetupStep
+        courseId={pendingCourse.id}
+        courseName={pendingCourse.name}
+        mode={mode}
+        busy={busy}
+        onBack={() => setPendingCourse(null)}
+        onStart={(courseTeeId, teeColor) =>
+          startWith(pendingCourse.id, { courseTeeId, teeColor })
+        }
       />
     )
   }
@@ -416,7 +450,7 @@ export default function NewRound() {
             {localResults.map((c) => (
               <Pressable
                 key={c.id}
-                onPress={() => startWith(c.id)}
+                onPress={() => setPendingCourse({ id: c.id, name: c.name })}
                 disabled={busy}
                 style={{
                   borderTopWidth: 1,
@@ -516,6 +550,121 @@ export default function NewRound() {
           Course data from OpenGolfAPI · ODbL licensed
         </Text>
       </ScrollView>
+    </View>
+  )
+}
+
+// Setup step shown after a course is resolved but before the round is
+// created — mirrors web's NewRoundPage where the tee is an up-front field.
+// Tee is optional so it never blocks pace of play; "Start round" works with
+// no tee picked, and the scorecard can still set it later.
+function RoundSetupStep({
+  courseId,
+  courseName,
+  mode,
+  busy,
+  onBack,
+  onStart,
+}: {
+  courseId: string
+  courseName: string
+  mode: 'live' | 'past'
+  busy: boolean
+  onBack: () => void
+  onStart: (courseTeeId: string | null, teeColor: string | null) => void
+}) {
+  const insets = useSafeAreaInsets()
+  const [teeId, setTeeId] = useState<string | null>(null)
+  const [teeColor, setTeeColor] = useState<string | null>(null)
+
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: '#F2EEE5',
+        paddingTop: insets.top + 14,
+        paddingHorizontal: 18,
+      }}
+    >
+      <Text style={{ ...KICKER, marginBottom: 6 }}>
+        {mode === 'past' ? 'Log past round' : 'Start live round'}
+      </Text>
+      <Text
+        style={[TYPE.serif, {
+          color: '#1C211C',
+          fontSize: 28,
+          fontWeight: '500',
+          fontStyle: 'italic',
+          marginBottom: 18,
+        }]}
+      >
+        {courseName}
+      </Text>
+
+      <Text style={{ ...KICKER, marginBottom: 4 }}>Tee played</Text>
+      <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 12, marginBottom: 12 }]}>
+        Optional — add the tee's rating and slope for a handicap differential.
+        You can set it later from the scorecard.
+      </Text>
+
+      <ScrollView keyboardShouldPersistTaps="handled" style={{ flex: 1 }}>
+        <TeePicker
+          courseId={courseId}
+          selectedTeeId={teeId}
+          onSelect={(t) => {
+            setTeeId(t.id)
+            setTeeColor(t.tee_color)
+          }}
+          busy={busy}
+        />
+      </ScrollView>
+
+      <View
+        style={{
+          flexDirection: 'row',
+          gap: 10,
+          paddingVertical: 14,
+          paddingBottom: insets.bottom + 14,
+        }}
+      >
+        <Pressable
+          onPress={onBack}
+          disabled={busy}
+          style={{
+            flex: 1,
+            borderWidth: 1,
+            borderColor: '#D9D2BF',
+            borderRadius: 2,
+            paddingVertical: 14,
+            alignItems: 'center',
+            opacity: busy ? 0.5 : 1,
+          }}
+        >
+          <Text style={[TYPE.body, { color: '#5C6356', fontSize: 13 }]}>Back</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => onStart(teeId, teeColor)}
+          disabled={busy}
+          style={{
+            flex: 2,
+            backgroundColor: busy ? '#9F9580' : '#1F3D2C',
+            borderRadius: 2,
+            paddingVertical: 14,
+            alignItems: 'center',
+          }}
+        >
+          <Text
+            style={[TYPE.bodyBold, {
+              color: '#F2EEE5',
+              fontSize: 14,
+              fontWeight: '600',
+              letterSpacing: 0.3,
+            }]}
+          >
+            {busy ? 'Starting…' : mode === 'past' ? 'Log round →' : 'Start round →'}
+          </Text>
+        </Pressable>
+      </View>
     </View>
   )
 }

--- a/apps/mobile/components/round/RoundTeeSelector.tsx
+++ b/apps/mobile/components/round/RoundTeeSelector.tsx
@@ -16,27 +16,28 @@ const KICKER: import('react-native').TextStyle = {
   textTransform: 'uppercase',
 }
 
-// Picks (or adds) the tee played so the finalize pass can compute a WHS
-// score differential — a tee with course rating + slope is the one input
-// the crawler can't supply, so the player records it here. Mirrors the web
-// TeeSelector; persists course_tee_id + tee_color onto the round itself.
-export function RoundTeeSelector({
+// Presentational tee picker: lists a course's tees and lets the player add
+// one (rating/slope/yards). Selection is reported via `onSelect` — it does
+// NOT persist anything to a round, so it works both before a round exists
+// (round/new.tsx setup step) and against an existing round (the scorecard
+// wrapper below). Adding a tee creates a course-level `course_tees` row and
+// immediately selects it. `busy` lets a caller disable the list while it
+// persists the selection elsewhere.
+export function TeePicker({
   courseId,
-  roundId,
-  userId,
-  currentTeeId,
-  onChange,
+  selectedTeeId,
+  onSelect,
+  busy = false,
 }: {
   courseId: string
-  roundId: string
-  userId: string
-  currentTeeId: string | null
-  onChange: (tee: { id: string; color: string }) => void
+  selectedTeeId: string | null
+  onSelect: (tee: { id: string; tee_color: string }) => void
+  busy?: boolean
 }) {
   const [tees, setTees] = useState<CourseTeeRow[]>([])
   const [loading, setLoading] = useState(true)
   const [adding, setAdding] = useState(false)
-  const [busy, setBusy] = useState(false)
+  const [addBusy, setAddBusy] = useState(false)
 
   useEffect(() => {
     let active = true
@@ -61,31 +62,13 @@ export function RoundTeeSelector({
     }
   }, [courseId])
 
-  async function selectTee(tee: { id: string; tee_color: string }) {
-    setBusy(true)
-    try {
-      const { error } = await updateRound(
-        supabase,
-        roundId,
-        { course_tee_id: tee.id, tee_color: tee.tee_color },
-        userId,
-      )
-      if (error) throw error
-      onChange({ id: tee.id, color: tee.tee_color })
-    } catch (e) {
-      Alert.alert('Could not set tee', (e as Error).message)
-    } finally {
-      setBusy(false)
-    }
-  }
-
   async function addTee(vals: {
     color: string
     rating: number | null
     slope: number | null
     yards: number | null
   }) {
-    setBusy(true)
+    setAddBusy(true)
     try {
       const { data, error } = await upsertCourseTees(supabase, [
         {
@@ -104,9 +87,122 @@ export function RoundTeeSelector({
         return [...without, created]
       })
       setAdding(false)
-      await selectTee(created)
+      onSelect({ id: created.id, tee_color: created.tee_color })
     } catch (e) {
       Alert.alert('Could not add tee', (e as Error).message)
+    } finally {
+      setAddBusy(false)
+    }
+  }
+
+  const disabled = busy || addBusy
+
+  if (loading) {
+    return (
+      <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 13 }]}>Loading tees…</Text>
+    )
+  }
+
+  return (
+    <View style={{ gap: 8 }}>
+      {tees.map((t) => {
+        const active = selectedTeeId === t.id
+        const hasRating = t.course_rating != null && t.slope_rating != null
+        return (
+          <Pressable
+            key={t.id}
+            onPress={() => onSelect({ id: t.id, tee_color: t.tee_color })}
+            disabled={disabled}
+            style={{
+              flexDirection: 'row',
+              alignItems: 'baseline',
+              justifyContent: 'space-between',
+              backgroundColor: active ? '#1F3D2C' : '#FBF8F1',
+              borderWidth: 1,
+              borderColor: active ? '#1F3D2C' : '#D9D2BF',
+              borderRadius: 2,
+              paddingVertical: 12,
+              paddingHorizontal: 14,
+              opacity: disabled ? 0.5 : 1,
+            }}
+          >
+            <Text
+              style={[TYPE.serif, {
+                color: active ? '#F2EEE5' : '#1C211C',
+                fontSize: 16,
+                fontStyle: 'italic',
+                fontWeight: '500',
+                textTransform: 'capitalize',
+              }]}
+            >
+              {t.tee_color}
+            </Text>
+            <Text
+              style={{
+                ...KICKER,
+                color: active ? 'rgba(242,238,229,0.75)' : '#5C6356',
+              }}
+            >
+              {hasRating ? `${t.course_rating?.toFixed(1)} / ${t.slope_rating}` : 'No rating'}
+            </Text>
+          </Pressable>
+        )
+      })}
+
+      {adding ? (
+        <AddTeeForm busy={addBusy} onCancel={() => setAdding(false)} onSubmit={addTee} />
+      ) : (
+        <Pressable
+          onPress={() => setAdding(true)}
+          disabled={disabled}
+          style={{
+            borderWidth: 1,
+            borderColor: '#D9D2BF',
+            borderStyle: 'dashed',
+            borderRadius: 2,
+            paddingVertical: 11,
+            alignItems: 'center',
+          }}
+        >
+          <Text style={{ ...KICKER, color: '#5C6356' }}>+ Add tee</Text>
+        </Pressable>
+      )}
+    </View>
+  )
+}
+
+// Scorecard wrapper: a labelled section that persists the picked tee onto
+// the round (course_tee_id + tee_color) so the finalize pass can compute a
+// WHS score differential. A tee with course rating + slope is the one input
+// the crawler can't supply, so the player records it here.
+export function RoundTeeSelector({
+  courseId,
+  roundId,
+  userId,
+  currentTeeId,
+  onChange,
+}: {
+  courseId: string
+  roundId: string
+  userId: string
+  currentTeeId: string | null
+  onChange: (tee: { id: string; color: string }) => void
+}) {
+  const [busy, setBusy] = useState(false)
+
+  async function persist(tee: { id: string; tee_color: string }) {
+    setBusy(true)
+    try {
+      const { error } = await updateRound(
+        supabase,
+        roundId,
+        { course_tee_id: tee.id, tee_color: tee.tee_color },
+        userId,
+      )
+      if (error) throw error
+      onChange({ id: tee.id, color: tee.tee_color })
+    } catch (e) {
+      Alert.alert('Could not set tee', (e as Error).message)
     } finally {
       setBusy(false)
     }
@@ -125,75 +221,12 @@ export function RoundTeeSelector({
       <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 12, marginBottom: 12 }]}>
         Add the tee's rating and slope to get a handicap differential.
       </Text>
-
-      {loading ? (
-        <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 13 }]}>Loading tees…</Text>
-      ) : (
-        <View style={{ gap: 8 }}>
-          {tees.map((t) => {
-            const active = currentTeeId === t.id
-            const hasRating = t.course_rating != null && t.slope_rating != null
-            return (
-              <Pressable
-                key={t.id}
-                onPress={() => selectTee(t)}
-                disabled={busy}
-                style={{
-                  flexDirection: 'row',
-                  alignItems: 'baseline',
-                  justifyContent: 'space-between',
-                  backgroundColor: active ? '#1F3D2C' : '#FBF8F1',
-                  borderWidth: 1,
-                  borderColor: active ? '#1F3D2C' : '#D9D2BF',
-                  borderRadius: 2,
-                  paddingVertical: 12,
-                  paddingHorizontal: 14,
-                  opacity: busy ? 0.5 : 1,
-                }}
-              >
-                <Text
-                  style={[TYPE.serif, {
-                    color: active ? '#F2EEE5' : '#1C211C',
-                    fontSize: 16,
-                    fontStyle: 'italic',
-                    fontWeight: '500',
-                    textTransform: 'capitalize',
-                  }]}
-                >
-                  {t.tee_color}
-                </Text>
-                <Text
-                  style={{
-                    ...KICKER,
-                    color: active ? 'rgba(242,238,229,0.75)' : '#5C6356',
-                  }}
-                >
-                  {hasRating ? `${t.course_rating?.toFixed(1)} / ${t.slope_rating}` : 'No rating'}
-                </Text>
-              </Pressable>
-            )
-          })}
-
-          {adding ? (
-            <AddTeeForm busy={busy} onCancel={() => setAdding(false)} onSubmit={addTee} />
-          ) : (
-            <Pressable
-              onPress={() => setAdding(true)}
-              disabled={busy}
-              style={{
-                borderWidth: 1,
-                borderColor: '#D9D2BF',
-                borderStyle: 'dashed',
-                borderRadius: 2,
-                paddingVertical: 11,
-                alignItems: 'center',
-              }}
-            >
-              <Text style={{ ...KICKER, color: '#5C6356' }}>+ Add tee</Text>
-            </Pressable>
-          )}
-        </View>
-      )}
+      <TeePicker
+        courseId={courseId}
+        selectedTeeId={currentTeeId}
+        onSelect={persist}
+        busy={busy}
+      />
     </View>
   )
 }


### PR DESCRIPTION
## Problem (on-device, iPhone QA)

When tracking a **live** round on mobile there's no way to pick the tee you're playing. Web surfaces a tee picker at round creation (`NewRoundPage`); mobile only mounted `RoundTeeSelector` in the scorecard view (the past-round companion). The live flow and the course-pick screen never showed it.

This matters now that `course_tees` ratings/slopes are backfilled (#539) — the tee played is the one input WHS differentials need (#538), and a live-round player couldn't supply it without detouring to the scorecard.

## Approach — mirror web, tee at creation

Mobile's create flow is one-tap (pick course → round starts), so there was no place for a picker. Added a lightweight **setup step** after the course resolves and before the round is created:

- **`TeePicker`** — extracted the presentational tee list + add-tee form out of `RoundTeeSelector` (selection-only, no round write). The scorecard wrapper now consumes it too, so both surfaces share one implementation instead of duplicating ~150 lines.
- **`RoundSetupStep`** in `round/new.tsx` — shows the course name + the picker, then Back / Start. **Tee is optional** so it never blocks pace of play; `course_tee_id` + `tee_color` only get written when a tee is picked, and the scorecard can still set it later. All four course-selection paths (already-imported, OpenGolfAPI existing/new, manual add) route through it.

## Test
- `npm run typecheck` clean.
- The scorecard `RoundTeeSelector` is unchanged in behavior (now a thin wrapper over `TeePicker`).
- On-device QA pending.

Closes #542