### PR TITLE
fix(practice-plan): reword repair guidance 'weaknesses' -> 'focus areas'

### DIFF
--- a/supabase/functions/generate-practice-plan/claude.ts
+++ b/supabase/functions/generate-practice-plan/claude.ts
@@ -134,7 +134,7 @@ export function buildMessages(
   const guidance =
     `Validation failed: ${repair.errors.join('; ')}. Re-emit the tool call, corrected. ` +
     `Reference drills only by the 0-based number shown; emit no target numbers; ` +
-    `build exactly ${sessionCount} sessions; cover the top-2 weaknesses.`
+    `build exactly ${sessionCount} sessions; cover the top-2 focus areas.`
   return [
     { role: 'user', content: userPrompt },
     { role: 'assistant', content: repair.priorAssistantContent },


### PR DESCRIPTION
Cross-agent review follow-up to #581. The validation-retry repair guidance in `claude.ts` still said "cover the top-2 weaknesses" — model-facing, coverage-only (doesn't reach user-visible plan copy), but the last spot with the old framing. Reworded to "top-2 focus areas" for full alignment.

Needs the function redeployed to take effect (will do after merge).

Refs #573