### PR TITLE
fix(live-round): free the aim handle near the green (#473)

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -155,6 +155,13 @@ const AIM_EXTENSION_YARDS = 250
 // Android drag jank. Gating to ~25 Hz cuts that storm while the readouts
 // still track the finger; onDragEnd always applies the final position.
 const AIM_DRAG_THROTTLE_MS = 40
+// Distance labels are @rnmapbox MarkerViews that capture touches (their content
+// wrapper hardcodes the touch responder), so a label sitting at its leg's
+// midpoint steals the drag from the aim handle when that leg is short — the
+// near-green "can't drag the aim marker" bug (#473). Hide a label once its leg
+// is under this many yards; its midpoint is then within the handle's grab zone.
+// Tune on-device — the screen overlap is zoom-dependent, this is a geo proxy.
+const MIN_LABEL_LEG_YARDS = 20
 
 function extractCoord(feature: unknown): LatLng | null {
   const geom = (feature as { geometry?: { coordinates?: unknown } } | null)?.geometry
@@ -797,7 +804,9 @@ export function HoleMap({
             </Mapbox.PointAnnotation>
           )}
 
-          {aimMidpoint && aimDistanceYards !== null && (
+          {aimMidpoint &&
+            aimDistanceYards !== null &&
+            aimDistanceYards >= MIN_LABEL_LEG_YARDS && (
             <AimDistancePill
               midpoint={aimMidpoint}
               display={toDisplay(aimDistanceYards)}
@@ -811,7 +820,9 @@ export function HoleMap({
           {/* Remaining (aim→pin) — subordinate to the hero carry pill: a
               smaller, dimmer label on the aim→pin leg. Uses the already-
               computed aimToPinYards, run through the units helper. */}
-          {remainingMidpoint && aimToPinYards !== null && (
+          {remainingMidpoint &&
+            aimToPinYards !== null &&
+            aimToPinYards >= MIN_LABEL_LEG_YARDS && (
             <Mapbox.MarkerView
               id="remainingDistance"
               coordinate={toCoord(remainingMidpoint)}


### PR DESCRIPTION
## Problem
Near the green (short ball→aim leg) you can't drag the aim marker — the carry distance pill steals the touch. Root cause (per the issue): the distance labels are @rnmapbox `MarkerView`s whose content wrapper hardcodes the touch responder, so a label overlapping the draggable aim `PointAnnotation` captures the gesture. `pointerEvents:'none'` is a no-op against it (tried + reverted before).

## Fix (the lowest-risk option from the issue)
Hide each distance label once its leg is under `MIN_LABEL_LEG_YARDS` (20yd) — at that point its midpoint is inside the handle's grab zone. Applies to both the carry pill (ball→aim) and the remaining label (aim→pin). The persistent top **'to hole'** readout still shows distance near the green, so nothing critical is lost.

## Caveat
The overlap is a screen-space problem; the yard threshold is a zoom-dependent proxy. **20yd is a starting value that needs on-device tuning** — the issue explicitly flagged each option as 'a build'. Mobile-only, no e2e.

Closes #473