### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -8,7 +8,7 @@ const config: ExpoConfig = {
   name: 'OGA',
   slug: 'oga',
   scheme: 'oga',
-  version: '0.0.1',
+  version: '0.9.0',
   orientation: 'portrait',
   // New Architecture stays OFF for the SDK 53 migration. SDK 53 flips it
   // on by default, so this is an active opt-out (set during the SDK 52 step

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oga/mobile",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oga/web",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oga",
   "private": true,
-  "version": "0.0.1",
+  "version": "0.9.0",
   "packageManager": "pnpm@10.33.2",
   "scripts": {
     "dev": "turbo dev",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oga/core",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oga/supabase",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
Bumps all workspace `package.json` versions + mobile `app.config.ts` to **0.9.0** for the 0.9 release.

- iOS `buildNumber` left at `1` (store submission is a later step).
- pnpm-lock.yaml unaffected (pnpm doesn't pin a workspace package's own version — its only `0.0.1` refs are third-party deps).
- Mobile npm lockfile self-version reconciles on next `npm install` (mobile CI uses `npm install --legacy-peer-deps`, not `npm ci`).

Lands on `dev` first so it's included in the `dev → main` 0.9 release.