### PR TITLE
release: Xcode 26 EAS image for iOS builds

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -34,6 +34,9 @@
     "production": {
       "autoIncrement": true,
       "node": "20.18.0",
+      "ios": {
+        "image": "macos-sequoia-15.6-xcode-26.2"
+      },
       "env": {
         "npm_config_legacy_peer_deps": "true"
       }


### PR DESCRIPTION
Ships the EAS Xcode 26 image opt-in (#628) to main so iOS production builds off main can be submitted to the App Store (Apple's Xcode 26 requirement). Config-only; no app/version change.