### PR TITLE
feat(mobile): swipe-down-to-dismiss for live-round bottom sheets (#644)

### DIFF
--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from 'react'
 import { Modal, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
+import {
+  GestureDetector,
+  GestureHandlerRootView,
+} from 'react-native-gesture-handler'
+import Animated from 'react-native-reanimated'
 import { PressableTouch } from '../ui/PressableTouch'
+import { useSwipeToDismiss } from '../ui/useSwipeToDismiss'
 import {
   DEFAULT_BAG,
   LIE_SLOPES_FORWARD,
@@ -152,6 +158,8 @@ export function PastHoleShotsSheet({
   // One <Modal> with discriminated content (list vs editor) — NOT two
   // sibling Modals. iOS allows one presented modal per presenter, so the
   // old stacked-Modal edit flow silently failed to present (#293/#495).
+  const { pan, cardStyle } = useSwipeToDismiss(onClose)
+
   return (
     <Modal
       visible={visible}
@@ -159,6 +167,9 @@ export function PastHoleShotsSheet({
       animationType="slide"
       onRequestClose={editingShot ? () => setEditingShot(null) : onClose}
     >
+      {/* GHRootView required for the swipe-to-dismiss pan: RN Modal is a
+          separate native window on Android the app-root can't reach (#496). */}
+      <GestureHandlerRootView style={{ flex: 1 }}>
       <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' }}>
         <Pressable
           style={{ flex: 1 }}
@@ -175,27 +186,32 @@ export function PastHoleShotsSheet({
             onClose={() => setEditingShot(null)}
           />
         ) : (
-          <View
-            style={{
-              backgroundColor: '#FBF8F1',
-              borderTopLeftRadius: 12,
-              borderTopRightRadius: 12,
-              paddingHorizontal: 18,
-              paddingTop: 14,
-              paddingBottom: insets.bottom + 28,
-              maxHeight: '80%',
-            }}
+          <Animated.View
+            style={[
+              {
+                backgroundColor: '#FBF8F1',
+                borderTopLeftRadius: 12,
+                borderTopRightRadius: 12,
+                paddingHorizontal: 18,
+                paddingTop: 14,
+                paddingBottom: insets.bottom + 28,
+                maxHeight: '80%',
+              },
+              cardStyle,
+            ]}
           >
-            <View
-              style={{
-                alignSelf: 'center',
-                width: 32,
-                height: 4,
-                borderRadius: 2,
-                backgroundColor: '#D9D2BF',
-                marginBottom: 14,
-              }}
-            />
+            <GestureDetector gesture={pan}>
+              <View style={{ alignItems: 'center', paddingBottom: 14 }}>
+                <View
+                  style={{
+                    width: 32,
+                    height: 4,
+                    borderRadius: 2,
+                    backgroundColor: '#D9D2BF',
+                  }}
+                />
+              </View>
+            </GestureDetector>
             <Text style={{ ...KICKER, marginBottom: 4 }}>
               Hole {holeNumber ?? '—'}
               {par != null ? ` · Par ${par}` : ''}
@@ -243,9 +259,10 @@ export function PastHoleShotsSheet({
             >
               <Text style={{ ...KICKER, color: '#5C6356' }}>Close</Text>
             </Pressable>
-          </View>
+          </Animated.View>
         )}
       </View>
+      </GestureHandlerRootView>
     </Modal>
   )
 }
@@ -462,28 +479,35 @@ function EditShotSheet({
     onSave(buildUpdates())
   }
 
+  const { pan, cardStyle } = useSwipeToDismiss(onClose)
+
   return (
-    <View
-      style={{
-        backgroundColor: '#FBF8F1',
-        borderTopLeftRadius: 12,
-        borderTopRightRadius: 12,
-        paddingHorizontal: 18,
-        paddingTop: 14,
-        paddingBottom: insets.bottom + 28,
-        maxHeight: '90%',
-      }}
+    <Animated.View
+      style={[
+        {
+          backgroundColor: '#FBF8F1',
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+          paddingHorizontal: 18,
+          paddingTop: 14,
+          paddingBottom: insets.bottom + 28,
+          maxHeight: '90%',
+        },
+        cardStyle,
+      ]}
     >
-      <View
-        style={{
-          alignSelf: 'center',
-          width: 32,
-          height: 4,
-          borderRadius: 2,
-          backgroundColor: '#D9D2BF',
-          marginBottom: 14,
-        }}
-      />
+      <GestureDetector gesture={pan}>
+        <View style={{ alignItems: 'center', paddingBottom: 14 }}>
+          <View
+            style={{
+              width: 32,
+              height: 4,
+              borderRadius: 2,
+              backgroundColor: '#D9D2BF',
+            }}
+          />
+        </View>
+      </GestureDetector>
       <View
         style={{
           flexDirection: 'row',
@@ -665,7 +689,7 @@ function EditShotSheet({
           <Text style={{ ...KICKER, color: '#F2EEE5' }}>{saving ? 'Saving…' : 'Save'}</Text>
         </Pressable>
       </View>
-    </View>
+    </Animated.View>
   )
 }
 

--- a/apps/mobile/components/round/PuttingSheet.tsx
+++ b/apps/mobile/components/round/PuttingSheet.tsx
@@ -24,6 +24,15 @@ import { GreenDiagram } from './GreenDiagram'
 import { useUnits } from '../../hooks/useUnits'
 import { TYPE } from '../../lib/typography'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { GestureDetector } from 'react-native-gesture-handler'
+import Animated from 'react-native-reanimated'
+import { useSwipeToDismiss } from '../ui/useSwipeToDismiss'
+
+// Animated so the swipe-to-dismiss translateY drives the whole card. A
+// transform is post-layout, so it does NOT affect the ScrollView's absolute
+// maxHeight — the #643 scroll fix stays intact.
+const AnimatedKeyboardAvoidingView =
+  Animated.createAnimatedComponent(KeyboardAvoidingView)
 
 export interface PuttingValue {
   puttDistanceFt?: number
@@ -179,31 +188,37 @@ export function PuttingSheet({
 
   const insets = useSafeAreaInsets()
   const { height: windowHeight } = useWindowDimensions()
+  const { pan, cardStyle } = useSwipeToDismiss(onClose)
   const distance = value.puttDistanceFt ?? 0
 
   return (
-    <KeyboardAvoidingView
+    <AnimatedKeyboardAvoidingView
       behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      style={{
-        backgroundColor: '#FBF8F1',
-        borderTopLeftRadius: 12,
-        borderTopRightRadius: 12,
-        paddingHorizontal: 18,
-        paddingTop: 10,
-        paddingBottom: insets.bottom + 24,
-        maxHeight: '90%',
-      }}
+      style={[
+        {
+          backgroundColor: '#FBF8F1',
+          borderTopLeftRadius: 12,
+          borderTopRightRadius: 12,
+          paddingHorizontal: 18,
+          paddingTop: 10,
+          paddingBottom: insets.bottom + 24,
+          maxHeight: '90%',
+        },
+        cardStyle,
+      ]}
     >
-      <View
-        style={{
-          alignSelf: 'center',
-          width: 32,
-          height: 4,
-          borderRadius: 2,
-          backgroundColor: '#D9D2BF',
-          marginBottom: 14,
-        }}
-      />
+      <GestureDetector gesture={pan}>
+        <View style={{ alignItems: 'center', paddingBottom: 14 }}>
+          <View
+            style={{
+              width: 32,
+              height: 4,
+              borderRadius: 2,
+              backgroundColor: '#D9D2BF',
+            }}
+          />
+        </View>
+      </GestureDetector>
       <View
         style={{
           flexDirection: 'row',
@@ -463,7 +478,7 @@ export function PuttingSheet({
           </Pressable>
         </View>
       </ScrollView>
-    </KeyboardAvoidingView>
+    </AnimatedKeyboardAvoidingView>
   )
 }
 

--- a/apps/mobile/components/round/Scorecard.tsx
+++ b/apps/mobile/components/round/Scorecard.tsx
@@ -1,6 +1,9 @@
 import { useMemo, useState } from 'react'
 import { Pressable, ScrollView, Text, View } from 'react-native'
+import { GestureDetector } from 'react-native-gesture-handler'
+import Animated from 'react-native-reanimated'
 import type { Database } from '@oga/supabase'
+import { useSwipeToDismiss } from '../ui/useSwipeToDismiss'
 import { FONT, TYPE } from '../../lib/typography'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
@@ -48,32 +51,38 @@ export function ScorecardModal({
     (h) => !h.yards && h.tee_lat == null,
   )
   const [hintDismissed, setHintDismissed] = useState(false)
+  const { pan, cardStyle } = useSwipeToDismiss(onClose)
   let runningTotal = 0
   let runningPar = 0
   return (
     <View style={{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' }}>
       <Pressable style={{ flex: 1 }} onPress={onClose} />
-      <View
-        style={{
-          backgroundColor: '#FBF8F1',
-          borderTopLeftRadius: 12,
-          borderTopRightRadius: 12,
-          paddingHorizontal: 18,
-          paddingTop: 14,
-          paddingBottom: 28,
-          maxHeight: '85%',
-        }}
+      <Animated.View
+        style={[
+          {
+            backgroundColor: '#FBF8F1',
+            borderTopLeftRadius: 12,
+            borderTopRightRadius: 12,
+            paddingHorizontal: 18,
+            paddingTop: 14,
+            paddingBottom: 28,
+            maxHeight: '85%',
+          },
+          cardStyle,
+        ]}
       >
-        <View
-          style={{
-            alignSelf: 'center',
-            width: 32,
-            height: 4,
-            borderRadius: 2,
-            backgroundColor: '#D9D2BF',
-            marginBottom: 14,
-          }}
-        />
+        <GestureDetector gesture={pan}>
+          <View style={{ alignItems: 'center', paddingBottom: 14 }}>
+            <View
+              style={{
+                width: 32,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: '#D9D2BF',
+              }}
+            />
+          </View>
+        </GestureDetector>
         <Text
           style={{
             ...KICKER,
@@ -340,7 +349,7 @@ export function ScorecardModal({
         >
           <Text style={{ ...KICKER, color: '#5C6356' }}>Close</Text>
         </Pressable>
-      </View>
+      </Animated.View>
     </View>
   )
 }

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -1,7 +1,11 @@
 import { useMemo, useState } from 'react'
 import { Modal, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import Svg, { Circle, Line as SvgLine } from 'react-native-svg'
-import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import {
+  GestureDetector,
+  GestureHandlerRootView,
+} from 'react-native-gesture-handler'
+import Animated from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import {
   DEFAULT_BAG,
@@ -20,6 +24,7 @@ import {
 import { useUserBag } from '../../hooks/useUserBag'
 import { TYPE } from '../../lib/typography'
 import { PuttingSheet } from './PuttingSheet'
+import { useSwipeToDismiss } from '../ui/useSwipeToDismiss'
 
 export interface ShotLoggerValue {
   club?: Club
@@ -130,6 +135,9 @@ export function ShotLogger({
 
   const insets = useSafeAreaInsets()
   const isOnGreen = value.lieType === 'green'
+  // Swipe-dismiss for the non-putt card; the on-green branch delegates to
+  // PuttingSheet, which owns its own swipe-dismiss.
+  const { pan, cardStyle } = useSwipeToDismiss(onClose)
 
   return (
     <Modal
@@ -195,26 +203,31 @@ export function ShotLogger({
             }
           />
         ) : (
-        <View
-          style={{
-            backgroundColor: '#FBF8F1',
-            borderTopLeftRadius: 12,
-            borderTopRightRadius: 12,
-            paddingHorizontal: 18,
-            paddingTop: 10,
-            paddingBottom: insets.bottom + 28,
-          }}
+        <Animated.View
+          style={[
+            {
+              backgroundColor: '#FBF8F1',
+              borderTopLeftRadius: 12,
+              borderTopRightRadius: 12,
+              paddingHorizontal: 18,
+              paddingTop: 10,
+              paddingBottom: insets.bottom + 28,
+            },
+            cardStyle,
+          ]}
         >
-          <View
-            style={{
-              alignSelf: 'center',
-              width: 32,
-              height: 4,
-              borderRadius: 2,
-              backgroundColor: '#D9D2BF',
-              marginBottom: 14,
-            }}
-          />
+          <GestureDetector gesture={pan}>
+            <View style={{ alignItems: 'center', paddingBottom: 14 }}>
+              <View
+                style={{
+                  width: 32,
+                  height: 4,
+                  borderRadius: 2,
+                  backgroundColor: '#D9D2BF',
+                }}
+              />
+            </View>
+          </GestureDetector>
           <View
             style={{
               flexDirection: 'row',
@@ -457,7 +470,7 @@ export function ShotLogger({
               </Text>
             </Pressable>
           </View>
-        </View>
+        </Animated.View>
         )}
       </View>
       </GestureHandlerRootView>

--- a/apps/mobile/components/round/hole/HoleModals.tsx
+++ b/apps/mobile/components/round/hole/HoleModals.tsx
@@ -211,7 +211,11 @@ export function HoleModals(props: HoleModalsProps) {
         animationType="slide"
         onRequestClose={() => setScorecardOpen(false)}
       >
-        <ScorecardModal
+        {/* GHRootView required: RN Modal is a separate native window on
+            Android, so the swipe-to-dismiss pan wouldn't reach ScorecardModal
+            without its own root (#496). Mirrors the putting modal above. */}
+        <GestureHandlerRootView style={{ flex: 1 }}>
+          <ScorecardModal
           holes={holes}
           holeScores={holeScores}
           currentHoleNumber={holeNumber}
@@ -223,7 +227,8 @@ export function HoleModals(props: HoleModalsProps) {
           }}
           onChangePar={onChangePar}
           onClose={() => setScorecardOpen(false)}
-        />
+          />
+        </GestureHandlerRootView>
       </Modal>
     </>
   )

--- a/apps/mobile/components/ui/useSwipeToDismiss.ts
+++ b/apps/mobile/components/ui/useSwipeToDismiss.ts
@@ -1,0 +1,59 @@
+import { Gesture } from 'react-native-gesture-handler'
+import {
+  runOnJS,
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated'
+
+// Swipe-down-to-dismiss for the live-round bottom sheets (scorecard, putting,
+// shot logger, past-hole shots). Returns:
+//   - `pan`: attach via <GestureDetector> to the sheet's GRABBER / header
+//     region ONLY — never the card or an inner ScrollView, or the drag fights
+//     the scroll (and, in the putting sheet, GreenDiagram's own pan).
+//   - `cardStyle`: put on an <Animated.View> wrapping the card so it follows
+//     the finger down.
+//
+// The gesture must live inside a <GestureHandlerRootView> that is itself inside
+// the RN <Modal> — on Android the Modal is a separate native window the app-
+// root gesture handler can't reach (#496). Each sheet keeps its own Modal,
+// backdrop, KeyboardAvoidingView, maxHeight and Close button; this only adds
+// the drag layer.
+//
+// On dismiss we don't animate translateY off-screen: the sheet's Modal owns
+// `animationType="slide"`, so it slides the card the rest of the way out from
+// wherever the drag left it, then unmounts its children — which disposes this
+// shared value, so the next open starts fresh at 0. No manual reset needed.
+const DISMISS_DISTANCE = 120
+const DISMISS_VELOCITY = 800
+
+export function useSwipeToDismiss(onClose: () => void) {
+  const translateY = useSharedValue(0)
+  const reduceMotion = useReducedMotion()
+
+  const pan = Gesture.Pan()
+    // Only claim the gesture after a clear downward move, so a tap on the
+    // grabber/header still reaches the buttons underneath and an upward drag
+    // isn't stolen from anything above.
+    .activeOffsetY(10)
+    .failOffsetY(-10)
+    .onUpdate((e) => {
+      translateY.value = Math.max(0, e.translationY)
+    })
+    .onEnd((e) => {
+      if (e.translationY > DISMISS_DISTANCE || e.velocityY > DISMISS_VELOCITY) {
+        runOnJS(onClose)()
+      } else {
+        translateY.value = reduceMotion
+          ? 0
+          : withSpring(0, { damping: 22, stiffness: 240 })
+      }
+    })
+
+  const cardStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }))
+
+  return { pan, cardStyle }
+}


### PR DESCRIPTION
Adds swipe-down-to-dismiss to the live-round bottom sheets (scorecard, putting, shot logger, past-hole shots), per issue #644.

## Approach
Scoped down from an earlier "shared BottomSheet that owns the Modal + backdrop + card" idea after a 3-agent review — that shape is a **hard blocker** (PuttingSheet is mounted twice, once *inside* ShotLogger's own Modal, so a Modal-owning wrapper double-nests Modals, reviving #293/#495). Instead:

- New `components/ui/useSwipeToDismiss.ts` (~40 lines): a `translateY` shared value + a `Gesture.Pan` bound to the **grabber region only** (never the card or an inner ScrollView, so it doesn't fight the scroll or GreenDiagram's own pan). Returns `{ pan, cardStyle }`.
- Adopted **additively** in each sheet: wrap the existing card in `Animated.View style={cardStyle}`, wrap the existing grabber in `GestureDetector`. Each sheet keeps its own Modal, backdrop, KeyboardAvoidingView, `maxHeight`, and Close button (backdrop-tap asymmetry preserved — ShotLogger/putting intentionally omit tap-to-close so a stray tap can't discard an in-progress log).
- Added `GestureHandlerRootView` inside the scorecard + past-hole-shots Modals (the putting/shot-logger ones already had one) — RN Modal is a separate native window on Android the app-root gesture handler can't reach (#496).
- **@gorhom/bottom-sheet rejected**: compatible with the pinned deps, but more invasive (swaps ScrollView/TextInput internals + a portal provider) and rides reanimated's worklet ABI right as SDK 54 / reanimated 4 (which pulls react-native-worklets) is on the roadmap.

## Protecting #643
The putting sheet's card is driven via an animated `KeyboardAvoidingView`; the `translateY` is a post-layout transform, so it can't affect the ScrollView's absolute `windowHeight*0.72` scroll range — the #643 fix is untouched. Tree structure and `maxHeight:'90%'` unchanged.

## Verification
- `npm run typecheck` (mobile) green.
- **Not yet device-QA'd** — swipe gesture, the grabber drag-target size, and the Android separate-window behavior want an on-device pass before merge.

Closes #644
