### PR TITLE
feat(mobile): per-club distance stats (max/min/avg total) on Stats + Patterns

### DIFF
--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -7,6 +7,8 @@ import {
   CLUBS,
   LIE_SLOPES,
   LIE_TYPES,
+  YARDS_TO_METERS,
+  clubDistanceStats,
   computeDispersion,
   computeDispersionStats,
   dispersionVerdict,
@@ -121,6 +123,10 @@ export default function Patterns() {
   }, [shots, lieType, lieSlope])
 
   const stats = useMemo(() => computeDispersionStats(points), [points])
+
+  // Total distance for the selected club (across all its shots, not the
+  // lie-filtered dispersion set). null until there are tracked shots.
+  const clubDist = useMemo(() => clubDistanceStats(shots)[0] ?? null, [shots])
 
   const shareCardRef = useRef<View>(null)
   const [sharing, setSharing] = useState(false)
@@ -246,6 +252,22 @@ export default function Patterns() {
 
         <Entrance index={4}>
         <Section kicker="Pattern summary">
+          {clubDist && (
+            <View
+              style={{
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                gap: 18,
+                marginBottom: 18,
+              }}
+            >
+              <Stat label="Avg distance" value={toDisplay(clubDist.avg)} />
+              <Stat
+                label="Range"
+                value={`${Math.round(unit === 'meters' ? clubDist.min * YARDS_TO_METERS : clubDist.min)}–${Math.round(unit === 'meters' ? clubDist.max * YARDS_TO_METERS : clubDist.max)}`}
+              />
+            </View>
+          )}
           {stats ? (
             <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 18 }}>
               <Stat label="Sample" value={`${stats.sampleSize} shots`} />

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -3,8 +3,10 @@ import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-na
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
 import Svg, { Line as SvgLine } from 'react-native-svg'
 import {
+  clubDistanceStats,
   computeDetailedStats,
   DEFAULT_HANDICAP,
+  formatClubLabel,
   formatSG,
   sgStandouts,
   symmetricNiceTicks,
@@ -117,6 +119,16 @@ export default function Stats() {
   const sgAxis = useMemo(
     () => symmetricNiceTicks(chartSeries.flatMap((s) => s.data.map((d) => d.y))),
     [chartSeries],
+  )
+
+  // Per-club total distance (max/min/avg), from every tracked shot's
+  // start→end across the loaded rounds.
+  const clubDistances = useMemo(
+    () =>
+      clubDistanceStats(
+        rounds.flatMap((r) => (r.hole_scores ?? []).flatMap((hs) => hs.shots ?? [])),
+      ),
+    [rounds],
   )
 
   const stats: DetailedStats | null = useMemo(
@@ -531,6 +543,78 @@ export default function Stats() {
                     <StatTile label="Rough shots" value={String(stats.recovery.totalRoughShots)} />
                   </View>
                 )}
+              </Section>
+              </Entrance>
+            )}
+
+            {clubDistances.length > 0 && (
+              <Entrance index={6}>
+              <Section kicker="Club distances">
+                <Text
+                  style={[TYPE.body, {
+                    color: '#8A8B7E',
+                    fontSize: 12,
+                    marginTop: -4,
+                    marginBottom: 12,
+                  }]}
+                >
+                  Total distance, not carry · avg (min–max)
+                </Text>
+                <View style={{ gap: 10 }}>
+                  {clubDistances.map((c) => {
+                    const conv = (y: number) =>
+                      unit === 'meters' ? Math.round(y * YARDS_TO_METERS) : Math.round(y)
+                    return (
+                      <View
+                        key={c.club}
+                        style={{ flexDirection: 'row', alignItems: 'baseline', gap: 10 }}
+                      >
+                        <Text
+                          style={[TYPE.bodyBold, {
+                            flex: 1,
+                            color: '#1C211C',
+                            fontSize: 14,
+                            textTransform: 'capitalize',
+                          }]}
+                          numberOfLines={1}
+                        >
+                          {formatClubLabel({ club_type: c.club })}
+                        </Text>
+                        <Text
+                          style={[TYPE.serif, {
+                            color: '#1C211C',
+                            fontSize: 16,
+                            fontVariant: ['tabular-nums'],
+                          }]}
+                        >
+                          {toDisplay(c.avg)}
+                        </Text>
+                        <Text
+                          style={[TYPE.body, {
+                            width: 84,
+                            textAlign: 'right',
+                            color: '#5C6356',
+                            fontSize: 12,
+                            fontVariant: ['tabular-nums'],
+                          }]}
+                        >
+                          {conv(c.min)}–{conv(c.max)}
+                        </Text>
+                        <Text
+                          style={[TYPE.body, {
+                            width: 26,
+                            textAlign: 'right',
+                            color: '#8A8B7E',
+                            fontSize: 11,
+                            fontVariant: ['tabular-nums'],
+                          }]}
+                        >
+                          {c.count}
+                        </Text>
+                      </View>
+                    )
+                  })}
+                </View>
               </Section>
               </Entrance>
             )}

--- a/packages/core/src/__tests__/clubDistance.test.ts
+++ b/packages/core/src/__tests__/clubDistance.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { clubDistanceStats } from '../stats'
+
+// Pure-latitude deltas → predictable haversine distance (~121,740 yd per
+// degree of latitude). 0.0020° ≈ 243 yd, 0.00125° ≈ 152 yd.
+function mk(club: string, dLat: number, lie_type = 'fairway') {
+  return {
+    club,
+    lie_type,
+    start_lat: 35,
+    start_lng: -97,
+    end_lat: 35 + dLat,
+    end_lng: -97,
+  }
+}
+
+describe('clubDistanceStats', () => {
+  it('groups by club, sorted longest-first, with min/max/avg/count', () => {
+    const res = clubDistanceStats([
+      mk('driver', 0.002),
+      mk('driver', 0.0024),
+      mk('7i', 0.00125),
+    ])
+    expect(res.map((r) => r.club)).toEqual(['driver', '7i']) // longer avg first
+    const driver = res[0]!
+    expect(driver.count).toBe(2)
+    expect(driver.min).toBeLessThan(driver.max)
+    expect(driver.avg).toBeGreaterThan(driver.min)
+    expect(driver.avg).toBeLessThan(driver.max)
+    expect(driver.avg).toBeGreaterThan(200) // ~243–292 yd band
+  })
+
+  it('excludes putts, greenside, and missing-coord shots', () => {
+    const res = clubDistanceStats([
+      mk('putter', 0.0005),
+      mk('lw', 0.0008, 'green'),
+      {
+        club: '8i',
+        lie_type: 'fairway',
+        start_lat: 35,
+        start_lng: -97,
+        end_lat: null,
+        end_lng: null,
+      },
+    ])
+    expect(res).toEqual([])
+  })
+
+  it('clamps GPS-zero and absurd distances out', () => {
+    const res = clubDistanceStats([
+      mk('9i', 0.000005), // ~0.6 yd < 3
+      mk('9i', 1), // ~120k yd > 450
+    ])
+    expect(res).toEqual([])
+  })
+})

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -542,6 +542,67 @@ export function ballStrikingStats(rounds: DetailedRound[]): BallStrikingStats {
   }
 }
 
+export interface ClubDistanceStat {
+  club: string
+  /** Shortest tracked total distance with this club, yards. */
+  min: number
+  /** Longest tracked total distance with this club, yards. */
+  max: number
+  /** Mean total distance with this club, yards. */
+  avg: number
+  /** Number of shots backing the numbers (reliability hint). */
+  count: number
+}
+
+// Min/max/avg TOTAL distance per club (start → end haversine — total, not
+// carry, since we only have ball positions). Putts and greenside shots are
+// excluded; a loose 3–450 yd clamp drops GPS-zero placements and wild
+// outliers. Sorted longest-first so a bag reads driver → wedges. Takes a flat
+// shot list so both the stats page (flattened rounds) and the per-club
+// patterns page feed it the same way.
+const CLUB_DISTANCE_MIN_YARDS = 3
+const CLUB_DISTANCE_MAX_YARDS = 450
+
+export function clubDistanceStats(
+  shots: {
+    club: string | null
+    lie_type: string | null
+    start_lat: number | null
+    start_lng: number | null
+    end_lat: number | null
+    end_lng: number | null
+  }[],
+): ClubDistanceStat[] {
+  const byClub = new Map<string, number[]>()
+  for (const s of shots) {
+    if (!s.club || s.club === 'putter' || s.lie_type === 'green') continue
+    if (
+      s.start_lat == null ||
+      s.start_lng == null ||
+      s.end_lat == null ||
+      s.end_lng == null
+    ) {
+      continue
+    }
+    const d = haversineYards(s.start_lat, s.start_lng, s.end_lat, s.end_lng)
+    if (d < CLUB_DISTANCE_MIN_YARDS || d > CLUB_DISTANCE_MAX_YARDS) continue
+    const arr = byClub.get(s.club)
+    if (arr) arr.push(d)
+    else byClub.set(s.club, [d])
+  }
+  const out: ClubDistanceStat[] = []
+  for (const [club, ds] of byClub) {
+    out.push({
+      club,
+      min: Math.min(...ds),
+      max: Math.max(...ds),
+      avg: ds.reduce((a, b) => a + b, 0) / ds.length,
+      count: ds.length,
+    })
+  }
+  return out.sort((a, b) => b.avg - a.avg)
+}
+
 // ---------------------------------------------------------------------------
 // Section 4: Short Game
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
"How far do I hit each club" — one of the most-loved golf stats. Adds per-club distance to the Stats and Shot Patterns pages.

## Data (reuses the existing pipeline)
New pure `@oga/core` **`clubDistanceStats(shots)`**: per club, **min / max / avg / count** of TOTAL distance = `haversineYards(start → end)` — the exact computation the existing driver-avg stat already does. Excludes putts + greenside (`putter` / `lie_type === 'green'`), clamps 3–450 yd to drop GPS-zero/duff noise, sorted longest-first. Takes a flat shot list so both surfaces feed it the same way. **Total distance, not carry** (we only have ball positions) — labeled as such. Tested (3 cases).

## Stats page — "Club distances" table
```
CLUB DISTANCES        Total distance, not carry · avg (min–max)
Driver     258   231–276   12
3 wood     232   214–245    7
7 iron     163   148–171    9
PW         118    96–129    6
```
Avg in serif (per DESIGN), min–max + sample count alongside. Hidden when there's no shot-coord data yet (like proximity).

## Patterns page — per-club readout
Adds **Avg distance** + **Range** to the selected club's Pattern summary — visible even below the 5-shot dispersion threshold (distance only needs start+end coords, not aim).

## Notes
- Unit-aware (yd/m) via the user's prefs.
- Driver-avg tile in Ball Striking still stands (headline); this adds the full bag.
- Additive — no schema/data/query changes; flows through the same `rounds`/`shots` already loaded.

## Verification
`pnpm typecheck` (web + core + supabase) ✅ · `pnpm --filter @oga/core test` → **551 passed** (3 new) ✅ · mobile `tsc` ✅. Not on-device yet.

Branched off `dev`. Not merging without your okay.