### PR TITLE
feat(web): club distances on Stats (parity with mobile)

### DIFF
--- a/apps/web/src/pages/stats/StrokesGainedPage.tsx
+++ b/apps/web/src/pages/stats/StrokesGainedPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
+import { clubDistanceStats } from '@oga/core'
 import { useDetailedStats } from '../../hooks/useDetailedStats'
 import { EmptyState, Skeleton } from './components/Section'
 import { Segmented } from './components/Segmented'
@@ -7,12 +8,24 @@ import { ScoringSection } from './sections/ScoringSection'
 import { BallStrikingSection } from './sections/BallStrikingSection'
 import { ShortGameSection } from './sections/ShortGameSection'
 import { PatternsSection } from './sections/PatternsSection'
+import { ClubDistancesSection } from './sections/ClubDistancesSection'
 
 const N_OPTIONS: readonly number[] = [5, 10, 20]
 
 export function StrokesGainedPage() {
   const [n, setN] = useState<number>(10)
   const stats = useDetailedStats(n)
+  // Per-club total distance, from every tracked shot's start→end across the
+  // loaded rounds (same flatten the mobile Stats screen feeds clubDistanceStats).
+  const clubDistances = useMemo(
+    () =>
+      clubDistanceStats(
+        stats.rounds.flatMap((r) =>
+          (r.hole_scores ?? []).flatMap((hs) => hs.shots ?? []),
+        ),
+      ),
+    [stats.rounds],
+  )
 
   return (
     <div>
@@ -58,6 +71,7 @@ export function StrokesGainedPage() {
           <BallStrikingSection data={stats.data} />
           <ShortGameSection data={stats.data} />
           <PatternsSection data={stats.data} />
+          <ClubDistancesSection clubDistances={clubDistances} />
         </>
       )}
     </div>

--- a/apps/web/src/pages/stats/sections/ClubDistancesSection.tsx
+++ b/apps/web/src/pages/stats/sections/ClubDistancesSection.tsx
@@ -1,0 +1,64 @@
+import type { ClubDistanceStat } from '@oga/core'
+import { formatClubLabel, YARDS_TO_METERS } from '@oga/core'
+import { useUnits } from '../../../hooks/useUnits'
+import { Section } from '../components/Section'
+
+// Per-club total distance (avg + min–max), from every tracked shot's
+// start→end across the loaded rounds. Mirrors the mobile Stats section so
+// both surfaces read the same @oga/core computation.
+export function ClubDistancesSection({
+  clubDistances,
+}: {
+  clubDistances: ClubDistanceStat[]
+}) {
+  const { unit, toDisplay } = useUnits()
+  if (clubDistances.length === 0) return null
+  // avg shows the unit via toDisplay; the range shows bare numbers in the same
+  // unit so the row doesn't repeat "yd" three times.
+  const conv = (y: number) =>
+    unit === 'meters' ? Math.round(y * YARDS_TO_METERS) : Math.round(y)
+  return (
+    <Section kicker="Club distances">
+      <div
+        className="text-caddie-ink-dim"
+        style={{ fontSize: 12, marginTop: -8, marginBottom: 14 }}
+      >
+        Total distance, not carry · avg (min–max)
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        {clubDistances.map((c) => (
+          <div
+            key={c.club}
+            className="flex items-baseline"
+            style={{ gap: 12, borderBottom: '1px solid #EBE5D6', padding: '9px 0' }}
+          >
+            <div
+              className="font-medium text-caddie-ink capitalize"
+              style={{ flex: 1, fontSize: 14 }}
+            >
+              {formatClubLabel({ club_type: c.club })}
+            </div>
+            <div
+              className="font-serif text-caddie-ink"
+              style={{ fontSize: 16, fontVariant: 'tabular-nums' }}
+            >
+              {toDisplay(c.avg)}
+            </div>
+            <div
+              className="text-caddie-ink-dim"
+              style={{ width: 96, textAlign: 'right', fontSize: 13, fontVariant: 'tabular-nums' }}
+            >
+              {conv(c.min)}–{conv(c.max)}
+            </div>
+            <div
+              className="text-caddie-ink-mute"
+              style={{ width: 64, textAlign: 'right', fontSize: 12 }}
+            >
+              {c.count} shot{c.count === 1 ? '' : 's'}
+            </div>
+          </div>
+        ))}
+      </div>
+    </Section>
+  )
+}


### PR DESCRIPTION
## What
Mobile's Stats screen shows per-club **total distance** (avg + min–max range + shot count) via `@oga/core` `clubDistanceStats`, but the web Stats page never got it. This adds a **Club distances** section at the bottom of web Stats, matching mobile.

## How
- New `ClubDistancesSection` (`apps/web/src/pages/stats/sections/`), reusing the shared `Section` + `useUnits` + `formatClubLabel`.
- Computed in `StrokesGainedPage` from `stats.rounds` (the rounds-with-shots the page already loads) — same flatten the mobile screen uses. No new fetch.
- Reuses the existing `@oga/core` `clubDistanceStats` (already unit-tested).

## Verify
- `pnpm typecheck` passes.
- Eyeball on the Vercel preview (signed-in → Stats, scroll to bottom). Shows avg with unit + bare min–max range + shot count per club, longest-first.

Closes the web/mobile club-distance parity gap.