### PR TITLE
chore(eas): pin Xcode 26 image for iOS production builds

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -34,6 +34,9 @@
     "production": {
       "autoIncrement": true,
       "node": "20.18.0",
+      "ios": {
+        "image": "macos-sequoia-15.6-xcode-26.2"
+      },
       "env": {
         "npm_config_legacy_peer_deps": "true"
       }


### PR DESCRIPTION
Apple requires App Store uploads to be built with **Xcode 26+** since 2026-04-28. We're on **Expo SDK 53**, whose default EAS image is Xcode 16 — so the iOS production build was rejected at submission.

Opt into Xcode 26 by pinning `"image": "macos-sequoia-15.6-xcode-26.2"` on the production iOS profile (per Expo's guidance for SDK ≤53).

⚠️ Expo notes SDK 53 isn't guaranteed compatible with Xcode 26 (depends on native libs). If the rebuild fails, the proper fix is an SDK 54 upgrade (separate effort). Config-only change.