### PR TITLE
polish(mobile): render intended emphasis on Android (fontWeight → bodyBold)

### DIFF
--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -574,7 +574,7 @@ function ClubRow({
         <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 16 }]}>⠿</Text>
       </Pressable>
       <View style={{ flex: 1 }}>
-        <Text style={[TYPE.body, { color: '#1C211C', fontSize: 16, fontWeight: '500' }]}>
+        <Text style={[TYPE.bodyBold, { color: '#1C211C', fontSize: 16 }]}>
           {club.name}
         </Text>
         <Text style={{ ...KICKER, marginTop: 2 }}>

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -308,7 +308,7 @@ function FocusAreas({ areas }: { areas: StoredFocusArea[] }) {
               asChild
             >
               <Pressable hitSlop={6} style={{ marginTop: 6 }}>
-                <Text style={[TYPE.body, { color: ACCENT, fontSize: 13, fontWeight: '600' }]}>
+                <Text style={[TYPE.bodyBold, { color: ACCENT, fontSize: 13 }]}>
                   {a.article.title} →
                 </Text>
               </Pressable>

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -389,7 +389,7 @@ export default function ProfileTab() {
         >
           <View>
             <Text style={{ ...KICKER, marginBottom: 2 }}>Equipment</Text>
-            <Text style={[TYPE.body, { color: '#1C211C', fontSize: 16, fontWeight: '500' }]}>
+            <Text style={[TYPE.bodyBold, { color: '#1C211C', fontSize: 16 }]}>
               My Bag
             </Text>
           </View>
@@ -658,7 +658,7 @@ function DeleteAccountModal({
                 opacity: busy ? 0.5 : 1,
               }}
             >
-              <Text style={[TYPE.body, { color: '#5C6356', fontSize: 13, fontWeight: '500' }]}>Cancel</Text>
+              <Text style={[TYPE.bodyBold, { color: '#5C6356', fontSize: 13 }]}>Cancel</Text>
             </Pressable>
 
             {phase === 'confirm' ? (

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -658,7 +658,9 @@ function DeleteAccountModal({
                 opacity: busy ? 0.5 : 1,
               }}
             >
-              <Text style={[TYPE.bodyBold, { color: '#5C6356', fontSize: 13 }]}>Cancel</Text>
+              {/* regular weight — secondary Cancel, must not compete with the
+                  destructive Delete action (#598 review). */}
+              <Text style={[TYPE.body, { color: '#5C6356', fontSize: 13 }]}>Cancel</Text>
             </Pressable>
 
             {phase === 'confirm' ? (

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -657,7 +657,7 @@ function ScoringDistBar({
         {visible.map((s) => (
           <View key={s.key} style={{ flex: s.count, backgroundColor: s.color, justifyContent: 'center', alignItems: 'center' }}>
             {s.pct >= 8 && (
-              <Text style={[TYPE.body, { color: '#F2EEE5', fontSize: 11, fontWeight: '500', fontVariant: ['tabular-nums'] }]}>
+              <Text style={[TYPE.bodyBold, { color: '#F2EEE5', fontSize: 11, fontVariant: ['tabular-nums'] }]}>
                 {s.pct.toFixed(0)}%
               </Text>
             )}

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -132,7 +132,7 @@ export default function Login() {
             opacity: !canSubmit ? 0.5 : 1,
           }}
         >
-          <Text style={[TYPE.body, { color: '#FFFFFF', fontSize: 13, fontWeight: '500' }]}>
+          <Text style={[TYPE.bodyBold, { color: '#FFFFFF', fontSize: 13 }]}>
             {loading ? 'Signing in…' : 'Sign in'}
           </Text>
         </Pressable>

--- a/apps/mobile/app/(auth)/onboarding.tsx
+++ b/apps/mobile/app/(auth)/onboarding.tsx
@@ -245,7 +245,7 @@ export default function MobileOnboarding() {
           opacity: saving ? 0.5 : 1,
         }}
       >
-        <Text style={[TYPE.body, { color: '#FFFFFF', fontSize: 13, fontWeight: '500' }]}>
+        <Text style={[TYPE.bodyBold, { color: '#FFFFFF', fontSize: 13 }]}>
           {saving ? 'Saving…' : 'Start tracking'}
         </Text>
       </Pressable>
@@ -266,7 +266,7 @@ export default function MobileOnboarding() {
           opacity: saving ? 0.5 : 1,
         }}
       >
-        <Text style={[TYPE.body, { color: '#1F3D2C', fontSize: 13, fontWeight: '500' }]}>
+        <Text style={[TYPE.bodyBold, { color: '#1F3D2C', fontSize: 13 }]}>
           Set up later →
         </Text>
       </Pressable>

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -174,7 +174,7 @@ export default function Signup() {
             opacity: !canSubmit ? 0.5 : 1,
           }}
         >
-          <Text style={[TYPE.body, { fontSize: 13, fontWeight: '500' }]} className="text-white">
+          <Text style={[TYPE.bodyBold, { fontSize: 13 }]} className="text-white">
             {loading ? 'Creating…' : 'Create account'}
           </Text>
         </Pressable>

--- a/apps/mobile/components/home/RecentRoundsList.tsx
+++ b/apps/mobile/components/home/RecentRoundsList.tsx
@@ -157,7 +157,7 @@ export function RecentRoundsList({
                   alignItems: 'flex-end',
                 }}
               >
-                <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 13, fontWeight: '500' }]}>
+                <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 13 }]}>
                   See all rounds →
                 </Text>
               </Pressable>

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -318,7 +318,7 @@ function NavChevron({
         opacity: disabled ? 0.3 : 1,
       }}
     >
-      <Text style={[TYPE.body, { color: CREAM, fontSize: 20, fontWeight: '500' }]}>
+      <Text style={[TYPE.bodyBold, { color: CREAM, fontSize: 20 }]}>
         {dir === 'prev' ? '‹' : '›'}
       </Text>
     </PressableTouch>

--- a/apps/mobile/components/ui/ConfirmDialog.tsx
+++ b/apps/mobile/components/ui/ConfirmDialog.tsx
@@ -106,7 +106,7 @@ export function ConfirmDialog({
                 opacity: busy ? 0.5 : 1,
               }}
             >
-              <Text style={[TYPE.body, { color: '#5C6356', fontSize: 13, fontWeight: '500' }]}>
+              <Text style={[TYPE.bodyBold, { color: '#5C6356', fontSize: 13 }]}>
                 {cancelLabel}
               </Text>
             </Pressable>

--- a/apps/mobile/components/ui/ConfirmDialog.tsx
+++ b/apps/mobile/components/ui/ConfirmDialog.tsx
@@ -106,7 +106,10 @@ export function ConfirmDialog({
                 opacity: busy ? 0.5 : 1,
               }}
             >
-              <Text style={[TYPE.bodyBold, { color: '#5C6356', fontSize: 13 }]}>
+              {/* Cancel stays regular weight (de-emphasized) — it shouldn't
+                  compete with the destructive confirm action. The old '500'
+                  was intended de-emphasis that just never rendered on Android. */}
+              <Text style={[TYPE.body, { color: '#5C6356', fontSize: 13 }]}>
                 {cancelLabel}
               </Text>
             </Pressable>


### PR DESCRIPTION
Fixes the "Android isn't rendering all the fonts correctly in the right places" QA note (device QA 2026-06-12).

## Root cause
On Android, RN **ignores inline `fontWeight` when a custom `fontFamily` is set** — the family name picks the file. `TYPE.body` = Epilogue-Regular (400), and Epilogue bundles **no 500/600 weight**. So `<Text style={[TYPE.body, { fontWeight: '500'|'600' }]}>` (used for button labels, titles, links) rendered **plain regular on Android** but heavier on iOS. That's both the cross-platform inconsistency *and* why emphasized text "doesn't stand out" on Android.

## Fix
The 11 sites that intend emphasis → `TYPE.bodyBold` (Epilogue-Bold 700, the bundled emphasis face), dropping the now-dead inline `fontWeight`. The single muted `See all rounds →` caption stays regular (its 500 was a no-op anyway). **Weight/style only — no color/size/spacing touched.**

Sites: login/signup/onboarding CTAs, ConfirmDialog & delete-account Cancel, My Bag row + club-name title, practice article links, stats bar % labels, map nav chevrons.

## Scope
Deliberately narrow: only the **visible-divergence class** (`TYPE.body` + emphasis weight). The ~200 other inline `fontWeight` uses render correctly on Android already (family name wins) — sweeping them would be churn with no visible change, so they're left alone.

## On "making small text pop"
Per DESIGN.md, muted text (`#8A8B7E`) is intentionally muted — pop comes from serif headlines, big serif numbers, and sparing accent, not from recoloring tokens. This PR's real-emphasis-on-Android *is* the in-system pop win; I did not do a speculative global contrast bump. If you want specific labels promoted, point me at them.

## Verification
Mobile typecheck green. Not on-device — visual; QA: buttons/titles read bold on Android, unchanged on iOS.

Branched off `dev`. Not merging — review first.