### PR TITLE
fix(mobile): swipe-dismissed sheets reopen off-screen (#644 residual)

### DIFF
--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -158,7 +158,7 @@ export function PastHoleShotsSheet({
   // One <Modal> with discriminated content (list vs editor) — NOT two
   // sibling Modals. iOS allows one presented modal per presenter, so the
   // old stacked-Modal edit flow silently failed to present (#293/#495).
-  const { pan, cardStyle } = useSwipeToDismiss(onClose)
+  const { pan, cardStyle } = useSwipeToDismiss(onClose, visible)
 
   return (
     <Modal

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -137,7 +137,7 @@ export function ShotLogger({
   const isOnGreen = value.lieType === 'green'
   // Swipe-dismiss for the non-putt card; the on-green branch delegates to
   // PuttingSheet, which owns its own swipe-dismiss.
-  const { pan, cardStyle } = useSwipeToDismiss(onClose)
+  const { pan, cardStyle } = useSwipeToDismiss(onClose, visible)
 
   return (
     <Modal

--- a/apps/mobile/components/ui/useSwipeToDismiss.ts
+++ b/apps/mobile/components/ui/useSwipeToDismiss.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useLayoutEffect } from 'react'
 import { Gesture } from 'react-native-gesture-handler'
 import {
   runOnJS,
@@ -40,7 +40,10 @@ export function useSwipeToDismiss(onClose: () => void, isOpen = true) {
   const translateY = useSharedValue(0)
   const reduceMotion = useReducedMotion()
 
-  useEffect(() => {
+  // useLayoutEffect (not useEffect): apply the reset before the reopened
+  // subtree paints, so the card never shows one frame at the stale drag offset
+  // mid-open animation.
+  useLayoutEffect(() => {
     if (isOpen) translateY.value = 0
   }, [isOpen])
 

--- a/apps/mobile/components/ui/useSwipeToDismiss.ts
+++ b/apps/mobile/components/ui/useSwipeToDismiss.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { Gesture } from 'react-native-gesture-handler'
 import {
   runOnJS,
@@ -23,14 +24,25 @@ import {
 //
 // On dismiss we don't animate translateY off-screen: the sheet's Modal owns
 // `animationType="slide"`, so it slides the card the rest of the way out from
-// wherever the drag left it, then unmounts its children — which disposes this
-// shared value, so the next open starts fresh at 0. No manual reset needed.
+// wherever the drag left it.
+//
+// The exit leaves translateY at the drag offset. Sheets that FULLY unmount on
+// close (rendered inside a parent <Modal>, e.g. PuttingSheet/ScorecardModal)
+// dispose this shared value and reopen fresh — they can omit `isOpen`. But
+// sheets that stay mounted and only toggle their OWN inner Modal's `visible`
+// (ShotLogger, PastHoleShotsSheet) keep the offset, so they reopen off-screen
+// (#644 residual). Pass `isOpen` and we reset to 0 on each (re)open — done
+// while hidden, so the exit animation is untouched.
 const DISMISS_DISTANCE = 120
 const DISMISS_VELOCITY = 800
 
-export function useSwipeToDismiss(onClose: () => void) {
+export function useSwipeToDismiss(onClose: () => void, isOpen = true) {
   const translateY = useSharedValue(0)
   const reduceMotion = useReducedMotion()
+
+  useEffect(() => {
+    if (isOpen) translateY.value = 0
+  }, [isOpen])
 
   const pan = Gesture.Pan()
     // Only claim the gesture after a clear downward move, so a tap on the


### PR DESCRIPTION
Bug found during on-device QA of the past-round logger.

## Repro
Log a past round → open the shot sheet → swipe down to dismiss → reopen it → **it's off-screen and never comes back** (workaround: leave the round and re-enter, which unmounts the sheet).

## Cause
The #646 swipe hook left `translateY` at the drag offset on dismiss, relying on the sheet's `<Modal>` unmounting its children to dispose the shared value ("No manual reset needed"). That holds for sheets rendered **inside** a parent `<Modal>` (PuttingSheet, ScorecardModal — they fully unmount), but **not** for sheets that are always mounted and only toggle their **own** inner Modal's `visible` (**ShotLogger**, **PastHoleShotsSheet**) — the hook lives in the component body, so the offset persists across close/reopen. This is exactly the residual the #646 self-review flagged (and the triage wrongly dismissed).

## Fix
`useSwipeToDismiss(onClose, isOpen?)` — resets `translateY` to 0 on each (re)open, done while the sheet is hidden so the slide-out exit animation is untouched (resetting on *dismiss* would break the "slide out from where you left it" exit). Passed `visible` at the two always-mounted call sites. The nested `EditShotSheet` is a keyed ternary (remounts per open) and the parent-`<Modal>` sheets unmount, so they reset for free — `isOpen` defaults to `true`, leaving them unchanged.

## Verification
`npm run typecheck` (mobile) clean. **Not yet device-tested** — wants an on-device pass on the next EAS build (gesture/animation behavior; no unit coverage for Reanimated).