### PR TITLE
fix(mobile): completed_at is the round lifecycle flag (review follow-up to #589)

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -434,15 +434,8 @@ export default function RoundIndex() {
         supabase.from('hole_scores').select('*').eq('round_id', round.id),
       ])
       if (rRes.data) {
-        let saved = rRes.data as RoundRow & {
+        const saved = rRes.data as RoundRow & {
           courses?: { name: string | null } | null
-        }
-        // completeRound writes `total_score: totalScore || null`, so an
-        // all-zero past round comes back null — which would re-strand it on
-        // the live map on next open (#514). Preserve the non-null sentinel.
-        if (saved.total_score == null) {
-          await updateRound(supabase, round.id, { total_score: 0 }, user.id)
-          saved = { ...saved, total_score: 0 }
         }
         setRound(saved)
       }

--- a/apps/mobile/hooks/useActiveRound.ts
+++ b/apps/mobile/hooks/useActiveRound.ts
@@ -9,8 +9,11 @@ export interface ActiveRound {
   currentHole: number
 }
 
-// Active = total_score IS NULL AND played_at within the last day, so a
-// round abandoned a week ago doesn't haunt the home screen forever.
+// Active = not finalized (completed_at IS NULL) AND no score yet
+// (total_score IS NULL) AND played_at within the last day, so a round
+// abandoned a week ago doesn't haunt the home screen forever. completed_at
+// is the canonical finalized flag; the total_score guard also keeps seeded
+// past rounds (scored, but no completed_at) out of the banner.
 // The current hole is the highest hole the player has logged a score
 // on, +1 (capped at 18) — so resuming jumps back to where they left
 // off, not hole 1.
@@ -34,6 +37,7 @@ export function useActiveRound(): ActiveRound | null {
           .from('rounds')
           .select('id, played_at, course_id, courses(name)')
           .eq('user_id', user.id)
+          .is('completed_at', null)
           .is('total_score', null)
           .gte('played_at', oneDayAgo)
           .order('played_at', { ascending: false })

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -32,8 +32,10 @@ interface CompleteArgs {
 // Mobile equivalent of apps/web/src/hooks/useCompleteRound (sans the
 // react-query / handicap-index recalc plumbing). Drains the pending
 // shot queue, runs computeRoundSG over the persisted shots, and stamps
-// total_score / SG fields onto the round so total_score IS NOT NULL —
-// which removes the round from the home-screen Resume banner.
+// completed_at + SG/score fields onto the round. completed_at is what
+// marks the round finalized — it removes it from the home-screen Resume
+// banner and routes it to the read-only summary (total_score may be null
+// when no scores were entered).
 export async function completeRound({
   roundId,
   courseId,
@@ -197,13 +199,12 @@ export async function completeRound({
       sg_putting: round2(result.round.putting),
       sg_total: round2(result.round.total),
       completed_at: new Date().toISOString(),
-      // Store the real total (incl. 0 for a round finalized without scores) —
-      // never coerce 0 → null. A null total_score is the "never finalized"
-      // signal the round-entry screen routes on; nulling it here stranded
-      // finalized rounds in the live map. completed_at is the canonical
-      // finalized flag, but keeping total_score honest matters for any
-      // total_score-null check (Resume banner, in-progress list).
-      total_score: result.totals.totalScore,
+      // null when no scores were entered — total_score is the SCORE, not a
+      // lifecycle flag. completed_at (set above) is the canonical "finalized"
+      // signal for routing and the Resume banner, so a scoreless finalized
+      // round stays null here and is correctly excluded from score averages
+      // (computed stats null-filter total_score).
+      total_score: result.totals.totalScore || null,
       total_putts: result.totals.totalPutts || null,
       fairways_hit:
         result.totals.fairwaysTotal > 0 ? result.totals.fairwaysHit : null,


### PR DESCRIPTION
Addresses the code-review on #589 (which I merged before reading — this closes the loop).

## What the review caught
- `handleSaveSG` had a `if (saved.total_score == null) { updateRound({total_score: 0}) }` fallback whose comment described the old `|| null` contract. With routing now on `completed_at`, that branch is dead and the comment was a lie.

## What I found verifying the rest
- The review also suggested fixing `total_putts: totalPutts || null` the same way `total_score` was. **Rejected** — `shortGameStats` (`packages/core/src/stats.ts:562`) null-filters `total_putts`, so storing `0` would drag putt averages. `scoringStats` (`stats.ts:366`) null-filters `total_score` the same way — meaning my merged `total_score`-stores-`0` change risked the identical corruption for a round finalized with no scores entered.

## Fix — make `completed_at` the lifecycle flag, `total_score` just the score
- `handleSaveSG`: remove the dead fallback + stale comment.
- `completeRound`: restore `total_score: result.totals.totalScore || null` (null = no score → correctly excluded from null-filtered score/putt stats).
- `useActiveRound`: gate the Resume banner on `completed_at IS NULL` **and** `total_score IS NULL`, so a scoreless finalized round leaves the banner and seeded scored rounds never show as active.
- Routing (#589) already keys on `completed_at`, so a finalized round opens the read-only summary regardless of score.

`total_putts` left as-is (correct). Mobile typecheck clean. No schema changes.