### PR TITLE
chore(db): prune 24 legacy pre-v2 drills (source NULL)

### DIFF
--- a/supabase/migrations/0039_prune_legacy_drills.sql
+++ b/supabase/migrations/0039_prune_legacy_drills.sql
@@ -1,15 +1,16 @@
 -- Prune the legacy pre-v2 drills that predate the curated corpus (0034 v2
--- data + 0035 v1 corpus). 0030 seeded an original ~40-drill set and added the
--- `source` column; the v2 corpus was inserted alongside it with a non-null
--- `source`, so the originals were never removed. On prod that left the drill
--- library at 149 instead of the intended 125.
+-- data + 0035 v1 corpus). An older seed.sql seeded an original ~40-drill set
+-- (0030 only added the `source`/`verified` columns); the v2 corpus was loaded
+-- alongside those rows with a non-null `source`, so the originals were never
+-- removed. On prod that left the drill library at 149 instead of the intended
+-- 125.
 --
 -- The leftovers are uniquely identified by `source IS NULL AND verified =
 -- false` — every curated drill carries a non-null source. Verified at write:
 --   prod: 149 total, 24 with source IS NULL  -> removes those 24 (→ 125)
 --   dev:  125 total,  0 with source IS NULL  -> no-op
--- Also makes a fresh full migrate converge to 125 (0030 inserts them, this
--- deletes them).
+-- A fresh DB has no drills until seed.sql runs (which now carries the 125-drill
+-- v2 corpus), so this delete is a harmless no-op on a clean migrate.
 --
 -- Practice plans store drill ids in a jsonb `drills.sessions[].blocks[].drill_id`
 -- (no FK), so a deleted id can't cascade — the Practice UI already null-guards a

--- a/supabase/migrations/0039_prune_legacy_drills.sql
+++ b/supabase/migrations/0039_prune_legacy_drills.sql
@@ -1,0 +1,19 @@
+-- Prune the legacy pre-v2 drills that predate the curated corpus (0034 v2
+-- data + 0035 v1 corpus). 0030 seeded an original ~40-drill set and added the
+-- `source` column; the v2 corpus was inserted alongside it with a non-null
+-- `source`, so the originals were never removed. On prod that left the drill
+-- library at 149 instead of the intended 125.
+--
+-- The leftovers are uniquely identified by `source IS NULL AND verified =
+-- false` — every curated drill carries a non-null source. Verified at write:
+--   prod: 149 total, 24 with source IS NULL  -> removes those 24 (→ 125)
+--   dev:  125 total,  0 with source IS NULL  -> no-op
+-- Also makes a fresh full migrate converge to 125 (0030 inserts them, this
+-- deletes them).
+--
+-- Practice plans store drill ids in a jsonb `drills.sessions[].blocks[].drill_id`
+-- (no FK), so a deleted id can't cascade — the Practice UI already null-guards a
+-- missing drill (PR #544), and the plan generator only draws from verified
+-- drills, so a live plan referencing one of these is unlikely.
+delete from public.drills
+where source is null and verified = false;


### PR DESCRIPTION
Live-QA #560 — "is 149 drills the right number?". **No, 125 is.**

Verified against both DBs: **prod = 149, dev = 125, 0 dups either side.** The 24 extra on prod all carry `source IS NULL` + `verified = false` — the original pre-v2 corpus (0030) that the v2 corpus (0034/0035) added alongside but never removed. (Names: Gate drill, Wedge ladder, Lag putting clock, 9-shot grid, etc. — all the simple un-attributed ones.)

`0039` deletes `drills WHERE source IS NULL AND verified = false` → removes exactly those 24 on prod, **no-op on dev** (0 such rows), and makes a fresh full migrate converge to 125.

⚠️ **NOT applied to prod by me** (deleting prod rows while the user's asleep) — apply via the prod CLI channel (`supabase db push`) when you're ready. Practice-plan drill ids are jsonb (no FK) and the UI null-guards a missing drill (#544), so cascade risk is low. Closes #560