### PR TITLE
fix(mobile): live-round camera — past-round up-the-hole orientation + greenside PLACE_BALL zoom

### DIFF
--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -185,9 +185,12 @@ export function PastRoundMap({
   )
   // Tee-first so the camera orients "up the hole" — useHoleCamera computes
   // heading from center→pin, and centering on the pin (as before) made
-  // origin == target, collapsing the bearing to north-up. Mirrors the live
-  // view's center priority (LiveRoundSession: tee ?? courseCenter ?? ball).
-  const center = tee ?? effectivePin ?? courseCenter ?? OKC_FALLBACK
+  // origin == target, collapsing the bearing to north-up. Pin is deliberately
+  // NOT in the fallback chain, matching the live view (LiveRoundSession:
+  // tee ?? courseCenter ?? ball): a hole with a round-pin but no surveyed tee
+  // would otherwise resolve center == pin and re-collapse the heading. When no
+  // tee resolves, courseCenter still gives a non-coincident origin.
+  const center = tee ?? courseCenter ?? OKC_FALLBACK
 
   const [placed, setPlaced] = useState<PlacedShot[]>([])
   const [activeIdx, setActiveIdx] = useState(0)

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -183,7 +183,11 @@ export function PastRoundMap({
         : null,
     [currentHole],
   )
-  const center = effectivePin ?? tee ?? courseCenter ?? OKC_FALLBACK
+  // Tee-first so the camera orients "up the hole" — useHoleCamera computes
+  // heading from center→pin, and centering on the pin (as before) made
+  // origin == target, collapsing the bearing to north-up. Mirrors the live
+  // view's center priority (LiveRoundSession: tee ?? courseCenter ?? ball).
+  const center = tee ?? effectivePin ?? courseCenter ?? OKC_FALLBACK
 
   const [placed, setPlaced] = useState<PlacedShot[]>([])
   const [activeIdx, setActiveIdx] = useState(0)

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -273,12 +273,26 @@ export function useHoleCamera({
     if (phase !== 'PLACE_BALL') return
     if (!cameraRef.current) return
     if (!ball) return
+    // Tighten the frame near the green so marking a ball on/around the green
+    // stays a green close-up. A flat zoom 17 (fairway-approach framing) read
+    // as a jarring zoom-out when marking a greenside/putt shot. Remaining
+    // distance (ball→pin) is the signal — same one SET_AIM uses. Capped at 17
+    // on the loose end so ≥80-yd approaches keep the existing framing; only
+    // the short end tightens. No pin resolvable → keep 17.
+    const target = roundPin ?? pin ?? null
+    const distYd = target ? distanceYards(ball, target) : null
+    const zoom =
+      distYd == null ? 17
+      : distYd >= 80 ? 17
+      : distYd >= 60 ? 17.5
+      : distYd >= 30 ? 18
+      : 19
     try {
       cameraRef.current.setCamera({
         centerCoordinate: toCoord(ball),
-        zoomLevel: 17,
+        zoomLevel: zoom,
         pitch: 0,
-        heading: headingUpTheHole(ball, roundPin ?? pin),
+        heading: headingUpTheHole(ball, target),
         animationDuration: 800,
       })
       reframePlaceBallRef.current = false


### PR DESCRIPTION
Two small live-round camera fixes found during on-device (sideload) QA, one commit each. Both in the shared camera path (`useHoleCamera` / `PastRoundMap`).

## 1. Past-round map now orients "up the hole" (like live)
`PastRoundMap` centered on the pin (`effectivePin ?? tee ?? …`), but `useHoleCamera` derives the up-the-hole heading from `center → pin`. Centering on the pin made origin == target → `headingUpTheHole`'s `<5yd` guard tripped → **north-up**. The live view centers tee-first, which is why only it oriented.

Flip the center priority to `tee ?? effectivePin ?? courseCenter ?? OKC_FALLBACK`, mirroring `LiveRoundSession`. **Parity, not beyond:** synthetic holes with no tee geometry still fall through and stay north-up — same as live. Verified `center` feeds only the `<HoleMap>` prop (no pin-centered logic depends on it).

## 2. Greenside PLACE_BALL frame stays tight
Marking a shot on/around the green snapped to a flat `zoom 17` (fairway-approach framing) — a jarring zoom-out from a green close-up when logging a chip/putt. SET_AIM already scales by ball→pin distance; the PLACE_BALL reframe didn't. Gave it the same signal, **capped at 17 on the loose end** so ≥80-yd approaches keep their current framing and only the short end tightens (60-80→17.5, 30-60→18, <30→19). No resolvable pin → keep 17.

### On the GPS question
Deliberately *not* GPS-based — GPS says where you are, not where the green is. Remaining distance (ball→pin) is the real "near the green" signal, and it's the same one SET_AIM already uses.

## Verification
`npm run typecheck` (mobile) clean. **Not yet device-tested** — wants an on-device pass on the next EAS build (both are camera-framing changes; unit tests don't cover Mapbox camera behavior).