### PR TITLE
fix(web): save-path data-integrity cluster (#660, #662, #664, #661)

### DIFF
--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -5,6 +5,7 @@ import {
   buildInitialRows,
   formatClubLabel,
   haversineYards,
+  isPuttShot,
   type Club,
   type LieType,
   type PuttDirectionResult,
@@ -350,7 +351,7 @@ function ShotRow({
   // Putt-ness is user intent only — lie 'green' (set when a putt is placed)
   // or club 'putter'. Raw distance must NOT classify: a chip/bunker inside
   // 30 yd is not a putt, and unmapped rows read distanceToPin 0 (#660).
-  const isPutt = row.lieType === 'green' || row.club === 'putter'
+  const isPutt = isPuttShot(row.lieType, row.club)
   const { toDisplay, toDisplayFt } = useUnits()
   const { bag } = useUserBag()
   // Source the club options from the user's bag, falling back to

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   DEFAULT_BAG,
   LIE_TYPES,
-  NEAR_GREEN_YARDS,
   buildInitialRows,
   formatClubLabel,
   haversineYards,
@@ -124,8 +123,11 @@ export function HoleReviewSheet({
       baseRows.map((row, idx) => {
         const inline = putts[idx]
         if (!inline) return row
+        // A placed putt is on the green by definition — pin lieType so putt
+        // classification keys off real intent (lie/club), not raw distance.
         return {
           ...row,
+          lieType: 'green',
           puttMade: inline.puttMade,
           puttDistanceResult: inline.puttDistanceResult,
           puttDirectionResult: inline.puttDirectionResult,
@@ -345,12 +347,10 @@ function ShotRow({
   // Mirror mobile's PUTTING_RADIUS_YARDS — any shot starting within 30 yd
   // of the pin gets the putt entry surface (made/short/long, miss left/
   // right, distance in feet) rather than the standard club + lie row.
-  // Lie-type 'green' and club 'putter' still trigger it, so an explicit
-  // putt row stays a putt even if the start coords drifted past 30 yd.
-  const isPutt =
-    row.lieType === 'green' ||
-    row.club === 'putter' ||
-    row.distanceToPin <= NEAR_GREEN_YARDS
+  // Putt-ness is user intent only — lie 'green' (set when a putt is placed)
+  // or club 'putter'. Raw distance must NOT classify: a chip/bunker inside
+  // 30 yd is not a putt, and unmapped rows read distanceToPin 0 (#660).
+  const isPutt = row.lieType === 'green' || row.club === 'putter'
   const { toDisplay, toDisplayFt } = useUnits()
   const { bag } = useUserBag()
   // Source the club options from the user's bag, falling back to

--- a/apps/web/src/components/rounds/HoleScoreCard.tsx
+++ b/apps/web/src/components/rounds/HoleScoreCard.tsx
@@ -4,6 +4,7 @@ import type { Database } from '@oga/supabase'
 import { useUpsertHoleScore } from '../../hooks/useHoleScores'
 import { useUnits } from '../../hooks/useUnits'
 import { supabase } from '../../lib/supabase'
+import { toUserMessage } from '../../lib/errors'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
@@ -94,6 +95,7 @@ export function HoleScoreCard({
   // need it (par-4 default is wrong for the par 3s and 5s) and real
   // courses occasionally have stale data the player wants to correct.
   const [parOverride, setParOverride] = useState<number | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const effectivePar = parOverride ?? hole.par
 
   // Hydrate the form from server state once per holeScore.id. Subsequent
@@ -149,26 +151,34 @@ export function HoleScoreCard({
     // pick rather than the par-4 placeholder default.
     const holeForEnsure =
       parOverride != null ? { ...hole, par: parOverride } : hole
-    const realHoleId = await ensureRealHole(holeForEnsure)
-    upsert.mutate({
-      id: holeScore?.id,
-      round_id: roundId,
-      hole_id: realHoleId,
-      score: numericScore,
-      putts:
-        next.putts !== undefined
-          ? next.putts
-          : putts === ''
+    // ensureRealHole can reject and the upsert can fail (network/RLS). Both
+    // were fire-and-forget: the typed value stayed on screen with nothing
+    // saved and no signal, so the round silently "lost" holes (#664).
+    setSaveError(null)
+    try {
+      const realHoleId = await ensureRealHole(holeForEnsure)
+      await upsert.mutateAsync({
+        id: holeScore?.id,
+        round_id: roundId,
+        hole_id: realHoleId,
+        score: numericScore,
+        putts:
+          next.putts !== undefined
+            ? next.putts
+            : putts === ''
+              ? null
+              : Number(putts),
+        fairway_hit:
+          effectivePar <= 3
             ? null
-            : Number(putts),
-      fairway_hit:
-        effectivePar <= 3
-          ? null
-          : next.fairway_hit !== undefined
-            ? next.fairway_hit
-            : fairway,
-      gir: next.gir !== undefined ? next.gir : gir,
-    })
+            : next.fairway_hit !== undefined
+              ? next.fairway_hit
+              : fairway,
+        gir: next.gir !== undefined ? next.gir : gir,
+      })
+    } catch (err) {
+      setSaveError(toUserMessage(err))
+    }
   }
 
   const isPar3 = effectivePar === 3
@@ -341,6 +351,14 @@ export function HoleScoreCard({
           {shotCount > 0 ? `${shotCount} shots` : 'Add shots'}
         </button>
       </div>
+      {saveError && (
+        <div
+          className="col-span-12 text-caddie-neg"
+          style={{ fontSize: 12, marginTop: 4 }}
+        >
+          {saveError}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -28,6 +28,7 @@ import {
 import { useAuth } from '../../hooks/useAuth'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { useUnits } from '../../hooks/useUnits'
+import { toUserMessage } from '../../lib/errors'
 import { GreenDiagram } from '../round/GreenDiagram'
 import { ChipGroup, Field } from './shots/formInputs'
 import {
@@ -114,6 +115,7 @@ export function ShotEntryModal({
     emptyDraft(holeShots.length + 1, holeShots.length === 0),
   )
   const [editing, setEditing] = useState<string | null>(null)
+  const [saveError, setSaveError] = useState<string | null>(null)
 
   // Read the latest holeShots count via ref so the reset effect doesn't
   // need it as a dep — a refetch ticking the count up shouldn't wipe the
@@ -140,6 +142,16 @@ export function ShotEntryModal({
 
   async function save(opts?: { madeOverride?: boolean }) {
     if (!user) return
+    setSaveError(null)
+    // Derive the shot_number from the freshest shot list at save time, not
+    // from draft.shotNumber. cancelEdit() recomputed the draft number from a
+    // stale render closure, so a second consecutive add reused the previous
+    // number and hit the unique (hole_score_id, shot_number) constraint —
+    // silently, since the old catch only rethrew (#661). holeShots is sorted
+    // ascending, so the last element carries the max.
+    const shotNumber = editing
+      ? draft.shotNumber
+      : (holeShotsRef.current.at(-1)?.shot_number ?? 0) + 1
     const isPuttSave = draft.lieType === 'green'
     const made =
       opts?.madeOverride === true
@@ -159,7 +171,7 @@ export function ShotEntryModal({
     const insert: ShotInsert = {
       hole_score_id: holeScoreId,
       user_id: user.id,
-      shot_number: draft.shotNumber,
+      shot_number: shotNumber,
       club: isPuttSave ? 'putter' : draft.club ?? null,
       lie_type: draft.lieType ?? null,
       lie_slope: null,
@@ -206,7 +218,9 @@ export function ShotEntryModal({
         // eslint-disable-next-line no-console
         console.error('[ShotEntryModal/save]', err, insert)
       }
-      throw err
+      // Surface in the modal instead of rethrowing — the onClick callers never
+      // caught, so the failure was an unhandled rejection with no user signal.
+      setSaveError(toUserMessage(err))
     }
   }
 
@@ -484,6 +498,21 @@ export function ShotEntryModal({
                 />
               </Field>
             </div>
+
+            {saveError && (
+              <div
+                className="text-caddie-neg"
+                style={{
+                  border: '1px solid #A33A2A',
+                  borderRadius: 4,
+                  padding: '10px 12px',
+                  fontSize: 13,
+                  marginTop: 16,
+                }}
+              >
+                {saveError}
+              </div>
+            )}
 
             <div
               className="flex justify-end"

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -12,6 +12,7 @@ import {
   formatDistance,
   formatPuttDistance,
   haversineYards,
+  isPuttShot,
   type Club,
   type DistanceUnit,
   type LieType,
@@ -124,8 +125,17 @@ export function ShotEntryModal({
   const holeShotsRef = useRef(holeShots)
   holeShotsRef.current = holeShots
 
+  // Highest shot_number this session has issued for the current hole. Guards
+  // the refetch race: useCreateShot invalidates without awaiting, so a fast
+  // second add can fire before holeShotsRef reflects the first insert — the
+  // fresh-max alone would then repeat a number. max(freshMax, lastIssued)+1
+  // stays monotonic across consecutive adds regardless of refetch timing.
+  // Reset per hole (effect below).
+  const lastIssuedNumberRef = useRef(0)
+
   useEffect(() => {
     if (editing) return
+    lastIssuedNumberRef.current = 0
     const len = holeShotsRef.current.length
     setDraft(emptyDraft(len + 1, len === 0))
   }, [holeScoreId, editing])
@@ -148,10 +158,13 @@ export function ShotEntryModal({
     // stale render closure, so a second consecutive add reused the previous
     // number and hit the unique (hole_score_id, shot_number) constraint —
     // silently, since the old catch only rethrew (#661). holeShots is sorted
-    // ascending, so the last element carries the max.
+    // ascending, so the last element carries the max; lastIssuedNumberRef
+    // covers the fast-second-add-before-refetch case (see its declaration).
+    const freshMax = holeShotsRef.current.at(-1)?.shot_number ?? 0
     const shotNumber = editing
       ? draft.shotNumber
-      : (holeShotsRef.current.at(-1)?.shot_number ?? 0) + 1
+      : Math.max(freshMax, lastIssuedNumberRef.current) + 1
+    if (!editing) lastIssuedNumberRef.current = shotNumber
     const isPuttSave = draft.lieType === 'green'
     const made =
       opts?.madeOverride === true
@@ -248,8 +261,7 @@ export function ShotEntryModal({
     // the pin so SG for this shot stays accurate. Skipped for putts
     // (distance_to_target stays null; putt_distance_ft tracks that flow
     // and isn't auto-recalculated on drag).
-    const editIsPutt =
-      editingRow.lie_type === 'green' || editingRow.club === 'putter'
+    const editIsPutt = isPuttShot(editingRow.lie_type, editingRow.club)
     const newDistance =
       !editIsPutt && pinLat != null && pinLng != null
         ? Math.round(haversineYards(point.lat, point.lng, pinLat, pinLng))
@@ -628,7 +640,7 @@ function formatShotSummary(
   next: ShotRow | undefined,
   unit: DistanceUnit,
 ): string {
-  if (s.lie_type === 'green' || s.club === 'putter') {
+  if (isPuttShot(s.lie_type, s.club)) {
     const result =
       (s.putt_result &&
         PUTT_RESULT_LABELS[s.putt_result as keyof typeof PUTT_RESULT_LABELS]) ??

--- a/apps/web/src/pages/practice/PracticePlanPage.tsx
+++ b/apps/web/src/pages/practice/PracticePlanPage.tsx
@@ -745,10 +745,10 @@ function FeedbackSection({ planId, initial }: { planId: string; initial: string 
         style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 6 }}
       >
         <span
-          className="font-mono text-caddie-ink-mute"
+          className={`font-mono ${saveFeedback.isError ? 'text-caddie-neg' : 'text-caddie-ink-mute'}`}
           style={{ fontSize: 10, letterSpacing: '0.04em', textTransform: 'uppercase' }}
         >
-          {showSaved ? 'Saved' : ''}
+          {saveFeedback.isError ? "Couldn't save — try again" : showSaved ? 'Saved' : ''}
         </span>
         <span
           className="font-mono text-caddie-ink-mute"
@@ -795,7 +795,14 @@ export function PracticePlanPage() {
   }
 
   const onGenerate = () => generate.mutate()
-  const errorNotice = generate.error ? <ErrorNotice error={generate.error} /> : null
+  // Surface generate errors and failed drill-completion toggles (#664 —
+  // updateProgress was fire-and-forget; a failed toggle silently reverted
+  // on next load) in the same page-level notice slot.
+  const errorNotice = generate.error ? (
+    <ErrorNotice error={generate.error} />
+  ) : updateProgress.error ? (
+    <ErrorNotice error={updateProgress.error} />
+  ) : null
 
   if (planQuery.isLoading) {
     return <LoadingState />

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -375,7 +375,13 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
           updates: {
             start_lat: point.lat,
             start_lng: point.lng,
-            ...(isPutt ? {} : { distance_to_target: newDistance }),
+            // Only rewrite distance when a pin actually resolves. Without
+            // this guard, dragging a shot on an unmapped/pin-less hole wrote
+            // distance_to_target: null and destroyed a previously valid
+            // stored distance (#662).
+            ...(!isPutt && effectivePin
+              ? { distance_to_target: newDistance }
+              : {}),
           },
         })
       } catch (err) {
@@ -611,6 +617,13 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
           putts: puttCount,
           fairway_hit: existing?.fairway_hit ?? inferred.fairway,
           gir: existing?.gir ?? inferred.gir,
+          // Persist a manually placed pin. On unmapped courses no hole_scores
+          // row exists until this upsert, so persistRoundPin's update no-ops
+          // and the pin lived only in pinOverride state — lost on reload and
+          // then nulling shot distances on drag (#662). This is the write.
+          ...(pinOverride
+            ? { pin_lat: pinOverride.lat, pin_lng: pinOverride.lng }
+            : {}),
         })
         const hs = hsResult ?? existing
         if (!hs) throw new Error('hole_score upsert returned no row')

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_HANDICAP,
   haversineYards,
   inferHoleStats,
+  isPuttShot,
   NEAR_GREEN_YARDS,
 } from '@oga/core'
 import type { PlacedPoint } from '../../../components/round/RoundMap'
@@ -582,8 +583,8 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         // Match HoleReviewSheet's isPutt — putt-ness is user intent (lie
         // 'green', set when a putt is placed, or club 'putter'), never raw
         // distance (a near-green chip isn't a putt; unmapped rows read 0).
-        const puttCount = rows.filter(
-          (r) => r.lieType === 'green' || r.club === 'putter',
+        const puttCount = rows.filter((r) =>
+          isPuttShot(r.lieType, r.club),
         ).length
         // Materialize the synthetic hole if needed before upserting the
         // hole_score (FK to holes.id). The RPC inserts only (course_id,
@@ -641,7 +642,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         if (delErr) throw delErr
 
         for (const row of rows) {
-          const isPuttRow = row.lieType === 'green' || row.club === 'putter'
+          const isPuttRow = isPuttShot(row.lieType, row.club)
           // Persist the aim only if the player actually set/dragged it — an
           // untouched auto-spawn suggestion is dropped so it can't enter the
           // dispersion dataset (aim must be explicit to count).

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -573,13 +573,11 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         // derived from the rows so the scorecard reflects what was placed
         // without needing a manual entry.
         const existing = scoresByHoleId.get(activeHole.id)
-        // Match HoleReviewSheet's isPutt — any shot starting within 30 yd
-        // of the pin counts as a putt for the scorecard's putt total.
+        // Match HoleReviewSheet's isPutt — putt-ness is user intent (lie
+        // 'green', set when a putt is placed, or club 'putter'), never raw
+        // distance (a near-green chip isn't a putt; unmapped rows read 0).
         const puttCount = rows.filter(
-          (r) =>
-            r.lieType === 'green' ||
-            r.club === 'putter' ||
-            r.distanceToPin <= NEAR_GREEN_YARDS,
+          (r) => r.lieType === 'green' || r.club === 'putter',
         ).length
         // Materialize the synthetic hole if needed before upserting the
         // hole_score (FK to holes.id). The RPC inserts only (course_id,
@@ -630,10 +628,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         if (delErr) throw delErr
 
         for (const row of rows) {
-          const isPuttRow =
-            row.lieType === 'green' ||
-            row.club === 'putter' ||
-            row.distanceToPin <= NEAR_GREEN_YARDS
+          const isPuttRow = row.lieType === 'green' || row.club === 'putter'
           // Persist the aim only if the player actually set/dragged it — an
           // untouched auto-spawn suggestion is dropped so it can't enter the
           // dispersion dataset (aim must be explicit to count).

--- a/packages/core/src/__tests__/round.test.ts
+++ b/packages/core/src/__tests__/round.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildInitialRows,
   inferHoleCount,
+  isPuttShot,
   legacySlopeToAxes,
   type PlacedPoint,
 } from '../round'
@@ -108,6 +109,25 @@ describe('buildInitialRows', () => {
     expect(rows).toHaveLength(1)
     expect(rows[0]!.isLastShot).toBe(true)
     expect(rows[0]!.endLat).toBe(PIN)
+  })
+})
+
+describe('isPuttShot', () => {
+  it('green lie is a putt', () => {
+    expect(isPuttShot('green', 'driver')).toBe(true)
+  })
+  it('putter club is a putt', () => {
+    expect(isPuttShot('fairway', 'putter')).toBe(true)
+  })
+  it('near-green chip (rough/wedge) is NOT a putt', () => {
+    expect(isPuttShot('rough', 'gap-wedge')).toBe(false)
+  })
+  it('sand shot is NOT a putt', () => {
+    expect(isPuttShot('sand', '56')).toBe(false)
+  })
+  it('null/undefined fields are NOT a putt', () => {
+    expect(isPuttShot(null, null)).toBe(false)
+    expect(isPuttShot(undefined, undefined)).toBe(false)
   })
 })
 

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -79,6 +79,20 @@ export function inferHoleCount(holeNumbers: number[]): 9 | 18 {
   return Math.max(...holeNumbers) <= 9 ? 9 : 18
 }
 
+// Single source of truth for putt classification: a shot is a putt when its
+// lie is the green or its club is the putter. Feeds putt counts, the putt-only
+// persisted columns, and SG putting, so every surface must agree. Distance to
+// the pin must NOT factor in — a near-green chip isn't a putt, and unmapped
+// rows read distanceToPin 0 (#660, which was a drift between hand-copied
+// predicates). Takes raw fields (not a shaped row) so camelCase ReviewedShotRow
+// and snake_case DB rows share it.
+export function isPuttShot(
+  lieType: string | null | undefined,
+  club: string | null | undefined,
+): boolean {
+  return lieType === 'green' || club === 'putter'
+}
+
 export function buildInitialRows(
   points: PlacedPoint[],
   par: number,


### PR DESCRIPTION
Four web save-path data-integrity bugs from the 2026-07-06 audit, one commit each. All `apps/web`; no `@oga/core`, migrations, secrets, or deps.

## #660 — putts classified by raw distance, not intent
The save path + review UI treated any shot within 30 yd of the pin as a putt regardless of the "No, I'm not putting" dialog — a near-green chip lost `distance_to_target` and inflated the putt count. On unmapped courses `distanceToPin` is 0 for every row, so **every** shot became a putt. Putt-ness now keys on user intent only: lie `green` (pinned when a putt is placed) or club `putter`.

## #662 — manual pin never persisted; drag then nulled distance
On unmapped courses no `hole_scores` row exists until `saveReviewedHole`, so `persistRoundPin`'s UPDATE no-oped and a placed pin lived only in `pinOverride` — gone on reload. Then a shot-marker drag with no resolved pin wrote `distance_to_target: null`, destroying a valid stored distance. Now the upsert persists `pinOverride`, and drag only rewrites distance when a pin resolves.

## #664 — fire-and-forget scorecard + practice-plan saves
`HoleScoreCard.persist` void-fired the upsert (and left `ensureRealHole` rejections unhandled); practice-plan feedback + drill-toggle mutations had no `onError`. A failed write kept the typed value on screen with nothing saved and no message. Added a try/catch + inline error slot on the scorecard, and error surfaces on both practice mutations.

## #661 — ShotEntryModal second consecutive add failed silently
`cancelEdit()` recomputed the draft `shot_number` from a stale render closure, so a second add reused the number and hit `unique (hole_score_id, shot_number)`; `save()` only rethrew and the onClick never caught → unhandled rejection, no UI. Now `shot_number` is derived fresh at save time (max+1) and failures surface inline.

**Runtime-reproduced #661 in a browser** against the dev fixture (two "Add shot" clicks → only shot 5 persisted, console 23505 + 409); re-verified after the fix that both shots persist cleanly.

## Verification
- `pnpm typecheck` (workspace) green; `pnpm --filter @oga/web typecheck` green per commit.
- #661 browser repro before + after (bundled chromium + dev storageState).
- Still wants a manual browser QA pass on the #660/#662 map/review flows and the #664 failure paths.

Closes #660
Closes #662
Closes #664
Closes #661