### PR TITLE
fix(mobile): live-round revisited holes show shot breadcrumb + explicit 'Add a shot' (#484)

### DIFF
--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -525,7 +525,10 @@ export default function LiveRoundSession({
           }
           showLocationPuck={
             finalState.roundState !== 'SHOT_DETAIL' &&
-            finalState.roundState !== 'PUTTING'
+            finalState.roundState !== 'PUTTING' &&
+            // Hide the live GPS puck while revisiting a played hole — that hole
+            // is in breadcrumb-only review mode until "Add a shot" (#484).
+            !finalState.isRevisitingPlayedHole
           }
           onSetAim={(loc) => {
             // A user drag / long-press is an explicit aim — mark it touched so
@@ -607,6 +610,7 @@ export default function LiveRoundSession({
             finalState.ball != null &&
             !ballMoved
           }
+          isRevisitingPlayedHole={finalState.isRevisitingPlayedHole}
           totalShotsThisHole={totalShotsThisHole}
           holeNumber={holeNumber}
           holeCount={data.holeCount}
@@ -625,6 +629,12 @@ export default function LiveRoundSession({
           }}
           onSkipAim={actions.skipAim}
           onMarkBallHere={actions.markBallHere}
+          onAddShot={() => {
+            // Opt back into the live append flow on a revisited played hole:
+            // re-arm the GPS ball + auto-aim and enter PLACE_BALL (#484).
+            finalState.setAppendEngaged(true)
+            finalState.setRoundState('PLACE_BALL')
+          }}
           onFinishHole={actions.finishHole}
           onPrev={() => actions.navigateHole(-1)}
           onNext={() => actions.navigateHole(1)}

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -41,8 +41,9 @@ interface MapBottomChromeProps {
   onRePlaceBall: () => void
   onSkipAim: () => void
   onMarkBallHere: () => void
-  /** Opt into the live append flow on a revisited played hole. */
-  onAddShot: () => void
+  /** Opt into the live append flow on a revisited played hole. Optional — its
+   *  partner `isRevisitingPlayedHole` is the only path that reaches it. */
+  onAddShot?: () => void
   onFinishHole: () => void
   onPrev: () => void
   onNext: () => void
@@ -99,7 +100,7 @@ function ContextualActions(p: MapBottomChromeProps) {
   if (p.isRevisitingPlayedHole) {
     return (
       <>
-        <PrimaryCta label="+ Add a shot" disabled={p.saving} onPress={p.onAddShot} />
+        <PrimaryCta label="+ Add a shot" disabled={p.saving} onPress={() => p.onAddShot?.()} />
         {p.totalShotsThisHole > 0 && (
           <TextChip
             label={p.holeNumber < p.holeCount ? 'Finish hole · next →' : 'Finish round'}

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -26,6 +26,10 @@ interface MapBottomChromeProps {
   /** Live mode only: the ball marker is currently tracking the player's GPS
    *  (not manually dragged). Drives the GPS-explicit place-ball CTA + hint. */
   ballFromGps?: boolean
+  /** True when the player has navigated back to a hole that already has logged
+   *  shots and hasn't opted into adding another. The live mark-ball CTA is
+   *  replaced by an explicit "Add a shot" affordance (#484). */
+  isRevisitingPlayedHole?: boolean
   totalShotsThisHole: number
   holeNumber: number
   holeCount: number
@@ -37,6 +41,8 @@ interface MapBottomChromeProps {
   onRePlaceBall: () => void
   onSkipAim: () => void
   onMarkBallHere: () => void
+  /** Opt into the live append flow on a revisited played hole. */
+  onAddShot: () => void
   onFinishHole: () => void
   onPrev: () => void
   onNext: () => void
@@ -84,6 +90,23 @@ function ContextualActions(p: MapBottomChromeProps) {
           <TextChip label="← Re-place ball" onPress={p.onRePlaceBall} />
           <TextChip label="Skip aim" onPress={p.onSkipAim} />
         </View>
+      </>
+    )
+  }
+  // Revisiting a played hole: the live mark-ball flow is suppressed (no
+  // GPS ball, no auto-aim, no line-to-green). Show the existing-shot breadcrumb
+  // only, with an explicit "Add a shot" opt-in plus the finish affordance. #484.
+  if (p.isRevisitingPlayedHole) {
+    return (
+      <>
+        <PrimaryCta label="+ Add a shot" disabled={p.saving} onPress={p.onAddShot} />
+        {p.totalShotsThisHole > 0 && (
+          <TextChip
+            label={p.holeNumber < p.holeCount ? 'Finish hole · next →' : 'Finish round'}
+            onPress={p.onFinishHole}
+            strong
+          />
+        )}
       </>
     )
   }

--- a/apps/mobile/components/round/hole/useHoleState.ts
+++ b/apps/mobile/components/round/hole/useHoleState.ts
@@ -47,6 +47,17 @@ export interface UseHoleStateResult {
   aimHintVisible: boolean
   setAimHintVisible: Dispatch<SetStateAction<boolean>>
   nearPin: boolean
+  /** True when the player has navigated BACK to a hole that already has
+   *  logged shots and has NOT yet opted into adding another shot. Live aids
+   *  (auto-aim spawn, GPS ball watcher/marker, line-to-green) are suppressed
+   *  while this is true — the hole shows only the existing shot breadcrumb.
+   *  Pressing "Add a shot" (or marking a ball) flips it false and re-arms the
+   *  live append flow. See #484 (live-round revisit). */
+  isRevisitingPlayedHole: boolean
+  /** Opt back into the live append flow on a revisited hole (clears
+   *  isRevisitingPlayedHole for this hole visit). markBallHere also sets it so
+   *  the natural shot-to-shot flow keeps the aids on. */
+  setAppendEngaged: Dispatch<SetStateAction<boolean>>
 }
 
 export function useHoleState({
@@ -87,6 +98,20 @@ export function useHoleState({
   // by AsyncStorage so it only appears the first time the player ever
   // sets an aim point on this device, then auto-dismisses after 3s.
   const [aimHintVisible, setAimHintVisible] = useState(false)
+  // Set true once the player engages the live append flow on THIS hole visit —
+  // either by pressing "Add a shot" on a revisited hole or by marking a ball
+  // (the natural shot-to-shot flow). Reset on hole change. Combined with
+  // hasPriorShots it distinguishes "navigated back to a played hole" (suppress
+  // live aids) from "actively logging on this hole" (aids on). Anchoring to
+  // an in-visit action sidesteps the async shot-count load — hasPriorShots can
+  // arrive a beat late without flipping the verdict. See #484.
+  const [appendEngaged, setAppendEngaged] = useState(false)
+  // Revisiting = the hole already has shots AND the player hasn't engaged the
+  // append flow this visit. On a fresh hole hasPriorShots is false (aids on);
+  // after marking shot 1 appendEngaged is true (aids stay on for shot 2+);
+  // navigating back later resets appendEngaged so the played hole opens in the
+  // suppressed, breadcrumb-only posture until "Add a shot".
+  const isRevisitingPlayedHole = hasPriorShots && !appendEngaged
 
   // First-aim hint: when `aim` first transitions to non-null, check
   // AsyncStorage. If the hint hasn't been shown on this device, mark
@@ -118,6 +143,9 @@ export function useHoleState({
   // re-fires per shot. No-pin holes fall back to long-press-to-start.
   const effectivePin = roundPin ?? storedPin ?? null
   useEffect(() => {
+    // Suppressed while revisiting a played hole — no live aim aid until the
+    // player opts into adding a shot (#484).
+    if (isRevisitingPlayedHole) return
     if (roundState !== 'SET_AIM') return
     if (aim || !ball || !effectivePin) return
     setAim({
@@ -125,6 +153,7 @@ export function useHoleState({
       lng: ball.lng + AIM_AUTOSPAWN_FRACTION * (effectivePin.lng - ball.lng),
     })
   }, [
+    isRevisitingPlayedHole,
     roundState,
     aim,
     ball?.lat,
@@ -156,6 +185,9 @@ export function useHoleState({
   useEffect(() => {
     if (!currentHoleId) return
     if (isPastMode) return
+    // Suppressed while revisiting a played hole — no GPS ball watcher/marker
+    // until the player opts into adding a shot (#484).
+    if (isRevisitingPlayedHole) return
     if (roundState !== 'PLACE_BALL') return
     let active = true
     let subscription: Location.LocationSubscription | null = null
@@ -305,7 +337,7 @@ export function useHoleState({
       kalmanStateRef.current = null
       manuallyPlacedRef.current = false
     }
-  }, [currentHoleId, isPastMode, roundState, gpsNonce])
+  }, [currentHoleId, isPastMode, isRevisitingPlayedHole, roundState, gpsNonce])
 
   // Hole change resets per-hole state. The screen is resident (#264) so
   // nothing remounts on a hole switch — without an explicit reset the
@@ -325,6 +357,10 @@ export function useHoleState({
     setBall(null)
     setAim(null)
     setRoundState('PLACE_BALL')
+    // Each hole entry starts un-engaged: a played hole opens in the
+    // breadcrumb-only review posture until the player taps "Add a shot". A
+    // fresh hole has no prior shots, so isRevisitingPlayedHole is false anyway.
+    setAppendEngaged(false)
   }, [currentHoleId])
 
   // Default shot 1's ball marker to the tee box so the player starts from a
@@ -380,5 +416,7 @@ export function useHoleState({
     aimHintVisible,
     setAimHintVisible,
     nearPin,
+    isRevisitingPlayedHole,
+    setAppendEngaged,
   }
 }

--- a/apps/mobile/components/round/hole/useHoleState.ts
+++ b/apps/mobile/components/round/hole/useHoleState.ts
@@ -98,19 +98,11 @@ export function useHoleState({
   // by AsyncStorage so it only appears the first time the player ever
   // sets an aim point on this device, then auto-dismisses after 3s.
   const [aimHintVisible, setAimHintVisible] = useState(false)
-  // Set true once the player engages the live append flow on THIS hole visit —
-  // either by pressing "Add a shot" on a revisited hole or by marking a ball
-  // (the natural shot-to-shot flow). Reset on hole change. Combined with
-  // hasPriorShots it distinguishes "navigated back to a played hole" (suppress
-  // live aids) from "actively logging on this hole" (aids on). Anchoring to
-  // an in-visit action sidesteps the async shot-count load — hasPriorShots can
-  // arrive a beat late without flipping the verdict. See #484.
+  // Set true once the player engages the live append flow on this hole visit —
+  // via "Add a shot" or by marking a ball. Reset on hole change. Anchoring to an
+  // in-visit action (not an entry-time shot-count snapshot) sidesteps the async
+  // shot-count load: hasPriorShots can arrive a beat late without flipping it.
   const [appendEngaged, setAppendEngaged] = useState(false)
-  // Revisiting = the hole already has shots AND the player hasn't engaged the
-  // append flow this visit. On a fresh hole hasPriorShots is false (aids on);
-  // after marking shot 1 appendEngaged is true (aids stay on for shot 2+);
-  // navigating back later resets appendEngaged so the played hole opens in the
-  // suppressed, breadcrumb-only posture until "Add a shot".
   const isRevisitingPlayedHole = hasPriorShots && !appendEngaged
 
   // First-aim hint: when `aim` first transitions to non-null, check

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -121,6 +121,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     manuallyPlacedRef,
     lastSavedShotLocalIdRef,
     gpsPosition,
+    setAppendEngaged,
   } = state
 
   function buildPayload(meta: ShotLoggerValue | null): ShotPayload | null {
@@ -354,6 +355,11 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       return
     }
     const ballSnapshot = { lat: source.lat, lng: source.lng }
+    // Marking a ball IS engaging the live append flow for this hole visit —
+    // keeps the aids on across the natural shot-to-shot loop even after the
+    // hole gains prior shots (otherwise shot 2+ on a hole would read as a
+    // revisit and suppress). See #484.
+    setAppendEngaged(true)
     manuallyPlacedRef.current = true
     const prevLocalId = lastSavedShotLocalIdRef.current
     if (prevLocalId != null) {


### PR DESCRIPTION
## Symptom
During a live round, navigating **back** to a previously-played hole dropped the player into the live append-shot flow: the only actions were "Mark ball" (logging a *new* shot) and "Finish hole", and the live GPS ball + auto-aim redrew a line-to-green over the already-logged shots.

## Root cause
A live round always mounts `LiveRoundSession`, which has no review mode — the #593 shot-stepper lives only in `PastRoundMap`, which a live round never reaches. So a revisited played hole re-entered the `PLACE_BALL → SET_AIM` append state machine.

## Fix (Option C — owner-selected)
Treat a revisited played hole as breadcrumb-only review until the player explicitly opts in:
- New `isRevisitingPlayedHole = hasPriorShots && !appendEngaged` (`hasPriorShots` = this hole already has logged shots). `appendEngaged` resets on every hole change and is set true by **marking a ball** (keeps aids on across the natural shot-to-shot loop) and by the new **"+ Add a shot"** button.
- While revisiting: the auto-aim spawn, the GPS ball watcher/marker, and the GPS location puck are all gated off — so the line-to-green and live ball can't render; the existing shot breadcrumb stays visible.
- `MapBottomChrome` shows a "+ Add a shot" primary CTA (built with the existing `PressableTouch` + static-style + `android_ripple` pattern) plus the finish affordance. Tapping it re-arms the live append flow for that hole.

## Testing
- `npm run typecheck` (mobile) — clean.
- On-device repro recommended: in a live round, go back to a played hole → should show the shot breadcrumb only (no roaming ball/line), with "+ Add a shot" to resume logging.

## Notes
Mobile-only. Did not pursue Option B (composing `PastRoundMap` into the live session) per the owner's choice. Minor self-correcting flicker possible when navigating from an empty hole to a played one before `hasPriorShots` resolves; end state always correct.