### PR TITLE
fix(mobile): resolve Fraunces italic on Android app-wide

### DIFF
--- a/apps/mobile/app/(app)/_layout.tsx
+++ b/apps/mobile/app/(app)/_layout.tsx
@@ -94,8 +94,6 @@ export default function AppLayout() {
           style={[TYPE.serif, {
             color: '#F2EEE5',
             fontSize: 20,
-            fontWeight: '500',
-            fontStyle: 'italic',
             marginBottom: 10,
             textAlign: 'center',
           }]}

--- a/apps/mobile/app/(app)/bag.tsx
+++ b/apps/mobile/app/(app)/bag.tsx
@@ -379,8 +379,6 @@ export default function BagScreen() {
               style={[TYPE.serif, {
                 color: '#1C211C',
                 fontSize: 22,
-                fontWeight: '500',
-                fontStyle: 'italic',
                 marginBottom: 18,
               }]}
             >

--- a/apps/mobile/app/(app)/drills.tsx
+++ b/apps/mobile/app/(app)/drills.tsx
@@ -119,7 +119,7 @@ export default function Drills() {
               {filtered.length} drill{filtered.length === 1 ? '' : 's'}
             </Text>
             {filtered.length === 0 ? (
-              <Text style={[TYPE.serif, { color: INK_DIM, fontSize: 17, fontStyle: 'italic', paddingTop: 14 }]}>
+              <Text style={[TYPE.serif, { color: INK_DIM, fontSize: 17, paddingTop: 14 }]}>
                 No drills match those filters.
               </Text>
             ) : (
@@ -196,14 +196,14 @@ function DrillCard({ drill }: { drill: Drill }) {
     <View style={{ borderBottomWidth: 1, borderColor: LINE, paddingVertical: 16 }}>
       <View style={{ flexDirection: 'row', justifyContent: 'space-between', gap: 12 }}>
         <Pressable onPress={() => canExpand && setOpen((o) => !o)} disabled={!canExpand} style={{ flex: 1 }}>
-          <Text style={[TYPE.serif, { color: INK, fontSize: 18, fontStyle: 'italic', fontWeight: '500', lineHeight: 23 }]}>
+          <Text style={[TYPE.serif, { color: INK, fontSize: 18, lineHeight: 23 }]}>
             {drill.name}
             {canExpand ? <Text style={{ color: INK_MUTE, fontSize: 13 }}>{open ? '  ▲' : '  ▼'}</Text> : null}
           </Text>
         </Pressable>
         <View style={{ alignItems: 'flex-end', minWidth: 64 }}>
           {drill.duration_min != null ? (
-            <Text style={[TYPE.serif, { color: INK, fontSize: 18, fontStyle: 'italic', lineHeight: 20 }]}>
+            <Text style={[TYPE.serif, { color: INK, fontSize: 18, lineHeight: 20 }]}>
               {drill.duration_min} min
             </Text>
           ) : null}

--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -175,8 +175,6 @@ export default function Home() {
             {
               color: '#1C211C',
               fontSize: 28,
-              fontStyle: 'italic',
-              fontWeight: '500',
               lineHeight: 32,
               marginBottom: 6,
             },
@@ -188,7 +186,7 @@ export default function Home() {
           Last {rounds.length} round{rounds.length === 1 ? '' : 's'}
         </Text>
         <Pressable onPress={scrollToLearn} hitSlop={6} style={{ marginBottom: 22 }}>
-          <Text style={[TYPE.bodyItalic, { color: '#8A8B7E', fontSize: 13, fontStyle: 'italic' }]}>
+          <Text style={[TYPE.bodyItalic, { color: '#8A8B7E', fontSize: 13 }]}>
             ↓ New to a stat? The yardage book's at the bottom.
           </Text>
         </Pressable>
@@ -202,7 +200,6 @@ export default function Home() {
                 {
                   color: '#1C211C',
                   fontSize: 16,
-                  fontStyle: 'italic',
                   lineHeight: 24,
                   marginBottom: 22,
                 },
@@ -273,8 +270,6 @@ export default function Home() {
                 {
                   color: '#1C211C',
                   fontSize: 22,
-                  fontStyle: 'italic',
-                  fontWeight: '500',
                 },
               ]}
             >
@@ -360,7 +355,7 @@ function HomeTile({
       <Text style={[TYPE.kicker, { color: '#8A8B7E', fontSize: 10, fontWeight: '500', letterSpacing: 1.4, textTransform: 'uppercase', marginBottom: 10 }]}>
         {label}
       </Text>
-      <Text style={[TYPE.serif, { color: valueColor, fontSize: 28, fontStyle: 'italic', fontWeight: '500', fontVariant: ['tabular-nums'] }]}>
+      <Text style={[TYPE.serif, { color: valueColor, fontSize: 28 }]}>
         {value}
       </Text>
     </View>

--- a/apps/mobile/app/(app)/learn/[article].tsx
+++ b/apps/mobile/app/(app)/learn/[article].tsx
@@ -4,7 +4,7 @@ import { findLearnArticle } from '@oga/core'
 import { AppBar } from '../../../components/ui/AppBar'
 import { BODY, C, KICKER, TITLE } from '../../../components/learn/primitives'
 import { MOBILE_ARTICLES } from '../../../components/learn/articles'
-import { TYPE } from '../../../lib/typography'
+import { FONT, TYPE } from '../../../lib/typography'
 
 export default function ArticleScreen() {
   const router = useRouter()
@@ -51,7 +51,7 @@ function NotFound() {
   return (
     <View>
       <Text style={TITLE}>Article not found.</Text>
-      <Text style={{ ...BODY, color: C.inkDim, fontStyle: 'italic' }}>
+      <Text style={{ ...BODY, color: C.inkDim, fontFamily: FONT.bodyItalic }}>
         That guide does not exist yet.
       </Text>
     </View>
@@ -92,7 +92,7 @@ function StubBody({ title }: { title: string }) {
     <View>
       <Text style={{ ...KICKER, marginBottom: 10 }}>Coming soon</Text>
       <Text style={TITLE}>{title}</Text>
-      <Text style={{ ...BODY, color: C.mute, fontStyle: 'italic' }}>
+      <Text style={{ ...BODY, color: C.mute, fontFamily: FONT.bodyItalic }}>
         This guide is being written. Check back soon.
       </Text>
     </View>

--- a/apps/mobile/app/(app)/learn/index.tsx
+++ b/apps/mobile/app/(app)/learn/index.tsx
@@ -46,8 +46,6 @@ export default function LearnScreen() {
           style={[TYPE.serif, {
             color: C.ink,
             fontSize: 22,
-            fontStyle: 'italic',
-            fontWeight: '500',
             lineHeight: 28,
             marginBottom: 8,
           }]}
@@ -114,8 +112,6 @@ function ArticleRow({
             style={[TYPE.serif, {
               color: titleColor,
               fontSize: 17,
-              fontStyle: 'italic',
-              fontWeight: '500',
             }]}
           >
             {article.title}
@@ -150,7 +146,7 @@ function ArticleRow({
               </Text>
             )}
             <Text
-              style={[TYPE.serif, { color: C.mute, fontSize: 18, fontStyle: 'italic' }]}
+              style={[TYPE.serif, { color: C.mute, fontSize: 18 }]}
             >
               →
             </Text>
@@ -182,8 +178,6 @@ function SectionBlock({
         style={[TYPE.serif, {
           color: C.ink,
           fontSize: 24,
-          fontStyle: 'italic',
-          fontWeight: '500',
           lineHeight: 30,
           marginBottom: 14,
         }]}

--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -292,7 +292,6 @@ export default function Patterns() {
                 color: '#1C211C',
                 fontSize: 15,
                 lineHeight: 22,
-                fontStyle: 'italic',
               }]}
             >
               Need at least <Text style={[TYPE.bodyItalic, { fontWeight: '500' }]}>five shots</Text>{' '}

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -122,8 +122,6 @@ export default function Practice() {
               style={[TYPE.serif, {
                 color: INK,
                 fontSize: 26,
-                fontStyle: 'italic',
-                fontWeight: '500',
                 lineHeight: 31,
                 marginBottom: isExpired ? 14 : 18,
               }]}
@@ -150,7 +148,7 @@ export default function Practice() {
                 {generating ? (
                   <ActivityIndicator color={CREAM} />
                 ) : (
-                  <Text style={[TYPE.serif, { color: CREAM, fontSize: 16, fontStyle: 'italic', fontWeight: '500' }]}>
+                  <Text style={[TYPE.serif, { color: CREAM, fontSize: 16 }]}>
                     Generate this week’s plan
                   </Text>
                 )}
@@ -202,7 +200,7 @@ export default function Practice() {
             <View style={{ borderTopWidth: 1, borderColor: LINE, marginTop: 28, paddingTop: 18 }}>
               <Link href={'/(app)/drills' as never} asChild>
                 <Pressable hitSlop={6}>
-                  <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
+                  <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17 }]}>
                     Browse all drills →
                   </Text>
                 </Pressable>
@@ -231,8 +229,6 @@ function NoPlan({
         style={[TYPE.serif, {
           color: INK,
           fontSize: 28,
-          fontStyle: 'italic',
-          fontWeight: '500',
           lineHeight: 32,
           marginBottom: 8,
         }]}
@@ -260,7 +256,7 @@ function NoPlan({
         {generating ? (
           <ActivityIndicator color={CREAM} />
         ) : (
-          <Text style={[TYPE.serif, { color: CREAM, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
+          <Text style={[TYPE.serif, { color: CREAM, fontSize: 17 }]}>
             Generate this week’s plan
           </Text>
         )}
@@ -278,14 +274,14 @@ function NoPlan({
         <Text style={{ ...KICKER, marginBottom: 10 }}>Reference</Text>
         <Link href={'/(app)/drills' as never} asChild>
           <Pressable>
-            <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
+            <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17 }]}>
               Browse all drills →
             </Text>
           </Pressable>
         </Link>
         <Link href={'/(app)/learn' as never} asChild>
           <Pressable style={{ marginTop: 10 }}>
-            <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17, fontStyle: 'italic', fontWeight: '500' }]}>
+            <Text style={[TYPE.serif, { color: ACCENT, fontSize: 17 }]}>
               Learn the stats →
             </Text>
           </Pressable>
@@ -311,7 +307,7 @@ function FocusAreas({ areas }: { areas: StoredFocusArea[] }) {
       <Text style={{ ...KICKER, marginBottom: 10 }}>What to work on</Text>
       {areas.map((a, i) => (
         <View key={`focus-${i}`} style={{ marginBottom: 14 }}>
-          <Text style={[TYPE.serif, { color: INK, fontSize: 16, fontStyle: 'italic', fontWeight: '500' }]}>
+          <Text style={[TYPE.serif, { color: INK, fontSize: 16 }]}>
             {CATEGORY_LABEL[a.category] ?? a.category}
           </Text>
           <Text style={[TYPE.body, { color: INK_DIM, fontSize: 13, lineHeight: 19, marginTop: 2 }]}>
@@ -428,7 +424,7 @@ function DrillRowItem({
         style={{ flex: 1, flexDirection: 'row', gap: 12 }}
       >
         <Text
-          style={[TYPE.serif, { color: INK_MUTE, fontSize: 24, fontStyle: 'italic', lineHeight: 26, minWidth: 30 }]}
+          style={[TYPE.serif, { color: INK_MUTE, fontSize: 24, lineHeight: 26, minWidth: 30 }]}
         >
           {String(index).padStart(2, '0')}
         </Text>
@@ -439,8 +435,6 @@ function DrillRowItem({
               style={[TYPE.serif, {
                 color: completed ? INK_MUTE : INK,
                 fontSize: 18,
-                fontStyle: 'italic',
-                fontWeight: '500',
                 lineHeight: 23,
                 flex: 1,
               }]}
@@ -453,7 +447,7 @@ function DrillRowItem({
 
             {/* Right rail — minutes + block type tag + optional target. */}
             <View style={{ alignItems: 'flex-end', minWidth: 64 }}>
-              <Text style={[TYPE.serif, { color: INK, fontSize: 18, fontStyle: 'italic', lineHeight: 20 }]}>
+              <Text style={[TYPE.serif, { color: INK, fontSize: 18, lineHeight: 20 }]}>
                 {block.minutes} min
               </Text>
               <Text

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -225,9 +225,6 @@ export default function ProfileTab() {
             style={[TYPE.serif, {
               color: '#1C211C',
               fontSize: 56,
-              fontStyle: 'italic',
-              fontWeight: '500',
-              fontVariant: ['tabular-nums'],
               lineHeight: 60,
             }]}
           >
@@ -393,7 +390,7 @@ export default function ProfileTab() {
               My Bag
             </Text>
           </View>
-          <Text style={[TYPE.bodyItalic, { color: '#1F3D2C', fontSize: 18, fontStyle: 'italic' }]}>→</Text>
+          <Text style={[TYPE.bodyItalic, { color: '#1F3D2C', fontSize: 18 }]}>→</Text>
         </Pressable>
 
         <Pressable
@@ -608,8 +605,6 @@ function DeleteAccountModal({
             style={[TYPE.serif, {
               color: '#1C211C',
               fontSize: 22,
-              fontStyle: 'italic',
-              fontWeight: '500',
               lineHeight: 28,
               marginBottom: 10,
             }]}

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -575,8 +575,6 @@ export default function RoundIndex() {
             style={[TYPE.serif, {
               color: '#F2EEE5',
               fontSize: 17,
-              fontWeight: '500',
-              fontStyle: 'italic',
             }]}
           >
             {courseName}
@@ -1027,7 +1025,6 @@ function RoundNudge({ focus, picks }: { focus: RoundFocus; picks: DrillRow[] }) 
           color: '#1C211C',
           fontSize: 16,
           lineHeight: 22,
-          fontStyle: 'italic',
           marginBottom: picks.length ? 12 : 0,
         }]}
       >

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -416,9 +416,7 @@ export default function NewRound() {
         style={[TYPE.serif, {
           color: '#1C211C',
           fontSize: 28,
-          fontWeight: '500',
           marginBottom: 14,
-          fontStyle: 'italic',
         }]}
       >
         {mode === 'past' ? 'Pick the course you played' : 'Pick a course to start'}
@@ -610,8 +608,6 @@ function RoundSetupStep({
         style={[TYPE.serif, {
           color: '#1C211C',
           fontSize: 28,
-          fontWeight: '500',
-          fontStyle: 'italic',
           marginBottom: 18,
         }]}
       >
@@ -732,8 +728,6 @@ function ManualCourseForm({
           style={[TYPE.serif, {
             color: '#1C211C',
             fontSize: 28,
-            fontStyle: 'italic',
-            fontWeight: '500',
             marginBottom: 18,
           }]}
         >

--- a/apps/mobile/app/(app)/rounds.tsx
+++ b/apps/mobile/app/(app)/rounds.tsx
@@ -183,8 +183,6 @@ export default function RoundsList() {
                         style={[TYPE.serif, {
                           color: '#1C211C',
                           fontSize: 17,
-                          fontWeight: '500',
-                          fontStyle: 'italic',
                         }]}
                       >
                         {r.courses?.name ?? 'Round'}

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -197,8 +197,6 @@ export default function Stats() {
               style={[TYPE.serif, {
                 color: '#1C211C',
                 fontSize: 22,
-                fontStyle: 'italic',
-                fontWeight: '500',
               }]}
             >
               No rounds yet.
@@ -259,8 +257,6 @@ export default function Stats() {
                     <Text
                       style={[TYPE.serif, {
                         fontSize: 26,
-                        fontStyle: 'italic',
-                        fontWeight: '500',
                         color:
                           s.value > 0
                             ? '#1F3D2C'
@@ -674,9 +670,6 @@ function StatTile({ label, value }: { label: string; value: string }) {
         style={[TYPE.serif, {
           color: '#1C211C',
           fontSize: 20,
-          fontStyle: 'italic',
-          fontWeight: '500',
-          fontVariant: ['tabular-nums'],
         }]}
       >
         {value}
@@ -727,9 +720,6 @@ function StatRow({
           style={[TYPE.serif, {
             color: valueColor,
             fontSize: 20,
-            fontStyle: 'italic',
-            fontWeight: '500',
-            fontVariant: ['tabular-nums'],
           }]}
         >
           {value}
@@ -787,7 +777,7 @@ function ScoringDistBar({
 
 function Insufficient({ note }: { note: string }) {
   return (
-    <Text style={[TYPE.bodyItalic, { color: '#8A8B7E', fontSize: 13, fontStyle: 'italic', marginBottom: 8 }]}>
+    <Text style={[TYPE.bodyItalic, { color: '#8A8B7E', fontSize: 13, marginBottom: 8 }]}>
       {note}
     </Text>
   )
@@ -825,8 +815,6 @@ function StandoutCallout({ sg }: { sg: SGAverages }) {
         style={[TYPE.serif, {
           color: '#1C211C',
           fontSize: 17,
-          fontStyle: 'italic',
-          fontWeight: '500',
           lineHeight: 24,
         }]}
       >

--- a/apps/mobile/components/errors/ErrorBoundary.tsx
+++ b/apps/mobile/components/errors/ErrorBoundary.tsx
@@ -51,8 +51,6 @@ function ErrorScreen({ error, onReset }: { error: Error; onReset: () => void }) 
         <View style={{ maxWidth: 480 }}>
           <Text
             style={[TYPE.serif, {
-              fontStyle: 'italic',
-              fontWeight: '500',
               fontSize: 32,
               color: '#1C211C',
               textAlign: 'center',

--- a/apps/mobile/components/home/LearnPreview.tsx
+++ b/apps/mobile/components/home/LearnPreview.tsx
@@ -80,7 +80,7 @@ function PreviewRow({
     >
       <View style={{ flex: 1, paddingRight: 12 }}>
         <View style={{ flexDirection: 'row', alignItems: 'baseline', flexWrap: 'wrap' }}>
-          <Text style={[TYPE.serif, { color: '#1C211C', fontSize: 16, fontStyle: 'italic', fontWeight: '500' }]}>
+          <Text style={[TYPE.serif, { color: '#1C211C', fontSize: 16 }]}>
             {article.title}
           </Text>
           {article.status === 'draft' && (
@@ -95,7 +95,7 @@ function PreviewRow({
         {reading != null && (
           <Text style={[TYPE.kicker, KICKER, { color: '#8A8B7E', marginBottom: 4 }]}>{reading} min</Text>
         )}
-        <Text style={[TYPE.serif, { color: '#8A8B7E', fontSize: 18, fontStyle: 'italic' }]}>→</Text>
+        <Text style={[TYPE.serif, { color: '#8A8B7E', fontSize: 18 }]}>→</Text>
       </View>
     </Pressable>
   )

--- a/apps/mobile/components/home/RecentRoundsList.tsx
+++ b/apps/mobile/components/home/RecentRoundsList.tsx
@@ -112,8 +112,6 @@ export function RecentRoundsList({
                         {
                           color: '#1C211C',
                           fontSize: 17,
-                          fontWeight: '500',
-                          fontStyle: 'italic',
                         },
                       ]}
                     >
@@ -181,9 +179,6 @@ function SGValue({ value }: { value: number | null }) {
         {
           color,
           fontSize: 17,
-          fontStyle: 'italic',
-          fontWeight: '500',
-          fontVariant: ['tabular-nums'],
         },
       ]}
     >

--- a/apps/mobile/components/home/ResumeRoundBanner.tsx
+++ b/apps/mobile/components/home/ResumeRoundBanner.tsx
@@ -103,8 +103,6 @@ export function ResumeRoundBanner({ round }: { round: ActiveRound }) {
             {
               color: '#1C211C',
               fontSize: 15,
-              fontWeight: '500',
-              fontStyle: 'italic',
             },
           ]}
         >

--- a/apps/mobile/components/home/SGBreakdown.tsx
+++ b/apps/mobile/components/home/SGBreakdown.tsx
@@ -98,8 +98,6 @@ function SGBar({
           {
             color,
             fontSize: 15,
-            fontStyle: 'italic',
-            fontWeight: '500',
             width: 56,
             textAlign: 'right',
             fontVariant: ['tabular-nums'],

--- a/apps/mobile/components/learn/articles/Benchmarks.tsx
+++ b/apps/mobile/components/learn/articles/Benchmarks.tsx
@@ -384,10 +384,8 @@ function BenchmarkBar({
           <Text
             style={{
               fontFamily: FONT.serifItalic,
-              fontStyle: 'italic',
               fontSize: 13,
               color: C.inkDim,
-              fontVariant: ['tabular-nums'],
             }}
           >
             Scratch · {row.format(scratchValue)}
@@ -499,8 +497,6 @@ function BenchmarkBar({
           <Text
             style={{
               fontFamily: FONT.serifItalic,
-              fontStyle: 'italic',
-              fontVariant: ['tabular-nums'],
             }}
           >
             {row.format(row.values[6]!)}
@@ -511,8 +507,6 @@ function BenchmarkBar({
           <Text
             style={{
               fontFamily: FONT.serifItalic,
-              fontStyle: 'italic',
-              fontVariant: ['tabular-nums'],
             }}
           >
             {row.format(row.values[0]!)}
@@ -534,8 +528,6 @@ function BenchmarkBar({
           <Text
             style={{
               fontFamily: FONT.serifItalic,
-              fontStyle: 'italic',
-              fontVariant: ['tabular-nums'],
             }}
           >
             {row.format(me!)}

--- a/apps/mobile/components/learn/articles/BuildingYourBag.tsx
+++ b/apps/mobile/components/learn/articles/BuildingYourBag.tsx
@@ -277,8 +277,6 @@ function SampleBag() {
               color: C.ink,
               fontFamily: FONT.serifItalic,
               fontSize: 15,
-              fontStyle: 'italic',
-              fontWeight: '500',
               marginBottom: 4,
             }}
           >

--- a/apps/mobile/components/learn/articles/FittingsWithCoaches.tsx
+++ b/apps/mobile/components/learn/articles/FittingsWithCoaches.tsx
@@ -272,7 +272,6 @@ function FitterTable() {
               color: C.ink,
               fontFamily: FONT.serifItalic,
               fontSize: 15,
-              fontStyle: 'italic',
               marginBottom: 2,
             }}
           >

--- a/apps/mobile/components/learn/articles/GuideToFittings.tsx
+++ b/apps/mobile/components/learn/articles/GuideToFittings.tsx
@@ -362,7 +362,7 @@ function Fit({
 }) {
   return (
     <View style={{ borderTopWidth: 1, borderTopColor: C.line, paddingTop: 12, marginBottom: 12 }}>
-      <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 18, fontStyle: 'italic', marginBottom: 6 }}>
+      <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 18, marginBottom: 6 }}>
         {name}
       </Text>
       <Text style={{ color: C.inkDim, fontFamily: FONT.body, fontSize: 14, lineHeight: 22 }}>
@@ -386,7 +386,7 @@ function FitTag({ children }: { children: ReactNode }) {
 function QA({ lead, children }: { lead: string; children: ReactNode }) {
   return (
     <View style={{ borderTopWidth: 1, borderTopColor: C.line, paddingTop: 10, marginBottom: 10 }}>
-      <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, fontStyle: 'italic', marginBottom: 4 }}>
+      <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, marginBottom: 4 }}>
         {lead}
       </Text>
       <Text style={{ color: C.inkDim, fontFamily: FONT.body, fontSize: 14, lineHeight: 22 }}>{children}</Text>
@@ -421,7 +421,7 @@ function FitByHandicap() {
           key={r.stage}
           style={{ paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: C.line }}
         >
-          <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, fontStyle: 'italic', marginBottom: 4 }}>
+          <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, marginBottom: 4 }}>
             {r.stage}
           </Text>
           <Text style={{ color: C.inkDim, fontFamily: FONT.body, fontSize: 14, lineHeight: 21 }}>{r.advice}</Text>

--- a/apps/mobile/components/learn/articles/HowToPractice.tsx
+++ b/apps/mobile/components/learn/articles/HowToPractice.tsx
@@ -389,7 +389,7 @@ function SessionRows() {
           }}
         >
           <View style={{ flexDirection: 'row', justifyContent: 'space-between', marginBottom: 4 }}>
-            <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, fontStyle: 'italic', fontWeight: '500' }}>
+            <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15 }}>
               {r.phase}
             </Text>
             <Text style={{ color: C.inkDim, fontFamily: FONT.mono, fontSize: 12, fontVariant: ['tabular-nums'] }}>

--- a/apps/mobile/components/learn/articles/MeasurableGoals.tsx
+++ b/apps/mobile/components/learn/articles/MeasurableGoals.tsx
@@ -197,7 +197,7 @@ function AnatomyTable() {
           style={{ paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: C.line }}
         >
           <Text
-            style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, fontStyle: 'italic', fontWeight: '500', marginBottom: 4 }}
+            style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, marginBottom: 4 }}
           >
             {r.part}
           </Text>

--- a/apps/mobile/components/learn/articles/Operation36.tsx
+++ b/apps/mobile/components/learn/articles/Operation36.tsx
@@ -333,7 +333,6 @@ function Rung({
         style={{
           fontFamily: FONT.serifItalic,
           fontSize: 18,
-          fontStyle: 'italic',
           color: goal ? '#F2EEE5' : C.ink,
           minWidth: 78,
         }}

--- a/apps/mobile/components/learn/articles/PracticeModes.tsx
+++ b/apps/mobile/components/learn/articles/PracticeModes.tsx
@@ -334,8 +334,6 @@ function CombineTable() {
               color: C.ink,
               fontFamily: FONT.serifItalic,
               fontSize: 15,
-              fontStyle: 'italic',
-              fontWeight: '500',
               marginBottom: 4,
             }}
           >

--- a/apps/mobile/components/learn/articles/PracticeVsScoringRound.tsx
+++ b/apps/mobile/components/learn/articles/PracticeVsScoringRound.tsx
@@ -388,8 +388,6 @@ function ModeTable() {
               color: C.ink,
               fontFamily: FONT.serifItalic,
               fontSize: 14,
-              fontStyle: 'italic',
-              fontWeight: '500',
               marginBottom: 6,
             }}
           >

--- a/apps/mobile/components/learn/articles/SelfDiagnosis.tsx
+++ b/apps/mobile/components/learn/articles/SelfDiagnosis.tsx
@@ -328,7 +328,6 @@ function Example({
           color: C.ink,
           fontFamily: FONT.serifItalic,
           fontSize: 16,
-          fontStyle: 'italic',
           marginBottom: 8,
         }}
       >
@@ -398,7 +397,7 @@ function FlowQ({ n, q }: { n: string; q: string }) {
         }}
       >
         <Text style={{ fontFamily: FONT.mono, fontSize: 10, letterSpacing: 1.4, color: C.mute }}>{n}</Text>
-        <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 17, fontStyle: 'italic' }}>{q}</Text>
+        <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 17 }}>{q}</Text>
       </View>
     </View>
   )
@@ -474,7 +473,6 @@ function Chip({
         style={{
           fontFamily: FONT.bodyItalic,
           fontSize: 14,
-          fontStyle: 'italic',
           color: accent ? '#F2EEE5' : C.ink,
         }}
       >

--- a/apps/mobile/components/learn/articles/StrokesGained.tsx
+++ b/apps/mobile/components/learn/articles/StrokesGained.tsx
@@ -136,7 +136,7 @@ function WorkedExample() {
       >
         Slightly below baseline. Hit it to <Em>10 feet</Em> instead and the
         number flips: 2.86 − 1.61 − 1 ={' '}
-        <Text style={{ fontFamily: FONT.serifItalic, fontStyle: 'italic' }}>
+        <Text style={{ fontFamily: FONT.serifItalic }}>
           +0.25
         </Text>{' '}
         — a quarter of a stroke gained on a single approach. Stack eighteen of
@@ -166,10 +166,7 @@ function ExampleStat({
           color,
           fontFamily: FONT.serifItalic,
           fontSize: 26,
-          fontStyle: 'italic',
-          fontWeight: '500',
           lineHeight: 28,
-          fontVariant: ['tabular-nums'],
         }}
       >
         {value}
@@ -220,7 +217,7 @@ function SGCategoriesTable() {
         <DefRow key={r.cat} term={r.cat}>
           <Text style={{ color: C.ink }}>{r.what}</Text>
           {'\n'}
-          <Text style={{ fontFamily: FONT.bodyItalic, fontStyle: 'italic', color: C.inkDim }}>
+          <Text style={{ fontFamily: FONT.bodyItalic, color: C.inkDim }}>
             {r.example}
           </Text>
         </DefRow>

--- a/apps/mobile/components/learn/articles/SwingVariations.tsx
+++ b/apps/mobile/components/learn/articles/SwingVariations.tsx
@@ -559,7 +559,7 @@ function HallOfFame() {
           }}
         >
           <Text
-            style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 16, fontStyle: 'italic', marginBottom: 6 }}
+            style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 16, marginBottom: 6 }}
           >
             {p.name}
           </Text>
@@ -608,7 +608,7 @@ function BodyTypeTable() {
           style={{ paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: C.line }}
         >
           <Text
-            style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, fontStyle: 'italic', marginBottom: 4 }}
+            style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, marginBottom: 4 }}
           >
             {r.type}
           </Text>

--- a/apps/mobile/components/learn/articles/TrainingAids.tsx
+++ b/apps/mobile/components/learn/articles/TrainingAids.tsx
@@ -400,7 +400,7 @@ function Aid({
   return (
     <View style={{ borderTopWidth: 1, borderTopColor: C.line, paddingTop: 14, marginBottom: 14 }}>
       {svg ? <Figure caption={caption}>{svg}</Figure> : null}
-      <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 18, fontStyle: 'italic', fontWeight: '500', marginBottom: 6 }}>
+      <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 18, marginBottom: 6 }}>
         {name}
       </Text>
       <Text style={{ color: C.inkDim, fontFamily: FONT.body, fontSize: 14, lineHeight: 22, marginBottom: 8 }}>

--- a/apps/mobile/components/learn/primitives.tsx
+++ b/apps/mobile/components/learn/primitives.tsx
@@ -48,8 +48,6 @@ export const TITLE: TextStyle = {
   color: C.ink,
   fontFamily: FONT.serifItalic,
   fontSize: 26,
-  fontStyle: 'italic',
-  fontWeight: '500',
   lineHeight: 32,
   marginBottom: 14,
 }
@@ -73,8 +71,6 @@ const H3_STYLE: TextStyle = {
   color: C.ink,
   fontFamily: FONT.serifItalic,
   fontSize: 19,
-  fontStyle: 'italic',
-  fontWeight: '500',
   lineHeight: 25,
   marginTop: 22,
   marginBottom: 12,
@@ -84,8 +80,6 @@ const H4_STYLE: TextStyle = {
   color: C.ink,
   fontFamily: FONT.serifItalic,
   fontSize: 16,
-  fontStyle: 'italic',
-  fontWeight: '500',
   lineHeight: 22,
   marginTop: 16,
   marginBottom: 8,
@@ -97,7 +91,7 @@ export function Strong({ children }: { children: ReactNode }) {
 }
 
 export function Em({ children }: { children: ReactNode }) {
-  return <Text style={{ fontFamily: FONT.bodyItalic, fontStyle: 'italic' }}>{children}</Text>
+  return <Text style={{ fontFamily: FONT.bodyItalic }}>{children}</Text>
 }
 
 export function Link({ href, children }: { href: string; children: ReactNode }) {
@@ -237,7 +231,7 @@ export function DefRow({
         borderTopColor: C.line,
       }}
     >
-      <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, fontStyle: 'italic', fontWeight: '500', marginBottom: 4 }}>
+      <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, marginBottom: 4 }}>
         {term}
       </Text>
       <Text style={{ color: C.inkDim, fontFamily: FONT.body, fontSize: 14, lineHeight: 20 }}>{children}</Text>
@@ -309,7 +303,7 @@ export function Sources({
       <Text style={{ ...KICKER, marginBottom: 4 }}>Sources</Text>
       {items.map((s, i) => (
         <View key={i} style={{ paddingVertical: 10, borderTopWidth: 1, borderTopColor: C.line }}>
-          <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 14, fontStyle: 'italic', fontWeight: '500', marginBottom: 3 }}>
+          <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 14, marginBottom: 3 }}>
             {s.href ? <Link href={s.href}>{s.name}</Link> : s.name}
           </Text>
           <Text style={{ color: C.inkDim, fontFamily: FONT.body, fontSize: 13, lineHeight: 19 }}>{s.note}</Text>
@@ -329,7 +323,7 @@ export function ResourceList({
     <View style={{ marginVertical: 6 }}>
       {items.map((r, i) => (
         <View key={i} style={{ paddingVertical: 12, borderTopWidth: 1, borderTopColor: C.line }}>
-          <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15, fontStyle: 'italic', fontWeight: '500' }}>
+          <Text style={{ color: C.ink, fontFamily: FONT.serifItalic, fontSize: 15 }}>
             {r.title}
             {r.by ? <Text style={{ color: C.inkDim, fontFamily: FONT.body, fontStyle: 'normal', fontWeight: '400' }}> — {r.by}</Text> : null}
           </Text>
@@ -372,7 +366,7 @@ export function DevNote({
       }}
     >
       <Text style={{ ...KICKER, color: tone, marginBottom: 4 }}>{label} · dev only</Text>
-      <Text style={{ color: C.inkDim, fontFamily: FONT.bodyItalic, fontSize: 13, fontStyle: 'italic', lineHeight: 19 }}>
+      <Text style={{ color: C.inkDim, fontFamily: FONT.bodyItalic, fontSize: 13, lineHeight: 19 }}>
         {children}
       </Text>
     </View>

--- a/apps/mobile/components/practice/drillDisplay.tsx
+++ b/apps/mobile/components/practice/drillDisplay.tsx
@@ -1,6 +1,6 @@
 import { Text } from 'react-native'
 import type { BlockType, PlanCategory } from '@oga/core'
-import { TYPE } from '../../lib/typography'
+import { FONT, TYPE } from '../../lib/typography'
 
 // Shared drill-display vocabulary + the instructions renderer, used by both the
 // Practice plan screen (plan blocks) and the Drill library screen (browse-all).
@@ -64,7 +64,7 @@ export function renderInstructions(text: string) {
             {seg.text}
           </Text>
         ) : seg.kind === 'i' ? (
-          <Text key={si} style={{ fontStyle: 'italic' }}>
+          <Text key={si} style={{ fontFamily: FONT.bodyItalic }}>
             {seg.text}
           </Text>
         ) : (

--- a/apps/mobile/components/round/GreenDiagram.tsx
+++ b/apps/mobile/components/round/GreenDiagram.tsx
@@ -219,9 +219,6 @@ export function GreenDiagram({
               {
                 color: '#1C211C',
                 fontSize: 28,
-                fontStyle: 'italic',
-                fontWeight: '500',
-                fontVariant: ['tabular-nums'],
                 lineHeight: 30,
               },
             ]}

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -330,8 +330,6 @@ export default function LiveRoundSession({
             {
               color: '#1C211C',
               fontSize: 20,
-              fontStyle: 'italic',
-              fontWeight: '500',
               textAlign: 'center',
               marginBottom: 10,
             },
@@ -465,8 +463,6 @@ export default function LiveRoundSession({
               {
                 color: '#F2EEE5',
                 fontSize: 17,
-                fontWeight: '500',
-                fontStyle: 'italic',
               },
             ]}
           >

--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -204,8 +204,6 @@ export function PastHoleShotsSheet({
               style={[TYPE.serif, {
                 color: '#1C211C',
                 fontSize: 22,
-                fontStyle: 'italic',
-                fontWeight: '500',
                 marginBottom: 14,
               }]}
             >
@@ -509,8 +507,6 @@ function EditShotSheet({
           style={[TYPE.serif, {
             color: '#1C211C',
             fontSize: 17,
-            fontStyle: 'italic',
-            fontWeight: '500',
           }]}
         >
           Shot {shot.shot_number}

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -604,8 +604,6 @@ export function PastRoundMap({
           style={[TYPE.serif, {
             color: '#F2EEE5',
             fontSize: 16,
-            fontStyle: 'italic',
-            fontWeight: '500',
           }]}
         >
           Hole {holeNumber}
@@ -811,8 +809,6 @@ export function PastRoundMap({
                   style={[TYPE.serif, {
                     color: '#F2EEE5',
                     fontSize: 16,
-                    fontStyle: 'italic',
-                    fontWeight: '500',
                   }]}
                 >
                   Shot {activePos + 1} of {placedReal.length}

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -220,8 +220,6 @@ export function PuttingSheet({
               {
                 color: '#1C211C',
                 fontSize: 22,
-                fontStyle: 'italic',
-                fontWeight: '500',
               },
             ]}
           >

--- a/apps/mobile/components/round/RoundTeeSelector.tsx
+++ b/apps/mobile/components/round/RoundTeeSelector.tsx
@@ -130,8 +130,6 @@ export function TeePicker({
               style={[TYPE.serif, {
                 color: active ? '#F2EEE5' : '#1C211C',
                 fontSize: 16,
-                fontStyle: 'italic',
-                fontWeight: '500',
                 textTransform: 'capitalize',
               }]}
             >

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -235,8 +235,6 @@ export function ShotLogger({
                   {
                     color: '#1C211C',
                     fontSize: 22,
-                    fontWeight: '500',
-                    fontStyle: 'italic',
                   },
                 ]}
               >

--- a/apps/mobile/components/ui/ConfirmDialog.tsx
+++ b/apps/mobile/components/ui/ConfirmDialog.tsx
@@ -69,8 +69,6 @@ export function ConfirmDialog({
               {
                 color: '#1C211C',
                 fontSize: 22,
-                fontStyle: 'italic',
-                fontWeight: '500',
                 lineHeight: 28,
                 marginBottom: message ? 10 : 22,
               },


### PR DESCRIPTION
## Problem
Custom fonts are selected by family **name** only. Layering `fontStyle: 'italic'` or `fontWeight` on an already-named face makes the Android font manager fail to resolve it and fall back to **system sans** — iOS tolerates it, so the bug only showed on Android. Result: every italic in the app (handicap index, stats numbers, practice/drill names, learn articles, round screens) rendered as plain sans on Android while looking correct on iOS. Caught comparing the iOS vs Android store screenshots.

## Fix
- **90 sites** already had a named italic face (`TYPE.serif`, `TYPE.bodyItalic`, `FONT.serifItalic`/`FONT.bodyItalic`) → stripped the redundant `fontStyle: 'italic'` + sibling `fontWeight`.
- **3 sites** were bare `fontStyle: 'italic'` with no face → swapped to `fontFamily: FONT.bodyItalic`.
- **93 sites, 41 files.** Matches the known-good splash wordmark pattern (bare `fontFamily`, nothing layered).

## fontVariant
The sweep incidentally dropped `fontVariant: ['tabular-nums']` where it sat in the same style object as a removed `fontStyle`. The remaining ~45 `tabular-nums` (scorecard/stats number columns) are **left in place** — on-device verification (Android EAS build) confirms named-face numbers with `tabular-nums` render Fraunces correctly, so it is **not** an Android fallback trigger and the column alignment is worth keeping.

## Verification
- `npm run typecheck` passes.
- **Android EAS build installed on-device — Fraunces italic now renders across the app. ✅**
- mono/kicker/bodyBold weights untouched.