### PR TITLE
fix(mobile): remove iOS donation CTAs (App Review 3.1.1)

### DIFF
--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Linking,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   Text,
@@ -430,70 +431,114 @@ export default function ProfileTab() {
             padding: 18,
           }}
         >
-          <Text style={{ ...KICKER, marginBottom: 10 }}>Support OGA</Text>
-          <Text
-            style={[TYPE.body, {
-              color: '#1C211C',
-              fontSize: 14,
-              lineHeight: 20,
-              marginBottom: 14,
-            }]}
-          >
-            OGA is free and open source. If it helps your game,
-            consider buying us a round.
-          </Text>
-          <View style={{ flexDirection: 'row', gap: 10 }}>
-            <Pressable
-              accessibilityRole="link"
-              accessibilityLabel="Open Ko-fi sponsorship page"
-              onPress={() => Linking.openURL('https://ko-fi.com/nartana')}
-              style={{
-                flex: 1,
-                borderWidth: 1,
-                borderColor: '#1F3D2C',
-                paddingVertical: 12,
-                alignItems: 'center',
-                borderRadius: 2,
-              }}
-            >
+          {/* iOS: no donation CTAs — App Review 3.1.1 requires IAP or removal.
+              A neutral website link (no payment framing) is allowed; donors
+              find Ko-fi / GitHub Sponsors on the site. Android keeps them. */}
+          {Platform.OS === 'ios' ? (
+            <>
+              <Text style={{ ...KICKER, marginBottom: 10 }}>OGA on the web</Text>
               <Text
-                style={[TYPE.bodyBold, {
-                  color: '#1F3D2C',
-                  fontSize: 13,
-                  fontWeight: '600',
-                  letterSpacing: 0.3,
+                style={[TYPE.body, {
+                  color: '#1C211C',
+                  fontSize: 14,
+                  lineHeight: 20,
+                  marginBottom: 14,
                 }]}
               >
-                Ko-fi ↗
+                OGA is free and open source. Learn more at oga.golf.
               </Text>
-            </Pressable>
-            <Pressable
-              accessibilityRole="link"
-              accessibilityLabel="Open GitHub Sponsors page"
-              onPress={() =>
-                Linking.openURL('https://github.com/sponsors/cner-smith')
-              }
-              style={{
-                flex: 1,
-                borderWidth: 1,
-                borderColor: '#1F3D2C',
-                paddingVertical: 12,
-                alignItems: 'center',
-                borderRadius: 2,
-              }}
-            >
+              <Pressable
+                accessibilityRole="link"
+                accessibilityLabel="Open the OGA website"
+                onPress={() => Linking.openURL('https://oga.golf')}
+                style={{
+                  borderWidth: 1,
+                  borderColor: '#1F3D2C',
+                  paddingVertical: 12,
+                  alignItems: 'center',
+                  borderRadius: 2,
+                }}
+              >
+                <Text
+                  style={[TYPE.bodyBold, {
+                    color: '#1F3D2C',
+                    fontSize: 13,
+                    fontWeight: '600',
+                    letterSpacing: 0.3,
+                  }]}
+                >
+                  Website · oga.golf ↗
+                </Text>
+              </Pressable>
+            </>
+          ) : (
+            <>
+              <Text style={{ ...KICKER, marginBottom: 10 }}>Support OGA</Text>
               <Text
-                style={[TYPE.bodyBold, {
-                  color: '#1F3D2C',
-                  fontSize: 13,
-                  fontWeight: '600',
-                  letterSpacing: 0.3,
+                style={[TYPE.body, {
+                  color: '#1C211C',
+                  fontSize: 14,
+                  lineHeight: 20,
+                  marginBottom: 14,
                 }]}
               >
-                GitHub ↗
+                OGA is free and open source. If it helps your game,
+                consider buying us a round.
               </Text>
-            </Pressable>
-          </View>
+              <View style={{ flexDirection: 'row', gap: 10 }}>
+                <Pressable
+                  accessibilityRole="link"
+                  accessibilityLabel="Open Ko-fi sponsorship page"
+                  onPress={() => Linking.openURL('https://ko-fi.com/nartana')}
+                  style={{
+                    flex: 1,
+                    borderWidth: 1,
+                    borderColor: '#1F3D2C',
+                    paddingVertical: 12,
+                    alignItems: 'center',
+                    borderRadius: 2,
+                  }}
+                >
+                  <Text
+                    style={[TYPE.bodyBold, {
+                      color: '#1F3D2C',
+                      fontSize: 13,
+                      fontWeight: '600',
+                      letterSpacing: 0.3,
+                    }]}
+                  >
+                    Ko-fi ↗
+                  </Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="link"
+                  accessibilityLabel="Open GitHub Sponsors page"
+                  onPress={() =>
+                    Linking.openURL('https://github.com/sponsors/cner-smith')
+                  }
+                  style={{
+                    flex: 1,
+                    borderWidth: 1,
+                    borderColor: '#1F3D2C',
+                    paddingVertical: 12,
+                    alignItems: 'center',
+                    borderRadius: 2,
+                  }}
+                >
+                  <Text
+                    style={[TYPE.bodyBold, {
+                      color: '#1F3D2C',
+                      fontSize: 13,
+                      fontWeight: '600',
+                      letterSpacing: 0.3,
+                    }]}
+                  >
+                    GitHub ↗
+                  </Text>
+                </Pressable>
+              </View>
+            </>
+          )}
         </View>
 
         <Pressable

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { BackHandler, Pressable, StyleSheet } from 'react-native'
+import { BackHandler, Platform, Pressable, StyleSheet } from 'react-native'
 import { useRouter } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { FONT } from '../../lib/typography'
@@ -98,7 +98,11 @@ export default function Welcome() {
         <Animated.Text style={[styles.wordmark, logoStyle]}>oga.</Animated.Text>
         <Animated.Text style={[styles.tagline, taglineStyle]}>Track every shot.</Animated.Text>
         <Animated.Text style={[styles.support, supportStyle]}>
-          Free and open source · Ko-fi support appreciated
+          {/* iOS drops the Ko-fi mention — App Review 3.1.1 (no donation
+              steering). Android keeps it. */}
+          {Platform.OS === 'ios'
+            ? 'Free and open source'
+            : 'Free and open source · Ko-fi support appreciated'}
         </Animated.Text>
       </Pressable>
     </>


### PR DESCRIPTION
## Why

App Store **rejected build 1.0 (5)** under **Guideline 3.1.1 – Business – Payments – In-App Purchase** (Submission ID 41c98b77…, reviewed on iPad Air 11" M3, 2026-07-02):

> The app allows users to contribute donations … with a mechanism other than In-App Purchase. Although these donations may be optional, they must use In-App Purchase since they are associated with receiving digital content or services.

Donations to a non-nonprofit developer are treated as digital-content purchases and must use IAP **or be removed**. External-Safari links and the US-storefront external-link allowance do **not** exempt donation CTAs. This reverses the earlier #307 conclusion (which relied on Guideline 3.2.2(iv)) — that reasoning only holds for a registered nonprofit.

## What (chosen fix: remove on iOS)

Gate the donation CTAs to non-iOS via `Platform.OS`:

- **`profile.tsx`** — the "Support OGA" card on iOS becomes a **neutral "Website · oga.golf" link** (no donate/support/payment wording). Android keeps the Ko-fi + GitHub Sponsors buttons.
- **`welcome.tsx`** — iOS splash drops the "Ko-fi support appreciated" line; Android keeps it.

**Android and web are unchanged** — all donation links remain there.

## Result on iOS

No Ko-fi, no GitHub Sponsors, no payment call-to-action anywhere. Donors reach the options via the neutral website link → oga.golf.

## Verification

- Mobile typecheck green (`npm run typecheck`).
- Manual grep confirms every remaining Ko-fi/Sponsors reference is inside the Android-only branch.

## Follow-up (not in this PR)

EAS iOS production build → resubmit → reply in App Store Connect noting donations were removed from the iOS app.