### PR TITLE
fix(mobile): live-round data-loss traps — 9-hole phantom resume + load-error delete (#650, #653)

### DIFF
--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -312,8 +312,8 @@ export default function LiveRoundSession({
       ? 'Something went wrong loading this round.'
       : `Hole ${holeNumber} isn't set up for this round yet.`
     const subline = data.error
-      ? 'Check your connection and try again, or exit to clear the round.'
-      : 'This usually means the course was created without per-hole layout data. Exit to discard the round and start fresh.'
+      ? 'Check your connection and try again, or leave and resume this round later.'
+      : 'Try again, or leave and pick this round back up from the home screen.'
     return (
       <View
         style={{
@@ -380,10 +380,10 @@ export default function LiveRoundSession({
         </Pressable>
         <Pressable
           accessibilityRole="button"
-          accessibilityLabel="Exit round and discard"
+          accessibilityLabel="Leave and go to the home screen"
           onPress={() => setActiveDialog('exit')}
           style={{
-            backgroundColor: '#A33A2A',
+            backgroundColor: '#5C6356',
             borderRadius: 2,
             paddingVertical: 14,
             paddingHorizontal: 24,
@@ -400,17 +400,15 @@ export default function LiveRoundSession({
               },
             ]}
           >
-            Exit round
+            Leave to home
           </Text>
         </Pressable>
         <ConfirmDialog
           visible={activeDialog === 'exit'}
           title="Leave this round?"
-          message="Nothing's been logged yet, so the round will be discarded."
-          confirmLabel="Leave round"
+          message="Your round is saved — you can resume it from the home screen."
+          confirmLabel="Leave"
           cancelLabel="Stay"
-          destructive
-          busy={actions.deleting}
           onConfirm={actions.handleExitFromError}
           onCancel={() => setActiveDialog(null)}
         />

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -69,7 +69,7 @@ export interface UseShotActionsResult {
   finishHole: () => void
   handleEndRound: () => Promise<void>
   handleDeleteRound: () => Promise<void>
-  handleExitFromError: () => Promise<void>
+  handleExitFromError: () => void
 }
 
 export function useShotActions(input: UseShotActionsInput): UseShotActionsResult {
@@ -538,26 +538,15 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     }
   }
 
-  async function handleExitFromError() {
-    if (round && user) {
-      setDeleting(true)
-      try {
-        const { error: delErr } = await deleteRound(supabase, round.id, user.id)
-        if (delErr) {
-          // eslint-disable-next-line no-console
-          console.error('[hole/exitFromError]', delErr.message)
-          Alert.alert('Could not discard round', delErr.message)
-          return
-        }
-      } finally {
-        setDeleting(false)
-        // Guard against clobbering a different dialog the user may have
-        // opened during the async window.
-        setActiveDialog(prev => (prev === 'exit' ? null : prev))
-      }
-    } else {
-      setActiveDialog(prev => (prev === 'exit' ? null : prev))
-    }
+  function handleExitFromError() {
+    // Leave to home WITHOUT deleting. A load error (network blip on a
+    // rounds-deep resume) or a missing hole means the round is still
+    // resumable — and synthetic no-layout courses are now playable (#614),
+    // so there's no "unplayable, discard it" case left to justify a delete.
+    // The old delete-on-exit destroyed a whole logged round on a transient
+    // failure, behind copy that claimed nothing was logged (#653). The
+    // round stays resumable, and is still deletable from the home list.
+    setActiveDialog(prev => (prev === 'exit' ? null : prev))
     router.replace('/(app)')
   }
 

--- a/apps/mobile/hooks/useActiveRound.ts
+++ b/apps/mobile/hooks/useActiveRound.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 import { useFocusEffect } from 'expo-router'
+import { inferHoleCount } from '@oga/core'
 import { supabase } from '../lib/supabase'
 import { useAuth } from './useAuth'
 
@@ -15,8 +16,8 @@ export interface ActiveRound {
 // is the canonical finalized flag; the total_score guard also keeps seeded
 // past rounds (scored, but no completed_at) out of the banner.
 // The current hole is the highest hole the player has logged a score
-// on, +1 (capped at 18) — so resuming jumps back to where they left
-// off, not hole 1.
+// on, +1 (capped at the round's hole count, not a hardcoded 18) — so
+// resuming jumps back to where they left off, not hole 1.
 //
 // Re-runs every time the host screen gains focus. Without that,
 // deleting the active round from the hole/end-round screens left a
@@ -53,18 +54,32 @@ export function useActiveRound(): ActiveRound | null {
           course_id: string
           courses?: { name: string | null } | null
         }
+        // Fetch ALL hole_scores (not just scored ones): the round's hole
+        // rows are batch-created at round start, so their hole numbers give
+        // the round's true hole count. maxHole (highest SCORED hole) drives
+        // where to resume; holeCount clamps it so a fully-played 9-hole
+        // round resumes at 9, not a phantom hole 10 whose error screen used
+        // to offer a one-tap round deletion (#650).
         const { data: hs } = await supabase
           .from('hole_scores')
           .select('score, holes(number)')
           .eq('round_id', round.id)
-          .gt('score', 0)
         if (!active) return
-        const maxHole = (hs ?? []).reduce<number>((acc, row) => {
-          const n = (row as { holes?: { number?: number | null } | null })
-            .holes?.number
-          return typeof n === 'number' && n > acc ? n : acc
+        const rows = (hs ?? []) as Array<{
+          score: number | null
+          holes?: { number?: number | null } | null
+        }>
+        const holeNumbers = rows
+          .map((row) => row.holes?.number)
+          .filter((n): n is number => typeof n === 'number')
+        const holeCount = inferHoleCount(holeNumbers)
+        const maxHole = rows.reduce<number>((acc, row) => {
+          const n = row.holes?.number
+          return (row.score ?? 0) > 0 && typeof n === 'number' && n > acc
+            ? n
+            : acc
         }, 0)
-        const next = Math.min(18, Math.max(1, maxHole + 1))
+        const next = Math.min(holeCount, Math.max(1, maxHole + 1))
         setActiveRound({
           id: round.id,
           courseName: round.courses?.name ?? 'Round',


### PR DESCRIPTION
Two mobile data-loss traps from the 2026-07-06 audit — both let an ordinary flow destroy a fully-logged round. One commit each.

## #650 — 9-hole resume → phantom hole 10 → delete trap
`useActiveRound` computed the resume hole as `min(18, maxScoredHole + 1)`. On a fully-played 9-hole round that's hole 10, which doesn't exist → the hole screen's error branch → a one-tap "discard the round" (which #653 also fixes). Now: fetch **all** of the round's `hole_scores` (batch-created at round start, so their numbers give the true hole count), infer the count via `inferHoleCount`, and clamp the resume hole to it. A 9-hole round resumes at 9, never 10.

## #653 — load-error screen deleted the round
The error branch (`data.error || !currentHole`) served **one** delete dialog — "Nothing's been logged yet, so the round will be discarded" → `deleteRound` — for both a transient **load failure** (a resumable, holes-deep round under bad signal) and a genuinely missing hole. A network blip on resume could destroy the whole round behind copy asserting it was empty.

`handleExitFromError` no longer deletes — it navigates home. Rationale: a load error is resumable, and synthetic no-layout courses became playable when the no-layout banner was removed (#614), so the "unplayable → discard" case that justified the delete is gone. The round stays resumable and is still deletable from the home round list. Copy corrected on both the screen and the (now non-destructive) confirm; button recolored from alarm-red to neutral, "Exit round" → "Leave to home".

## Notes
- The `[id]/index.tsx` URL clamp still bounds a raw `?hole=` param to 1–18 — but with #650 the banner never emits an out-of-range hole, `navigateHole` already guards `> holeCount`, and #653 makes the error screen safe if one ever slips through. Left as-is (it can't cheaply know the hole count pre-mount).
- Merge note: `useShotActions.ts` is also touched by the in-flight sync PR #681 (a different function, `handleEndRound`) — no line overlap, but sequence the merges.

## Verification
Mobile `npm run typecheck` green. Not device-QA'd — wants a 9-hole resume repro + a bad-signal resume repro on device.

Closes #650
Closes #653
