### PR TITLE
fix(patterns): drop putter from the Shot Patterns club picker

### DIFF
--- a/apps/web/src/pages/patterns/ShotPatternsPage.tsx
+++ b/apps/web/src/pages/patterns/ShotPatternsPage.tsx
@@ -145,7 +145,9 @@ export function ShotPatternsPage() {
 
       <Section kicker="Club">
         <div className="flex flex-wrap" style={{ gap: 6 }}>
-          {CLUBS.map((c) => (
+          {/* Putter excluded: aim-relative yards dispersion is meaningless for
+              putts (mirrors the clubAccuracy putt exclusion, #574). */}
+          {CLUBS.filter((c) => c !== 'putter').map((c) => (
             <button
               key={c}
               type="button"


### PR DESCRIPTION
Web parallel of #574 (caught by cross-agent review of #579). The Shot Patterns club picker exposed a **Putter** chip rendering a meaningless aim-relative yards dispersion. Filtered `putter` out of the picker; default club stays `7i`.

Refs #574