### PR TITLE
release: iOS donation-CTA removal + Turnstile key sanitization → main

### DIFF
--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   Linking,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   Text,
@@ -430,70 +431,114 @@ export default function ProfileTab() {
             padding: 18,
           }}
         >
-          <Text style={{ ...KICKER, marginBottom: 10 }}>Support OGA</Text>
-          <Text
-            style={[TYPE.body, {
-              color: '#1C211C',
-              fontSize: 14,
-              lineHeight: 20,
-              marginBottom: 14,
-            }]}
-          >
-            OGA is free and open source. If it helps your game,
-            consider buying us a round.
-          </Text>
-          <View style={{ flexDirection: 'row', gap: 10 }}>
-            <Pressable
-              accessibilityRole="link"
-              accessibilityLabel="Open Ko-fi sponsorship page"
-              onPress={() => Linking.openURL('https://ko-fi.com/nartana')}
-              style={{
-                flex: 1,
-                borderWidth: 1,
-                borderColor: '#1F3D2C',
-                paddingVertical: 12,
-                alignItems: 'center',
-                borderRadius: 2,
-              }}
-            >
+          {/* iOS: no donation CTAs — App Review 3.1.1 requires IAP or removal.
+              A neutral website link (no payment framing) is allowed; donors
+              find Ko-fi / GitHub Sponsors on the site. Android keeps them. */}
+          {Platform.OS === 'ios' ? (
+            <>
+              <Text style={{ ...KICKER, marginBottom: 10 }}>OGA on the web</Text>
               <Text
-                style={[TYPE.bodyBold, {
-                  color: '#1F3D2C',
-                  fontSize: 13,
-                  fontWeight: '600',
-                  letterSpacing: 0.3,
+                style={[TYPE.body, {
+                  color: '#1C211C',
+                  fontSize: 14,
+                  lineHeight: 20,
+                  marginBottom: 14,
                 }]}
               >
-                Ko-fi ↗
+                OGA is free and open source. Learn more at oga.golf.
               </Text>
-            </Pressable>
-            <Pressable
-              accessibilityRole="link"
-              accessibilityLabel="Open GitHub Sponsors page"
-              onPress={() =>
-                Linking.openURL('https://github.com/sponsors/cner-smith')
-              }
-              style={{
-                flex: 1,
-                borderWidth: 1,
-                borderColor: '#1F3D2C',
-                paddingVertical: 12,
-                alignItems: 'center',
-                borderRadius: 2,
-              }}
-            >
+              <Pressable
+                accessibilityRole="link"
+                accessibilityLabel="Open the OGA website"
+                onPress={() => Linking.openURL('https://oga.golf')}
+                style={{
+                  borderWidth: 1,
+                  borderColor: '#1F3D2C',
+                  paddingVertical: 12,
+                  alignItems: 'center',
+                  borderRadius: 2,
+                }}
+              >
+                <Text
+                  style={[TYPE.bodyBold, {
+                    color: '#1F3D2C',
+                    fontSize: 13,
+                    fontWeight: '600',
+                    letterSpacing: 0.3,
+                  }]}
+                >
+                  Website · oga.golf ↗
+                </Text>
+              </Pressable>
+            </>
+          ) : (
+            <>
+              <Text style={{ ...KICKER, marginBottom: 10 }}>Support OGA</Text>
               <Text
-                style={[TYPE.bodyBold, {
-                  color: '#1F3D2C',
-                  fontSize: 13,
-                  fontWeight: '600',
-                  letterSpacing: 0.3,
+                style={[TYPE.body, {
+                  color: '#1C211C',
+                  fontSize: 14,
+                  lineHeight: 20,
+                  marginBottom: 14,
                 }]}
               >
-                GitHub ↗
+                OGA is free and open source. If it helps your game,
+                consider buying us a round.
               </Text>
-            </Pressable>
-          </View>
+              <View style={{ flexDirection: 'row', gap: 10 }}>
+                <Pressable
+                  accessibilityRole="link"
+                  accessibilityLabel="Open Ko-fi sponsorship page"
+                  onPress={() => Linking.openURL('https://ko-fi.com/nartana')}
+                  style={{
+                    flex: 1,
+                    borderWidth: 1,
+                    borderColor: '#1F3D2C',
+                    paddingVertical: 12,
+                    alignItems: 'center',
+                    borderRadius: 2,
+                  }}
+                >
+                  <Text
+                    style={[TYPE.bodyBold, {
+                      color: '#1F3D2C',
+                      fontSize: 13,
+                      fontWeight: '600',
+                      letterSpacing: 0.3,
+                    }]}
+                  >
+                    Ko-fi ↗
+                  </Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="link"
+                  accessibilityLabel="Open GitHub Sponsors page"
+                  onPress={() =>
+                    Linking.openURL('https://github.com/sponsors/cner-smith')
+                  }
+                  style={{
+                    flex: 1,
+                    borderWidth: 1,
+                    borderColor: '#1F3D2C',
+                    paddingVertical: 12,
+                    alignItems: 'center',
+                    borderRadius: 2,
+                  }}
+                >
+                  <Text
+                    style={[TYPE.bodyBold, {
+                      color: '#1F3D2C',
+                      fontSize: 13,
+                      fontWeight: '600',
+                      letterSpacing: 0.3,
+                    }]}
+                  >
+                    GitHub ↗
+                  </Text>
+                </Pressable>
+              </View>
+            </>
+          )}
         </View>
 
         <Pressable

--- a/apps/mobile/app/(auth)/welcome.tsx
+++ b/apps/mobile/app/(auth)/welcome.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { BackHandler, Pressable, StyleSheet } from 'react-native'
+import { BackHandler, Platform, Pressable, StyleSheet } from 'react-native'
 import { useRouter } from 'expo-router'
 import { StatusBar } from 'expo-status-bar'
 import { FONT } from '../../lib/typography'
@@ -98,7 +98,11 @@ export default function Welcome() {
         <Animated.Text style={[styles.wordmark, logoStyle]}>oga.</Animated.Text>
         <Animated.Text style={[styles.tagline, taglineStyle]}>Track every shot.</Animated.Text>
         <Animated.Text style={[styles.support, supportStyle]}>
-          Free and open source · Ko-fi support appreciated
+          {/* iOS drops the Ko-fi mention — App Review 3.1.1 (no donation
+              steering). Android keeps it. */}
+          {Platform.OS === 'ios'
+            ? 'Free and open source'
+            : 'Free and open source · Ko-fi support appreciated'}
         </Animated.Text>
       </Pressable>
     </>

--- a/apps/web/public/captcha.html
+++ b/apps/web/public/captcha.html
@@ -10,7 +10,15 @@
     body { display: flex; align-items: center; justify-content: center; }
   </style>
   <script>
-    const siteKey = new URLSearchParams(window.location.search).get('siteKey');
+    // Strip stray angle brackets / whitespace before handing the key to
+    // Turnstile. A site key copied from a "<your-key-here>" style placeholder
+    // (e.g. into the EXPO_PUBLIC_TURNSTILE_SITE_KEY env var) arrives wrapped in
+    // "<...>", which Turnstile rejects by silently failing to render — no
+    // widget, no error, submit button stuck disabled. Sanitizing here fixes
+    // already-shipped app builds without a rebuild, since the app loads this
+    // page remotely.
+    const rawSiteKey = new URLSearchParams(window.location.search).get('siteKey');
+    const siteKey = (rawSiteKey || '').replace(/[<>\s]/g, '');
 
     function initTurnstile() {
       turnstile.render('#widget', {


### PR DESCRIPTION
Release PR: **`dev` → `main`** (production). Ships 2 commits.

## What's shipping

- **fix(mobile): remove iOS donation CTAs (App Review 3.1.1)** (#634) — clears the App Store rejection of build 1.0(5). Ko-fi + GitHub Sponsors CTAs gated off on iOS (neutral `oga.golf` website link instead); Android + web unchanged.
- **fix(web): sanitize Turnstile site key in captcha WebView page** (#630/#631).

## Notes

- Migrations: dev + prod already synced at `0038` — no DB change in this release.
- Merging deploys web to production (Vercel) and lands the donation fix on `main` for the iOS resubmission build.
- Follow-up (not in this PR): EAS iOS production build → App Store resubmit → reply in App Store Connect.