### PR TITLE
fix(web): sidebar uses the oga. brandmark

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -95,9 +95,13 @@ export function Sidebar() {
       >
         <div
           className="font-serif text-caddie-bg"
-          style={{ fontSize: 18, fontWeight: 500 }}
+          style={{ fontSize: 22, fontWeight: 500, fontStyle: 'italic' }}
         >
-          OGA
+          oga
+          {/* Upright period — the "o." brand mark. Cream (not forest) on the
+              dark sidebar, matching the splash treatment where the forest
+              period would vanish against #1C211C. */}
+          <span style={{ fontStyle: 'normal' }}>.</span>
         </div>
         <div
           className="font-mono uppercase text-white/45"


### PR DESCRIPTION
The app sidebar showed a plain uppercase **OGA**; the rest of the brand (landing nav, splash) uses the lowercase **oga.** wordmark (Fraunces italic + upright period). Mirror it in the sidebar.

Period is cream on the dark sidebar — matching the splash, since the forest `#1F3D2C` period would be invisible against `#1C211C`. Typography itself was already correct on web (Tailwind: Fraunces/Epilogue/Inconsolata, all loaded); this was just the wordmark.