### PR TITLE
fix(stats): exclude putts from club accuracy

### DIFF
--- a/packages/core/src/__tests__/stats.test.ts
+++ b/packages/core/src/__tests__/stats.test.ts
@@ -483,3 +483,42 @@ describe('sgStandouts', () => {
     expect(s.strongest).toEqual({ key: 'putting', value: 0.9 })
   })
 })
+
+describe('clubAccuracy — putter exclusion', () => {
+  // A putter with full start/aim/end coords would otherwise bucket into club
+  // accuracy with a meaningless yards dispersion. Build 3 such putts + 3 real
+  // 7i shots (the n >= 3 floor) and assert only the iron survives.
+  function coordShot(overrides: Partial<ShotRow>): ShotRow {
+    return makeShot({
+      start_lat: 35.0,
+      start_lng: -97.5,
+      aim_lat: 35.001,
+      aim_lng: -97.5,
+      end_lat: 35.001,
+      end_lng: -97.4999,
+      ...overrides,
+    })
+  }
+  const round = makeRound({
+    hole_scores: [
+      makeHoleScore({
+        holes: makeHole({ id: 'h1', number: 1, par: 4 }),
+        shots: [
+          coordShot({ shot_number: 1, club: '7i', lie_type: 'fairway' }),
+          coordShot({ shot_number: 2, club: '7i', lie_type: 'fairway' }),
+          coordShot({ shot_number: 3, club: '7i', lie_type: 'fairway' }),
+          coordShot({ shot_number: 4, club: 'putter', lie_type: 'green' }),
+          coordShot({ shot_number: 5, club: 'putter', lie_type: 'green' }),
+          coordShot({ shot_number: 6, club: 'putter', lie_type: 'green' }),
+        ],
+      }),
+    ],
+  })
+
+  it('omits the putter and keeps full-swing clubs', () => {
+    const entries = computeDetailedStats([round], 15).clubAccuracy
+    const clubs = entries.map((e) => e.club)
+    expect(clubs).toContain('7i')
+    expect(clubs).not.toContain('putter')
+  })
+})

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -680,6 +680,10 @@ export function clubAccuracy(rounds: DetailedRound[]): ClubAccuracyEntry[] {
   for (const { shots } of flatten(rounds)) {
     for (const s of shots) {
       if (!s.club) continue
+      // Club accuracy is a full-swing dispersion stat. Putts carry start/aim/
+      // end coords too, but their lateral miss in yards is meaningless and
+      // would otherwise surface the putter in "most accurate" — exclude them.
+      if (s.club === 'putter' || s.lie_type === 'green') continue
       if (
         s.start_lat == null ||
         s.start_lng == null ||


### PR DESCRIPTION
Fixes the putter showing up under Stats → Club Accuracy with a yards dispersion. `clubAccuracy` now skips `club === 'putter'` / `lie_type === 'green'`. Adds a `@oga/core` test (540 pass).

Closes #574