### PR TITLE
fix(home): capitalize the bright-spot category in the round insight

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -201,7 +201,7 @@ export default function Home() {
               {homeStats.weakest.value >= 0 ? (
                 <>Everything is net positive. <Text style={[TYPE.bodyBold, { fontWeight: '600' }]}>{homeStats.strongest.label}</Text> leads at {fmtSG(homeStats.strongest.value)} a round.</>
               ) : (
-                <><Text style={[TYPE.bodyBold, { fontWeight: '600' }]}>{homeStats.weakest.label}.</Text> Your biggest leak — costing about {fmtAbs(homeStats.weakest.value)} a round. {homeStats.strongest.label.toLowerCase()} is the bright spot at {fmtSG(homeStats.strongest.value)}.</>
+                <><Text style={[TYPE.bodyBold, { fontWeight: '600' }]}>{homeStats.weakest.label}.</Text> Your biggest leak — costing about {fmtAbs(homeStats.weakest.value)} a round. {homeStats.strongest.label} is the bright spot at {fmtSG(homeStats.strongest.value)}.</>
               )}
             </Text>
 


### PR DESCRIPTION
The Home "Good round" insight rendered "...a round. putting is the bright spot..." — lowercase at a sentence start. Dropped the `.toLowerCase()` on the strongest-category label (labels are already sentence-case).

Closes #578