### PR TITLE
fix(share): correct wordmark + URL on share cards

### DIFF
--- a/apps/mobile/components/round/ShareableScorecardCard.tsx
+++ b/apps/mobile/components/round/ShareableScorecardCard.tsx
@@ -115,7 +115,7 @@ export function ShareableScorecardCard({
               color: c.ink,
             }}
           >
-            OGA
+            oga<Text style={{ fontFamily: FONT.serif }}>.</Text>
           </Text>
         </View>
         <Text style={{ ...KICKER, color: c.inkMute }}>Scorecard</Text>
@@ -252,7 +252,7 @@ export function ShareableScorecardCard({
             color: c.inkMute,
           }}
         >
-          opengolfapp
+          oga.golf
         </Text>
       </View>
     </View>

--- a/apps/web/src/components/round/ShareableScorecardCard.tsx
+++ b/apps/web/src/components/round/ShareableScorecardCard.tsx
@@ -122,7 +122,7 @@ export function ShareableScorecardCard({
               color: c.ink,
             }}
           >
-            OGA
+            oga<span style={{ fontStyle: 'normal' }}>.</span>
           </div>
         </div>
         <div style={{ ...KICKER_STYLE, color: c.inkMute, textAlign: 'right' }}>
@@ -258,7 +258,7 @@ export function ShareableScorecardCard({
             color: c.inkMute,
           }}
         >
-          opengolfapp-web.vercel.app
+          oga.golf
         </div>
       </footer>
     </div>

--- a/apps/web/src/pages/patterns/components/ShotPatternsShareCard.tsx
+++ b/apps/web/src/pages/patterns/components/ShotPatternsShareCard.tsx
@@ -89,7 +89,7 @@ export function ShotPatternsShareCard({
               color: C.ink,
             }}
           >
-            OGA
+            oga<span style={{ fontStyle: 'normal' }}>.</span>
           </div>
         </div>
         <div style={{ ...KICKER, fontSize: 12, color: C.inkMute, textAlign: 'right' }}>


### PR DESCRIPTION
The brand refresh never reached the share cards (live-QA finding).

- **Wordmark** `OGA` → lowercase italic `oga.` (upright period), matching the landing footer — on the **scorecard** and **shot-pattern** cards, **web + mobile**.
- **Footer URL** `opengolfapp-web.vercel.app` / `opengolfapp` → `oga.golf` on the scorecard cards (the shot-pattern card already used `oga.golf`).

Visual-only; typechecks clean on web + mobile.

Follow-ups filed separately (different concerns): share-card tee detail (yardage/rating/slope) + verifying Fraunces embeds in the html-to-image capture (the 'wrong font' symptom).