### PR TITLE
fix(mobile): on-map tee box always derives from the first shot, not stored coords

### DIFF
--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -175,12 +175,10 @@ export default function LiveRoundSession({
   // teed off — the FIRST shot's start — never the surveyed holes.tee_lat (real
   // tee boxes move daily; the stored coord lies about where you hit from).
   // While placing shot 1 that's the live ball as you drag it, so the marker
-  // tracks it reactively (this is the fix: previously `data.tee ?? …` let the
-  // stored tee win on shot 1 and the box stayed pinned to survey coords while
-  // the player adjusted their drive). After shot 1, `data.tee` is the SAVED
-  // first-shot start (= previousShots[0]). The stored course tee inside
-  // `data.tee` is consulted ONLY as a last resort — before any first shot
-  // exists — so the hole isn't marker-less on entry.
+  // tracks it reactively. After shot 1, `data.tee` is the SAVED first-shot
+  // start (= previousShots[0]). The stored course tee inside `data.tee` is
+  // consulted ONLY as a last resort — before any first shot exists — so the
+  // hole isn't marker-less on entry.
   const teeBox = useMemo<[LatLng, LatLng] | null>(() => {
     const origin =
       (data.shotNumber === 1 ? finalState.ball : null) ?? data.tee

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -171,12 +171,19 @@ export default function LiveRoundSession({
   ])
 
   // Two-dot tee box flanking the tee, oriented down the line of play (toward the
-  // aim, else the pin). The tee IS the first shot's start — like past-round
-  // (PastRoundMap): the course tee when known, otherwise the shot-1 ball as you
-  // place it (persisted as the hole tee on save, see useShotActions). After
-  // shot 1 it lives in data.tee, so the dots stay put on later shots.
+  // aim, else the pin). The marker ALWAYS derives from where the player actually
+  // teed off — the FIRST shot's start — never the surveyed holes.tee_lat (real
+  // tee boxes move daily; the stored coord lies about where you hit from).
+  // While placing shot 1 that's the live ball as you drag it, so the marker
+  // tracks it reactively (this is the fix: previously `data.tee ?? …` let the
+  // stored tee win on shot 1 and the box stayed pinned to survey coords while
+  // the player adjusted their drive). After shot 1, `data.tee` is the SAVED
+  // first-shot start (= previousShots[0]). The stored course tee inside
+  // `data.tee` is consulted ONLY as a last resort — before any first shot
+  // exists — so the hole isn't marker-less on entry.
   const teeBox = useMemo<[LatLng, LatLng] | null>(() => {
-    const origin = data.tee ?? (data.shotNumber === 1 ? finalState.ball : null)
+    const origin =
+      (data.shotNumber === 1 ? finalState.ball : null) ?? data.tee
     if (!origin) return null
     const toward = finalState.aim ?? data.roundPin ?? data.storedPin
     const heading = toward

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -292,8 +292,7 @@ export function PastRoundMap({
   // Tee box = two dots flanking the tee shot, perpendicular to the line of
   // play. ALWAYS derived from the first placed shot's start (where the player
   // actually teed off) — the stored course tee is consulted ONLY as a last
-  // resort when no first shot exists yet. Dragging shot 1 moves placed[0].start,
-  // so the box tracks it reactively. Oriented toward that shot's aim, then pin.
+  // resort when no first shot exists yet. Oriented toward that shot's aim, then pin.
   const teeBox = useMemo<[LatLng, LatLng] | null>(() => {
     const origin = placed[0]?.start ?? tee
     if (!origin) return null

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -290,8 +290,10 @@ export function PastRoundMap({
   )
 
   // Tee box = two dots flanking the tee shot, perpendicular to the line of
-  // play. Derived from the first placed shot (falling back to the stored
-  // course tee), oriented toward that shot's aim, then the pin.
+  // play. ALWAYS derived from the first placed shot's start (where the player
+  // actually teed off) — the stored course tee is consulted ONLY as a last
+  // resort when no first shot exists yet. Dragging shot 1 moves placed[0].start,
+  // so the box tracks it reactively. Oriented toward that shot's aim, then pin.
   const teeBox = useMemo<[LatLng, LatLng] | null>(() => {
     const origin = placed[0]?.start ?? tee
     if (!origin) return null


### PR DESCRIPTION
## Decision
Product call: the on-map tee box should **always** anchor to where the player actually teed off — their **first shot's start** — never the surveyed `holes.tee_lat/tee_lng`. Real tee boxes move daily, so the stored coordinate misrepresents where you hit from. Stored tee data stays useful only for course rating / slope / handicap (`course_tees`), which is a separate concept from the map marker.

## Symptom
On a hole with map-placed shots, the tee marker stayed pinned to the stored survey coordinate and did **not** track the player's first shot.

## Root cause (live path)
`LiveRoundSession` built the tee origin as `data.tee ?? (shotNumber === 1 ? ball : null)`. `data.tee` resolves to `previousShots[0] ?? storedTee`, and `previousShots` excludes the current ball — so while placing shot 1, `data.tee === storedTee` (non-null on OSM-mapped holes) and the `??` short-circuited, pinning the box to survey coords.

## Fix
- Reorder to `(shotNumber === 1 ? ball : null) ?? data.tee` — the live first-shot ball wins on shot 1 (reactive), the **saved** first-shot start anchors it afterward, and the stored course tee is consulted **only** as a last resort before any first shot exists (so the hole isn't marker-less on entry).
- Past/review path (`PastRoundMap`, `placed[0].start ?? tee`) was already correct — comment only, documenting the locked decision.

## Testing
- `npm run typecheck` (mobile) — clean.
- On-device repro recommended: place/adjust your first shot → tee box should track it; stored survey coords should no longer pin it.