### PR TITLE
polish(mobile): subtle staggered entrance animations across the main screens

### DIFF
--- a/apps/mobile/app/(app)/drills.tsx
+++ b/apps/mobile/app/(app)/drills.tsx
@@ -5,6 +5,7 @@ import { getDrills } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
 import type { BlockType, PlanCategory } from '@oga/core'
 import { AppBar } from '../../components/ui/AppBar'
+import { Entrance } from '../../components/ui/Entrance'
 import {
   BLOCK_TYPE_LABEL,
   CATEGORY_LABEL,
@@ -73,6 +74,7 @@ export default function Drills() {
     <View style={{ flex: 1, backgroundColor: CREAM }}>
       <AppBar eyebrow="Practice" title="Drill library" />
       <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 48 }}>
+        <Entrance index={0}>
         <Pressable hitSlop={6} onPress={() => router.back()} style={{ marginBottom: 16 }}>
           <Text style={{ ...KICKER, color: INK_MUTE }}>← Practice plan</Text>
         </Pressable>
@@ -86,7 +88,9 @@ export default function Drills() {
           Every drill the plan generator can draw from. Each one explains the why,
           the how, and the rep target — no gimmicks.
         </Text>
+        </Entrance>
 
+        <Entrance index={1}>
         <FilterRow
           label="Part of the game"
           active={category}
@@ -101,6 +105,7 @@ export default function Drills() {
           labelFor={(m) => BLOCK_TYPE_LABEL[m]}
           onPick={setMode}
         />
+        </Entrance>
 
         {loading ? (
           <View style={{ paddingTop: 32, alignItems: 'center' }}>
@@ -109,7 +114,7 @@ export default function Drills() {
         ) : error ? (
           <Text style={[TYPE.body, { color: NEG, fontSize: 13, marginTop: 24 }]}>{error}</Text>
         ) : (
-          <>
+          <Entrance index={2}>
             <Text style={{ ...KICKER, marginTop: 22, marginBottom: 2 }}>
               {filtered.length} drill{filtered.length === 1 ? '' : 's'}
             </Text>
@@ -120,7 +125,7 @@ export default function Drills() {
             ) : (
               filtered.map((drill) => <DrillCard key={drill.id} drill={drill} />)
             )}
-          </>
+          </Entrance>
         )}
       </ScrollView>
     </View>

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
-import Animated, { FadeInDown } from 'react-native-reanimated'
 import { formatSG } from '@oga/core'
 import { deleteRound, getProfile, getRecentRounds } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
@@ -11,6 +10,7 @@ import { syncPendingShots } from '../../lib/sync'
 import { pendingCount } from '../../lib/db'
 import { AppBar } from '../../components/ui/AppBar'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { Entrance } from '../../components/ui/Entrance'
 import { ResumeRoundBanner } from '../../components/home/ResumeRoundBanner'
 import { SGBreakdown } from '../../components/home/SGBreakdown'
 import { SGTrendChart } from '../../components/home/SGTrendChart'
@@ -168,7 +168,7 @@ export default function Home() {
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
       <AppBar eyebrow={eyebrow} title={profile?.username ?? 'Home'} />
       <ScrollView ref={scrollRef} contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
-        <Animated.View entering={FadeInDown.duration(380)}>
+        <Entrance index={0}>
         <Text
           style={[
             TYPE.serif,
@@ -192,10 +192,10 @@ export default function Home() {
             ↓ New to a stat? The yardage book's at the bottom.
           </Text>
         </Pressable>
-        </Animated.View>
+        </Entrance>
 
         {rounds.length > 0 && (
-          <Animated.View entering={FadeInDown.duration(380).delay(80)}>
+          <Entrance index={1}>
             <Text
               style={[
                 TYPE.bodyItalic,
@@ -230,14 +230,14 @@ export default function Home() {
                 <HomeTile label="Best round" value={homeStats.bestScore != null ? homeStats.bestScore.toString() : '—'} />
               </View>
             </View>
-          </Animated.View>
+          </Entrance>
         )}
 
-        <Animated.View entering={FadeInDown.duration(380).delay(160)}>
+        <Entrance index={2}>
           {activeRound && <ResumeRoundBanner round={activeRound} />}
           {!activeRound && <StartLiveRoundCTA />}
           <LogPastRoundCTA />
-        </Animated.View>
+        </Entrance>
 
         {pending > 0 && (
           <View
@@ -256,7 +256,7 @@ export default function Home() {
           </View>
         )}
 
-        <Animated.View entering={FadeInDown.duration(380).delay(240)}>
+        <Entrance index={3}>
         {rounds.length === 0 ? (
           <View
             style={{
@@ -300,14 +300,14 @@ export default function Home() {
             <SGTrendChart data={trend} />
           </>
         )}
-        </Animated.View>
+        </Entrance>
 
-        <Animated.View entering={FadeInDown.duration(380).delay(320)}>
+        <Entrance index={4}>
           <RecentRoundsList
             rounds={rounds}
             onRequestDelete={(id, name) => setPendingDelete({ id, name })}
           />
-        </Animated.View>
+        </Entrance>
 
         <View
           onLayout={(e) => {

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
+import Animated, { FadeInDown } from 'react-native-reanimated'
 import { formatSG } from '@oga/core'
 import { deleteRound, getProfile, getRecentRounds } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
@@ -167,6 +168,7 @@ export default function Home() {
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
       <AppBar eyebrow={eyebrow} title={profile?.username ?? 'Home'} />
       <ScrollView ref={scrollRef} contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
+        <Animated.View entering={FadeInDown.duration(380)}>
         <Text
           style={[
             TYPE.serif,
@@ -190,9 +192,10 @@ export default function Home() {
             ↓ New to a stat? The yardage book's at the bottom.
           </Text>
         </Pressable>
+        </Animated.View>
 
         {rounds.length > 0 && (
-          <>
+          <Animated.View entering={FadeInDown.duration(380).delay(80)}>
             <Text
               style={[
                 TYPE.bodyItalic,
@@ -227,12 +230,14 @@ export default function Home() {
                 <HomeTile label="Best round" value={homeStats.bestScore != null ? homeStats.bestScore.toString() : '—'} />
               </View>
             </View>
-          </>
+          </Animated.View>
         )}
 
-        {activeRound && <ResumeRoundBanner round={activeRound} />}
-        {!activeRound && <StartLiveRoundCTA />}
-        <LogPastRoundCTA />
+        <Animated.View entering={FadeInDown.duration(380).delay(160)}>
+          {activeRound && <ResumeRoundBanner round={activeRound} />}
+          {!activeRound && <StartLiveRoundCTA />}
+          <LogPastRoundCTA />
+        </Animated.View>
 
         {pending > 0 && (
           <View
@@ -251,6 +256,7 @@ export default function Home() {
           </View>
         )}
 
+        <Animated.View entering={FadeInDown.duration(380).delay(240)}>
         {rounds.length === 0 ? (
           <View
             style={{
@@ -294,11 +300,14 @@ export default function Home() {
             <SGTrendChart data={trend} />
           </>
         )}
+        </Animated.View>
 
-        <RecentRoundsList
-          rounds={rounds}
-          onRequestDelete={(id, name) => setPendingDelete({ id, name })}
-        />
+        <Animated.View entering={FadeInDown.duration(380).delay(320)}>
+          <RecentRoundsList
+            rounds={rounds}
+            onRequestDelete={(id, name) => setPendingDelete({ id, name })}
+          />
+        </Animated.View>
 
         <View
           onLayout={(e) => {

--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -25,6 +25,7 @@ import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useUnits } from '../../hooks/useUnits'
 import { AppBar } from '../../components/ui/AppBar'
+import { Entrance } from '../../components/ui/Entrance'
 import { FONT, TYPE } from '../../lib/typography'
 
 const KICKER: import('react-native').TextStyle = {
@@ -155,6 +156,7 @@ export default function Patterns() {
     <View style={{ flex: 1, backgroundColor: '#F2EEE5' }}>
       <AppBar eyebrow={`Club ${club}`} title="Shot Patterns" />
       <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 40 }}>
+        <Entrance index={0}>
         <Section kicker="Club">
           <ChipRow
             value={club}
@@ -162,7 +164,9 @@ export default function Patterns() {
             onChange={(v) => v && setClub(v)}
           />
         </Section>
+        </Entrance>
 
+        <Entrance index={1}>
         <Section kicker="Lie type">
           <ChipRow
             value={lieType}
@@ -171,7 +175,9 @@ export default function Patterns() {
             labelFor={(v) => (v === ANY ? 'any' : (v as string).replace(/_/g, ' '))}
           />
         </Section>
+        </Entrance>
 
+        <Entrance index={2}>
         <Section kicker="Lie slope">
           <ChipRow
             value={lieSlope}
@@ -180,7 +186,9 @@ export default function Patterns() {
             labelFor={(v) => (v === ANY ? 'any' : (v as string).replace(/_/g, ' '))}
           />
         </Section>
+        </Entrance>
 
+        <Entrance index={3}>
         <Section kicker="Pattern">
           {loading ? (
             <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 13 }]}>Loading…</Text>
@@ -220,7 +228,9 @@ export default function Patterns() {
             </>
           )}
         </Section>
+        </Entrance>
 
+        <Entrance index={4}>
         <Section kicker="Pattern summary">
           {stats ? (
             <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 18 }}>
@@ -254,6 +264,7 @@ export default function Patterns() {
             </Text>
           )}
         </Section>
+        </Entrance>
 
         {stats && (
           <View

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 
 import { Link } from 'expo-router'
 import type { StoredBlock, StoredFocusArea, StoredSession } from '@oga/core'
 import { AppBar } from '../../components/ui/AppBar'
+import { Entrance } from '../../components/ui/Entrance'
 import { PressableTouch } from '../../components/ui/PressableTouch'
 import {
   BLOCK_TYPE_LABEL,
@@ -115,6 +116,7 @@ export default function Practice() {
           <NoPlan generating={generating} error={error} onGenerate={generate} />
         ) : (
           <>
+            <Entrance index={0}>
             <Text style={{ ...KICKER, marginBottom: 8 }}>{kicker}</Text>
             <Text
               style={[TYPE.serif, {
@@ -158,11 +160,21 @@ export default function Practice() {
             {error ? (
               <Text style={[TYPE.body, { color: NEG, fontSize: 13, marginBottom: 14 }]}>{error}</Text>
             ) : null}
+            </Entrance>
 
-            {plan.coach_note ? <ReasoningPanel note={plan.coach_note} /> : null}
+            {plan.coach_note ? (
+              <Entrance index={1}>
+                <ReasoningPanel note={plan.coach_note} />
+              </Entrance>
+            ) : null}
 
-            {focusAreas.length > 0 ? <FocusAreas areas={focusAreas} /> : null}
+            {focusAreas.length > 0 ? (
+              <Entrance index={2}>
+                <FocusAreas areas={focusAreas} />
+              </Entrance>
+            ) : null}
 
+            <Entrance index={3}>
             {sessions.map((session, i) => (
               <SessionBlock
                 key={`session-${i}`}
@@ -173,7 +185,9 @@ export default function Practice() {
                 onToggle={toggleCompletion}
               />
             ))}
+            </Entrance>
 
+            <Entrance index={4}>
             {plan.id ? (
               <FeedbackSection key={plan.id} initial={plan.feedback ?? ''} onSave={submitFeedback} />
             ) : null}
@@ -194,6 +208,7 @@ export default function Practice() {
                 </Pressable>
               </Link>
             </View>
+            </Entrance>
           </>
         )}
       </ScrollView>

--- a/apps/mobile/app/(app)/rounds.tsx
+++ b/apps/mobile/app/(app)/rounds.tsx
@@ -14,6 +14,7 @@ import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { AppBar } from '../../components/ui/AppBar'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { Entrance } from '../../components/ui/Entrance'
 import { FONT, TYPE } from '../../lib/typography'
 
 interface RoundRow {
@@ -118,6 +119,7 @@ export default function RoundsList() {
             No rounds yet.
           </Text>
         ) : (
+          <Entrance index={0}>
           <View style={{ borderTopWidth: 1, borderColor: '#D9D2BF' }}>
             {rounds.map((r) => (
               <Swipeable
@@ -226,6 +228,7 @@ export default function RoundsList() {
               </Swipeable>
             ))}
           </View>
+          </Entrance>
         )}
       </ScrollView>
       <ConfirmDialog

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -18,6 +18,7 @@ import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useUnits } from '../../hooks/useUnits'
 import { AppBar } from '../../components/ui/AppBar'
+import { Entrance } from '../../components/ui/Entrance'
 import { TYPE } from '../../lib/typography'
 
 const N_OPTIONS = [5, 10, 20] as const
@@ -196,6 +197,7 @@ export default function Stats() {
           <>
             {stats && <StandoutCallout sg={stats.sg} />}
 
+            <Entrance index={0}>
             <Section kicker={`Avg — last ${rounds.length} rounds`}>
               <View
                 style={{
@@ -253,7 +255,9 @@ export default function Stats() {
                 ))}
               </View>
             </Section>
+            </Entrance>
 
+            <Entrance index={1}>
             <Section kicker={`SG trend — last ${rounds.length} rounds`}>
               <VictoryChart
                 height={CHART_HEIGHT}
@@ -339,8 +343,10 @@ export default function Stats() {
                 ))}
               </View>
             </Section>
+            </Entrance>
 
             {stats && (
+              <Entrance index={2}>
               <Section kicker="Scoring">
                 <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12, marginBottom: 14 }}>
                   <StatTile label="Avg score" value={fmtNum(stats.scoring.avgScore, 1)} />
@@ -357,9 +363,11 @@ export default function Stats() {
                   total={stats.scoringDistribution.total}
                 />
               </Section>
+              </Entrance>
             )}
 
             {stats && (
+              <Entrance index={3}>
               <Section kicker="Ball striking">
                 <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12 }}>
                   <StatTile label="Fairways" value={fmtPct(stats.ballStriking.fairwayPct)} />
@@ -374,9 +382,11 @@ export default function Stats() {
                   />
                 </View>
               </Section>
+              </Entrance>
             )}
 
             {stats && (
+              <Entrance index={4}>
               <Section kicker="Short game">
                 <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 12 }}>
                   <StatTile label="Putts/round" value={fmtNum(stats.shortGame.puttsPerRound, 1)} />
@@ -387,9 +397,11 @@ export default function Stats() {
                   <StatTile label="Sand save" value={fmtPct(stats.shortGame.sandSavePct)} />
                 </View>
               </Section>
+              </Entrance>
             )}
 
             {stats && (
+              <Entrance index={5}>
               <Section kicker="Patterns">
                 <Subkicker>Miss tendency</Subkicker>
                 {stats.missTendency.length === 0 ? (
@@ -510,6 +522,7 @@ export default function Stats() {
                   </View>
                 )}
               </Section>
+              </Entrance>
             )}
           </>
         )}

--- a/apps/mobile/components/ui/Entrance.tsx
+++ b/apps/mobile/components/ui/Entrance.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react'
+import Animated, { FadeInDown } from 'react-native-reanimated'
+
+// Shared gentle entrance for screen content blocks. Wrap a screen's major
+// sections and pass an incrementing `index` to stagger them as they mount /
+// as their data arrives. Restrained per DESIGN.md — one direction, short,
+// no bounce. (#600)
+const STAGGER_MS = 80
+const DURATION_MS = 380
+
+export function Entrance({
+  index = 0,
+  children,
+}: {
+  index?: number
+  children: ReactNode
+}) {
+  return (
+    <Animated.View entering={FadeInDown.duration(DURATION_MS).delay(index * STAGGER_MS)}>
+      {children}
+    </Animated.View>
+  )
+}


### PR DESCRIPTION
Adds the "extra pop" from device-QA (2026-06-12), kept on-brand and now applied across the app.

## What
A shared **`<Entrance index={n}>`** wrapper (`components/ui/Entrance.tsx`) applies a gentle Reanimated `FadeInDown` (380ms, staggered `index*80ms`) to each screen's major content blocks, so they settle in as they mount / as data arrives instead of popping.

Applied to **6 screens**: home, stats, patterns, practice, rounds, drills — wrapping each screen's top-level `Section`s / logical groups (home: 5, stats: 6, patterns: 5, practice: 5, drills: 3, rounds: 1 list container).

## Restraint (per DESIGN.md)
One direction, short duration, no bounce/loop — a settle-in, not a show. Timing is centralized in `Entrance.tsx` (one place to tune).

## Correctness notes
- **Measurement safety:** blocks whose child uses `onLayout` for scroll positioning are left **unwrapped** (an entrance translate would corrupt the measured y) — only the home `LearnPreview` had this; it's untouched.
- **Lists** are wrapped as a single container (no per-item entrance — janky on long lists). No `FlatList` is involved.
- **Conditionals:** the `<Entrance>` sits *inside* each `{cond && …}` guard so an empty animated view never mounts.
- **Reduce-motion:** Reanimated 3.17 auto-skips entering animations under the OS Reduce-Motion setting (accessible by default).

## Cross-check
Reviewed by an independent agent pass: **clean — no blockers/high/med**. Verified additive-only (no logic/style/data changes), balanced JSX, no measurement/layout/list/flex regressions, typecheck exit 0. Lone Low note: reduce-motion is implicit (library default) rather than explicit — optional follow-up, not a bug.

## Verification
Mobile typecheck green. Not on-device — QA: open each tab, confirm blocks settle in gently with no flicker/jank on Android + iOS; confirm the home "yardage book" scroll-to hint still lands correctly.

Branched off `dev`. Not merging — review + on-device pass first.