### PR TITLE
fix(round-map): mirror mobile tee box on web (two dots from first shot)

### DIFF
--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -226,7 +226,6 @@ export function RoundMap({
     handicap,
     onMovePoint,
     onMovePin,
-    onMoveTee,
     onSetAim,
     onMoveExistingShot,
     onMoveExistingShotAim,

--- a/apps/web/src/components/round/map/RoundMapInstructionStrip.tsx
+++ b/apps/web/src/components/round/map/RoundMapInstructionStrip.tsx
@@ -116,26 +116,8 @@ export function RoundMapInstructionStrip({
     )
   }
   const placeButtons =
-    (needsTee && onStartPlaceTee) || (needsPin && onStartPlacePin) ? (
+    needsPin && onStartPlacePin ? (
       <>
-        {needsTee && onStartPlaceTee && (
-          <button
-            type="button"
-            onClick={onStartPlaceTee}
-            style={{
-              border: '1px solid #5C6356',
-              borderRadius: 2,
-              padding: '6px 10px',
-              fontSize: 12,
-              background: 'transparent',
-              color: '#5C6356',
-              fontWeight: 600,
-              letterSpacing: '0.02em',
-            }}
-          >
-            Place tee box
-          </button>
-        )}
         {needsPin && onStartPlacePin && (
           <button
             type="button"

--- a/apps/web/src/components/round/map/markerFactories.ts
+++ b/apps/web/src/components/round/map/markerFactories.ts
@@ -72,6 +72,26 @@ export function makeAimMarker(): HTMLElement {
   return outer
 }
 
+// Understated tee-box dot. Two of these flank the tee shot (perpendicular to
+// the line of play), mirroring the mobile redesign — deliberately quieter than
+// the old draggable 'TEE' badge. Non-interactive.
+export function makeTeeDotMarker(): HTMLElement {
+  const outer = document.createElement('div')
+  const dot = document.createElement('div')
+  dot.style.cssText = [
+    'width:9px',
+    'height:9px',
+    'border-radius:999px',
+    'background:#FBF8F1',
+    'border:1.5px solid rgba(28,33,28,0.55)',
+    'box-shadow:0 0 0 1px rgba(255,255,255,0.25)',
+    'pointer-events:none',
+  ].join(';')
+  outer.appendChild(dot)
+  outer.title = 'Tee box'
+  return outer
+}
+
 export function makeDistancePill(
   label: string,
   opts: { sublabel?: string; tone?: 'pos' | 'neg' } = {},

--- a/apps/web/src/components/round/map/useMapLayers.ts
+++ b/apps/web/src/components/round/map/useMapLayers.ts
@@ -2,8 +2,10 @@ import { useCallback, useEffect, useRef, type MutableRefObject } from 'react'
 import { mapboxgl } from '../../../lib/mapbox'
 import {
   arcGeoJSON,
+  bearingDegrees,
   calculateShotSG,
   circleGeoJSON,
+  destinationYards,
   getExpectedStrokes,
   haversineYards,
   NEAR_GREEN_YARDS,
@@ -16,8 +18,8 @@ import {
   makeAimMarker,
   makeDistancePill,
   makeFlagMarker,
-  makeIconMarker,
   makeNumberedMarker,
+  makeTeeDotMarker,
   MARKER_COLORS,
 } from './markerFactories'
 import {
@@ -75,6 +77,11 @@ const placedLineSourceId = 'placed-line'
 // path actually taken.
 const AIM_COLOR = '#FBF8F1'
 
+// Half-width of the tee box: each dot sits this far either side of the tee
+// shot, perpendicular to the line of play. ~4 yd ≈ a real teeing ground.
+// Mirrors the mobile redesign (PastRoundMap TEE_BOX_HALF_YARDS).
+const TEE_BOX_HALF_YARDS = 4
+
 // A single shot's aim: where the player stood (`start`) and where they
 // aimed (`aim`), both as [lng, lat]. The latest aimed shot gets the full
 // planning treatment (solid start→aim→pin bend + dotted start→pin
@@ -119,31 +126,34 @@ export function useMapLayers({
     for (const m of markerRefs.current) m.remove()
     markerRefs.current = []
 
-    // Tee marker — draggable when a parent handler is wired in.
-    if (effectiveTee) {
-      const parts = makeIconMarker('TEE', '#FBF8F1', '#5C6356')
-      const marker = new mapboxgl.Marker({
-        element: parts.outer,
-        draggable: !!onMoveTee,
-      })
-        .setLngLat([effectiveTee.lng, effectiveTee.lat])
-        .addTo(map)
-      if (onMoveTee) {
-        attachDragFx({
-          outer: parts.outer,
-          content: parts.content,
-          marker,
-          tooltip: 'Drag to move tee',
-        })
-        marker.on('dragend', () => {
-          const ll = marker.getLngLat()
-          userPlacedRef.current = true
-          onMoveTee({ lat: ll.lat, lng: ll.lng })
-        })
-      } else {
-        parts.outer.title = 'Tee box'
+    // Tee box — two understated dots flanking the tee shot, perpendicular to
+    // the line of play (mirrors the mobile redesign; no draggable tee). Origin
+    // is the first shot's start, falling back to the stored course tee; the
+    // line of play points at that shot's aim, then the pin.
+    const teeShot = [...existingShots]
+      .filter((s) => s.startLat != null && s.startLng != null)
+      .sort((a, b) => a.shotNumber - b.shotNumber)[0]
+    const teeOrigin: PlacedPoint | null =
+      placedPoints[0] ??
+      (teeShot ? { lat: teeShot.startLat!, lng: teeShot.startLng! } : null) ??
+      effectiveTee
+    if (teeOrigin) {
+      const teeToward: PlacedPoint | null =
+        placedAims?.[0] ??
+        (teeShot && teeShot.aimLat != null && teeShot.aimLng != null
+          ? { lat: teeShot.aimLat, lng: teeShot.aimLng }
+          : null) ??
+        effectivePin
+      const heading = teeToward
+        ? bearingDegrees(teeOrigin.lat, teeOrigin.lng, teeToward.lat, teeToward.lng)
+        : 0
+      for (const sign of [-90, 90]) {
+        const p = destinationYards(teeOrigin, heading + sign, TEE_BOX_HALF_YARDS)
+        const marker = new mapboxgl.Marker({ element: makeTeeDotMarker() })
+          .setLngLat([p.lng, p.lat])
+          .addTo(map)
+        markerRefs.current.push(marker)
       }
-      markerRefs.current.push(marker)
     }
 
     // Pin marker — draggable when a parent handler is wired in.

--- a/apps/web/src/components/round/map/useMapLayers.ts
+++ b/apps/web/src/components/round/map/useMapLayers.ts
@@ -62,7 +62,6 @@ interface UseMapLayersInput {
   handicap: number
   onMovePoint: (idx: number, point: PlacedPoint) => void
   onMovePin: ((point: PlacedPoint) => void) | undefined
-  onMoveTee: ((point: PlacedPoint) => void) | undefined
   onSetAim: ((index: number, point: PlacedPoint | null) => void) | undefined
   onMoveExistingShot: ((shotId: string, point: PlacedPoint) => void) | undefined
   onMoveExistingShotAim: ((shotId: string, point: PlacedPoint) => void) | undefined
@@ -105,7 +104,6 @@ export function useMapLayers({
   handicap,
   onMovePoint,
   onMovePin,
-  onMoveTee,
   onSetAim,
   onMoveExistingShot,
   onMoveExistingShotAim,
@@ -562,7 +560,6 @@ export function useMapLayers({
     placedAims,
     onMovePoint,
     onMovePin,
-    onMoveTee,
     onSetAim,
     onMoveExistingShot,
     onMoveExistingShotAim,

--- a/apps/web/src/components/round/map/useMapSetup.ts
+++ b/apps/web/src/components/round/map/useMapSetup.ts
@@ -144,14 +144,10 @@ export function useMapSetup({
     const map = mapRef.current
     if (!map) return
     function onClick(e: mapboxgl.MapMouseEvent) {
-      // Tee / pin placement wins over every other click outcome — even
-      // when shots already exist, the user explicitly entered placement
-      // mode from the strip and the next tap should land the marker.
-      if (placementMode === 'tee' && onMoveTee) {
-        userPlacedRef.current = true
-        onMoveTee({ lat: e.lngLat.lat, lng: e.lngLat.lng })
-        return
-      }
+      // Pin placement wins over every other click outcome — even when shots
+      // already exist, the user explicitly entered placement mode from the
+      // strip and the next tap should land the marker. (The tee is no longer
+      // placed manually — it's derived from the first shot, mirroring mobile.)
       if (placementMode === 'pin' && onMovePin) {
         userPlacedRef.current = true
         onMovePin({ lat: e.lngLat.lat, lng: e.lngLat.lng })


### PR DESCRIPTION
Live-QA #564. Mirrors the mobile redesign: the draggable `TEE` badge + manual tee-placement flow are replaced by **two understated dots** flanking the tee shot, derived from the first shot (origin = first shot start, falling back to the stored tee; perpendicular to the line of play, ±4yd — reusing `@oga/core` `bearingDegrees`/`destinationYards`, identical geometry to mobile).

Removed: the 'Place tee box' button + the `placementMode==='tee'` tap branch (pin placement untouched).

**Note:** `teeOverride` stays in the round hooks (now never set) so the LENGTH-based synthetic-holes detection is byte-for-byte unchanged — cleaning up that vestigial state is a deliberate separate follow-up (it's entangled with the synthetic-holes landmine). Web typechecks clean. **Needs browser QA on the dev deploy** before it rides a release. Closes #564