### PR TITLE
fix(putt): derive break direction from aim, drop the Break (line) chips

### DIFF
--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -74,11 +74,18 @@ const BREAK_SLOPE_OPTIONS: { value: BreakDirectionVertical; label: string }[] = 
   { value: 'flat', label: 'Flat' },
   { value: 'downhill', label: 'Downhill' },
 ]
-const BREAK_LINE_OPTIONS: { value: BreakDirectionHorizontal; label: string }[] = [
-  { value: 'left_to_right', label: 'L → R' },
-  { value: 'straight', label: 'Straight' },
-  { value: 'right_to_left', label: 'R → L' },
-]
+// The horizontal break is derived from the aim line rather than chosen: the
+// player aims to the side the putt breaks FROM, so a right-of-hole aim plays a
+// right-to-left break and vice-versa. Mirrors GreenDiagram's formatAim 2-inch
+// deadband so a dead-straight aim leaves the axis unset, letting the vertical
+// slope carry the legacy combined label.
+function horizontalBreakFromAim(
+  offsetInches: number,
+): BreakDirectionHorizontal | undefined {
+  if (offsetInches > 2) return 'right_to_left'
+  if (offsetInches < -2) return 'left_to_right'
+  return undefined
+}
 
 const SLOPE_INTENSITY_LABELS = ['Flat', 'Slight', 'Moderate', 'Strong', 'Severe']
 
@@ -167,13 +174,6 @@ export function PuttingSheet({
     setValue((prev) => ({
       ...prev,
       breakDirectionVertical: prev.breakDirectionVertical === v ? undefined : v,
-    }))
-  }
-
-  function setBreakLine(v: BreakDirectionHorizontal) {
-    setValue((prev) => ({
-      ...prev,
-      breakDirectionHorizontal: prev.breakDirectionHorizontal === v ? undefined : v,
     }))
   }
 
@@ -292,7 +292,13 @@ export function PuttingSheet({
               horizontal: value.breakDirectionHorizontal,
             }) ?? 'straight'
           }
-          onAimChange={(n) => set('aimOffsetInches', n)}
+          onAimChange={(n) =>
+            setValue((prev) => ({
+              ...prev,
+              aimOffsetInches: n,
+              breakDirectionHorizontal: horizontalBreakFromAim(n),
+            }))
+          }
         />
 
         <View style={{ marginTop: 14 }}>
@@ -373,22 +379,6 @@ export function PuttingSheet({
           </View>
           <Text style={[TYPE.kicker, { ...KICKER, marginTop: 8, color: '#8A8B7E' }]}>
             Tap again to clear · leave blank if green was level
-          </Text>
-        </Section>
-
-        <Section title="Break (line)">
-          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
-            {BREAK_LINE_OPTIONS.map((b) => (
-              <Chip
-                key={b.value}
-                label={b.label}
-                active={value.breakDirectionHorizontal === b.value}
-                onPress={() => setBreakLine(b.value)}
-              />
-            ))}
-          </View>
-          <Text style={[TYPE.kicker, { ...KICKER, marginTop: 8, color: '#8A8B7E' }]}>
-            Tap again to clear · leave blank if there was no break
           </Text>
         </Section>
 


### PR DESCRIPTION
Resolves the green-diagram contradiction where the corner label ("Straight") could disagree with the drawn curve + caption ("12 in right") because they came from two independent inputs.

The manual **Break (line)** chips are removed; `breakDirectionHorizontal` is now derived from the aim handle's offset sign — aim right of the hole → right-to-left break, aim left → left-to-right, with a ±2in deadband matching `formatAim`'s. Label, curve, and caption now share one source. Vertical slope (uphill/downhill) is unchanged and still carries the combined label when the aim is straight.

Mobile typecheck green. Mobile-only, no e2e — **needs on-device QA**: drag the aim each way and confirm the corner label matches the curve, and that a straight aim with an uphill/downhill slope still labels correctly.

Closes #576