### PR TITLE
fix(mobile): harden shot sync queue + completeRound sync race (#651, #652)

### DIFF
--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -11,6 +11,7 @@ import { deleteRound, getProfile } from '@oga/supabase'
 import { supabase } from '../../../lib/supabase'
 import {
   insertPendingShot,
+  pendingCount,
   setPendingShotEnd,
   type ShotPayload,
 } from '../../../lib/db'
@@ -498,6 +499,46 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     endInFlightRef.current = true
     setEnding(true)
     try {
+      // Drain the queue before finalizing (#651). syncPendingShots joins
+      // an in-flight run instead of no-oping, but a joined run may have
+      // snapshotted the queue before the final putt's row landed — if
+      // anything is still pending after the first pass, run once more now
+      // that the previous run has settled.
+      await syncPendingShots().catch(() => undefined)
+      if ((await pendingCount()) > 0) {
+        await syncPendingShots().catch(() => undefined)
+      }
+      const unsynced = await pendingCount()
+      if (unsynced > 0) {
+        // Shots that never reached the server would silently vanish from
+        // totals/SG (completeRound reads the server's shot set). Make the
+        // player choose: keep the round open and retry with a better
+        // connection, or knowingly finalize over what synced. cancelable:
+        // false so the Android back button can't dismiss without
+        // resolving.
+        const finishAnyway = await new Promise<boolean>((resolve) => {
+          Alert.alert(
+            'Some shots have not synced',
+            `${unsynced} shot${unsynced === 1 ? ' has' : 's have'} not reached the server. ` +
+              'Finishing now will compute totals and strokes gained without ' +
+              `${unsynced === 1 ? 'it' : 'them'}. You can keep the round open and finish later with a better connection.`,
+            [
+              {
+                text: 'Keep round open',
+                style: 'cancel',
+                onPress: () => resolve(false),
+              },
+              {
+                text: 'Finish anyway',
+                style: 'destructive',
+                onPress: () => resolve(true),
+              },
+            ],
+            { cancelable: false },
+          )
+        })
+        if (!finishAnyway) return
+      }
       const { data: profile } = await getProfile(supabase, user.id)
       const handicap =
         (profile as { handicap_index?: number | null } | null)?.handicap_index ??

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -42,6 +42,13 @@ export async function completeRound({
   userId,
   handicap,
 }: CompleteArgs): Promise<void> {
+  // Drain the pending queue before reading shots. syncPendingShots joins
+  // an in-flight background run (#651), so this genuinely waits for the
+  // final hole's shots instead of no-oping while a save-triggered sync
+  // holds the lock. The caller (handleEndRound) has already drained,
+  // re-checked pendingCount, and made the player acknowledge any rows
+  // that still can't reach the server — so a failure here proceeds by
+  // design: finalizing over what synced is the acknowledged fallback.
   await syncPendingShots().catch(() => undefined)
 
   const [holesRes, holeScoresRes, shotsRes, teesRes, roundRes] = await Promise.all([

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -1,4 +1,5 @@
 import { AppState, type AppStateStatus } from 'react-native'
+import { uuid } from 'expo-modules-core'
 import * as SQLite from 'expo-sqlite'
 import type { Database } from '@oga/supabase'
 
@@ -7,12 +8,14 @@ export type ShotPayload = Database['public']['Tables']['shots']['Insert']
 export interface PendingShot {
   local_id: number
   remote_id: string | null
-  // 'broken' = JSON.parse(payload) failed at least once; the row is
-  // quarantined so sync stops retrying it forever (#292). All reads
-  // filter `WHERE status = 'pending'` so broken rows become invisible
-  // to consumers. There's intentionally no CHECK constraint on this
-  // column — CREATE TABLE IF NOT EXISTS skips on existing installs, so
-  // a CHECK can't be retro-applied. The TypeScript union is the gate.
+  // 'broken' = quarantined so sync stops retrying it forever: either
+  // JSON.parse(payload) failed (#292) or the server deterministically
+  // rejects the row — constraint/data-class errors that no retry can
+  // fix (#652). All reads filter `WHERE status = 'pending'` so broken
+  // rows become invisible to consumers. There's intentionally no CHECK
+  // constraint on this column — CREATE TABLE IF NOT EXISTS skips on
+  // existing installs, so a CHECK can't be retro-applied. The
+  // TypeScript union is the gate.
   status: 'pending' | 'synced' | 'broken'
   payload: string
   created_at: number
@@ -33,6 +36,14 @@ function getDb(): Promise<SQLite.SQLiteDatabase> {
           created_at INTEGER NOT NULL
         );
       `)
+      // Purge rows that finished syncing in a previous session — nothing
+      // ever deleted them, so the table grew unbounded (#652). Synced rows
+      // are only read back within a session (setPendingShotEnd patches a
+      // just-synced shot's end coords via remote_id), and that path keys
+      // off an in-memory ref that doesn't survive a restart, so rows from
+      // prior sessions are pure dead weight. 'broken' rows are kept as
+      // diagnostic evidence; they're rare by construction.
+      await db.runAsync(`DELETE FROM pending_shots WHERE status = 'synced'`)
       return db
     })()
   }
@@ -41,9 +52,16 @@ function getDb(): Promise<SQLite.SQLiteDatabase> {
 
 export async function insertPendingShot(payload: ShotPayload): Promise<number> {
   const db = await getDb()
+  // Client-generated PK (#652). The shots table defaults to
+  // gen_random_uuid(), but a server-assigned id means a retried insert
+  // whose first attempt committed with a lost response creates a
+  // duplicate shot. Baking the id in at creation makes every sync
+  // attempt for this row idempotent — and keeps it stable through
+  // setPendingShotEnd's payload rewrites.
+  const withId: ShotPayload = payload.id ? payload : { ...payload, id: uuid.v4() }
   const result = await db.runAsync(
     `INSERT INTO pending_shots (status, payload, created_at) VALUES ('pending', ?, ?)`,
-    JSON.stringify(payload),
+    JSON.stringify(withId),
     Date.now(),
   )
   return result.lastInsertRowId
@@ -65,13 +83,15 @@ export async function markShotSynced(localId: number, remoteId: string): Promise
   )
 }
 
-// Quarantine a corrupt pending row so sync stops retrying it forever
-// (#292). Set when JSON.parse(row.payload) throws. The `WHERE status =
-// 'pending'` filter on every read keeps broken rows out of subsequent
-// passes. Internally try/catch'd so callers (which are already inside a
-// parse-fail catch) can't have the real failure masked by a downstream
-// marker-write failure — the parse error log is what actually surfaces
-// what went wrong.
+// Quarantine a poisoned pending row so sync stops retrying it forever.
+// Set when JSON.parse(row.payload) throws (#292) or when the server
+// permanently rejects the row — constraint/data-class errors a retry
+// can never fix (#652). The `WHERE status = 'pending'` filter on every
+// read keeps broken rows out of subsequent passes. Internally
+// try/catch'd so callers (which are already inside a failure path)
+// can't have the real failure masked by a downstream marker-write
+// failure — the original error log is what actually surfaces what went
+// wrong.
 export async function markShotBroken(localId: number): Promise<void> {
   try {
     const db = await getDb()
@@ -85,9 +105,20 @@ export async function markShotBroken(localId: number): Promise<void> {
   }
 }
 
-export async function deletePendingShot(localId: number): Promise<void> {
+// Rewrites a pending row's payload in place. Sync uses this to persist a
+// backfilled client id onto rows queued before insertPendingShot started
+// generating ids (#652) — without the write-back, each sync pass would
+// mint a fresh id and defeat the idempotency it exists to provide.
+export async function updatePendingShotPayload(
+  localId: number,
+  payload: string,
+): Promise<void> {
   const db = await getDb()
-  await db.runAsync(`DELETE FROM pending_shots WHERE local_id = ?`, localId)
+  await db.runAsync(
+    `UPDATE pending_shots SET payload = ? WHERE local_id = ?`,
+    payload,
+    localId,
+  )
 }
 
 export async function pendingCount(): Promise<number> {

--- a/apps/mobile/lib/sync.ts
+++ b/apps/mobile/lib/sync.ts
@@ -11,37 +11,22 @@ import {
 } from './db'
 import { supabase } from './supabase'
 
-// Module-scope lock that survives a Fast Refresh and prevents two
-// concurrent syncPendingShots() calls from racing the same SQLite rows.
-// A timestamp + TTL guards against the lock getting stuck `true` after a
-// crash mid-flight: if the current process can't have been holding it
-// for that long, we know it's stale and reset.
-let inFlight = false
-let inFlightSince: number | null = null
+// Module-scope lock: the promise of the active run IS the lock. It
+// prevents two concurrent runs from racing the same SQLite rows, and a
+// second caller JOINS the in-flight run instead of getting a silent
+// { synced: 0, failed: 0 } no-op — completeRound used to read that
+// no-op as "queue drained" and finalize totals/SG over shots the
+// concurrent save-triggered background sync was still inserting (#651).
+// The timestamp + TTL guards against joining a zombie run (e.g. a fetch
+// hung without a timeout): past the TTL a fresh run starts instead —
+// same recovery the old boolean lock had.
+let activeRun: Promise<SyncResult> | null = null
+let activeRunSince = 0
 const LOCK_TTL_MS = 30_000
 const CHUNK_SIZE = 50
 const RETRY_DELAY_MS = 2_000
 
-function acquireLock(): boolean {
-  if (inFlight) {
-    if (inFlightSince != null && Date.now() - inFlightSince > LOCK_TTL_MS) {
-      // eslint-disable-next-line no-console
-      console.warn('[sync] stale lock detected, resetting')
-      inFlight = false
-      inFlightSince = null
-    } else {
-      return false
-    }
-  }
-  inFlight = true
-  inFlightSince = Date.now()
-  return true
-}
-
-function releaseLock(): void {
-  inFlight = false
-  inFlightSince = null
-}
+type SyncResult = { synced: number; failed: number }
 
 // Upsert on the client-generated PK (#652): a retry whose first attempt
 // committed server-side but lost the response (course LTE) re-sends the
@@ -106,89 +91,101 @@ async function syncRowsIndividually(
   return { synced, failed }
 }
 
-export async function syncPendingShots(): Promise<{ synced: number; failed: number }> {
-  if (!acquireLock()) return { synced: 0, failed: 0 }
+export function syncPendingShots(): Promise<SyncResult> {
+  if (activeRun && Date.now() - activeRunSince <= LOCK_TTL_MS) {
+    return activeRun
+  }
+  if (activeRun) {
+    // eslint-disable-next-line no-console
+    console.warn('[sync] stale run detected, starting fresh')
+  }
+  const run = runSync().finally(() => {
+    // Only clear if a stale-run replacement hasn't already taken over.
+    if (activeRun === run) activeRun = null
+  })
+  activeRun = run
+  activeRunSince = Date.now()
+  return run
+}
+
+async function runSync(): Promise<SyncResult> {
   let synced = 0
   let failed = 0
-  try {
-    const pending = await listPendingShots()
-    for (let i = 0; i < pending.length; i += CHUNK_SIZE) {
-      const chunk = pending.slice(i, i + CHUNK_SIZE)
-      // Parallel arrays: payloads[j] parsed from validRows[j]. The
-      // success loop below must map against validRows, NOT chunk — a
-      // corrupt row skipped here would otherwise shift every later row
-      // onto the wrong remote id (#652).
-      const validRows: PendingShot[] = []
-      const payloads: ShotPayload[] = []
-      for (const row of chunk) {
-        let payload: ShotPayload
-        try {
-          payload = JSON.parse(row.payload) as ShotPayload
-        } catch (e) {
-          // Malformed pending payload — quarantine so sync stops retrying
-          // it forever on every reconnect (#292).
-          // eslint-disable-next-line no-console
-          console.error(
-            '[db/payload-corrupt] local_id=%d msg=%s',
-            row.local_id,
-            (e as Error).message,
-          )
-          void markShotBroken(row.local_id)
-          failed += 1
-          continue
-        }
-        if (!payload.id) {
-          // Rows queued before insertPendingShot started generating
-          // client ids (#652): assign one and persist it so every future
-          // retry re-sends the same PK instead of minting a fresh id.
-          payload.id = uuid.v4()
-          await updatePendingShotPayload(row.local_id, JSON.stringify(payload))
-        }
-        validRows.push(row)
-        payloads.push(payload)
-      }
-      if (payloads.length === 0) continue
-      let { data, error } = await insertChunk(payloads)
-      if (error && !isPermanentError(error)) {
-        // Single retry after a short delay. Transient network/server
-        // hiccups (intermittent connectivity, brief 5xx) are common
-        // mid-round; one retry covers most without burning bandwidth.
-        // On second failure the chunk stays in the pending queue —
-        // markShotSynced never runs, so rows will be picked up by the
-        // next NetInfo reconnect / AppState foreground / manual call.
-        await new Promise((r) => setTimeout(r, RETRY_DELAY_MS))
-        const retry = await insertChunk(payloads)
-        data = retry.data
-        error = retry.error
-      }
-      if (error && isPermanentError(error)) {
-        const perRow = await syncRowsIndividually(validRows, payloads)
-        synced += perRow.synced
-        failed += perRow.failed
-        continue
-      }
-      if (error || !data) {
+  const pending = await listPendingShots()
+  for (let i = 0; i < pending.length; i += CHUNK_SIZE) {
+    const chunk = pending.slice(i, i + CHUNK_SIZE)
+    // Parallel arrays: payloads[j] parsed from validRows[j]. The
+    // success loop below must map against validRows, NOT chunk — a
+    // corrupt row skipped here would otherwise shift every later row
+    // onto the wrong remote id (#652).
+    const validRows: PendingShot[] = []
+    const payloads: ShotPayload[] = []
+    for (const row of chunk) {
+      let payload: ShotPayload
+      try {
+        payload = JSON.parse(row.payload) as ShotPayload
+      } catch (e) {
+        // Malformed pending payload — quarantine so sync stops retrying
+        // it forever on every reconnect (#292).
         // eslint-disable-next-line no-console
-        console.warn('[sync] chunk failed after retry, leaving pending:', error?.message ?? 'no data')
-        failed += validRows.length
+        console.error(
+          '[db/payload-corrupt] local_id=%d msg=%s',
+          row.local_id,
+          (e as Error).message,
+        )
+        void markShotBroken(row.local_id)
+        failed += 1
         continue
       }
-      // Reconcile by the client-generated id rather than trusting
-      // response ordering — every payload carries its id by this point.
-      const returnedIds = new Set(data.map((r) => r.id))
-      for (let j = 0; j < validRows.length; j++) {
-        const row = validRows[j]
-        const payload = payloads[j]
-        if (row && payload?.id && returnedIds.has(payload.id)) {
-          await markShotSynced(row.local_id, payload.id)
-          synced += 1
-        } else {
-          failed += 1
-        }
+      if (!payload.id) {
+        // Rows queued before insertPendingShot started generating
+        // client ids (#652): assign one and persist it so every future
+        // retry re-sends the same PK instead of minting a fresh id.
+        payload.id = uuid.v4()
+        await updatePendingShotPayload(row.local_id, JSON.stringify(payload))
+      }
+      validRows.push(row)
+      payloads.push(payload)
+    }
+    if (payloads.length === 0) continue
+    let { data, error } = await insertChunk(payloads)
+    if (error && !isPermanentError(error)) {
+      // Single retry after a short delay. Transient network/server
+      // hiccups (intermittent connectivity, brief 5xx) are common
+      // mid-round; one retry covers most without burning bandwidth.
+      // On second failure the chunk stays in the pending queue —
+      // markShotSynced never runs, so rows will be picked up by the
+      // next NetInfo reconnect / AppState foreground / manual call.
+      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS))
+      const retry = await insertChunk(payloads)
+      data = retry.data
+      error = retry.error
+    }
+    if (error && isPermanentError(error)) {
+      const perRow = await syncRowsIndividually(validRows, payloads)
+      synced += perRow.synced
+      failed += perRow.failed
+      continue
+    }
+    if (error || !data) {
+      // eslint-disable-next-line no-console
+      console.warn('[sync] chunk failed after retry, leaving pending:', error?.message ?? 'no data')
+      failed += validRows.length
+      continue
+    }
+    // Reconcile by the client-generated id rather than trusting
+    // response ordering — every payload carries its id by this point.
+    const returnedIds = new Set(data.map((r) => r.id))
+    for (let j = 0; j < validRows.length; j++) {
+      const row = validRows[j]
+      const payload = payloads[j]
+      if (row && payload?.id && returnedIds.has(payload.id)) {
+        await markShotSynced(row.local_id, payload.id)
+        synced += 1
+      } else {
+        failed += 1
       }
     }
-  } finally {
-    releaseLock()
   }
   return { synced, failed }
 }

--- a/apps/mobile/lib/sync.ts
+++ b/apps/mobile/lib/sync.ts
@@ -1,6 +1,14 @@
 import { AppState } from 'react-native'
+import { uuid } from 'expo-modules-core'
 import NetInfo from '@react-native-community/netinfo'
-import { listPendingShots, markShotBroken, markShotSynced, type ShotPayload } from './db'
+import {
+  listPendingShots,
+  markShotBroken,
+  markShotSynced,
+  updatePendingShotPayload,
+  type PendingShot,
+  type ShotPayload,
+} from './db'
 import { supabase } from './supabase'
 
 // Module-scope lock that survives a Fast Refresh and prevents two
@@ -35,8 +43,67 @@ function releaseLock(): void {
   inFlightSince = null
 }
 
+// Upsert on the client-generated PK (#652): a retry whose first attempt
+// committed server-side but lost the response (course LTE) re-sends the
+// same ids and lands on DO UPDATE instead of duplicating shots. The local
+// payload is always the freshest copy of the row while it's pending, so
+// the conflict-update path is a safe no-op-or-refresh. Shots RLS is a
+// single FOR-ALL-own-rows policy, so the update arm passes.
 async function insertChunk(payloads: ShotPayload[]) {
-  return supabase.from('shots').insert(payloads).select('id')
+  return supabase.from('shots').upsert(payloads, { onConflict: 'id' }).select('id')
+}
+
+// Postgres class 22 (data exception) and 23 (integrity constraint —
+// 23505 unique violation, 23503 FK violation) rejections are
+// deterministic: the same payload gets the same refusal on every retry,
+// so retrying forever just blocks the queue. Everything else — network
+// drop (empty code), 5xx, expired-JWT PGRST301 — is treated as transient
+// and stays pending; quarantining rows on an auth hiccup would eat the
+// whole queue.
+function isPermanentError(error: { code?: string } | null | undefined): boolean {
+  const code = error?.code ?? ''
+  return code.startsWith('22') || code.startsWith('23')
+}
+
+// Per-row fallback for a chunk the server permanently rejected (#652).
+// Chunks insert atomically, so one poison row (e.g. 23505 on
+// unique(hole_score_id, shot_number), FK gone after a web-side delete)
+// used to fail all ≤50 rows — and every future sync pass — forever.
+// Inserting one row at a time isolates the poison: deterministic
+// rejections are quarantined, everything else syncs or stays pending.
+async function syncRowsIndividually(
+  rows: PendingShot[],
+  payloads: ShotPayload[],
+): Promise<{ synced: number; failed: number }> {
+  let synced = 0
+  let failed = 0
+  for (let j = 0; j < rows.length; j++) {
+    const row = rows[j]
+    const payload = payloads[j]
+    if (!row || !payload?.id) {
+      failed += 1
+      continue
+    }
+    const { data, error } = await insertChunk([payload])
+    if (!error && data && data.length === 1) {
+      await markShotSynced(row.local_id, payload.id)
+      synced += 1
+    } else if (isPermanentError(error)) {
+      // eslint-disable-next-line no-console
+      console.error(
+        '[sync/poison] quarantining local_id=%d code=%s msg=%s',
+        row.local_id,
+        error?.code,
+        error?.message,
+      )
+      await markShotBroken(row.local_id)
+      failed += 1
+    } else {
+      // Transient mid-fallback — leave pending for the next trigger.
+      failed += 1
+    }
+  }
+  return { synced, failed }
 }
 
 export async function syncPendingShots(): Promise<{ synced: number; failed: number }> {
@@ -47,10 +114,16 @@ export async function syncPendingShots(): Promise<{ synced: number; failed: numb
     const pending = await listPendingShots()
     for (let i = 0; i < pending.length; i += CHUNK_SIZE) {
       const chunk = pending.slice(i, i + CHUNK_SIZE)
+      // Parallel arrays: payloads[j] parsed from validRows[j]. The
+      // success loop below must map against validRows, NOT chunk — a
+      // corrupt row skipped here would otherwise shift every later row
+      // onto the wrong remote id (#652).
+      const validRows: PendingShot[] = []
       const payloads: ShotPayload[] = []
       for (const row of chunk) {
+        let payload: ShotPayload
         try {
-          payloads.push(JSON.parse(row.payload) as ShotPayload)
+          payload = JSON.parse(row.payload) as ShotPayload
         } catch (e) {
           // Malformed pending payload — quarantine so sync stops retrying
           // it forever on every reconnect (#292).
@@ -61,14 +134,22 @@ export async function syncPendingShots(): Promise<{ synced: number; failed: numb
             (e as Error).message,
           )
           void markShotBroken(row.local_id)
+          failed += 1
+          continue
         }
+        if (!payload.id) {
+          // Rows queued before insertPendingShot started generating
+          // client ids (#652): assign one and persist it so every future
+          // retry re-sends the same PK instead of minting a fresh id.
+          payload.id = uuid.v4()
+          await updatePendingShotPayload(row.local_id, JSON.stringify(payload))
+        }
+        validRows.push(row)
+        payloads.push(payload)
       }
-      if (payloads.length === 0) {
-        failed += chunk.length
-        continue
-      }
+      if (payloads.length === 0) continue
       let { data, error } = await insertChunk(payloads)
-      if (error || !data || data.length !== payloads.length) {
+      if (error && !isPermanentError(error)) {
         // Single retry after a short delay. Transient network/server
         // hiccups (intermittent connectivity, brief 5xx) are common
         // mid-round; one retry covers most without burning bandwidth.
@@ -80,23 +161,30 @@ export async function syncPendingShots(): Promise<{ synced: number; failed: numb
         data = retry.data
         error = retry.error
       }
-      if (error || !data || data.length !== payloads.length) {
-        // eslint-disable-next-line no-console
-        console.warn('[sync] chunk failed after retry, leaving pending:', error?.message ?? 'shape mismatch')
-        failed += chunk.length
+      if (error && isPermanentError(error)) {
+        const perRow = await syncRowsIndividually(validRows, payloads)
+        synced += perRow.synced
+        failed += perRow.failed
         continue
       }
-      // supabase-js returns inserted rows in input order, so we can map
-      // each pending local_id to its remote id by index.
-      for (let j = 0; j < chunk.length; j++) {
-        const row = chunk[j]
-        const remote = data[j]
-        if (!row || !remote) {
+      if (error || !data) {
+        // eslint-disable-next-line no-console
+        console.warn('[sync] chunk failed after retry, leaving pending:', error?.message ?? 'no data')
+        failed += validRows.length
+        continue
+      }
+      // Reconcile by the client-generated id rather than trusting
+      // response ordering — every payload carries its id by this point.
+      const returnedIds = new Set(data.map((r) => r.id))
+      for (let j = 0; j < validRows.length; j++) {
+        const row = validRows[j]
+        const payload = payloads[j]
+        if (row && payload?.id && returnedIds.has(payload.id)) {
+          await markShotSynced(row.local_id, payload.id)
+          synced += 1
+        } else {
           failed += 1
-          continue
         }
-        await markShotSynced(row.local_id, remote.id)
-        synced += 1
       }
     }
   } finally {


### PR DESCRIPTION
Two audit-filed defect sets in the mobile pending-shot sync pipeline, one commit each.

## #652 — Sync-queue hardening (`lib/sync.ts`, `lib/db.ts`)

| Defect | Fix |
|---|---|
| **Poison pill** — chunks insert atomically; a server-permanently-rejected row (23505/23503) failed its whole chunk, and all future sync, forever | `isPermanentError()` classifies Postgres class 22/23 as deterministic; on a permanent chunk failure, `syncRowsIndividually()` inserts one row at a time, quarantines the poison row(s) via `markShotBroken`, and lets the rest through. Network/5xx keep the transient single-retry. |
| **Chunk index misalignment** — `data[j]` (payloads order) mapped against `chunk[j]` (chunk order) once a corrupt row was skipped | Parse loop builds parallel `validRows`/`payloads` arrays; success reconciles by the client-generated id against a `Set` of returned ids — no ordering trust at all. |
| **No idempotency** — retry after a committed-but-lost-response insert duplicated shots | `insertPendingShot` bakes a client-generated uuid into the payload; `insertChunk` upserts `onConflict: 'id'`, so a re-send lands on `DO UPDATE` (local payload is the freshest copy while pending — safe refresh). Legacy queued rows get an id backfilled and persisted on first sync pass (`updatePendingShotPayload`). |
| **`pending_shots` never pruned + dead `deletePendingShot`** | Synced rows purged at db open; dead function removed (replaced by `updatePendingShotPayload`, which the backfill needs). |

## #651 — completeRound sync-lock no-op race (`lib/sync.ts`, `lib/completeRound.ts`, `useShotActions.ts`)

The boolean lock returned an instant `{synced: 0, failed: 0}` no-op to concurrent callers; `completeRound` discarded it and stamped `completed_at` + totals/SG while the final putt's save-triggered background sync was still inserting. Fix: the lock becomes a module-level promise of the active run — concurrent callers **join** the in-flight run and get its real result. `handleEndRound` drains the queue before calling `completeRound`, re-runs once if rows landed after the joined run's snapshot, then checks `pendingCount()`; if rows still can't reach the server, an Alert forces a choice: **Keep round open** (round stays live, retry later) or **Finish anyway** (knowingly finalize over what synced).

## Design decisions

- **uuid source:** `uuid.v4()` from `expo-modules-core` — already an exact-pinned transitive dep (2.5.0), typed export, backed by the native Expo runtime generator (`globalThis.expo.uuidv4`). Zero new dependencies; `expo-crypto` is NOT installed so it was not an option without touching `package.json`.
- **Idempotency shape:** upsert-on-PK rather than "treat 23505-on-PK as already-synced" — the upsert path never surfaces the ambiguous 23505 at all, so any 23505 that remains is the natural `unique(hole_score_id, shot_number)` key = genuine poison. Shots RLS is one `FOR ALL` own-rows policy, so the `ON CONFLICT DO UPDATE` arm passes.
- **Permanent-error classification:** conservative — only Postgres classes 22/23. Blanket 4xx would quarantine the entire queue on an expired JWT (PGRST301) or a signed-out RLS denial; those stay transient/pending.
- **Join vs retry-loop:** join-in-flight (module-level promise). The promise *is* the lock, so it can't go stale like the boolean; the 30s TTL survives as "don't join a zombie run, start fresh" to keep the old hung-fetch recovery.
- **Prune strategy:** purge `status='synced'` at db open rather than delete-on-sync — `setPendingShotEnd` patches a just-synced shot's end coords via `remote_id` within a session (`markBallHere` remote-patch path), so deleting at sync time would break that. The ref driving that path (`lastSavedShotLocalIdRef`) is in-memory and doesn't survive a restart, so startup purge loses nothing. `broken` rows are kept as diagnostic evidence.
- **Warn-UX:** pre-stamp Alert in `handleEndRound` (not a return value from `completeRound`) so the warning genuinely precedes `completed_at`. The check is device-global `pendingCount()` rather than round-scoped — any pending row is un-synced shot data, so the superset warning is still truthful and avoids a new round-scoped SQLite query. "Keep round open" simply returns; the end dialog closes and the player can retry End Round later.

## Manual verification reasoning (no mobile unit-test infra)

Walking each defect through the final code:

1. **Poison row:** queue = [A(poison-23505-natural-key), B, C]. `insertChunk` upserts all three → 23505 → `isPermanentError('23505')` true → no transient retry burned → `syncRowsIndividually`: B and C each upsert alone and succeed → `markShotSynced(B)`, `markShotSynced(C)`; A alone → 23505 → `markShotBroken(A)`. Next pass: `listPendingShots` filters `status='pending'` → queue empty. Sync unblocked, no reinstall.
2. **Corrupt row mid-chunk:** queue = [X(corrupt JSON), Y, Z]. Parse loop quarantines X (`markShotBroken`, `failed+=1`) and never pushes it to `validRows`/`payloads`. Success loop iterates `validRows` = [Y, Z] and checks each `payload.id` against the returned-id `Set` — Y and Z get their own ids as `remote_id`; nothing is off-by-one, X's quarantine is never overwritten (the old bug marked X 'synced' with Y's remote id).
3. **Lost response:** insert of chunk with ids [i1, i2] commits server-side, response lost → supabase-js surfaces a transport error with empty `code` → not permanent → one 2s retry → upsert `onConflict:'id'` re-sends i1/i2 → `DO UPDATE` no-op-refresh, returns both rows → reconcile marks both synced with their client ids. Zero duplicates. Cross-run case identical because the id is persisted in the SQLite payload (at creation for new rows; backfilled + written back for legacy rows).
4. **Prune:** `getDb()` runs `DELETE FROM pending_shots WHERE status='synced'` once per session before any read. Rows synced this session survive until next launch, keeping the `setPendingShotEnd` → remote end-coords patch working; prior sessions' rows are gone. `deletePendingShot` no longer exists; `grep` confirms zero callers existed.
5. **#651 race:** final putt saves → `persistShot` fires background sync (holds `activeRun`). Player taps End Round → `handleEndRound` → `syncPendingShots()` returns *that same promise* (run snapshotted after the putt's `insertPendingShot`, which persistShot awaits before firing) → genuinely waits for the putt's insert. Belt-and-suspenders: if a joined run predated some rows, `pendingCount() > 0` triggers one fresh pass. Only then does `completeRound` read `getShotsForRound`.
6. **#651 failed-sync silent finalize:** airplane-mode sync leaves rows pending → both passes fail → `unsynced > 0` → Alert. "Keep round open" returns before `completeRound`; `finally` resets `ending`/`endInFlightRef` and closes the end dialog — round still resumable. "Finish anyway" proceeds, which is the documented acknowledged fallback (completeRound's internal drain keeps its `.catch(() => undefined)` for exactly this path).

`cd apps/mobile && npm run typecheck` passes after each commit.

**On-device QA still wanted:** poison-row quarantine + duplicate-prevention need a real flaky-network round (or airplane-mode toggling) to observe end-to-end; the Alert copy/flow should be eyeballed on Android + iOS.

Closes #651
Closes #652