### PR TITLE
feat(web): two-axis putt break with line derived from aim (#402 + #582 parity)

### DIFF
--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -11,6 +11,7 @@ import {
 import {
   FEET_TO_CM,
   combinedBreakDirection,
+  horizontalBreakFromAim,
   type BreakDirectionHorizontal,
   type BreakDirectionVertical,
   type GreenSpeed,
@@ -74,19 +75,6 @@ const BREAK_SLOPE_OPTIONS: { value: BreakDirectionVertical; label: string }[] = 
   { value: 'flat', label: 'Flat' },
   { value: 'downhill', label: 'Downhill' },
 ]
-// The horizontal break is derived from the aim line rather than chosen: the
-// player aims to the side the putt breaks FROM, so a right-of-hole aim plays a
-// right-to-left break and vice-versa. Mirrors GreenDiagram's formatAim 2-inch
-// deadband so a dead-straight aim leaves the axis unset, letting the vertical
-// slope carry the legacy combined label.
-function horizontalBreakFromAim(
-  offsetInches: number,
-): BreakDirectionHorizontal | undefined {
-  if (offsetInches > 2) return 'right_to_left'
-  if (offsetInches < -2) return 'left_to_right'
-  return undefined
-}
-
 const SLOPE_INTENSITY_LABELS = ['Flat', 'Slight', 'Moderate', 'Strong', 'Severe']
 
 const SPEED_OPTIONS: { value: GreenSpeed; label: string }[] = [

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -5,8 +5,10 @@ import {
   LIE_TYPE_LABELS,
   PUTT_RESULT_LABELS,
   SHOT_RESULT_LABELS,
+  combinedBreakDirection,
   combinedPuttResult,
   formatClubLabel,
+  horizontalBreakFromAim,
   formatDistance,
   formatPuttDistance,
   haversineYards,
@@ -172,7 +174,18 @@ export function ShotEntryModal({
       putt_direction_result: isPuttSave ? directionResult : null,
       putt_slope_pct: draft.puttSlopePct ?? null,
       green_speed: draft.greenSpeed ?? null,
-      break_direction: isPuttSave ? draft.breakDirection ?? null : null,
+      break_direction: isPuttSave
+        ? combinedBreakDirection({
+            vertical: draft.breakDirectionVertical,
+            horizontal: draft.breakDirectionHorizontal,
+          })
+        : null,
+      break_direction_vertical: isPuttSave
+        ? draft.breakDirectionVertical ?? null
+        : null,
+      break_direction_horizontal: isPuttSave
+        ? draft.breakDirectionHorizontal ?? null
+        : null,
       aim_offset_yards:
         isPuttSave && draft.aimOffsetInches != null
           ? Math.round((draft.aimOffsetInches / 36) * 10) / 10
@@ -410,9 +423,18 @@ export function ShotEntryModal({
                 <GreenDiagram
                   distanceFt={draft.puttDistanceFt ?? 0}
                   aimOffsetInches={draft.aimOffsetInches ?? 0}
-                  breakDirection={draft.breakDirection ?? 'straight'}
+                  breakDirection={
+                    combinedBreakDirection({
+                      vertical: draft.breakDirectionVertical,
+                      horizontal: draft.breakDirectionHorizontal,
+                    }) ?? 'straight'
+                  }
                   onAimChange={(n) =>
-                    setDraft((d) => ({ ...d, aimOffsetInches: n }))
+                    setDraft((d) => ({
+                      ...d,
+                      aimOffsetInches: n,
+                      breakDirectionHorizontal: horizontalBreakFromAim(n),
+                    }))
                   }
                 />
               )}

--- a/apps/web/src/components/rounds/shots/PuttFormFields.tsx
+++ b/apps/web/src/components/rounds/shots/PuttFormFields.tsx
@@ -1,4 +1,4 @@
-import { type BreakDirection, type GreenSpeed } from '@oga/core'
+import { type BreakDirectionVertical, type GreenSpeed } from '@oga/core'
 import {
   Field,
   NumericInput,
@@ -7,14 +7,11 @@ import {
 } from './formInputs'
 import type { DraftShot } from './draft'
 
-const BREAK_OPTIONS: {
-  value: Exclude<BreakDirection, 'left' | 'right'>
-  label: string
-}[] = [
-  { value: 'left_to_right', label: 'L → R' },
-  { value: 'straight', label: 'Straight' },
-  { value: 'right_to_left', label: 'R → L' },
+// Only the vertical (slope) axis is chosen manually. The horizontal (line)
+// axis is derived from the aim handle on the GreenDiagram — see ShotEntryModal.
+const BREAK_SLOPE_OPTIONS: { value: BreakDirectionVertical; label: string }[] = [
   { value: 'uphill', label: 'Uphill' },
+  { value: 'flat', label: 'Flat' },
   { value: 'downhill', label: 'Downhill' },
 ]
 
@@ -59,6 +56,13 @@ export function PuttFormFields({ draft, setDraft }: PuttFormFieldsProps) {
       ...d,
       puttMade: false,
       puttDirectionResult: d.puttDirectionResult === v ? undefined : v,
+    }))
+  }
+
+  function setBreakSlope(v: BreakDirectionVertical) {
+    setDraft((d) => ({
+      ...d,
+      breakDirectionVertical: d.breakDirectionVertical === v ? undefined : v,
     }))
   }
 
@@ -135,20 +139,24 @@ export function PuttFormFields({ draft, setDraft }: PuttFormFieldsProps) {
           Tap again to clear · leave blank if line was good
         </div>
       </Field>
-      <Field label="Break">
+      <Field label="Break (slope)">
         <div className="flex flex-wrap" style={{ gap: 6 }}>
-          {BREAK_OPTIONS.map((b) => (
+          {BREAK_SLOPE_OPTIONS.map((b) => (
             <button
               key={b.value}
               type="button"
-              onClick={() =>
-                setDraft((d) => ({ ...d, breakDirection: b.value }))
-              }
-              style={chipStyle(draft.breakDirection === b.value)}
+              onClick={() => setBreakSlope(b.value)}
+              style={chipStyle(draft.breakDirectionVertical === b.value)}
             >
               {b.label}
             </button>
           ))}
+        </div>
+        <div
+          className="font-mono uppercase text-caddie-ink-mute"
+          style={{ fontSize: 10, letterSpacing: '0.14em', marginTop: 8 }}
+        >
+          Tap again to clear · line break comes from your aim
         </div>
       </Field>
       <Field label="How much">

--- a/packages/core/src/__tests__/breakDirection.test.ts
+++ b/packages/core/src/__tests__/breakDirection.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
   combinedBreakDirection,
   decombinedBreakDirection,
+  horizontalBreakFromAim,
   type BreakDirection,
 } from '../types'
 
@@ -42,6 +43,24 @@ describe('combinedBreakDirection', () => {
     expect(
       combinedBreakDirection({ vertical: 'flat', horizontal: 'straight' }),
     ).toBe('straight')
+  })
+})
+
+describe('horizontalBreakFromAim', () => {
+  it('aim right of the hole → right_to_left break', () => {
+    expect(horizontalBreakFromAim(12)).toBe('right_to_left')
+    expect(horizontalBreakFromAim(3)).toBe('right_to_left')
+  })
+
+  it('aim left of the hole → left_to_right break', () => {
+    expect(horizontalBreakFromAim(-12)).toBe('left_to_right')
+    expect(horizontalBreakFromAim(-3)).toBe('left_to_right')
+  })
+
+  it('within the 2-inch deadband → undefined (lets vertical carry the label)', () => {
+    expect(horizontalBreakFromAim(0)).toBeUndefined()
+    expect(horizontalBreakFromAim(2)).toBeUndefined()
+    expect(horizontalBreakFromAim(-2)).toBeUndefined()
   })
 })
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -217,6 +217,21 @@ export function combinedBreakDirection(args: {
   return null
 }
 
+/** Derive the horizontal break axis from the aim-line offset (inches). The
+ *  player aims to the side the putt breaks FROM, so a right-of-hole aim plays a
+ *  right-to-left break and a left aim plays left-to-right. A 2-inch deadband
+ *  (matching the green diagram's aim label) returns `undefined` for a
+ *  dead-straight aim so the vertical slope can still carry the combined label.
+ *  Shared by the web and mobile putt sheets — both derive the line axis from
+ *  the aim handle rather than a manual chooser. */
+export function horizontalBreakFromAim(
+  offsetInches: number,
+): BreakDirectionHorizontal | undefined {
+  if (offsetInches > 2) return 'right_to_left'
+  if (offsetInches < -2) return 'left_to_right'
+  return undefined
+}
+
 /** Inverse of {@link combinedBreakDirection} — decompose a legacy
  *  BreakDirection value into the two new axes for the read-path
  *  fallback. Legacy single-letter `left` / `right` map onto the


### PR DESCRIPTION
Brings web putt-break logging to full parity with mobile's post-#582 `PuttingSheet`, closing **#402** (slope + line recordable simultaneously) and the **web half** of the green-diagram label/curve contradiction (#576/#582).

## Changes
- **`@oga/core`** — new shared `horizontalBreakFromAim(offsetInches)`: aim right of the hole → `right_to_left`, left → `left_to_right`, 2in deadband → unset (matches `formatAim`). + unit tests. Mobile `PuttingSheet` now imports it instead of a local copy (one source for the domain mapping, no drift).
- **`PuttFormFields`** — the single combined break selector (L→R/R→L/straight/uphill/downhill) is replaced by a **Break (slope)** axis (uphill/flat/downhill, toggle-to-clear) → `breakDirectionVertical`. The line axis is no longer chosen manually.
- **`ShotEntryModal`** — the horizontal axis is **derived from the GreenDiagram aim handle**; the corner label is computed via `combinedBreakDirection`; the write-path now persists **all three** columns (`break_direction` + `break_direction_vertical` + `break_direction_horizontal`).

## Why this shape
The #402 spec proposed re-adding a manual **Break (line)** chooser, but #576/#582 established that the line axis should come from the aim handle (one source → label, curve, and caption can't disagree). So slope stays manual; line is aim-derived — identical to mobile today.

## Verification
- web + mobile typecheck clean; 543 `@oga/core` tests pass (3 new for `horizontalBreakFromAim`).
- Read-path already mapped both axes via `shotRowToDraft`, so existing putts load correctly.
- **Manual QA**: log an uphill putt that also breaks (drag aim right) on web, reload — confirm slope=uphill persists and the line axis reads right-to-left.

Closes #402