### PR TITLE
fix(live-round): clarify the place-ball CTA marks the ball at your GPS (#483)

### DIFF
--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -88,6 +88,10 @@ export default function LiveRoundSession({
   // historical-shot scatter overlay; the render lands in T4. Off by
   // default — it's a summoned planning aid, not always-on clutter.
   const [dotsVisible, setDotsVisible] = useState(false)
+  // True once the player drags the ball off its GPS-tracked position this
+  // PLACE_BALL cycle — flips the place-ball CTA from "Mark ball at my GPS"
+  // to the generic "Mark ball here". Reset on each new placement / hole.
+  const [ballMoved, setBallMoved] = useState(false)
   // Aim overlay shape + size (T3). Tee → arc band, Appr → circle ring; the
   // rail index sizes each, kept per-mode so switching modes preserves the
   // other's pick. Default Tee, widest rail.
@@ -108,6 +112,7 @@ export default function LiveRoundSession({
     setLoggerOpen(false)
     setPinPlacementOpen(false)
     setLoggerInitial({})
+    setBallMoved(false)
     // Clear only hole-scoped dialogs (onGreen / aim). Session-scoped
     // confirms (delete / leave / end / exit) stay open across hole
     // navigation — a confirmDelete dialog mid-navigation should not
@@ -137,6 +142,12 @@ export default function LiveRoundSession({
     tee: data.tee,
     hasPriorShots: data.remoteShotCount + data.localShotCount > 0,
   })
+
+  // Each fresh PLACE_BALL entry (new shot, re-place) starts GPS-tracked, so the
+  // ball is back at the GPS dot until the player drags it again.
+  useEffect(() => {
+    if (finalState.roundState === 'PLACE_BALL') setBallMoved(false)
+  }, [finalState.roundState])
 
   // Camera anchors on the tee box — the player's starting point. Pin/green
   // is intentionally NOT a fallback; it would mis-frame the hole every time.
@@ -530,6 +541,7 @@ export default function LiveRoundSession({
             // (1 m²) — strong prior so any future un-freeze still
             // resists snapping back to a noisy raw fix.
             finalState.manuallyPlacedRef.current = true
+            setBallMoved(true)
             finalState.kalmanStateRef.current = {
               lat: loc.lat,
               lng: loc.lng,
@@ -589,6 +601,12 @@ export default function LiveRoundSession({
           saving={actions.saving}
           roundPin={data.roundPin}
           hasGps={finalState.gpsPosition != null}
+          ballFromGps={
+            !isPastMode &&
+            finalState.gpsPosition != null &&
+            finalState.ball != null &&
+            !ballMoved
+          }
           totalShotsThisHole={totalShotsThisHole}
           holeNumber={holeNumber}
           holeCount={data.holeCount}

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -23,6 +23,9 @@ interface MapBottomChromeProps {
   saving: boolean
   roundPin: { lat: number; lng: number } | null
   hasGps: boolean
+  /** Live mode only: the ball marker is currently tracking the player's GPS
+   *  (not manually dragged). Drives the GPS-explicit place-ball CTA + hint. */
+  ballFromGps?: boolean
   totalShotsThisHole: number
   holeNumber: number
   holeCount: number
@@ -84,18 +87,35 @@ function ContextualActions(p: MapBottomChromeProps) {
       </>
     )
   }
-  // PLACE_BALL
+  // PLACE_BALL. When the ball is GPS-tracked (live, not yet dragged), the CTA
+  // says so explicitly — otherwise it's the generic "here" for a dragged marker.
   const ballLabel = p.saving
     ? 'Saving…'
-    : p.ball
-      ? 'Mark ball here →'
-      : p.hasGps
-        ? 'Mark ball at my GPS →'
-        : 'Waiting for GPS…'
+    : p.ballFromGps
+      ? 'Mark ball at my GPS →'
+      : p.ball
+        ? 'Mark ball here →'
+        : p.hasGps
+          ? 'Mark ball at my GPS →'
+          : 'Waiting for GPS…'
   const ballDisabled = (!p.ball && !p.hasGps) || p.saving
   return (
     <>
       <PrimaryCta label={ballLabel} disabled={ballDisabled} onPress={p.onMarkBallHere} />
+      {p.ballFromGps && !p.saving && (
+        <View
+          style={{
+            backgroundColor: CHROME_BG,
+            borderRadius: 14,
+            paddingHorizontal: 12,
+            paddingVertical: 5,
+          }}
+        >
+          <Text style={[TYPE.body, { color: CREAM, fontSize: 11, opacity: 0.85 }]}>
+            The ball follows your GPS — drag to adjust.
+          </Text>
+        </View>
+      )}
       {p.totalShotsThisHole > 0 && (
         <TextChip
           label={p.holeNumber < p.holeCount ? 'Finish hole · next →' : 'Finish round'}


### PR DESCRIPTION
## Problem (your on-device feedback)
In the live flow there's no clear 'mark ball at my GPS' affordance. Root cause confirmed in code: live mode auto-tracks the ball to the player's GPS during PLACE_BALL (`useHoleState.ts:281` `setBall(smoothed)`), so `ball` is always set and `MapBottomChrome` always shows the generic **'Mark ball here →'** — the **'Mark ball at my GPS →'** branch (needs `!ball`) was effectively dead.

## Fix (A + C)
- **A — GPS-explicit label.** New derived `ballFromGps` (live + GPS + ball present + not yet dragged), threaded from `LiveRoundSession` via a reactive `ballMoved` flag (set on manual ball drag; reset on each fresh PLACE_BALL entry and hole change). CTA reads **'Mark ball at my GPS →'** while GPS-tracked, reverting to **'Mark ball here →'** once you drag the marker.
- **C — hint** under the CTA: *'The ball follows your GPS — drag to adjust.'*

## Verification
Mobile typecheck clean. **Mobile-only, no e2e — needs on-device QA**: start a live hole, confirm the CTA reads 'Mark ball at my GPS →' and the hint shows; drag the ball and confirm it flips to 'Mark ball here →'; re-place / next hole and confirm it resets to the GPS wording.

Closes #483