### PR TITLE
fix(web): sanitize Turnstile site key in captcha WebView page

### DIFF
--- a/apps/web/public/captcha.html
+++ b/apps/web/public/captcha.html
@@ -10,7 +10,15 @@
     body { display: flex; align-items: center; justify-content: center; }
   </style>
   <script>
-    const siteKey = new URLSearchParams(window.location.search).get('siteKey');
+    // Strip stray angle brackets / whitespace before handing the key to
+    // Turnstile. A site key copied from a "<your-key-here>" style placeholder
+    // (e.g. into the EXPO_PUBLIC_TURNSTILE_SITE_KEY env var) arrives wrapped in
+    // "<...>", which Turnstile rejects by silently failing to render — no
+    // widget, no error, submit button stuck disabled. Sanitizing here fixes
+    // already-shipped app builds without a rebuild, since the app loads this
+    // page remotely.
+    const rawSiteKey = new URLSearchParams(window.location.search).get('siteKey');
+    const siteKey = (rawSiteKey || '').replace(/[<>\s]/g, '');
 
     function initTurnstile() {
       turnstile.render('#widget', {


### PR DESCRIPTION
Ports the production hotfix #630 onto `dev` so the branches don't drift.

`captcha.html` strips `<`, `>`, and whitespace from the Turnstile site key before passing it to `turnstile.render()`. A key copied into `EXPO_PUBLIC_TURNSTILE_SITE_KEY` with placeholder brackets (`<0x4AAA...>`) silently fails to render the widget, blocking login/signup with no error.

Already merged to `main` and live on oga.golf; this keeps `dev` in sync. No app rebuild needed — the mobile app loads this page remotely.