### PR TITLE
feat(share): played-tee yardage + rating/slope on scorecard cards

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -21,6 +21,7 @@ import {
 } from '@oga/core'
 import {
   deleteRound,
+  getCourseTees,
   getDrills,
   getProfile,
   updateRound,
@@ -45,6 +46,7 @@ type HoleRow = Database['public']['Tables']['holes']['Row']
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
 type ShotRow = Database['public']['Tables']['shots']['Row']
 type DrillRow = Database['public']['Tables']['drills']['Row']
+type CourseTeeRow = Database['public']['Tables']['course_tees']['Row']
 
 const KICKER: import('react-native').TextStyle = {
   color: '#8A8B7E',
@@ -74,6 +76,26 @@ export default function RoundIndex() {
   const [shots, setShots] = useState<ShotRow[]>([])
   const [courseName, setCourseName] = useState<string>('Round')
   const [courseCenter, setCourseCenter] = useState<LatLng | null>(null)
+  // Played-tee detail for the share card (#562): rating/slope/yardage, matched
+  // by tee id then colour (same match the web card uses).
+  const [playedTee, setPlayedTee] = useState<CourseTeeRow | null>(null)
+  useEffect(() => {
+    const courseId = round?.course_id
+    if (!courseId) return
+    let cancelled = false
+    getCourseTees(supabase, courseId).then(({ data }) => {
+      if (cancelled || !data) return
+      const teeColor = round?.tee_color?.toLowerCase()
+      const tee =
+        data.find((t) => t.id === round?.course_tee_id) ??
+        (teeColor ? data.find((t) => t.tee_color === teeColor) : undefined) ??
+        null
+      setPlayedTee(tee)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [round?.course_id, round?.course_tee_id, round?.tee_color])
   // Scorecard ⇄ Map tabs (#514): the scorecard edits scores/putts/details,
   // the map places ball + aim geometry. `mapHole` is the hole the map is
   // focused on; its prev/next nav drives it.
@@ -574,6 +596,9 @@ export default function RoundIndex() {
               sg_putting: round.sg_putting,
               sg_total: round.sg_total,
               courseName,
+              course_rating: playedTee?.course_rating ?? null,
+              slope_rating: playedTee?.slope_rating ?? null,
+              total_yards: playedTee?.total_yards ?? null,
             }}
             holes={sortedHoles}
             scoresByHoleId={scoresByHoleId}

--- a/apps/mobile/components/round/ShareableScorecardCard.tsx
+++ b/apps/mobile/components/round/ShareableScorecardCard.tsx
@@ -18,6 +18,11 @@ export interface ShareableRoundData {
   sg_putting: number | null
   sg_total: number | null
   courseName: string | null
+  // Played-tee detail (optional): total yardage + course/slope rating, shown
+  // alongside the tee colour when the round names a rated tee.
+  course_rating?: number | null
+  slope_rating?: number | null
+  total_yards?: number | null
 }
 
 interface ShareableScorecardCardProps {
@@ -136,6 +141,10 @@ export function ShareableScorecardCard({
         <Text style={{ ...KICKER, color: c.inkDim, marginTop: 4 }}>
           {round.played_at}
           {round.tee_color ? ` · ${round.tee_color} tees` : ''}
+          {round.total_yards != null ? ` · ${round.total_yards} yd` : ''}
+          {round.course_rating != null && round.slope_rating != null
+            ? ` · ${round.course_rating.toFixed(1)}/${round.slope_rating}`
+            : ''}
         </Text>
       </View>
 

--- a/apps/web/src/components/round/ShareableScorecardCard.tsx
+++ b/apps/web/src/components/round/ShareableScorecardCard.tsx
@@ -18,6 +18,11 @@ export interface ShareableRoundData {
   sg_putting: number | null
   sg_total: number | null
   courses?: { name: string | null } | null
+  // Played-tee detail (optional): total yardage + course/slope rating, shown
+  // alongside the tee colour when the round names a rated tee.
+  course_rating?: number | null
+  slope_rating?: number | null
+  total_yards?: number | null
 }
 
 interface ShareableScorecardCardProps {
@@ -151,6 +156,10 @@ export function ShareableScorecardCard({
         >
           {round.played_at}
           {round.tee_color ? ` · ${round.tee_color} tees` : ''}
+          {round.total_yards != null ? ` · ${round.total_yards.toLocaleString()} yd` : ''}
+          {round.course_rating != null && round.slope_rating != null
+            ? ` · ${round.course_rating.toFixed(1)}/${round.slope_rating}`
+            : ''}
         </div>
       </section>
 

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -210,6 +210,16 @@ export function RoundDetailPage() {
 
   const holesPlayed = holeScores.length
   const totalRoundsLogged = allRounds.data?.length ?? 0
+  // The played tee (by id, then by colour) supplies rating/slope/yardage for
+  // the share card — same match RoundHeader uses.
+  const playedTee =
+    (teesQuery.data ?? []).find((t) => t.id === round.data.course_tee_id) ??
+    (round.data.tee_color
+      ? (teesQuery.data ?? []).find(
+          (t) => t.tee_color === round.data.tee_color?.toLowerCase(),
+        )
+      : undefined) ??
+    null
   const switchHole = (n: number) =>
     dispatchHoleView({ type: 'SWITCH_HOLE', holeNumber: n })
 
@@ -247,7 +257,12 @@ export function RoundDetailPage() {
       >
         <div ref={shareCardRef}>
           <ShareableScorecardCard
-            round={round.data}
+            round={{
+              ...round.data,
+              course_rating: playedTee?.course_rating ?? null,
+              slope_rating: playedTee?.slope_rating ?? null,
+              total_yards: playedTee?.total_yards ?? null,
+            }}
             holes={holes}
             scoresByHoleId={scoresByHoleId}
             tone={shareTone}


### PR DESCRIPTION
Live-QA #562. When a round names a rated tee, the scorecard share card shows the tee's **total yardage + course/slope rating** beside the tee colour — e.g. `black tees · 7790 yd · 77.2/152` — on **web + mobile**.

`ShareableRoundData` gains optional `course_rating`/`slope_rating`/`total_yards`. Web matches the played tee from the already-fetched `course_tees`; mobile adds a focused `getCourseTees` fetch (the tee selector keeps its tees internal). Typechecks clean both platforms. Closes #562

(The 'wrong font' part of #562 — verifying Fraunces embeds in the html-to-image capture — is tracked separately in the ticket; not touched here.)