### PR TITLE
chore: release v1.0.0

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -8,7 +8,7 @@ const config: ExpoConfig = {
   name: 'OGA',
   slug: 'oga',
   scheme: 'oga',
-  version: '0.9.0',
+  version: '1.0.0',
   orientation: 'portrait',
   // New Architecture stays OFF for the SDK 53 migration. SDK 53 flips it
   // on by default, so this is an active opt-out (set during the SDK 52 step


### PR DESCRIPTION
Pins v1.0.0 for the store launch:
- **Mobile store version → 1.0.0** (`apps/mobile/app.config.ts`) so the production builds ship as 1.0.0 (release-please doesn't manage this file).
- **`Release-As: 1.0.0`** footer so release-please tags the repo 1.0.0 (it computed 0.10.0 from conventional commits; this marks v1).

Production builds (AAB done off this branch; IPA pending Apple App Store credentials) are cut from this code.