### PR TITLE
fix(mobile): deleting an active round no longer bricks round viewing

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -137,8 +137,8 @@ export default function RoundIndex() {
     setRedirectToLive(false)
     ;(async () => {
       try {
-        // maybeSingle (not single): a deleted round returns null rather than
-        // throwing PGRST116 "cannot coerce the result to a single JSON object".
+        // A deleted round returns null rather than throwing PGRST116 "cannot
+        // coerce the result to a single JSON object".
         const { data: r, error: rErr } = await supabase
           .from('rounds')
           .select('*, courses(name, lat, lng)')

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -128,13 +128,22 @@ export default function RoundIndex() {
   useEffect(() => {
     if (!id) return
     let active = true
+    // Reset per-round state up front so a previously-viewed round's error or
+    // live-redirect can't leak onto the next one — e.g. after the active round
+    // is deleted from the home list, the stale `error` would otherwise keep the
+    // `if (error || !round)` guard tripped for every round opened afterward.
+    setLoading(true)
+    setError(null)
+    setRedirectToLive(false)
     ;(async () => {
       try {
+        // maybeSingle (not single): a deleted round returns null rather than
+        // throwing PGRST116 "cannot coerce the result to a single JSON object".
         const { data: r, error: rErr } = await supabase
           .from('rounds')
           .select('*, courses(name, lat, lng)')
           .eq('id', id)
-          .single()
+          .maybeSingle()
         if (rErr || !r) throw rErr ?? new Error('Round not found')
         if (!active) return
         const row = r as RoundRow & {
@@ -447,7 +456,7 @@ export default function RoundIndex() {
           .from('rounds')
           .select('*, courses(name, lat, lng)')
           .eq('id', round.id)
-          .single(),
+          .maybeSingle(),
         supabase.from('hole_scores').select('*').eq('round_id', round.id),
       ])
       if (rRes.data) {

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -126,11 +126,15 @@ export function useHoleData(
     setLoading(true)
     setError(null)
     try {
+      // maybeSingle (not single): if the round was deleted (e.g. from the home
+      // list) while this live session is still mounted, a 0-row result returns
+      // null instead of throwing PGRST116 "cannot coerce to a single JSON
+      // object" — surfaced cleanly as "Round not found" below.
       const { data: r, error: rErr } = await supabase
         .from('rounds')
         .select('*, courses(lat, lng)')
         .eq('id', id)
-        .single()
+        .maybeSingle()
       if (rErr || !r) throw rErr ?? new Error('Round not found')
       setRound(r)
       setCourseCenter(

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -126,10 +126,10 @@ export function useHoleData(
     setLoading(true)
     setError(null)
     try {
-      // maybeSingle (not single): if the round was deleted (e.g. from the home
-      // list) while this live session is still mounted, a 0-row result returns
-      // null instead of throwing PGRST116 "cannot coerce to a single JSON
-      // object" — surfaced cleanly as "Round not found" below.
+      // If the round was deleted (e.g. from the home list) while this live
+      // session is still mounted, a 0-row result returns null instead of
+      // throwing PGRST116 "cannot coerce to a single JSON object" — surfaced
+      // cleanly as "Round not found" below.
       const { data: r, error: rErr } = await supabase
         .from('rounds')
         .select('*, courses(lat, lng)')


### PR DESCRIPTION
## Symptom
With a live round in progress, going to the home screen and deleting that round from the recent-rounds list (without exiting live mode) bricked the app: it showed `cannot coerce the result to a single JSON object`, and afterward **no other round could be viewed**.

## Root cause
1. The round fetch used `.single()` in three places (`round/[id]/index.tsx` detail loader + SG refetch, `hole/useHoleData.ts` live loader). `.single()` throws PGRST116 on a 0-row result — exactly what a just-deleted round returns.
2. The `[id]` detail loader's effect never reset `error` / `redirectToLive` at the start of a run, so once the deleted round set `error`, the `if (error || !round)` guard stayed tripped for **every** round opened afterward → "can't view any other rounds".

## Fix
- Round fetches switched to `.maybeSingle()` — a deleted round resolves to `null` and surfaces cleanly as "Round not found" instead of throwing.
- The detail loader resets `loading` / `error` / `redirectToLive` up front each run so a prior round's error can't leak onto the next.

## Testing
- `npm run typecheck` (mobile) — clean.
- Mechanism confirmed from source; on-device repro recommended (delete the active live round from home, then open another round → should load normally, no PGRST116).

## Notes
Mobile-only. No `@oga/core` / web / migration surface touched. Does not address tearing down the still-mounted live session of the deleted round (it now shows a graceful "Round not found / exit" screen rather than bricking) — that hardening can be a follow-up if desired.