### PR TITLE
fix(mobile): live-round field bugs — camera orientation/zoom, GPS remount, putting scroll (#639–643)

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -299,7 +299,10 @@ export default function Home() {
 
         <Entrance index={4}>
           <RecentRoundsList
-            rounds={rounds}
+            // Exclude the active round — it already shows as the Resume banner
+            // above. Without this it renders in both places, so deleting it
+            // clears both and reads as "deleted two rounds". (#639)
+            rounds={rounds.filter((r) => r.id !== activeRound?.id)}
             onRequestDelete={(id, name) => setPendingDelete({ id, name })}
           />
         </Entrance>

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -23,6 +23,7 @@ import {
   createCourse,
   createHoles,
   createRound,
+  deleteRound,
   getCourseByExternalId,
   searchCourses,
   upsertCourseTees,
@@ -77,6 +78,11 @@ export default function NewRound() {
   } | null>(null)
   const [gps, setGps] = useState<GpsState>({ status: 'idle' })
   const searchAbort = useRef<AbortController | null>(null)
+  // Synchronous double-tap guard for round creation. `busy` state updates a
+  // tick later, so a fast double-tap on "Start round" could fire startWith
+  // twice and create two rounds — a ref blocks the second call immediately.
+  // (Mirrors persistShotInFlightRef in useShotActions.) (#639)
+  const startInFlightRef = useRef(false)
   const insets = useSafeAreaInsets()
 
   // Debounce 300ms.
@@ -178,8 +184,11 @@ export default function NewRound() {
     tee?: { courseTeeId: string | null; teeColor: string | null },
   ) {
     if (!user) return
+    if (startInFlightRef.current) return
+    startInFlightRef.current = true
     setBusy(true)
     setError(null)
+    let createdRoundId: string | null = null
     try {
       const today = todayLocalDate()
       const { data: round, error: roundError } = await createRound(supabase, {
@@ -198,6 +207,7 @@ export default function NewRound() {
           : {}),
       })
       if (roundError || !round) throw roundError ?? new Error('Round insert failed')
+      createdRoundId = round.id
 
       const { data: existingHoles, error: holesError } = await supabase
         .from('holes')
@@ -263,14 +273,27 @@ export default function NewRound() {
         if (hsError) throw hsError
       }
 
+      // Setup fully succeeded — clear so the catch below won't roll it back.
+      createdRoundId = null
       router.replace({
         pathname: '/(app)/round/[id]',
         params: { id: round.id, hole: '1', mode },
       })
     } catch (err) {
+      // Roll back a partially-created round so a failed hole / hole_scores
+      // setup doesn't leave a stray blank round in the list. (#639)
+      if (createdRoundId) {
+        // best-effort rollback — ignore any delete failure
+        try {
+          await deleteRound(supabase, createdRoundId, user.id)
+        } catch {
+          /* noop */
+        }
+      }
       setError((err as Error).message)
     } finally {
       setBusy(false)
+      startInFlightRef.current = false
     }
   }
 

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -6,6 +6,7 @@ import {
   ScrollView,
   Text,
   TextInput,
+  useWindowDimensions,
   View,
 } from 'react-native'
 import {
@@ -177,6 +178,7 @@ export function PuttingSheet({
   }
 
   const insets = useSafeAreaInsets()
+  const { height: windowHeight } = useWindowDimensions()
   const distance = value.puttDistanceFt ?? 0
 
   return (
@@ -260,13 +262,16 @@ export function PuttingSheet({
         </Pressable>
       </View>
 
-      {/* flexShrink:1 bounds the scroll area within the maxHeight:'90%' sheet.
-          Without it RN's default flexShrink:0 lets the ScrollView size to its
-          full content height and overflow the clamped sheet, so it isn't
-          scrollable until a state change (e.g. toggling "Holed it") forces a
-          re-layout that re-measures it. */}
+      {/* An ABSOLUTE maxHeight (not flexShrink deriving height from the
+          '90%' sheet) gives the ScrollView a scroll range that resolves in
+          the first layout pass — independent of the modal's slide transform
+          and the parent's percentage height. Previously the derived height
+          settled to content-height on first paint (nothing to scroll) and
+          only unlocked when a state change (toggling "Holed it") forced a
+          re-measure; app foreground re-measures made it recur (#643).
+          0.72·screen sits well under the 90% sheet so the two never fight. */}
       <ScrollView
-        style={{ flexShrink: 1 }}
+        style={{ maxHeight: windowHeight * 0.72, flexShrink: 1 }}
         contentContainerStyle={{ paddingTop: 14, paddingBottom: 8 }}
       >
         <GreenDiagram

--- a/apps/mobile/components/round/hole/useHoleState.ts
+++ b/apps/mobile/components/round/hole/useHoleState.ts
@@ -91,6 +91,10 @@ export function useHoleState({
   // local_id of the just-saved pending shot, so the next PLACE_BALL
   // can fill in that shot's end_lat/end_lng with the new ball position.
   const lastSavedShotLocalIdRef = useRef<number | null>(null)
+  // False until the hole-reset effect has run for a real hole once. Lets that
+  // effect tell the component's first mount (round resume → auto-engage) from
+  // later in-session hole switches (review posture). See #640.
+  const hasMountedHoleRef = useRef(false)
   const [roundState, setRoundState] = useState<RoundState>('PLACE_BALL')
   const [gpsPosition, setGpsPosition] = useState<LatLng | null>(null)
   const [gpsNonce, setGpsNonce] = useState(0)
@@ -177,9 +181,12 @@ export function useHoleState({
   useEffect(() => {
     if (!currentHoleId) return
     if (isPastMode) return
-    // Suppressed while revisiting a played hole — no GPS ball watcher/marker
-    // until the player opts into adding a shot (#484).
-    if (isRevisitingPlayedHole) return
+    // NOTE: the subscription runs even while revisiting a played hole so
+    // gpsPosition keeps updating — that drives the recenter button + "Mark
+    // ball" CTA, which were grey-locked when the whole effect was gated
+    // here (regression #640). The #484 review posture (no auto-place / no
+    // auto-aim) is enforced downstream at the setBall gate, not by skipping
+    // the whole watcher.
     if (roundState !== 'PLACE_BALL') return
     let active = true
     let subscription: Location.LocationSubscription | null = null
@@ -290,6 +297,11 @@ export function useHoleState({
             // strong prior — using the smoothed value would lie for
             // many readings after manual placement.
             setGpsPosition({ lat: rawPoint.lat, lng: rawPoint.lng })
+            // Review posture (#484): on a hole the player navigated BACK to,
+            // keep the GPS chip/recenter live (setGpsPosition above) but don't
+            // auto-drive the BALL marker — the hole shows only its existing
+            // shot breadcrumb until they opt into adding a shot.
+            if (isRevisitingPlayedHole) return
             // Manual placement freezes GPS-driven ball updates. Without
             // this, the next reading after a drag would re-init the
             // filter at the raw GPS point and snap ball back, wiping
@@ -349,10 +361,14 @@ export function useHoleState({
     setBall(null)
     setAim(null)
     setRoundState('PLACE_BALL')
-    // Each hole entry starts un-engaged: a played hole opens in the
-    // breadcrumb-only review posture until the player taps "Add a shot". A
-    // fresh hole has no prior shots, so isRevisitingPlayedHole is false anyway.
-    setAppendEngaged(false)
+    // The FIRST hole this component mounts with is the round's resume point
+    // (relaunch / navigate Home and back) — the player is actively on it, so
+    // engage it and let GPS auto-place resume without a "+ Add a shot" tap
+    // (regression #640). Only genuine in-session hole SWITCHES drop into the
+    // #484 breadcrumb-only review posture. A fresh hole has no prior shots, so
+    // isRevisitingPlayedHole is false regardless of this flag.
+    setAppendEngaged(!hasMountedHoleRef.current)
+    hasMountedHoleRef.current = true
   }, [currentHoleId])
 
   // Default shot 1's ball marker to the tee box so the player starts from a

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -480,7 +480,11 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     if (holeNumber < holeCount) {
       onHoleChange(holeNumber + 1)
     } else {
-      router.replace('/(app)')
+      // Last hole → finalize the round: completeRound writes total_score /
+      // sg_total / completed_at and routes to the summary. Without this the
+      // round stays unfinished (blank total, reappears as resumable). Same
+      // path as "End round early". (#639)
+      void handleEndRound()
     }
   }
 

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -92,6 +92,10 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   // before React commits the next render — both calls see `saving`
   // === false. The ref flips synchronously and blocks the second call.
   const persistShotInFlightRef = useRef(false)
+  // Same async-setter race as persistShot: `setEnding(true)` commits a tick
+  // late, so a fast double-tap of Finish (18th hole) or End round could fire
+  // completeRound twice. The ref flips synchronously and blocks the second.
+  const endInFlightRef = useRef(false)
   const [ending, setEnding] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [shotEntrySeq, setShotEntrySeq] = useState(0)
@@ -490,6 +494,8 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
 
   async function handleEndRound() {
     if (!round || !user) return
+    if (endInFlightRef.current) return
+    endInFlightRef.current = true
     setEnding(true)
     try {
       const { data: profile } = await getProfile(supabase, user.id)
@@ -506,6 +512,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     } catch (err) {
       Alert.alert('End round failed', (err as Error).message)
     } finally {
+      endInFlightRef.current = false
       setEnding(false)
       // Guard against clobbering a different dialog the user may have
       // opened during the async window (TS agent feedback on #293).

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -135,12 +135,57 @@ export function useHoleCamera({
   // at this course. Gated by distance to course centroid so testing from
   // home doesn't yank the camera to a parking lot 50 mi away.
   const autoCenteredRef = useRef(false)
+  // Pin coords the arriving PLACE_BALL heading was last applied to, so a
+  // late-loading pin re-frames the map exactly once (effect below) and GPS
+  // ticks don't re-rotate. Reset per hole alongside the auto-center latch.
+  const headingAppliedPinRef = useRef<string | null>(null)
   useEffect(() => {
     // Reset on hole change (center prop moves to new tee/centroid). When
     // the per-hole route is collapsed to one component (issue #264 fix),
     // this is still the right reset signal.
     autoCenteredRef.current = false
+    headingAppliedPinRef.current = null
   }, [center.lat, center.lng])
+
+  // The initial / hole-change frames compute the up-the-hole heading from
+  // roundPin ?? pin, which can be null when the tee/center resolves first —
+  // on synthetic holes the round pin loads from a separate fetch than the
+  // tee. Those two effects are latched (cameraInitialized / center-equality)
+  // so they won't re-fire when the pin arrives, leaving the map stuck north.
+  // Re-frame the arriving PLACE_BALL view once the pin resolves; SET_AIM and
+  // PIN own the camera in their own phases, so this is gated to PLACE_BALL.
+  // Keyed on the pin coords so it fires once per hole, not on every GPS tick.
+  useEffect(() => {
+    if (!styleLoaded) return
+    if (!cameraInitialized.current) return
+    if (phase !== 'PLACE_BALL') return
+    if (!cameraRef.current) return
+    const target = roundPin ?? pin ?? null
+    if (!target) return
+    const key = `${target.lat},${target.lng}`
+    if (headingAppliedPinRef.current === key) return
+    try {
+      cameraRef.current.setCamera({
+        centerCoordinate: toCoord(center),
+        zoomLevel: 17,
+        pitch: 0,
+        heading: headingUpTheHole(center, target),
+        animationDuration: 500,
+      })
+      headingAppliedPinRef.current = key
+    } catch {
+      // native camera released — retry on next change
+    }
+  }, [
+    styleLoaded,
+    phase,
+    center.lat,
+    center.lng,
+    roundPin?.lat,
+    roundPin?.lng,
+    pin?.lat,
+    pin?.lng,
+  ])
   useEffect(() => {
     if (!styleLoaded) return
     if (!cameraInitialized.current) return

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -1,10 +1,24 @@
 import { useEffect, useRef } from 'react'
 import Mapbox from '@rnmapbox/maps'
+import { bearingDegrees } from '@oga/core'
 import { distanceYards } from '../../../lib/maps'
 import type { HoleMapPhase, LatLng } from '../HoleMap.types'
 
 function toCoord(l: LatLng): [number, number] {
   return [l.lng, l.lat]
+}
+
+// Camera heading (deg CW from N) that puts direction-of-play — origin
+// (tee/ball) → target (pin) — toward the top of the screen ("up the hole").
+// Falls back to north-up (0) with no usable target or when the two points
+// are effectively coincident (synthetic holes with no real pin geometry).
+function headingUpTheHole(
+  origin: LatLng,
+  target: LatLng | null | undefined,
+): number {
+  if (!target) return 0
+  if (distanceYards(origin, target) < 5) return 0
+  return bearingDegrees(origin.lat, origin.lng, target.lat, target.lng)
 }
 
 interface UseHoleCameraOpts {
@@ -72,6 +86,7 @@ export function useHoleCamera({
         centerCoordinate: toCoord(center),
         zoomLevel: 17,
         pitch: 0,
+        heading: headingUpTheHole(center, roundPin ?? pin),
         animationDuration: 400,
       })
       cameraInitialized.current = true
@@ -106,6 +121,7 @@ export function useHoleCamera({
         centerCoordinate: toCoord(center),
         zoomLevel: 17,
         pitch: 0,
+        heading: headingUpTheHole(center, roundPin ?? pin),
         animationDuration: 800,
       })
       lastHoleCenterRef.current = center
@@ -162,7 +178,11 @@ export function useHoleCamera({
     }
     if (pinSnappedRef.current) return
     if (!cameraRef.current) return
-    const target = roundPin ?? pin ?? null
+    // Most prod courses are synthetic (no stored pin geometry), so
+    // roundPin/pin are null — without a fallback the effect early-returned
+    // and never framed the green. Fall back to where the player is (ball,
+    // else GPS) so tapping the pin tool zooms IN rather than doing nothing (#642).
+    const target = roundPin ?? pin ?? ball ?? gpsPosition ?? null
     if (!target) return
     try {
       cameraRef.current.setCamera({
@@ -174,7 +194,17 @@ export function useHoleCamera({
     } catch {
       // native camera released — retry on next pin change
     }
-  }, [isPinMode, roundPin?.lat, roundPin?.lng, pin?.lat, pin?.lng])
+  }, [
+    isPinMode,
+    roundPin?.lat,
+    roundPin?.lng,
+    pin?.lat,
+    pin?.lng,
+    ball?.lat,
+    ball?.lng,
+    gpsPosition?.lat,
+    gpsPosition?.lng,
+  ])
 
   // Mark whether we owe the camera a PLACE_BALL re-frame on the next
   // ball update. Set on phase transitions INTO PLACE_BALL (e.g. after
@@ -203,7 +233,7 @@ export function useHoleCamera({
         centerCoordinate: toCoord(ball),
         zoomLevel: 17,
         pitch: 0,
-        heading: 0,
+        heading: headingUpTheHole(ball, roundPin ?? pin),
         animationDuration: 800,
       })
       reframePlaceBallRef.current = false
@@ -236,17 +266,19 @@ export function useHoleCamera({
           lng: (ball.lng + target.lng) / 2,
         }
       : ball
-    const bearing = target
-      ? (Math.atan2(target.lng - ball.lng, target.lat - ball.lat) * 180) /
-        Math.PI
-      : 0
+    const bearing = headingUpTheHole(ball, target)
     const distYd = target ? distanceYards(ball, target) : null
+    // Short-game shots need a tighter frame — flatlining at 17 for
+    // anything under 80 yd made a 10-yd chip frame like an 80-yd
+    // approach, a jarring zoom-out from a green close-up (#642).
     const zoom =
       distYd == null ? 16
       : distYd >= 300 ? 16
       : distYd >= 150 ? 16.5
       : distYd >= 80 ? 17
-      : 17
+      : distYd >= 60 ? 17.5
+      : distYd >= 30 ? 18
+      : 19
     try {
       cameraRef.current.setCamera({
         centerCoordinate: toCoord(focus),


### PR DESCRIPTION
Live-round field bugs surfaced during on-course play (2026-07-05/06). Four fixes, one commit each. #644 (swipe-to-dismiss for bottom sheets) is split into a follow-up PR — it's a larger, on-device-QA-gated sheet refactor.

## Fixes

- **#639 — Finish round never finalizes** (from last session): finalize live rounds on finish; stop stray/duplicate rounds.
- **#641 / #642 — Camera** (`useHoleCamera.ts`): apply a tee/ball→pin bearing as the camera heading in the initial, hole-change and PLACE_BALL reframe effects (not just the fleeting SET_AIM step that reset to north on commit), via the canonical `bearingDegrees`. Add short-game zoom tiers so a greenside chip frames tight instead of flatlining at the 80-yd zoom; fall the PIN snap back to ball/GPS on synthetic holes so tapping the pin tool frames the green.
- **#640 — GPS button / auto-place after remount** (`useHoleState.ts`): keep the GPS watcher subscribed while revisiting a played hole so the recenter button + Mark-ball CTA stay live (the #484 review posture is now enforced at the `setBall` gate, not by skipping the whole watcher). Auto-engage the component's first-mounted hole (round resume) so auto-place resumes without a "+ Add a shot" tap.
- **#643 — Putting sheet not scrollable on first open** (`PuttingSheet.tsx`): give the putt ScrollView an absolute window-derived `maxHeight` so its scroll range resolves in the first layout pass, independent of the modal slide transform and the parent percentage height.

## Verification

- `npm run typecheck` (mobile) green.
- Not yet device-QA'd — all four are field-reproduced; behaviour changes are camera/GPS/layout and want an on-device pass before merge.

Closes #639
Closes #640
Closes #641
Closes #642
Closes #643
