### PR TITLE
fix(mobile): prompt for a pin on synthetic-course holes

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -25,7 +25,6 @@ import { AimDistancePill } from './markers/AimDistancePill'
 import { useHoleCamera } from './hooks/useHoleCamera'
 import {
   ExpStrokesPill,
-  MissingLayoutBanner,
   PinFirstCta,
   TeeBadge,
   ToHolePill,
@@ -85,13 +84,6 @@ interface HoleMapProps {
    */
   previousShots?: LatLng[]
   phase?: HoleMapPhase
-  /**
-   * True when this hole has no tee or pin coordinates in the DB —
-   * surfaces a small banner under the top hint so the player knows
-   * the missing distance pill / no auto-putt switch is data-driven,
-   * not a bug.
-   */
-  missingHoleLayout?: boolean
   /**
    * Latest smoothed GPS position. Drives the recenter button (which
    * camera-jumps to it) and the camera hook's auto-center-once
@@ -206,7 +198,6 @@ export function HoleMap({
   previousShots,
   phase = 'PLACE_BALL',
   aimCommitted = false,
-  missingHoleLayout = false,
   gpsPosition,
   courseCenter,
   holeNumber,
@@ -914,7 +905,6 @@ export function HoleMap({
             draggable midpoint, so the old "long-press to set aim" reminder is
             obsolete. Pin placement + ball-drag hints still show. */}
         {!isAimPhase && <TopHint isPinMode={isPinMode} />}
-        {missingHoleLayout && !isPinMode && <MissingLayoutBanner />}
         {!isPinMode && pinDistance !== null && (
           <>
             <ToHolePill display={toDisplay(pinDistance)} />
@@ -922,10 +912,10 @@ export function HoleMap({
           </>
         )}
         {/* Pin-first UX (Task 7): no pin yet → prompt for it, since distances,
-            expected strokes, and the dispersion overlay all need one. Skipped
-            when the whole hole layout is missing (MissingLayoutBanner covers
-            that case). */}
-        {!isPinMode && !effectivePin && !missingHoleLayout && (
+            expected strokes, and the dispersion overlay all need one. Shown
+            on no-layout (synthetic) holes too — placing a per-hole pin is
+            exactly what lights up the HUD there. */}
+        {!isPinMode && !effectivePin && (
           <PinFirstCta />
         )}
         {isPlaceBallPhase && (

--- a/apps/mobile/components/round/HoleMapOverlays.tsx
+++ b/apps/mobile/components/round/HoleMapOverlays.tsx
@@ -59,31 +59,6 @@ export function TopHint({ isPinMode }: TopHintProps) {
   )
 }
 
-export function MissingLayoutBanner() {
-  return (
-    <View
-      style={{
-        position: 'absolute',
-        // Below TopHint (top:82) so the two stack rather than overlap.
-        top: 126,
-        left: 12,
-        right: 12,
-        backgroundColor: 'rgba(28,33,28,0.78)',
-        borderWidth: 1,
-        borderColor: 'rgba(217,210,191,0.4)',
-        borderRadius: 2,
-        paddingHorizontal: 10,
-        paddingVertical: 6,
-      }}
-    >
-      <Text style={[TYPE.body, { color: '#F2EEE5', fontSize: 11, lineHeight: 14 }]}>
-        No hole layout for this course. Place shots manually — the distance
-        pill and putting auto-switch stay off until tee / pin coords land.
-      </Text>
-    </View>
-  )
-}
-
 // To Hole — distance from the current ball to the pin (top-left HUD pill).
 // Replaces the old bottom-right "X to pin" pill; matches the Shot Pattern
 // top-corner HUD layout.

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -512,7 +512,6 @@ export default function LiveRoundSession({
           gpsPosition={finalState.gpsPosition}
           courseCenter={data.courseCenter}
           holeNumber={holeNumber}
-          missingHoleLayout={data.tee == null && data.storedPin == null && data.roundPin == null}
           phase={
             pinPlacementOpen
               ? 'PIN'

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -640,7 +640,6 @@ export function PastRoundMap({
           // drag-only so stray taps don't move the selected shot). Logging:
           // always tap-to-place.
           tapToPlaceBall={completed ? adding : true}
-          missingHoleLayout={!effectivePin && !tee}
           gpsPosition={null}
           courseCenter={courseCenter}
           holeNumber={holeNumber}


### PR DESCRIPTION
## What

On synthetic courses (no `holes` rows — the majority of prod courses), the live map hit the `missingHoleLayout` path: it showed only a **passive** banner ("No hole layout… place shots manually") and **explicitly suppressed** the actionable `PinFirstCta`. Without a pin there are no distances, no expected strokes, and no dispersion — the core live-round value stayed dark, which made the flow feel broken.

## Change

- Surface the existing `PinFirstCta` ("Set the pin (below) to see your To Hole distance, expected strokes, and shot pattern") whenever **no pin is placed** — synthetic or mapped holes alike. The "Place pin" button is already in the left toolbar.
- Retire the passive `MissingLayoutBanner`. Once a per-hole pin is dropped, `missingHoleLayout` flips false and the HUD lights up anyway, so the prop is now dead — removed from `HoleMap` and both callers (`LiveRoundSession`, `PastRoundMap`).

Net −37 lines, reuses existing components, no new state. Non-blocking — the player is nudged but can still skip.

## Testing

- `npm run typecheck` clean.
- On-device QA pending (the user is QA).