### PR TITLE
fix(web): no-app account-deletion path for Play deletion URL

### DIFF
--- a/apps/web/src/pages/landing/PrivacyPage.tsx
+++ b/apps/web/src/pages/landing/PrivacyPage.tsx
@@ -116,6 +116,11 @@ export function PrivacyPage() {
             stays — it isn't yours to delete.
           </P>
           <P>
+            No longer have the app installed? Email{' '}
+            <ExtLink href="mailto:support@oga.golf">support@oga.golf</ExtLink>{' '}
+            to request deletion of your account and all of its data.
+          </P>
+          <P>
             If something goes wrong with self-service deletion, open a
             ticket on{' '}
             <ExtLink href="https://github.com/cner-smith/opengolfapp/issues">

--- a/apps/web/src/pages/landing/SupportPage.tsx
+++ b/apps/web/src/pages/landing/SupportPage.tsx
@@ -73,6 +73,16 @@ export function SupportPage() {
             permanent and immediate.
           </P>
           <P>
+            No longer have the app installed? Email{' '}
+            <a
+              href="mailto:support@oga.golf"
+              style={{ color: '#1F3D2C', textDecoration: 'underline' }}
+            >
+              support@oga.golf
+            </a>{' '}
+            to request deletion of your account and all of its data.
+          </P>
+          <P>
             For anything else about your data — a correction, an export, a
             question about what's stored — open an issue and we'll handle it.
             The full rundown of what we collect is on the{' '}


### PR DESCRIPTION
Google Play's account-deletion policy requires deletion to be requestable **without the app** (uninstalled users). The `/support` and `/privacy` deletion sections only described the in-app flow (Settings → Delete account).

Adds a line to both pages: *"No longer have the app installed? Email support@oga.golf to request deletion of your account and all of its data."* (`support@oga.golf` forwarding is live.)

This lets **`https://oga.golf/support`** be used as the Play Data Safety **data-deletion URL** and satisfy the policy. Copy-only; typecheck passes.