### PR TITLE
fix(mobile): widen scorecard FIR/GIR columns + fix splash brand font

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -772,10 +772,10 @@ export default function RoundIndex() {
             <Text style={{ ...KICKER, width: 48, textAlign: 'right', color: '#8A8B7E' }}>
               Putts
             </Text>
-            <Text style={{ ...KICKER, width: 28, textAlign: 'center', color: '#8A8B7E' }}>
+            <Text style={{ ...KICKER, width: 40, textAlign: 'center', color: '#8A8B7E' }}>
               FIR
             </Text>
-            <Text style={{ ...KICKER, width: 28, textAlign: 'center', color: '#8A8B7E' }}>
+            <Text style={{ ...KICKER, width: 40, textAlign: 'center', color: '#8A8B7E' }}>
               GIR
             </Text>
             <Text style={{ ...KICKER, width: 76, textAlign: 'right', color: '#8A8B7E' }}>
@@ -848,7 +848,7 @@ export default function RoundIndex() {
                   <Text
                     key={k}
                     style={[TYPE.kicker, {
-                      width: 28,
+                      width: 40,
                       textAlign: 'center',
                       fontSize: 14,
                       color: v === true ? '#1F3D2C' : '#C9C2B0',

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -121,7 +121,9 @@ const styles = StyleSheet.create({
     fontFamily: FONT.serifItalic,
     fontSize: 96,
     letterSpacing: -2,
-    lineHeight: 100,
+    // No tight lineHeight — Fraunces italic's deep "g" descender gets clipped to
+    // the line box on Android. Let the font's natural metrics size the box.
+    includeFontPadding: true,
   },
   tagline: {
     color: 'rgba(242,238,229,0.85)',

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -117,7 +117,6 @@ const styles = StyleSheet.create({
     color: '#FBF8F1',
     fontFamily: FONT.serifItalic,
     fontSize: 96,
-    fontStyle: 'italic',
     letterSpacing: -2,
     lineHeight: 100,
   },
@@ -125,7 +124,6 @@ const styles = StyleSheet.create({
     color: 'rgba(242,238,229,0.85)',
     fontFamily: FONT.serifItalic,
     fontSize: 18,
-    fontStyle: 'italic',
     marginTop: 18,
   },
   support: {

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -115,6 +115,9 @@ const styles = StyleSheet.create({
   },
   wordmark: {
     color: '#FBF8F1',
+    // No fontStyle: 'italic' — FONT.serifItalic is an already-italic named face
+    // (Fraunces-MediumItalic). On Android, layering an italic style on a face
+    // whose name encodes the italic axis breaks resolution → system-font fallback.
     fontFamily: FONT.serifItalic,
     fontSize: 96,
     letterSpacing: -2,


### PR DESCRIPTION
On-device QA surfaced two mobile issues; both fixed here.

## Scorecard FIR/GIR columns
The FIR (Fairway in Regulation) and GIR (Green in Regulation) columns were cramped at 28px, crowding the mono kicker headers and the check/dot indicators. Widened both to 40px (header + data rows), taking the extra 24px from the flex Hole column, which had ample room. Header and data cells stay aligned.

`apps/mobile/app/(app)/round/[id]/index.tsx`

## Login splash brand font
The `oga.` wordmark and tagline were rendering in a system fallback font on Android instead of the Fraunces italic brandmark. Cause: a redundant `fontStyle: 'italic'` declared alongside `fontFamily: FONT.serifItalic` (`Fraunces-MediumItalic`, an already-italic registered face). On Android, requesting an italic style against a family whose face is already italic can make the font manager fail resolution and fall back to a system serif/sans. Removed the redundant `fontStyle` from both styles; the italic is baked into the named face.

`apps/mobile/app/(auth)/welcome.tsx`

## Testing
- Verified on iOS preview build (on-device).
- Mobile-only RN styling changes; no `@oga/core` or web surface touched.