### PR TITLE
fix(round): relabel post-round practice CTA to a Practice pointer

### DIFF
--- a/apps/web/src/components/rounds/RoundSummary.tsx
+++ b/apps/web/src/components/rounds/RoundSummary.tsx
@@ -160,7 +160,7 @@ export function RoundSummary({
               borderRadius: 2,
             }}
           >
-            Generate practice plan{' '}
+            Go to Practice{' '}
             <span className="font-serif" style={{ fontStyle: 'italic' }}>
               →
             </span>


### PR DESCRIPTION
Live-QA #563. The round-summary CTA read 'Generate practice plan', implying per-round generation — but it already just `Link`s to `/practice` (plans are built from your last N rounds). Relabelled to 'Go to Practice'. Copy-only; typechecks clean. Closes #563