### PR TITLE
chore: CI web-build job + audit doc/hygiene corrections (#674, #675, #676)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@
 - [ ] Docs
 
 ## Testing
-- [ ] pnpm typecheck passes (4/4)
+- [ ] pnpm typecheck passes (3/3 workspace packages)
 - [ ] pnpm test passes (all)
 - [ ] pnpm --filter web build passes
 - [ ] Tested in browser at localhost:5173

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,20 @@ jobs:
           cd packages/supabase && npm install --legacy-peer-deps
           cd ../core && npm install --legacy-peer-deps
           cd ../../apps/mobile && npm install --legacy-peer-deps && npm run typecheck
+
+  web-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      # Exercises the real Vite/rollup production build (vercel.json's
+      # buildCommand) — tsc -b doesn't catch asset/import resolution breaks
+      # that only surface at deploy time. (#674)
+      - run: pnpm --filter @oga/web build

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -55,3 +55,20 @@ jobs:
         run: cd packages/core && npm install --legacy-peer-deps
       - name: Mobile typecheck
         run: cd apps/mobile && npm install --legacy-peer-deps && npm run typecheck
+
+  web-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install
+      # Exercises the real Vite/rollup production build (vercel.json's
+      # buildCommand) — tsc -b doesn't catch asset/import resolution breaks
+      # that only surface at deploy time. (#674)
+      - run: pnpm --filter @oga/web build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ dependencies, link a Supabase project, apply migrations, set env vars.
 Confirm a clean baseline before touching code:
 
 ```bash
-pnpm typecheck       # 4 packages must be clean
+pnpm typecheck       # 3 workspace packages (core, supabase, web) must be clean
 pnpm test            # Vitest, in @oga/core
 pnpm --filter web build
 cd apps/mobile && npm run typecheck

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ for all flags.
 
 ```bash
 # Web (http://localhost:5173)
-pnpm dev --filter web
+pnpm --filter web dev
 
 # Mobile — Expo Metro bundler, scan the QR code with the Expo Go app
 cd apps/mobile

--- a/docs/ios-submission.md
+++ b/docs/ios-submission.md
@@ -52,9 +52,10 @@ on EAS Cloud and install on the device via **internal (ad-hoc) distribution**; a
 simulator build is not useful here (it only runs in the macOS Simulator).
 
 ### Config status (already in place — #298/#304/#305 satisfied)
-- `eas.json` — all three profiles carry iOS keys. `development`/`preview` use
-  `ios.simulator: false` (device builds); `production` omits a platform key so
-  it builds both OSes. **No eas.json change needed.**
+- `eas.json` — all three profiles carry an `ios` key. `development`/`preview`
+  set `ios.simulator: false` (device builds); `production` pins
+  `ios.image` (the Xcode build image) and defaults to a device build.
+  **No eas.json change needed.**
 - `app.config.ts` `ios` — bundle id `golf.oga.app`, `buildNumber: '1'` (seed for
   `autoIncrement` with `appVersionSource: 'remote'`), `supportsTablet`,
   `ITSAppUsesNonExemptEncryption: false` (#304), `NSLocationWhenInUseUsage…`,
@@ -96,12 +97,10 @@ simulator build is not useful here (it only runs in the macOS Simulator).
 - [ ] App opens, brand splash → login screen, no cold-start crash.
 - [ ] Mapbox tiles render on a live-round map (validates BOTH tokens +
       `@rnmapbox/maps` iOS config).
-- [ ] Fonts: Fraunces headings render. **Known gap:** `JetBrainsMono-Medium`
-      is referenced in 2 places but is **not bundled** (no font file, not in
-      `useFonts` in `app/_layout.tsx`) — those mono labels fall back to the
-      system font on iOS *and* Android. Cosmetic, pre-existing, not a crash.
-      Decide before launch: bundle the font (OFL, add to `assets/fonts/` +
-      `useFonts`) or drop the 2 `fontFamily: 'JetBrainsMono-Medium'` refs.
+- [ ] Fonts: Fraunces headings + Inconsolata mono labels render. (The old
+      JetBrainsMono-Medium gap is closed — the typography migration replaced
+      every JetBrainsMono ref with bundled Inconsolata; no unbundled font
+      remains.)
 - [ ] VoiceOver on → navigate the rounds list, hear structured labels
       (cross-platform check of the merged a11y work).
 - [ ] iOS press feedback (#303) — controls dim on press; a non-played

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -92,7 +92,7 @@ Sign in to your deployed app as `demo@oga.app` / `ogademo123`.
 
 ## 5. Deploy the web app
 
-The repo has a `vercel.json` configured for the monorepo, so the easiest path is the README's deploy button or:
+The repo has a `vercel.json` configured for the monorepo, so the easiest path is to import the repo into Vercel (it auto-detects the config) or:
 
 ```bash
 npm i -g vercel


### PR DESCRIPTION
Audit CI + docs chores, one commit per issue.

## #674 — CI never ran the web production build
Added a `web-build` job (`pnpm --filter @oga/web build`) to `ci.yml` and `preview.yml`. CI ran typecheck/test/check-vendor/mobile but never the Vite/rollup build, though README/CONTRIBUTING/PR-template claim it does and `vercel.json`'s buildCommand is exactly that — a broken production build could pass CI and fail only at Vercel deploy. Verified the build passes locally before adding the job.

## #675 — public-doc + hygiene corrections
- README quickstart `pnpm dev --filter web` → `pnpm --filter web dev` (turbo needs `@oga/web`).
- CONTRIBUTING: `pnpm typecheck` = 3 workspace packages, not 4 (mobile is separate).
- PR template typecheck checkbox `(4/4)` → `(3/3 workspace packages)`.
- self-hosting.md: dropped the nonexistent "README deploy button" reference.
- Deleted the stray untracked root `app.json`.
- **`.env.example` dup-keys item was a false positive** — each key appears once; the `SUPABASE_*`/`VITE_*`/`EXPO_PUBLIC_*` families are distinct per-runtime vars. No change.

## #676 — stale runbook items
- `docs/ios-submission.md`: `eas.json` production carries `ios.image` (Xcode pin) — corrected the "omits a platform key" claim. (The audit's "no iOS keys" premise was itself outdated — the keys exist.)
- Removed the dead "JetBrainsMono-Medium not bundled" font gap — zero JetBrainsMono refs remain in mobile source (replaced by bundled Inconsolata).
- Version-bump staleness lives in the gitignored internal runbook; corrected there directly.

## Verification
`pnpm --filter @oga/web build` green locally; workflow YAML mirrors the existing typecheck job's setup.

Closes #674
Closes #675
Closes #676