### PR TITLE
fix(attribution): credit GolfCourseAPI + OpenStreetMap (ODbL) alongside OpenGolfAPI

### DIFF
--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   ActivityIndicator,
+  Linking,
   Pressable,
   ScrollView,
   Text,
@@ -552,7 +553,17 @@ export default function NewRound() {
         )}
 
         <Text style={{ ...KICKER, marginTop: 28, color: '#8A8B7E' }}>
-          Course data from OpenGolfAPI, GolfCourseAPI, and © OpenStreetMap
+          Course data from OpenGolfAPI, GolfCourseAPI, and ©{' '}
+          {/* OSM's ODbL attribution guidelines ask for a link to the copyright
+              page where possible — RN can, via Linking. */}
+          <Text
+            onPress={() =>
+              Linking.openURL('https://www.openstreetmap.org/copyright')
+            }
+            style={{ textDecorationLine: 'underline' }}
+          >
+            OpenStreetMap
+          </Text>{' '}
           contributors (ODbL)
         </Text>
       </ScrollView>

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -552,7 +552,8 @@ export default function NewRound() {
         )}
 
         <Text style={{ ...KICKER, marginTop: 28, color: '#8A8B7E' }}>
-          Course data from OpenGolfAPI · ODbL licensed
+          Course data from OpenGolfAPI, GolfCourseAPI, and © OpenStreetMap
+          contributors (ODbL)
         </Text>
       </ScrollView>
     </View>

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -88,8 +88,26 @@ export function AppShell({ children }: { children: ReactNode }) {
               style={{ textDecoration: 'underline' }}
             >
               OpenGolfAPI
+            </a>
+            ,{' '}
+            <a
+              href="https://golfcourseapi.com"
+              target="_blank"
+              rel="noreferrer noopener"
+              style={{ textDecoration: 'underline' }}
+            >
+              GolfCourseAPI
+            </a>
+            , and ©{' '}
+            <a
+              href="https://www.openstreetmap.org/copyright"
+              target="_blank"
+              rel="noreferrer noopener"
+              style={{ textDecoration: 'underline' }}
+            >
+              OpenStreetMap
             </a>{' '}
-            · ODbL licensed
+            contributors (ODbL)
           </footer>
         </div>
       </main>


### PR DESCRIPTION
Course data comes from **three** sources, but the app credited only one.

- **OpenGolfAPI** — course search/import (`packages/core/opengolfapi.ts`)
- **GolfCourseAPI** — tee ratings/slope backfill (`scripts/backfill-ratings.ts`)
- **OpenStreetMap** (via Overpass) — hole geometry (`scripts/crawl/osm-fetcher.ts`)

Both the web footer (`AppShell.tsx`) and the mobile new-round screen (`round/new.tsx`) said *"Course data from OpenGolfAPI · ODbL licensed"* — crediting only OpenGolfAPI, with OSM merely implied by "ODbL licensed." **OSM's ODbL legally requires** crediting "© OpenStreetMap contributors" by name.

Now both read: **"Course data from OpenGolfAPI, GolfCourseAPI, and © OpenStreetMap contributors (ODbL)."** Web links each source (opengolfapi.org / golfcourseapi.com / openstreetmap.org/copyright).

Web + mobile typecheck green. Branched off `dev`. Not merging without your okay.