### PR TITLE
fix(learn): center the Learn content column

### DIFF
--- a/apps/web/src/pages/learn/LearnArticlePage.tsx
+++ b/apps/web/src/pages/learn/LearnArticlePage.tsx
@@ -21,7 +21,7 @@ export function LearnArticlePage() {
   const isDraft = article.status === 'draft'
 
   return (
-    <div style={{ maxWidth: 760 }}>
+    <div style={{ maxWidth: 760, margin: '0 auto' }}>
       <BackLink />
       <Breadcrumb section={section} />
       {isDraft && <DraftBanner slug={article.id} />}

--- a/apps/web/src/pages/learn/LearnPage.tsx
+++ b/apps/web/src/pages/learn/LearnPage.tsx
@@ -13,7 +13,7 @@ export function LearnPage() {
   const filtered = useMemo(() => filterSections(LEARN_SECTIONS, query), [query])
 
   return (
-    <div style={{ maxWidth: 760 }}>
+    <div style={{ maxWidth: 760, margin: '0 auto' }}>
       <div style={{ marginBottom: 28 }}>
         <div className="kicker" style={{ marginBottom: 8 }}>
           Golf education


### PR DESCRIPTION
Live-QA finding: the Operation 36 ladder and self-diagnosis flowchart looked off-center (#6, #7).

**Root cause:** `AppShell` centers a 1100px main area, but `LearnArticlePage`/`LearnPage` used `maxWidth: 760` with **no `margin: 0 auto`** — so the Learn column hugged the left of that 1100, leaving dead space on the right. The figures center *within* the 760 column, so they looked shifted. One-line fix per page centers the whole Learn section.

Layout-only; typechecks clean.