### PR TITLE
fix(mobile): device-QA batch — past-round routing, live tee, home tile

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -145,9 +145,16 @@ export default function Home() {
     const avgScore = scoreRounds.length > 0
       ? scoreRounds.reduce((s, r) => s + (r.total_score ?? 0), 0) / scoreRounds.length
       : null
+    // total_score === 0 is the past-round-logger sentinel for "no score
+    // entered" (map-created rounds), so exclude it from the best-round min —
+    // otherwise a single unscored round always reads as a best of 0.
+    const realScores = rounds
+      .map((r) => r.total_score)
+      .filter((s): s is number => s != null && s > 0)
+    const bestScore = realScores.length > 0 ? Math.min(...realScores) : null
     const totalSG = avgs.reduce((s, a) => s + a.value, 0)
     const sorted = [...avgs].sort((a, b) => b.value - a.value)
-    return { avgScore, totalSG, weakest: sorted[sorted.length - 1]!, strongest: sorted[0]! }
+    return { avgScore, bestScore, totalSG, weakest: sorted[sorted.length - 1]!, strongest: sorted[0]! }
   }, [rounds])
 
   const eyebrow =
@@ -217,7 +224,7 @@ export default function Home() {
                   valueColor={homeStats.totalSG > 0 ? '#1F3D2C' : homeStats.totalSG < 0 ? '#A33A2A' : '#1C211C'}
                 />
                 <HomeTile label="Rounds" value={rounds.length.toString()} />
-                <HomeTile label="Categories" value={SG_KEYS.length.toString()} />
+                <HomeTile label="Best round" value={homeStats.bestScore != null ? homeStats.bestScore.toString() : '—'} />
               </View>
             </View>
           </>

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -142,12 +142,15 @@ export default function RoundIndex() {
             ? { lat: row.courses.lat, lng: row.courses.lng }
             : null,
         )
-        // Live round signal: total_score is null while a LIVE round is in
-        // progress. Past-round entry (#514) persists a total_score sentinel
-        // at creation and lands here on the editable scorecard — never the
-        // live map. The `mode !== 'past'` guard is belt-and-suspenders for
-        // the first render before the sentinel round row is re-read.
-        if (row.total_score == null && mode !== 'past') {
+        // Only redirect into the live state machine for a round that is
+        // genuinely unfinished: never finalized (completed_at null) AND has
+        // no score yet. completed_at is the canonical finalized flag, so a
+        // finalized round always opens the read-only tabbed view even if its
+        // total_score is null. The total_score guard keeps seeded past rounds
+        // (scored but no completed_at) out of the live map too; the
+        // `mode !== 'past'` guard covers the past-logger creation race.
+        const unfinished = row.completed_at == null && row.total_score == null
+        if (unfinished && mode !== 'past') {
           if (active) setRedirectToLive(true)
           return
         }

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -111,7 +111,12 @@ export function useHoleData(
     currentHoleScore?.pin_lat != null && currentHoleScore.pin_lng != null
       ? { lat: currentHoleScore.pin_lat, lng: currentHoleScore.pin_lng }
       : null
-  const tee: LatLng | null =
+  // The course's stored tee (OSM-mapped or synthetic). Used as the pre-shot
+  // fallback; once the player has hit, the live tee is their first shot's
+  // start (see `tee` below) — most courses now carry an OSM tee, and pinning
+  // the marker there instead of where the player actually teed off is wrong
+  // for the live round.
+  const storedTee: LatLng | null =
     currentHole?.tee_lat != null && currentHole.tee_lng != null
       ? { lat: currentHole.tee_lat, lng: currentHole.tee_lng }
       : null
@@ -219,6 +224,13 @@ export function useHoleData(
     }
     return out
   }, [remoteShotStarts, pendingForHole])
+
+  // Live tee anchor: the player's first shot's start IS the tee. Falls back to
+  // the stored course tee before the first shot (camera + pre-shot distances).
+  // useHoleData is live-round-only (past rounds use PastRoundMap), so this is
+  // the "GPS-first in live mode" anchor without touching the shared
+  // holes.tee_lat — writeTee still only persists for synthetic holes.
+  const tee: LatLng | null = previousShots[0] ?? storedTee
 
   const localPuttCount = useMemo(() => {
     let n = 0

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -197,7 +197,13 @@ export async function completeRound({
       sg_putting: round2(result.round.putting),
       sg_total: round2(result.round.total),
       completed_at: new Date().toISOString(),
-      total_score: result.totals.totalScore || null,
+      // Store the real total (incl. 0 for a round finalized without scores) —
+      // never coerce 0 → null. A null total_score is the "never finalized"
+      // signal the round-entry screen routes on; nulling it here stranded
+      // finalized rounds in the live map. completed_at is the canonical
+      // finalized flag, but keeping total_score honest matters for any
+      // total_score-null check (Resume banner, in-progress list).
+      total_score: result.totals.totalScore,
       total_putts: result.totals.totalPutts || null,
       fairways_hit:
         result.totals.fairwaysTotal > 0 ? result.totals.fairwaysHit : null,


### PR DESCRIPTION
On-device QA fixes (mobile).

## Past-round routing (the big one)
Opening a round from the list could drop you on the bare **live map with no tabs** instead of the read-only Scorecard⇄Map view. Root cause was a routing heuristic + a finalize bug, not a missing screen:
- `[id]/index.tsx` decided "live vs past" purely on `total_score == null`. A finalized round whose score is null then redirected into the live state machine.
- `completeRound.ts` wrote `total_score: totalScore || null`, so a round finalized **without entered hole-scores became `total_score = null`** — feeding the bad redirect.

Fixes:
- Redirect into the live flow **only when `completed_at == null AND total_score == null`** (and not the past-logger creation race). `completed_at` is the canonical finalized flag, so a finalized round always opens the tabbed scorecard. The `total_score` guard keeps seeded past rounds (scored, no `completed_at`) out of the live map too.
- `completeRound` stores the real total (incl. `0`) instead of coercing to null.

## Live tee anchor (GPS-first)
~82% of courses now carry an OSM `holes.tee_lat`, so the live tee box stopped following where you actually teed off and pinned to the OSM coordinate. Now in live mode the tee anchors to your **first shot's start**, with the OSM tee as the pre-shot fallback. Shared `holes.tee_lat` is never overwritten (`writeTee` still only persists synthetic holes); `useHoleData` is live-round-only so past rounds are unaffected.

## Home "By the numbers"
Replaced the static **Categories (4)** tile (always 4 — useless) with **Best round** (lowest real score; the `0` sentinel excluded).

## Verification
- Mobile typecheck clean.
- Data check (dev/prod): all real rounds are scored; the redirect change keeps them on the tabbed view and stops finalized-but-null-score rounds from hitting the live map.

Mobile-only; no schema changes. Wants on-device confirmation in a fresh build (past round opens to tabbed scorecard; live tee follows first shot).