### PR TITLE
feat(web): up-the-hole camera + two-column map rollout (round detail, mini-map, planner)

### DIFF
--- a/apps/web/src/components/plan/HoleStrategyMap.tsx
+++ b/apps/web/src/components/plan/HoleStrategyMap.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { bearingDegrees, coneRingGeoJSON, scatterGeoJSON, type GeoPoint } from '@oga/core'
-import { mapboxgl, MAPBOX_TOKEN_PRESENT } from '../../lib/mapbox'
+import { useEffect, useRef, useState } from 'react'
+import { coneRingGeoJSON, scatterGeoJSON, type GeoPoint } from '@oga/core'
+import { mapboxgl, MAPBOX_TOKEN_PRESENT, fitHoleUpward } from '../../lib/mapbox'
 import type { ClubDispersion } from '../../pages/rounds/hooks/useClubDispersion'
 
 export interface Leg {
@@ -171,27 +171,13 @@ export default function HoleStrategyMap({
   // bottom→top (like the mobile live-round map) and fitBounds so tee + pin are
   // both in view with padding. Re-fits when the hole changes (snap on the first
   // paint, animate on later prev/next-hole navigation).
-  const bearing = useMemo(
-    () => bearingDegrees(tee.lat, tee.lng, pin.lat, pin.lng),
-    [tee.lat, tee.lng, pin.lat, pin.lng],
-  )
   useEffect(() => {
     if (!mapLoaded) return
     const map = mapRef.current
     if (!map) return
-    const bounds = new mapboxgl.LngLatBounds([tee.lng, tee.lat], [tee.lng, tee.lat])
-    bounds.extend([pin.lng, pin.lat])
-    map.fitBounds(bounds, {
-      bearing,
-      // Generous top/bottom keeps tee + pin off the edges; the sides give the
-      // dispersion cone room since a 2-point bounds is near-zero-width.
-      padding: { top: 80, bottom: 80, left: 90, right: 90 },
-      maxZoom: 17.5,
-      animate: initialPositionDoneRef.current,
-      duration: 600,
-    })
+    fitHoleUpward(map, tee, pin, { animate: initialPositionDoneRef.current })
     initialPositionDoneRef.current = true
-  }, [mapLoaded, bearing, tee.lat, tee.lng, pin.lat, pin.lng])
+  }, [mapLoaded, tee.lat, tee.lng, pin.lat, pin.lng])
 
   // Per-leg overlays (dots, cone, aim marker) + the tee→…→pin route line +
   // the static tee/pin markers. Keyed on [legs, focusedLeg] per the brief;

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -199,6 +199,7 @@ export function RoundMap({
     cameraTarget,
     focusGreenSignal,
     effectivePin,
+    effectiveTee,
     placementMode,
     hasExistingShots,
     tapToPlaceDisabled,

--- a/apps/web/src/components/round/ShotMiniMap.tsx
+++ b/apps/web/src/components/round/ShotMiniMap.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { bearingDegrees } from '@oga/core'
 import { mapboxgl, MAPBOX_TOKEN_PRESENT } from '../../lib/mapbox'
 
 export interface ShotMiniMapProps {
@@ -91,6 +92,12 @@ export function ShotMiniMap({
       new mapboxgl.LngLatBounds(points[0]!, points[0]!),
     )
     map.fitBounds(bounds, {
+      // Rotate so the shot runs up-the-map (start bottom → end top) when an
+      // end point exists; leave north-up otherwise.
+      bearing:
+        endLat != null && endLng != null
+          ? bearingDegrees(startLat!, startLng!, endLat, endLng)
+          : undefined,
       padding: FIT_PADDING,
       maxZoom: MAX_ZOOM,
       duration: 0,

--- a/apps/web/src/components/round/map/RoundMapInstructionStrip.tsx
+++ b/apps/web/src/components/round/map/RoundMapInstructionStrip.tsx
@@ -21,11 +21,13 @@ interface RoundMapInstructionStripProps {
   /** Active hole number — surfaced in the manual-placement instruction
    *  copy so the user knows which hole they're marking up. */
   holeNumber?: number
-  /** True when no tee coordinate exists for this hole (DB null and no
-   *  session override). Drives the "Place tee box" entry button. */
+  /** Currently unused — the tee is derived from the first shot, not placed
+   *  manually. Kept for the existing placement plumbing. */
   needsTee?: boolean
-  /** True when no pin coordinate exists for this hole. */
-  needsPin?: boolean
+  /** Show the "Set pin" placement button. True while logging/editing a past
+   *  round on a geo-anchored hole — shown even when a pin coord already
+   *  exists so the player can override a wrong crawled pin. */
+  showPinButton?: boolean
   /** Active manual-placement mode. When set, the strip switches to a
    *  "tap to place …" prompt with a Cancel button. */
   placementMode?: 'tee' | 'pin' | null
@@ -54,7 +56,7 @@ export function RoundMapInstructionStrip({
   aimsSet = 0,
   holeNumber,
   needsTee = false,
-  needsPin = false,
+  showPinButton = false,
   placementMode = null,
   shotDragUndoLabel = null,
   onApplyShotDragUndo,
@@ -116,9 +118,9 @@ export function RoundMapInstructionStrip({
     )
   }
   const placeButtons =
-    needsPin && onStartPlacePin ? (
+    showPinButton && onStartPlacePin ? (
       <>
-        {needsPin && onStartPlacePin && (
+        {showPinButton && onStartPlacePin && (
           <button
             type="button"
             onClick={onStartPlacePin}
@@ -133,7 +135,7 @@ export function RoundMapInstructionStrip({
               letterSpacing: '0.02em',
             }}
           >
-            Place pin
+            Set pin
           </button>
         )}
       </>

--- a/apps/web/src/components/round/map/useMapSetup.ts
+++ b/apps/web/src/components/round/map/useMapSetup.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type RefObject } from 'react'
-import { mapboxgl, MAPBOX_TOKEN_PRESENT } from '../../../lib/mapbox'
+import { mapboxgl, MAPBOX_TOKEN_PRESENT, fitHoleUpward } from '../../../lib/mapbox'
 import type { PlacedPoint } from '../RoundMap'
 
 interface CameraTarget {
@@ -12,6 +12,10 @@ interface UseMapSetupInput {
   cameraTarget: CameraTarget
   focusGreenSignal: number | undefined
   effectivePin: PlacedPoint | null
+  /** Hole tee, when known. With effectivePin present the camera frames the
+   *  hole up-the-hole (rotated tee→pin); otherwise it falls back to the
+   *  north-up cameraTarget priority chain. */
+  effectiveTee: PlacedPoint | null
   // Click handler config
   placementMode: 'tee' | 'pin' | null | undefined
   hasExistingShots: boolean
@@ -39,6 +43,7 @@ export function useMapSetup({
   cameraTarget,
   focusGreenSignal,
   effectivePin,
+  effectiveTee,
   placementMode,
   hasExistingShots,
   tapToPlaceDisabled,
@@ -97,11 +102,15 @@ export function useMapSetup({
     if (!mapLoaded) return
     const map = mapRef.current
     if (!map) return
+    // Up-the-hole framing when both tee + pin are known (rotate tee→pin
+    // bottom→top). Falls back to the north-up cameraTarget for pin-only /
+    // course-centroid / OKC targets. Snap on the first paint, animate after.
     if (!initialPositionDoneRef.current) {
-      map.jumpTo({
-        center: cameraTarget.center,
-        zoom: cameraTarget.zoom,
-      })
+      if (effectiveTee && effectivePin) {
+        fitHoleUpward(map, effectiveTee, effectivePin, { animate: false })
+      } else {
+        map.jumpTo({ center: cameraTarget.center, zoom: cameraTarget.zoom })
+      }
       initialPositionDoneRef.current = true
       return
     }
@@ -109,12 +118,16 @@ export function useMapSetup({
       userPlacedRef.current = false
       return
     }
-    map.flyTo({
-      center: cameraTarget.center,
-      zoom: cameraTarget.zoom,
-      speed: 1.4,
-    })
-  }, [mapLoaded, cameraTarget])
+    if (effectiveTee && effectivePin) {
+      fitHoleUpward(map, effectiveTee, effectivePin, { animate: true })
+    } else {
+      map.flyTo({
+        center: cameraTarget.center,
+        zoom: cameraTarget.zoom,
+        speed: 1.4,
+      })
+    }
+  }, [mapLoaded, cameraTarget, effectiveTee, effectivePin])
 
   // After a non-holed putt save the parent bumps focusGreenSignal —
   // fly in tight on the green so the next putt placement lands on the

--- a/apps/web/src/lib/mapbox.ts
+++ b/apps/web/src/lib/mapbox.ts
@@ -1,5 +1,6 @@
 import mapboxgl from 'mapbox-gl'
 import 'mapbox-gl/dist/mapbox-gl.css'
+import { bearingDegrees } from '@oga/core'
 
 const TOKEN = import.meta.env.VITE_MAPBOX_TOKEN as string | undefined
 
@@ -12,3 +13,32 @@ if (TOKEN) {
 
 export { mapboxgl }
 export const MAPBOX_TOKEN_PRESENT = !!TOKEN
+
+/** Frame a hole "up-the-hole": rotate the camera so the tee→pin line runs
+ *  bottom→top, then fitBounds so both endpoints sit in view. Shared by the
+ *  planner map (HoleStrategyMap), the round-detail map (useMapSetup), and the
+ *  shot mini-map. Pure bearing math lives in @oga/core; this only composes the
+ *  Mapbox fitBounds call. `animate:false` (default) snaps; pass true to fly. */
+export function fitHoleUpward(
+  map: mapboxgl.Map,
+  tee: { lat: number; lng: number },
+  pin: { lat: number; lng: number },
+  opts: {
+    padding?: mapboxgl.PaddingOptions | number
+    maxZoom?: number
+    animate?: boolean
+    duration?: number
+  } = {},
+): void {
+  const bounds = new mapboxgl.LngLatBounds([tee.lng, tee.lat], [tee.lng, tee.lat])
+  bounds.extend([pin.lng, pin.lat])
+  map.fitBounds(bounds, {
+    bearing: bearingDegrees(tee.lat, tee.lng, pin.lat, pin.lng),
+    // Generous top/bottom keeps tee + pin off the edges; the sides give a
+    // dispersion cone room since a 2-point bounds is near-zero-width.
+    padding: opts.padding ?? { top: 80, bottom: 80, left: 90, right: 90 },
+    maxZoom: opts.maxZoom ?? 17.5,
+    animate: opts.animate ?? false,
+    duration: opts.duration ?? 600,
+  })
+}

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -397,6 +397,7 @@ export function RoundDetailPage() {
           placedAims={placedAims}
           aimMode={aimMode}
           missingHoleLayout={missingHoleLayout}
+          isLiveEntry={isLiveEntry}
           focusGreenSignal={focusGreenSignal}
           puttingOpen={puttingSheetForIdx != null}
           pinOverride={pinOverride}

--- a/apps/web/src/pages/rounds/components/MapView.tsx
+++ b/apps/web/src/pages/rounds/components/MapView.tsx
@@ -55,6 +55,10 @@ interface MapViewProps {
   /** True when the active hole has neither tee nor pin coordinates in
    *  the DB — drives the dismissable notice banner above the map. */
   missingHoleLayout: boolean
+  /** True when the session started in live mode. Gates the "Set pin"
+   *  placement button off during live-aim (pin stays derived/dragged);
+   *  it only appears while logging or editing a past round. */
+  isLiveEntry: boolean
   /** True while the putting sheet is open — suppresses tap-to-place so
    *  taps that hit the map under the sheet don't drop new shots. */
   puttingOpen: boolean
@@ -107,6 +111,7 @@ export function MapView({
   placedAims,
   aimMode,
   missingHoleLayout,
+  isLiveEntry,
   puttingOpen,
   focusGreenSignal,
   pinOverride,
@@ -173,10 +178,13 @@ export function MapView({
     (activeHoleGeo?.teeLat != null && activeHoleGeo?.teeLng != null
       ? { lat: activeHoleGeo.teeLat, lng: activeHoleGeo.teeLng }
       : null)
-  // Manual placement entry points only render when the active hole has
-  // no coord for that target. Tee/pin both null = course w/o hole layout.
+  // The tee is derived from the first shot (not placed manually); this flag
+  // is retained only for the existing strip plumbing.
   const needsTee = activeHoleGeo != null && effectiveTee == null
-  const needsPin = activeHoleGeo != null && effectivePin == null
+  // "Set pin" is available while logging or editing a PAST round on a
+  // geo-anchored hole — shown even when a pin coord already exists so the
+  // player can override a wrong crawled pin. Hidden during live-aim.
+  const showPinButton = !isLiveEntry && activeHoleGeo != null
   const remainingToPin =
     lastPoint && effectivePin
       ? Math.round(
@@ -269,7 +277,7 @@ export function MapView({
           aimsSet={placedAims.filter((a) => a != null).length}
           holeNumber={activeHoleNumber}
           needsTee={needsTee}
-          needsPin={needsPin}
+          showPinButton={showPinButton}
           placementMode={placementMode}
           shotDragUndoLabel={shotDragUndoLabel}
           onApplyShotDragUndo={onApplyShotDragUndo}

--- a/apps/web/src/pages/rounds/components/MapView.tsx
+++ b/apps/web/src/pages/rounds/components/MapView.tsx
@@ -1,5 +1,10 @@
 import { Suspense, lazy, useEffect, useState, type ReactNode } from 'react'
-import { getExpectedStrokes, haversineYards, NEAR_GREEN_YARDS } from '@oga/core'
+import {
+  getExpectedStrokes,
+  haversineYards,
+  NEAR_GREEN_YARDS,
+  type ShotMarkerCategory,
+} from '@oga/core'
 import type { Database } from '@oga/supabase'
 import {
   RoundMapInstructionStrip,
@@ -7,6 +12,7 @@ import {
   type HoleGeo,
   type PlacedPoint,
 } from '../../../components/round/RoundMap'
+import { MARKER_COLORS } from '../../../components/round/map/markerFactories'
 import { useClubDispersion } from '../hooks/useClubDispersion'
 
 // Lazy-load Mapbox GL JS only when the map tab is opened. Cuts ~2 MB off
@@ -246,9 +252,15 @@ export function MapView({
           </button>
         </div>
       )}
-      <div style={{ marginTop: 14 }}>
-        <RoundMapInstructionStrip
-          hasExistingShots={hasExistingShots}
+      <div
+        className="flex flex-col gap-3 lg:grid lg:gap-4 lg:grid-cols-[minmax(300px,360px)_1fr]"
+        style={{ marginTop: 14 }}
+      >
+        {/* Left column: controls + per-hole shot list. Below the map on
+            narrow screens (map-first), left of it on desktop. */}
+        <div className="lg:order-1">
+          <RoundMapInstructionStrip
+            hasExistingShots={hasExistingShots}
           editing={editingOnMap}
           shotsPlaced={placedPoints.length}
           remainingToPin={remainingToPin}
@@ -273,18 +285,25 @@ export function MapView({
           onClear={handlers.onClearPoints}
           onDone={handlers.onDoneWithHole}
           onDoneEditing={handlers.onDoneEditing}
-        />
-      </div>
-      <div
-        style={{
-          marginTop: 10,
-          height: 540,
-          border: '1px solid #D9D2BF',
-          borderRadius: 4,
-          overflow: 'hidden',
-          position: 'relative',
-        }}
-      >
+          />
+          <div style={{ marginTop: 16 }}>
+            <div className="kicker" style={{ marginBottom: 6 }}>
+              Shots
+            </div>
+            <ShotList shots={existingShots} />
+          </div>
+        </div>
+        {/* Right column: portrait up-the-hole map (leads on narrow). */}
+        <div
+          className="order-first lg:order-2"
+          style={{
+            height: 'min(78vh, 720px)',
+            border: '1px solid #D9D2BF',
+            borderRadius: 4,
+            overflow: 'hidden',
+            position: 'relative',
+          }}
+        >
         <Suspense fallback={<MapLoading />}>
           <RoundMap
             hole={activeHoleGeo}
@@ -331,6 +350,7 @@ export function MapView({
             onSelectRail={selectRail}
           />
         )}
+        </div>
       </div>
       {saveError && (
         <div
@@ -357,6 +377,90 @@ function MapLoading() {
       style={{ height: '100%', width: '100%', fontSize: 13 }}
     >
       Loading map…
+    </div>
+  )
+}
+
+const CATEGORY_LABEL: Record<ShotMarkerCategory, string> = {
+  tee: 'Tee',
+  approach: 'Approach',
+  'around-green': 'Around green',
+  putt: 'Putt',
+}
+
+function categoryColor(c: ShotMarkerCategory): string {
+  if (c === 'approach') return MARKER_COLORS.approach
+  if (c === 'putt' || c === 'around-green') return MARKER_COLORS.green
+  return MARKER_COLORS.tee
+}
+
+// Per-hole shot list for the map view's left column — number badge (colored
+// to match the map marker), category, and start→end distance. Reads the same
+// `existingShots` the map draws; co-located since MapView is its only caller.
+function ShotList({ shots }: { shots: ExistingShot[] }) {
+  const rows = shots
+    .filter((s) => s.startLat != null && s.startLng != null)
+    .sort((a, b) => a.shotNumber - b.shotNumber)
+  if (rows.length === 0) {
+    return (
+      <div
+        className="text-caddie-ink-mute"
+        style={{ fontSize: 12, padding: '6px 0' }}
+      >
+        No shots logged for this hole yet.
+      </div>
+    )
+  }
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      {rows.map((s) => {
+        const cat = s.category ?? 'approach'
+        const dist =
+          s.endLat != null && s.endLng != null
+            ? Math.round(
+                haversineYards(s.startLat!, s.startLng!, s.endLat, s.endLng),
+              )
+            : null
+        return (
+          <div
+            key={s.id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 10,
+              padding: '7px 0',
+              borderBottom: '1px solid #EBE5D6',
+            }}
+          >
+            <span
+              style={{
+                width: 20,
+                height: 20,
+                borderRadius: 999,
+                background: categoryColor(cat),
+                color: '#FBF8F1',
+                fontSize: 11,
+                fontWeight: 600,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                flexShrink: 0,
+              }}
+            >
+              {s.shotNumber}
+            </span>
+            <span style={{ fontSize: 13, flex: 1 }}>{CATEGORY_LABEL[cat]}</span>
+            {dist != null && (
+              <span
+                className="text-caddie-ink-dim font-mono"
+                style={{ fontSize: 12 }}
+              >
+                {dist} yd
+              </span>
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
Rolls the Course Planner's map treatment out to the other web Mapbox surfaces. **Web-only.**

**Stacked on #633** (`feature/course-planner`) — it needs `HoleStrategyMap`. When #633 merges to `dev`, this rebases onto `dev` and retargets. Spec: `docs/internal/web-map-uptheholecamera-rollout.md` + `docs/superpowers/specs/2026-07-01-web-map-treatment-rollout-design.md` (both gitignored/local).

## What

- **Shared helper** `apps/web/src/lib/mapbox.ts` → `fitHoleUpward(map, tee, pin)` — rotates the camera so tee→pin runs bottom→top and `fitBounds` frames both. Pure bearing math stays in `@oga/core`.
- **Round-detail `RoundMap`** (via `useMapSetup`): up-the-hole framing when tee+pin are known; north-up fallback for pin-only / course-centroid / OKC.
- **`MapView`**: two-column portrait layout — controls + per-hole shot list left, portrait map right; collapses map-first on narrow. Overlays stay map-anchored.
- **`ShotMiniMap`**: bearing on its `fitBounds` so the shot runs up-the-map.
- **`HoleStrategyMap`** (planner): refactored onto the shared helper — no behavior change.

## Not touched

`useMapLayers` drag/tap semantics, DemoMap (landing), Shot Patterns (SVG). No mobile.

## Verification

- Workspace typecheck green.
- Signed-in browser QA at 1440 + 390 (desktop two-column + phone map-first): rotated camera, shot list, overlays, planner unchanged.