### PR TITLE
chore(mobile): set up EAS Update (OTA) for review-free JS shipping

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -9,6 +9,22 @@ const config: ExpoConfig = {
   slug: 'oga',
   scheme: 'oga',
   version: '1.0.0',
+  // EAS Update (OTA). Ships JS/asset-only fixes to installed builds WITHOUT an
+  // App Store / Play review — Apple/Google permit interpreted-code updates that
+  // don't add native code or change the app's purpose. Native changes (SDK/RN
+  // bumps, new modules, permission or icon changes) still need a new reviewed
+  // binary. The `fingerprint` runtimeVersion policy enforces exactly that: an
+  // OTA update only lands on a build whose native fingerprint matches, so a JS
+  // update can never reach a binary missing its native code. Channels → update
+  // branches are set per-profile in eas.json. NOTE: the FIRST expo-updates
+  // build must be submitted + approved once before OTA is live (the already-
+  // shipped store build has no updates runtime).
+  updates: {
+    url: 'https://u.expo.dev/f852bb53-02fc-46a1-b509-4b2170cb6d84',
+  },
+  runtimeVersion: {
+    policy: 'fingerprint',
+  },
   orientation: 'portrait',
   // New Architecture stays OFF for the SDK 53 migration. SDK 53 flips it
   // on by default, so this is an active opt-out (set during the SDK 52 step

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -7,6 +7,7 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "channel": "development",
       "node": "20.18.0",
       "android": {
         "buildType": "apk"
@@ -20,6 +21,7 @@
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
       "node": "20.18.0",
       "android": {
         "buildType": "apk"
@@ -33,6 +35,7 @@
     },
     "production": {
       "autoIncrement": true,
+      "channel": "production",
       "node": "20.18.0",
       "ios": {
         "image": "macos-sequoia-15.6-xcode-26.2"

--- a/apps/mobile/package-lock.json
+++ b/apps/mobile/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oga/mobile",
-  "version": "0.0.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oga/mobile",
-      "version": "0.0.1",
+      "version": "0.9.0",
       "dependencies": {
         "@expo/vector-icons": "14.1.0",
         "@oga/core": "file:../../packages/core",
@@ -28,6 +28,7 @@
         "expo-splash-screen": "~0.30.10",
         "expo-sqlite": "~15.2.14",
         "expo-status-bar": "~2.2.3",
+        "expo-updates": "~0.28.18",
         "nativewind": "4.1.23",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -54,7 +55,7 @@
     },
     "../../packages/core": {
       "name": "@oga/core",
-      "version": "0.0.1",
+      "version": "0.9.0",
       "dependencies": {
         "@oga/supabase": "file:../supabase"
       },
@@ -65,7 +66,7 @@
     },
     "../../packages/supabase": {
       "name": "@oga/supabase",
-      "version": "0.0.1",
+      "version": "0.9.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.45.0"
       },
@@ -5482,6 +5483,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-eas-client": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.14.4.tgz",
+      "integrity": "sha512-TSL1BbBFIuXchJmPgbPnB7cGpOOuSGJcQ/L7gij/+zPjExwvKm5ckA5dlSulwoFhH8zQt4vb7bfISPSAWQVWBw==",
+      "license": "MIT"
+    },
     "node_modules/expo-file-system": {
       "version": "18.1.11",
       "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-18.1.11.tgz",
@@ -5745,6 +5752,40 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-structured-headers": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/expo-structured-headers/-/expo-structured-headers-4.1.0.tgz",
+      "integrity": "sha512-2X+aUNzC/qaw7/WyUhrVHNDB0uQ5rE12XA2H/rJXaAiYQSuOeU90ladaN0IJYV9I2XlhYrjXLktLXWbO7zgbag==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates": {
+      "version": "0.28.18",
+      "resolved": "https://registry.npmjs.org/expo-updates/-/expo-updates-0.28.18.tgz",
+      "integrity": "sha512-qbxRF8w/xPNiEWmZHDxK4XJ0ns4A9VpQg66jNeAEc8mrX9f7TG3TyLyLtydAP0F4aTNrBcSxah8K5VA90vcPig==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/code-signing-certificates": "^0.0.6",
+        "@expo/config": "~11.0.13",
+        "@expo/config-plugins": "~10.1.2",
+        "@expo/spawn-async": "^1.7.2",
+        "arg": "4.1.0",
+        "chalk": "^4.1.2",
+        "expo-eas-client": "~0.14.4",
+        "expo-manifests": "~0.16.6",
+        "expo-structured-headers": "~4.1.0",
+        "expo-updates-interface": "~1.1.0",
+        "glob": "^10.4.2",
+        "ignore": "^5.3.1",
+        "resolve-from": "^5.0.0"
+      },
+      "bin": {
+        "expo-updates": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
+      }
+    },
     "node_modules/expo-updates-interface": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-1.1.0.tgz",
@@ -5752,6 +5793,57 @@
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-updates/node_modules/arg": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
+      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "license": "MIT"
+    },
+    "node_modules/expo-updates/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/expo-updates/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-updates/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/exponential-backoff": {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -32,7 +32,7 @@
     "expo-splash-screen": "~0.30.10",
     "expo-sqlite": "~15.2.14",
     "expo-status-bar": "~2.2.3",
-    "expo-updates": "0.28.18",
+    "expo-updates": "~0.28.18",
     "nativewind": "4.1.23",
     "react": "19.0.0",
     "react-dom": "19.0.0",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -32,6 +32,7 @@
     "expo-splash-screen": "~0.30.10",
     "expo-sqlite": "~15.2.14",
     "expo-status-bar": "~2.2.3",
+    "expo-updates": "0.28.18",
     "nativewind": "4.1.23",
     "react": "19.0.0",
     "react-dom": "19.0.0",


### PR DESCRIPTION
Sets up over-the-air updates so pure-JS fixes ship to installed apps **without an App Store / Play review**. Apple/Google permit interpreted-code (JS) updates that add no native code and don't change the app's purpose — which is exactly the shape of the camera/swipe/Learn fixes we've been making.

## What changed
- **expo-updates 0.28.18** (SDK-53 version), exact-pinned like `expo` core.
- **app.config.ts:** `updates.url` (project `f852bb53…`) + `runtimeVersion: { policy: 'fingerprint' }`.
- **eas.json:** per-profile `channel` (development / preview / production) → update branches.

## Why `fingerprint` runtimeVersion
It's the safe policy: an OTA update only lands on a build whose **native fingerprint matches**, so a JS update can never reach a binary missing its native code. The simpler `appVersion` policy has a footgun (JS update landing on a native-mismatched build → crash) that fingerprint removes.

## ⚠️ Activation (important)
`expo-updates` is a native module, so OTA is **not live yet**. It activates only after a **new binary built with this config is submitted + approved once** (the currently-shipped store build has no updates runtime). After that:
```
eas update --branch production --message "fix: ..."
```
ships JS fixes to the production build with no review. Native changes still need a reviewed binary.

## Verification
`npm run typecheck` clean; `expo config` resolves updates + runtimeVersion; `expo-doctor` 17/18 (the 1 fail is the pre-existing intentional `metro.config.js` resolver override, unrelated). **Not device-tested** — needs the first expo-updates binary build to validate OTA end-to-end.