### PR TITLE
fix(web): sanitize Turnstile site key so production captcha loads

### DIFF
--- a/apps/web/public/captcha.html
+++ b/apps/web/public/captcha.html
@@ -10,7 +10,15 @@
     body { display: flex; align-items: center; justify-content: center; }
   </style>
   <script>
-    const siteKey = new URLSearchParams(window.location.search).get('siteKey');
+    // Strip stray angle brackets / whitespace before handing the key to
+    // Turnstile. A site key copied from a "<your-key-here>" style placeholder
+    // (e.g. into the EXPO_PUBLIC_TURNSTILE_SITE_KEY env var) arrives wrapped in
+    // "<...>", which Turnstile rejects by silently failing to render — no
+    // widget, no error, submit button stuck disabled. Sanitizing here fixes
+    // already-shipped app builds without a rebuild, since the app loads this
+    // page remotely.
+    const rawSiteKey = new URLSearchParams(window.location.search).get('siteKey');
+    const siteKey = (rawSiteKey || '').replace(/[<>\s]/g, '');
 
     function initTurnstile() {
       turnstile.render('#widget', {


### PR DESCRIPTION
## Problem

The production Android (Play Store early-access) build can't log in or sign up. The Turnstile box never loads, never verifies, and shows no error — the submit button just stays disabled.

Root cause: the production EAS env var \`EXPO_PUBLIC_TURNSTILE_SITE_KEY\` was set to \`<0x4AAAAAADJg4XtoY7a9rXJY>\` — the value was copied with the surrounding placeholder angle brackets. The app passes that key to \`https://oga.golf/captcha.html?siteKey=...\`, and \`turnstile.render()\` silently fails on the malformed key (no widget, no token, no error).

Worked in preview builds because the preview environment had a clean key; this is the first production build.

## Fix

Strip \`<\`, \`>\`, and whitespace from the site key in \`captcha.html\` before handing it to Turnstile.

Because the mobile app loads this page **remotely** from oga.golf, deploying this to production fixes **already-installed builds with no app rebuild or store resubmission** — as soon as oga.golf redeploys, existing apps can verify again.

## Follow-ups (not in this PR)
- Fix the EAS var itself to the clean value (\`0x4AAAAAADJg4XtoY7a9rXJY\`, no brackets) and rebuild — the web sanitizer is a safety net, not a substitute.
- Confirm the Supabase Auth Turnstile **secret** matches the same Cloudflare widget.
- Merge this into \`dev\` after \`main\` so the branches don't drift.

## Test
Manual: loading \`captcha.html?siteKey=<0x...>\` now renders the widget; previously blank.