### PR TITLE
polish(mobile): vector icons on home CTAs + clearer dispersion export button

### DIFF
--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -224,6 +224,8 @@ export default function Patterns() {
                     size={15}
                     color="#1F3D2C"
                   />
+                  {/* fontSize +1 over the 10px KICKER: deliberate, this is a
+                      tappable action label beside an icon, not a section eyebrow. */}
                   <Text style={{ ...KICKER, color: '#1F3D2C', fontSize: 11 }}>
                     {sharing ? 'Rendering…' : 'Export image'}
                   </Text>

--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -21,6 +21,7 @@ import {
   type Shot,
 } from '@oga/core'
 import { getShotsByClub } from '@oga/supabase'
+import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useUnits } from '../../hooks/useUnits'
@@ -201,19 +202,30 @@ export default function Patterns() {
                   accessibilityState={{ disabled: sharing }}
                   onPress={handleShare}
                   disabled={sharing}
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
                   style={({ pressed }) => ({
                     alignSelf: 'flex-start',
-                    marginTop: 14,
-                    paddingVertical: 9,
-                    paddingHorizontal: 14,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    gap: 7,
+                    marginTop: 22,
+                    marginBottom: 4,
+                    paddingVertical: 11,
+                    paddingHorizontal: 16,
+                    backgroundColor: '#EBE5D6',
                     borderWidth: 1,
                     borderColor: '#1F3D2C',
                     borderRadius: 2,
                     opacity: pressed || sharing ? 0.6 : 1,
                   })}
                 >
-                  <Text style={{ ...KICKER, color: '#1F3D2C' }}>
-                    {sharing ? 'Rendering…' : '↓ Export · 1200×630'}
+                  <MaterialCommunityIcons
+                    name="tray-arrow-down"
+                    size={15}
+                    color="#1F3D2C"
+                  />
+                  <Text style={{ ...KICKER, color: '#1F3D2C', fontSize: 11 }}>
+                    {sharing ? 'Rendering…' : 'Export image'}
                   </Text>
                 </Pressable>
               )}

--- a/apps/mobile/components/home/RoundCTAs.tsx
+++ b/apps/mobile/components/home/RoundCTAs.tsx
@@ -1,5 +1,6 @@
 import { Pressable, Text } from 'react-native'
 import { Link } from 'expo-router'
+import { MaterialCommunityIcons } from '@expo/vector-icons'
 import { TYPE } from '../../lib/typography'
 
 export function StartLiveRoundCTA() {
@@ -13,10 +14,14 @@ export function StartLiveRoundCTA() {
             backgroundColor: '#1F3D2C',
             borderRadius: 2,
             paddingVertical: 18,
+            flexDirection: 'row',
             alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
             marginBottom: 6,
           }}
         >
+          <MaterialCommunityIcons name="play" size={20} color="#F2EEE5" />
           <Text
             style={[
               TYPE.bodyBold,
@@ -28,7 +33,7 @@ export function StartLiveRoundCTA() {
               },
             ]}
           >
-            ▶  Start live round
+            Start live round
           </Text>
         </Pressable>
       </Link>
@@ -61,10 +66,14 @@ export function LogPastRoundCTA() {
           backgroundColor: 'transparent',
           borderRadius: 2,
           paddingVertical: 14,
+          flexDirection: 'row',
           alignItems: 'center',
+          justifyContent: 'center',
+          gap: 8,
           marginBottom: 22,
         }}
       >
+        <MaterialCommunityIcons name="plus" size={18} color="#1F3D2C" />
         <Text
           style={[
             TYPE.bodyBold,
@@ -76,7 +85,7 @@ export function LogPastRoundCTA() {
             },
           ]}
         >
-          +  Log past round
+          Log past round
         </Text>
       </Pressable>
     </Link>


### PR DESCRIPTION
Two small QA-driven polish fixes (from device QA 2026-06-12).

## 1. Home CTA icons (the iOS "goofy emoji" play button)
`StartLiveRoundCTA` / `LogPastRoundCTA` rendered a raw `▶` / `+` emoji in a Text — fine on Android, off on iOS. Swapped for **MaterialCommunityIcons** (`play` / `plus`) — already the app's icon set (tab bar, HoleMap) — in a centered icon+label row.

## 2. Dispersion export button visibility
The Patterns "Export" button was a 10px kicker with 9px padding, no hitSlop, border same color as text, 14px above — cramped and easy to miss. Now: chip background (`#EBE5D6`), `tray-arrow-down` icon, larger padding + `hitSlop`, more separation, label simplified to "Export image". Stays DESIGN-faithful (1px hairline border, mono kicker, no loud accent fill).

## Verification
Mobile typecheck green. Not on-device yet — visual-only changes; QA: home screen play/log buttons on iOS, Patterns export button prominence.

Branched off `dev`. Not merging — review first.