### PR TITLE
fix(web): bump shot_number guard only after a successful insert

### DIFF
--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -164,7 +164,6 @@ export function ShotEntryModal({
     const shotNumber = editing
       ? draft.shotNumber
       : Math.max(freshMax, lastIssuedNumberRef.current) + 1
-    if (!editing) lastIssuedNumberRef.current = shotNumber
     const isPuttSave = draft.lieType === 'green'
     const made =
       opts?.madeOverride === true
@@ -224,6 +223,11 @@ export function ShotEntryModal({
         await updateShot.mutateAsync({ id: editing, updates: insert })
       } else {
         await createShot.mutateAsync(insert)
+        // Bump the monotonic guard only AFTER a successful insert. Bumping it
+        // before would, on a failed save + retry, skip the failed number and
+        // leave a permanent gap in shot_number — breaking the editingNext
+        // lookup and stats inference (both assume contiguous numbering).
+        lastIssuedNumberRef.current = shotNumber
       }
       cancelEdit()
     } catch (err) {


### PR DESCRIPTION
Ports the #685 review fix to `dev` (the buggy code came from #683, merged here earlier).

**Bug:** `lastIssuedNumberRef` was bumped *before* the insert, so a failed save + retry recomputed `max(freshMax, ref)+1` off the already-bumped ref — skipping the failed number and leaving a permanent `shot_number` gap, which breaks the `editingNext` lookup and stats inference (both assume contiguous numbering). Same class as #661.

**Fix:** move the bump inside the `try`, after the insert resolves, so a failure leaves the ref untouched and the retry reuses the number.

Identical change to #685's fix commit (cherry-picked); web typecheck verified there.