### PR TITLE
fix(core): stats correctness — SG inflation, GIR inference, mobile handicap baseline (#668, #669, #673)

### DIFF
--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -16,7 +16,7 @@ import {
   type DetailedStats,
   type SGAverages,
 } from '@oga/core'
-import { getRoundsWithDetails } from '@oga/supabase'
+import { getProfile, getRoundsWithDetails } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useUnits } from '../../hooks/useUnits'
@@ -58,6 +58,26 @@ export default function Stats() {
   const [n, setN] = useState<number>(10)
   const [rounds, setRounds] = useState<DetailedRound[]>([])
   const [loading, setLoading] = useState(true)
+  // Player's handicap for SG baselines. Web (useDetailedStats) already uses
+  // the profile value; hardcoding DEFAULT_HANDICAP here benchmarked every
+  // player against the default bracket and made mobile disagree with web on
+  // the same rounds (#673).
+  const [handicap, setHandicap] = useState<number | null>(null)
+
+  useEffect(() => {
+    if (!user) return
+    let active = true
+    getProfile(supabase, user.id).then(({ data }) => {
+      if (!active) return
+      setHandicap(
+        (data as { handicap_index?: number | null } | null)?.handicap_index ??
+          null,
+      )
+    })
+    return () => {
+      active = false
+    }
+  }, [user?.id])
   const { width: screenWidth } = useWindowDimensions()
   const { unit, toDisplay } = useUnits()
 
@@ -132,8 +152,11 @@ export default function Stats() {
   )
 
   const stats: DetailedStats | null = useMemo(
-    () => (rounds.length > 0 ? computeDetailedStats(rounds, DEFAULT_HANDICAP) : null),
-    [rounds],
+    () =>
+      rounds.length > 0
+        ? computeDetailedStats(rounds, handicap ?? DEFAULT_HANDICAP)
+        : null,
+    [rounds, handicap],
   )
 
   return (

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -67,8 +67,12 @@ export default function Stats() {
   useEffect(() => {
     if (!user) return
     let active = true
-    getProfile(supabase, user.id).then(({ data }) => {
+    getProfile(supabase, user.id).then(({ data, error }) => {
       if (!active) return
+      if (error) {
+        // eslint-disable-next-line no-console
+        console.error('[stats/getProfile]', error.message)
+      }
       setHandicap(
         (data as { handicap_index?: number | null } | null)?.handicap_index ??
           null,

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -89,11 +89,14 @@ export async function completeRound({
     const hole = holesById.get(hs.hole_id)
     if (!hole) continue
     const holeShots = shots.filter((s) => s.hole_score_id === hs.id)
+    // No holedOut arg: mobile has no reliable signal that the last logged
+    // shot finished in the cup (no 'holed' shot_result exists), so off-green
+    // hole-outs conservatively don't count GIR here (#669). Web's review
+    // flow, which IS holed-out by construction, passes true.
     const inferred = inferHoleStats(
       holeShots.map((s) => ({
         shot_number: s.shot_number,
         lie_type: s.lie_type,
-        shot_result: s.shot_result,
       })),
       hole.par,
     )

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -89,16 +89,18 @@ export async function completeRound({
     const hole = holesById.get(hs.hole_id)
     if (!hole) continue
     const holeShots = shots.filter((s) => s.hole_score_id === hs.id)
-    // No holedOut arg: mobile has no reliable signal that the last logged
-    // shot finished in the cup (no 'holed' shot_result exists), so off-green
-    // hole-outs conservatively don't count GIR here (#669). Web's review
-    // flow, which IS holed-out by construction, passes true.
+    // holedOut when the shot log fully accounts for the score: length === score
+    // means every stroke was logged, so the last one holed. Incomplete logs
+    // (length < score) stay conservative — never a false positive. This lets
+    // off-green hole-outs (ace, holed approach, chip-in) count GIR (#669).
+    const holedOut = holeShots.length === hs.score
     const inferred = inferHoleStats(
       holeShots.map((s) => ({
         shot_number: s.shot_number,
         lie_type: s.lie_type,
       })),
       hole.par,
+      holedOut,
     )
     const nextFairway = hs.fairway_hit ?? inferred.fairway
     const nextGir = hs.gir ?? inferred.gir

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -593,13 +593,17 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         // manual entries from HoleScoreCard win via the ?? — re-saving
         // the map review never silently overwrites a value the player
         // explicitly toggled on the scorecard.
+        // holedOut=true: this flow is holed-out by construction — the final
+        // marker's end is the pin and `score: rows.length` below asserts the
+        // placed shots ARE the whole hole. Lets aces / holed approaches count
+        // as GIR (#669).
         const inferred = inferHoleStats(
           rows.map((r) => ({
             shot_number: r.shotNumber,
             lie_type: r.lieType,
-            shot_result: null,
           })),
           activeHole.par,
+          true,
         )
         const hsResult = await upsertHoleScore.mutateAsync({
           id: existing?.id,

--- a/packages/core/src/__tests__/holeInference.test.ts
+++ b/packages/core/src/__tests__/holeInference.test.ts
@@ -4,16 +4,10 @@ import { inferHoleStats } from '../holeInference'
 interface S {
   shot_number: number
   lie_type: string | null
-  shot_result?: string | null
 }
 
 const tee = (n: number): S => ({ shot_number: n, lie_type: 'tee' })
 const lie = (n: number, lt: string): S => ({ shot_number: n, lie_type: lt })
-const holed = (n: number, lt: string | null = 'tee'): S => ({
-  shot_number: n,
-  lie_type: lt,
-  shot_result: 'holed',
-})
 
 describe('inferHoleStats — fairway', () => {
   it('par 4, shot 2 lie=fairway → fairway: true', () => {
@@ -41,8 +35,14 @@ describe('inferHoleStats — fairway', () => {
     expect(inferHoleStats(shots, 5).fairway).toBe(true)
   })
 
-  it('hole-in-one on par 4 → fairway: false', () => {
-    expect(inferHoleStats([holed(1)], 4).fairway).toBe(false)
+  it('known hole-in-one on par 4 (holedOut) → fairway: false', () => {
+    expect(inferHoleStats([tee(1)], 4, true).fairway).toBe(false)
+  })
+
+  it('single logged shot WITHOUT holedOut → fairway: null (partial log, not an ace)', () => {
+    // A lone tee shot on a partially-logged hole says nothing about the
+    // fairway — only a known hole-out makes it a fairway-less ace (#669).
+    expect(inferHoleStats([tee(1)], 4).fairway).toBeNull()
   })
 
   it('empty shots → fairway: null', () => {
@@ -102,16 +102,33 @@ describe('inferHoleStats — gir', () => {
     expect(inferHoleStats(shots, 3).gir).toBe(false)
   })
 
-  it('hole-in-one par 3 → gir: true, fairway: null', () => {
-    const out = inferHoleStats([holed(1)], 3)
+  // Hole-outs from OFF the green (ace, holed approach, chip-in): the ball
+  // reaches the green ON the holing stroke, so GIR needs that stroke to be
+  // <= par-2 — one stroke stricter than the green-start branch (#669).
+  it('ace on par 3 (holedOut) → gir: true, fairway: null', () => {
+    const out = inferHoleStats([tee(1)], 3, true)
     expect(out.gir).toBe(true)
     expect(out.fairway).toBeNull()
   })
 
-  it('hole-in-one par 4 → gir: true, fairway: false', () => {
-    const out = inferHoleStats([holed(1)], 4)
+  it('ace on par 4 (holedOut) → gir: true, fairway: false', () => {
+    const out = inferHoleStats([tee(1)], 4, true)
     expect(out.gir).toBe(true)
     expect(out.fairway).toBe(false)
+  })
+
+  it('holed approach for eagle on par 4 (holedOut) → gir: true', () => {
+    const shots: S[] = [tee(1), lie(2, 'fairway')]
+    expect(inferHoleStats(shots, 4, true).gir).toBe(true)
+  })
+
+  it('chip-in for par on par 4 (holedOut) → gir: FALSE (reached green on stroke 3 > par-2)', () => {
+    const shots: S[] = [tee(1), lie(2, 'rough'), lie(3, 'rough')]
+    expect(inferHoleStats(shots, 4, true).gir).toBe(false)
+  })
+
+  it('hole-out-shaped shots WITHOUT holedOut → gir: false (no signal, conservative)', () => {
+    expect(inferHoleStats([tee(1)], 3).gir).toBe(false)
   })
 
   it('shots logged but none reach green → gir: false', () => {

--- a/packages/core/src/__tests__/holeInference.test.ts
+++ b/packages/core/src/__tests__/holeInference.test.ts
@@ -122,7 +122,7 @@ describe('inferHoleStats — gir', () => {
     expect(inferHoleStats(shots, 4, true).gir).toBe(true)
   })
 
-  it('chip-in for par on par 4 (holedOut) → gir: FALSE (reached green on stroke 3 > par-2)', () => {
+  it('chip-in for birdie on par 4 (holedOut) → gir: FALSE (reached green on stroke 3 > par-2)', () => {
     const shots: S[] = [tee(1), lie(2, 'rough'), lie(3, 'rough')]
     expect(inferHoleStats(shots, 4, true).gir).toBe(false)
   })

--- a/packages/core/src/__tests__/stats.test.ts
+++ b/packages/core/src/__tests__/stats.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
+  approachByDistance,
+  ballStrikingStats,
   computeDetailedStats,
   getProximityYards,
   scoringDistribution,
@@ -9,6 +11,7 @@ import {
   type DetailedHoleScore,
   type DetailedRound,
 } from '../stats'
+import { getExpectedStrokes } from '../sg-calculator'
 import { combinedPuttResult } from '../types'
 import type { Database } from '@oga/supabase'
 
@@ -520,5 +523,98 @@ describe('clubAccuracy — putter exclusion', () => {
     const clubs = entries.map((e) => e.club)
     expect(clubs).toContain('7i')
     expect(clubs).not.toContain('putter')
+  })
+})
+
+describe('approachByDistance', () => {
+  const HCP = 15
+  const hole = makeHole({ par: 4, number: 1 })
+  const band150 = (result: ReturnType<typeof approachByDistance>) =>
+    result.find((b) => b.minYards <= 150 && 150 < b.maxYards)!
+
+  function roundWithShots(shots: ReturnType<typeof makeShot>[]): DetailedRound {
+    return makeRound({
+      hole_scores: [makeHoleScore({ holes: hole, shots })],
+    })
+  }
+
+  it('SKIPS a shot whose next shot has no derivable position (was booked as holed, #668)', () => {
+    // 150-yd approach followed by a rough shot with NO distance data: the
+    // approach's end position is unknown — it must not score at all.
+    const rounds = [
+      roundWithShots([
+        makeShot({ shot_number: 1, lie_type: 'tee', distance_to_target: 380 }),
+        makeShot({ shot_number: 2, lie_type: 'fairway', distance_to_target: 150 }),
+        makeShot({ shot_number: 3, lie_type: 'rough', distance_to_target: null }),
+      ]),
+    ]
+    const band = band150(approachByDistance(rounds, HCP))
+    expect(band.shots).toBe(0)
+    expect(band.avgSg).toBeNull()
+  })
+
+  it('books a genuine hole-out (last shot of the hole) against expected strokes', () => {
+    const rounds = [
+      roundWithShots([
+        makeShot({ shot_number: 1, lie_type: 'tee', distance_to_target: 380 }),
+        makeShot({ shot_number: 2, lie_type: 'fairway', distance_to_target: 150 }),
+      ]),
+    ]
+    const band = band150(approachByDistance(rounds, HCP))
+    const start = getExpectedStrokes('approach', 150, undefined, HCP)!
+    expect(band.shots).toBe(1)
+    // Holed from 150: SG = E(start) − 0 − 1.
+    expect(band.avgSg).toBeCloseTo(start - 1, 5)
+  })
+
+  it('scores against the next shot when its expected strokes are derivable', () => {
+    const rounds = [
+      roundWithShots([
+        makeShot({ shot_number: 1, lie_type: 'tee', distance_to_target: 380 }),
+        makeShot({ shot_number: 2, lie_type: 'fairway', distance_to_target: 150 }),
+        makeShot({
+          shot_number: 3,
+          lie_type: 'green',
+          putt_distance_ft: 20,
+        }),
+      ]),
+    ]
+    const band = band150(approachByDistance(rounds, HCP))
+    const start = getExpectedStrokes('approach', 150, undefined, HCP)!
+    const end = getExpectedStrokes('putting', undefined, 20, HCP)!
+    expect(band.shots).toBe(1)
+    expect(band.avgSg).toBeCloseTo(start - end - 1, 5)
+  })
+})
+
+describe('ballStrikingStats — girPct', () => {
+  it('denominates on holes where GIR is known, not every hole row (#668)', () => {
+    const tracked = makeRound({
+      id: 'r-tracked',
+      hole_scores: [
+        makeHoleScore({ id: 'hs1', gir: true }),
+        makeHoleScore({ id: 'hs2', gir: true }),
+        makeHoleScore({ id: 'hs3', gir: false }),
+        makeHoleScore({ id: 'hs4', gir: false }),
+      ],
+    })
+    // Scorecard-only round: 3 holes, gir unknown everywhere — must not
+    // dilute the percentage as misses.
+    const scorecardOnly = makeRound({
+      id: 'r-card',
+      hole_scores: [
+        makeHoleScore({ id: 'hs5', gir: null }),
+        makeHoleScore({ id: 'hs6', gir: null }),
+        makeHoleScore({ id: 'hs7', gir: null }),
+      ],
+    })
+    expect(ballStrikingStats([tracked, scorecardOnly]).girPct).toBe(50)
+  })
+
+  it('returns null when no hole has a known GIR', () => {
+    const r = makeRound({
+      hole_scores: [makeHoleScore({ gir: null }), makeHoleScore({ gir: null })],
+    })
+    expect(ballStrikingStats([r]).girPct).toBeNull()
   })
 })

--- a/packages/core/src/holeInference.ts
+++ b/packages/core/src/holeInference.ts
@@ -8,33 +8,46 @@ export interface HoleInferred {
    *  or fewer. Null when no shots are present. */
   gir: boolean | null
   /** Tee shot finished in the fairway. Null on par 3 (concept doesn't
-   *  apply); false on par 4/5 holes-in-one (no fairway was hit). */
+   *  apply) or when a single logged shot can't be distinguished from a
+   *  partially-logged hole; false on a known par 4/5 hole-in-one. */
   fairway: boolean | null
 }
 
 interface ShotLike {
   shot_number: number
   lie_type: string | null
-  shot_result?: string | null
 }
 
+/**
+ * `holedOut` = the LAST shot in `shots` finished in the cup. Only the
+ * caller knows this: the web post-round review flow is holed-out by
+ * construction (the final marker ends at the pin and score = placed
+ * shots), so it passes true. Mobile has no reliable holing signal for
+ * off-green hole-outs (no 'holed' shot_result exists — the DB CHECK
+ * constraint excludes it, #669), so mobile callers omit it and get the
+ * conservative default.
+ */
 export function inferHoleStats(
   shots: ReadonlyArray<ShotLike>,
   par: number,
+  holedOut = false,
 ): HoleInferred {
-  const fairway = inferFairway(shots, par)
-  const gir = inferGir(shots, par)
+  const fairway = inferFairway(shots, par, holedOut)
+  const gir = inferGir(shots, par, holedOut)
   return { gir, fairway }
 }
 
 function inferFairway(
   shots: ReadonlyArray<ShotLike>,
   par: number,
+  holedOut: boolean,
 ): boolean | null {
   if (par < 4) return null
   if (shots.length === 0) return null
-  // Hole-in-one on par 4/5 — never reached a fairway.
-  if (shots.length === 1) return false
+  // One logged shot is a par-4/5 hole-in-one (never reached a fairway)
+  // only when we KNOW it holed out — otherwise it's a partially-logged
+  // hole and the fairway is simply unknown (#669).
+  if (shots.length === 1) return holedOut ? false : null
   const shot2 = shots.find((s) => s.shot_number === 2)
   if (!shot2) return null
   return shot2.lie_type === 'fairway'
@@ -43,18 +56,24 @@ function inferFairway(
 function inferGir(
   shots: ReadonlyArray<ShotLike>,
   par: number,
+  holedOut: boolean,
 ): boolean | null {
   if (shots.length === 0) return null
-  // lie_type is the start lie, so shot N on the green means the ball
-  // reached the green on shot N-1. GIR = on green in (par-2) strokes
-  // → shot (par-1) starts on green.
-  const threshold = par - 1
-  // First shot whose start lie is the green, OR the shot the player
-  // holed (handles hole-in-one where shot 1 starts on tee but
-  // shot_result='holed' means the ball reached the cup that stroke).
-  const reaching = shots.find(
-    (s) => s.lie_type === 'green' || s.shot_result === 'holed',
-  )
-  if (reaching) return reaching.shot_number <= threshold
+  // lie_type is the start lie, so shot N starting on the green means the
+  // ball reached the green on stroke N-1. GIR = on green in (par-2)
+  // strokes → the first green-start shot must be number <= par-1.
+  const greenNumbers = shots
+    .filter((s) => s.lie_type === 'green')
+    .map((s) => s.shot_number)
+  if (greenNumbers.length > 0) return Math.min(...greenNumbers) <= par - 1
+  // No shot ever STARTED on the green — the ball still reached it only by
+  // holing out from off the green (ace, chip-in, holed approach). The cup
+  // is on the green, so the ball got there ON the holing stroke itself:
+  // GIR when that stroke is <= par-2. Note this is one stroke stricter
+  // than the green-start branch — a chip-in for par (stroke par-1) is NOT
+  // a GIR, which the old dead `shot_result === 'holed'` branch got wrong.
+  if (holedOut) {
+    return Math.max(...shots.map((s) => s.shot_number)) <= par - 2
+  }
   return false
 }

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -308,9 +308,11 @@ export function approachByDistance(
       )
       if (startExpected == null) continue
 
+      // endExpected 0 = holed out — legitimate only when there is NO next
+      // shot (the hole's last shot ends at the cup in both save flows).
       let endExpected = 0
       const next = shots[i + 1]
-      if (next && (next.distance_to_target != null || next.lie_type === 'green')) {
+      if (next) {
         const nextCat = getShotCategory(
           {
             lieType: (next.lie_type as LieType | null) ?? undefined,
@@ -327,7 +329,14 @@ export function approachByDistance(
           nextDistFt ?? undefined,
           handicap,
         )
-        if (nextExpected != null) endExpected = nextExpected
+        // Mirror calculateRoundSG's skip (sg-calculator.ts): a next shot
+        // whose expected strokes can't be derived (no distance data) means
+        // this shot's end position is unknown — skip it entirely rather
+        // than booking it as holed, which awarded up to +2.95 SG per
+        // data-less shot and made this chart disagree with the round SG
+        // engine on identical data (#668).
+        if (nextExpected == null) continue
+        endExpected = nextExpected
       }
       const sg = calculateShotSG(startExpected, endExpected)
       const penaltyAdjust = s.penalty || s.ob ? -1 : 0
@@ -464,13 +473,20 @@ export interface BallStrikingStats {
 export function ballStrikingStats(rounds: DetailedRound[]): BallStrikingStats {
   let fwHit = 0
   let fwTotal = 0
-  let girTotal = 0
-  let holesPlayed = 0
+  let girHit = 0
+  let girKnown = 0
   for (const r of rounds) {
     fwHit += r.fairways_hit ?? 0
     fwTotal += r.fairways_total ?? 0
-    girTotal += r.gir ?? 0
-    holesPlayed += (r.hole_scores?.length ?? 0)
+    // GIR percentage denominates on holes where GIR is actually KNOWN
+    // (hole-level gir boolean set). Counting every hole_scores row put
+    // gir-null holes — scorecard-only rounds with no shot data — in the
+    // denominator as misses, diluting the percentage (#668).
+    for (const hs of r.hole_scores ?? []) {
+      if (hs.gir == null) continue
+      girKnown += 1
+      if (hs.gir) girHit += 1
+    }
   }
 
   const driveDistances: number[] = []
@@ -528,7 +544,7 @@ export function ballStrikingStats(rounds: DetailedRound[]): BallStrikingStats {
 
   return {
     fairwayPct: pct(fwHit, fwTotal),
-    girPct: holesPlayed > 0 ? pct(girTotal, holesPlayed) : null,
+    girPct: girKnown > 0 ? pct(girHit, girKnown) : null,
     drivingDistanceAvg:
       driveDistances.length > 0
         ? driveDistances.reduce((a, b) => a + b, 0) / driveDistances.length


### PR DESCRIPTION
Stats-correctness cluster from the 2026-07-06 internal audit — three fixes, one commit each, all numerically verified.

## Fixes

- **#668 — `approachByDistance` + `girPct`** (`packages/core/src/stats.ts`): a next shot with no derivable expected strokes was treated as a hole-out (`endExpected = 0`), awarding up to **+2.95 SG** per data-less shot and making the "SG by distance" chart disagree with `calculateRoundSG` on identical data — now mirrors the round engine's skip. `girPct` counted gir-null holes (scorecard-only rounds) in the denominator as misses — now denominates on holes where GIR is actually known. **First test coverage for both exports** (they were on the audit's untested list — exactly where the bugs lived).
- **#669 — dead `'holed'` GIR branch** (`packages/core/src/holeInference.ts`): `shot_result='holed'` is unreachable (0021 CHECK constraint; no writer), so aces/holed approaches never counted as GIR — and the dead branch's arithmetic would have wrongly counted chip-ins for par (green-start shots need ≤ par−1; off-green hole-outs reach the green ON the holing stroke, so ≤ par−2). Replaced with an explicit `holedOut` param: web's review flow passes `true` (holed-out by construction — final marker ends at the pin, `score = rows.length`); mobile omits it (no reliable off-green holing signal — documented at the call site). A single logged shot without `holedOut` now infers fairway `null` (partial log) instead of `false`. Old tests fed the unreachable input and masked the bug — rewritten with reachable inputs, including the chip-in-for-par case.
- **#673 — mobile stats DEFAULT_HANDICAP** (`apps/mobile/app/(app)/stats.tsx`): SG baselines were computed against the default bracket for every player; now fetches `profile.handicap_index` (fallback DEFAULT_HANDICAP), matching web's `useDetailedStats`.

## Behavior notes
- Mobile GIR for off-green hole-outs stays conservatively false (no signal exists on mobile) — same as before, but now documented; web logging of the same round infers it correctly.
- `hole_scores(*)` is already selected by `getRoundsWithDetails`, so the girPct change needs no query change.

## Verification
- `pnpm test`: **568 passed** (was ~547; new cases for approachByDistance, ballStrikingStats, and the rewritten holeInference suite).
- `pnpm typecheck` (3/3) + mobile `npm run typecheck` green.

Closes #668
Closes #669
Closes #673
