### PR TITLE
fix(mobile): on-device Android QA batch — practice, stats, splash, course search

### DIFF
--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -46,7 +46,10 @@ function asFocusAreas(value: unknown): StoredFocusArea[] {
 
 // UI safety net: rewrite any leaked raw snake_case category enums in displayed
 // prose (coach_note / focus reasons). `approach`/`putting` are already readable.
-function normalizeCategoryProse(text: string): string {
+// Tolerates null/undefined — a malformed plan (e.g. a focus area missing its
+// `reason`) must degrade to empty text, never crash the whole tab.
+function normalizeCategoryProse(text: string | null | undefined): string {
+  if (!text) return ''
   return text
     .replace(/\boff_tee\b/gi, 'off the tee')
     .replace(/\baround_green\b/gi, 'around the green')
@@ -330,7 +333,7 @@ function SessionBlock({
   completed: Set<string>
   onToggle: (blockId: string) => void
 }) {
-  const blocks = [...session.blocks].sort((a, b) => a.order - b.order)
+  const blocks = [...(session.blocks ?? [])].sort((a, b) => a.order - b.order)
   const doneCount = blocks.filter((b) => completed.has(b.id)).length
   return (
     <View style={{ borderTopWidth: 1, borderColor: LINE, paddingTop: 18, marginBottom: 28 }}>

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -222,7 +222,7 @@ function NoPlan({
           marginBottom: 8,
         }]}
       >
-        A column, not a checklist.
+        Your game, read closely.
       </Text>
       <Text style={[TYPE.body, { color: INK_DIM, fontSize: 14, lineHeight: 20, marginBottom: 22 }]}>
         Generate a plan calibrated to your recent rounds — a short read on where

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -424,10 +424,15 @@ export default function NewRound() {
       </Text>
       <TextInput
         placeholder="Search courses…"
+        placeholderTextColor="#8A8B7E"
         value={query}
         onChangeText={setQuery}
         autoCapitalize="words"
         style={[TYPE.body, {
+          // Explicit ink color — without it Android falls back to the system
+          // theme's text color, which is invisible on the cream input in dark
+          // mode. Matches the manual-course inputs (inputStyle).
+          color: '#1C211C',
           backgroundColor: '#FBF8F1',
           borderWidth: 1,
           borderColor: '#D9D2BF',

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -601,6 +601,9 @@ function StatRow({
       }}
     >
       <Text
+        numberOfLines={1}
+        adjustsFontSizeToFit
+        minimumFontScale={0.8}
         style={[TYPE.body, {
           color: '#1C211C',
           fontSize: 15,

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -95,7 +95,7 @@ export default function Welcome() {
         onPress={handleSkip}
         style={styles.screen}
       >
-        <Animated.Text style={[styles.wordmark, logoStyle]}>OGA</Animated.Text>
+        <Animated.Text style={[styles.wordmark, logoStyle]}>oga.</Animated.Text>
         <Animated.Text style={[styles.tagline, taglineStyle]}>Track every shot.</Animated.Text>
         <Animated.Text style={[styles.support, supportStyle]}>
           Free and open source · Ko-fi support appreciated

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -274,7 +274,15 @@ export function PuttingSheet({
         </Pressable>
       </View>
 
-      <ScrollView contentContainerStyle={{ paddingTop: 14, paddingBottom: 8 }}>
+      {/* flexShrink:1 bounds the scroll area within the maxHeight:'90%' sheet.
+          Without it RN's default flexShrink:0 lets the ScrollView size to its
+          full content height and overflow the clamped sheet, so it isn't
+          scrollable until a state change (e.g. toggling "Holed it") forces a
+          re-layout that re-measures it. */}
+      <ScrollView
+        style={{ flexShrink: 1 }}
+        contentContainerStyle={{ paddingTop: 14, paddingBottom: 8 }}
+      >
         <GreenDiagram
           distanceFt={distance}
           aimOffsetInches={value.aimOffsetInches ?? 0}

--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -68,7 +68,10 @@ function asFocusAreas(value: unknown): StoredFocusArea[] {
 
 // UI safety net: rewrite any leaked raw snake_case category enums in displayed
 // prose. `approach`/`putting` are already readable words and left untouched.
-function normalizeCategoryProse(text: string): string {
+// Tolerates null/undefined — a malformed plan (e.g. a focus area missing its
+// `reason`) must degrade to empty text, never crash the whole page.
+function normalizeCategoryProse(text: string | null | undefined): string {
+  if (!text) return ''
   return text
     .replace(/\boff_tee\b/gi, 'off the tee')
     .replace(/\baround_green\b/gi, 'around the green')
@@ -652,7 +655,7 @@ function SessionSection({
   completedIds: Set<string>
   onToggleComplete: (blockId: string) => void
 }) {
-  const blocks = [...session.blocks].sort((a, b) => a.order - b.order)
+  const blocks = [...(session.blocks ?? [])].sort((a, b) => a.order - b.order)
   const doneCount = blocks.filter((b) => b.id != null && completedIds.has(b.id)).length
   return (
     <section style={{ borderTop: `1px solid ${LINE}`, paddingTop: 18, marginBottom: 32 }}>

--- a/scripts/seed-demo.ts
+++ b/scripts/seed-demo.ts
@@ -436,6 +436,11 @@ async function insertPracticePlan(userId: string): Promise<void> {
     .limit(3)
   if (!drills || drills.length === 0) return
 
+  // Match the live storage shape (@oga/core StoredFocusArea / StoredSession):
+  // focus_areas use `reason` (not insight/sgValue) and `drills` is
+  // `{ sessions: [{ blocks }] }`. The Practice UI reads exactly these fields,
+  // so an out-of-date shape crashes the tab — keep this in lockstep.
+  const blockTypes = ['warmup', 'blocked', 'skill_game'] as const
   await supabase.from('practice_plans').insert({
     user_id: userId,
     based_on_rounds: 10,
@@ -443,28 +448,33 @@ async function insertPracticePlan(userId: string): Promise<void> {
     focus_areas: [
       {
         category: 'approach',
-        priority: 1,
-        sgValue: -1.2,
-        insight: 'Approach is your biggest opportunity — average 1.2 strokes lost per round.',
+        reason: 'Approach is your biggest opportunity — averaging 1.2 strokes lost per round.',
       },
       {
         category: 'around_green',
-        priority: 2,
-        sgValue: -0.1,
-        insight: 'Around-green play is roughly neutral; maintain with one drill.',
+        reason: 'Around-green play is roughly neutral; one drill keeps it sharp.',
       },
     ],
-    drills: drills.map((d) => ({
-      drillId: d.id,
-      name: d.name,
-      durationMin: d.duration_min,
-      facility: Array.isArray(d.facility) ? d.facility.join(', ') : '',
-      category: d.category,
-      description: d.description,
-      reason: 'Targets the lowest SG category.',
-    })),
-    ai_insight:
-      "Demo plan: putting is a real strength (+1.2 SG) so we're protecting it with one drill while loading up on approach work to chip away at the -1.2 SG gap.",
+    drills: {
+      sessions: [
+        {
+          title: 'Approach accuracy block',
+          total_minutes: drills.reduce((sum, d) => sum + (d.duration_min ?? 15), 0),
+          blocks: drills.map((d, i) => ({
+            id: `b-approach-${i}`,
+            order: i,
+            type: blockTypes[Math.min(i, blockTypes.length - 1)],
+            minutes: d.duration_min ?? 15,
+            rationale: 'Targets the lowest SG category.',
+            drill_id: d.id,
+            target: null,
+          })),
+        },
+      ],
+    },
+    ai_insight: 'Approach is the biggest drag on scoring — tighten iron dispersion this week.',
+    coach_note:
+      'Your approach game is the primary leak right now. Blocked reps to groove contact, then a skill game to transfer it under a little pressure.',
     completed_drill_ids: [],
   })
 }


### PR DESCRIPTION
On-device Android QA fixes (one batch, all small).

## Practice tab white-screened on a 'something went wrong / retry' loop
Root cause: `seed-demo.ts` wrote a stale `practice_plans` shape (`focus_areas` used `insight`, `drills` was a flat array) — the UI reads `area.reason`, so `normalizeCategoryProse(undefined).replace()` threw → ErrorBoundary loop. Only seeded accounts (demo/e2e) were affected; real generated plans use `reason`.
- Rewrite the seed to the live `@oga/core` shape (`{category, reason}`, `{sessions:[{blocks}]}`, + `coach_note`).
- Defensive guard (mobile + web): `normalizeCategoryProse()` tolerates null/undefined; session-blocks spread guards a missing array. A bad plan degrades, never white-screens.
- (Live demo dev+prod and e2e plans already regenerated/cleared out-of-band.)

## Practice lede contradicted the UI
"A column, not a checklist." sat above a literal checklist → **"Your game, read closely."** (keeps the editorial voice DESIGN.md asks for).

## Stats club labels wrapping
`DRIVER → 'DRIVE / R'`, `Ball Above/Below` — `StatRow` label now `numberOfLines={1}` + `adjustsFontSizeToFit` (minScale 0.8).

## Post-login splash showed old caps 'OGA'
`welcome.tsx` hardcoded "OGA"; brand wordmark is lowercase **"oga."** (matches the o. icon + landing). Font (Fraunces) was already correct.

## 'Pick a course' search text invisible in dark mode
The course-search `TextInput` set no text color → Android used the system-theme color (invisible on cream in dark mode). Added explicit ink `color` + `placeholderTextColor`. (login/signup get color via inline style / NativeWind class — verified, left as-is.)

## Test
mobile + web typecheck clean. On-device QA pending (next build).