### PR TITLE
feat(mobile): Learn access point in the Practice header (#524)

### DIFF
--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -113,6 +113,8 @@ export default function Practice() {
         right={
           <Link href={'/(app)/learn' as never} asChild>
             <PressableTouch
+              accessibilityRole="button"
+              accessibilityLabel="Learn articles"
               style={{
                 flexDirection: 'row',
                 alignItems: 'center',
@@ -124,8 +126,8 @@ export default function Practice() {
                 borderRadius: 2,
               }}
             >
-              <MaterialCommunityIcons name="book-open-variant" size={14} color="#F2EEE5" />
-              <Text style={{ color: '#F2EEE5', fontSize: 12, fontWeight: '600', letterSpacing: 0.3 }}>
+              <MaterialCommunityIcons name="book-open-variant" size={14} color={CREAM} />
+              <Text style={{ color: CREAM, fontSize: 12, fontWeight: '600', letterSpacing: 0.3 }}>
                 Learn
               </Text>
             </PressableTouch>

--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { ActivityIndicator, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import { Link } from 'expo-router'
+import { MaterialCommunityIcons } from '@expo/vector-icons'
 import type { StoredBlock, StoredFocusArea, StoredSession } from '@oga/core'
 import { AppBar } from '../../components/ui/AppBar'
 import { Entrance } from '../../components/ui/Entrance'
@@ -106,7 +107,31 @@ export default function Practice() {
 
   return (
     <View style={{ flex: 1, backgroundColor: CREAM }}>
-      <AppBar eyebrow="Today's focus" title="Practice" />
+      <AppBar
+        eyebrow="Today's focus"
+        title="Practice"
+        right={
+          <Link href={'/(app)/learn' as never} asChild>
+            <PressableTouch
+              style={{
+                flexDirection: 'row',
+                alignItems: 'center',
+                gap: 5,
+                paddingVertical: 6,
+                paddingHorizontal: 11,
+                borderWidth: 1,
+                borderColor: 'rgba(242,238,229,0.25)',
+                borderRadius: 2,
+              }}
+            >
+              <MaterialCommunityIcons name="book-open-variant" size={14} color="#F2EEE5" />
+              <Text style={{ color: '#F2EEE5', fontSize: 12, fontWeight: '600', letterSpacing: 0.3 }}>
+                Learn
+              </Text>
+            </PressableTouch>
+          </Link>
+        }
+      />
       <ScrollView contentContainerStyle={{ padding: 18, paddingBottom: 48 }}>
         {loading ? (
           <View style={{ paddingTop: 48, alignItems: 'center' }}>


### PR DESCRIPTION
Option A from the discoverability discussion — a title-bar entry point for Learn.

## Why
Learn (20 articles) was only reachable from the home-page CTA + a buried body link, so it was easy to miss. Adds a **"Learn" chip** (book icon + label) to the Practice `AppBar`'s free `right` slot, routing to the existing `/(app)/learn` route. The Practice screen is the natural home for it (improvement-focused), and it's now always visible in the header.

## Notes
- Uses the standard `PressableTouch` (iOS press-dim) + `<Link asChild>` pattern; matches the AppBar's cream-on-forest styling.
- Non-destructive: the existing home CTA + body links stay.
- Scoped to Practice per your suggestion. Stats' `right` slot is occupied by the L5/L10/L20 toggle — easy to add there too later if you want it in more places.

Addresses #524. **Not yet device-tested** — wants a visual confirmation on the next EAS build (typecheck green; RN layout not covered by unit tests).