### PR TITLE
fix(mobile): review polish — Learn chip hitSlop + PastRoundMap OKC guard

### DIFF
--- a/apps/mobile/app/(app)/practice.tsx
+++ b/apps/mobile/app/(app)/practice.tsx
@@ -115,6 +115,9 @@ export default function Practice() {
             <PressableTouch
               accessibilityRole="button"
               accessibilityLabel="Learn articles"
+              // Extend the touch target to the ~44pt minimum without bloating
+              // the compact chip's visual height (padding stays 6).
+              hitSlop={{ top: 10, bottom: 10, left: 6, right: 6 }}
               style={{
                 flexDirection: 'row',
                 alignItems: 'center',

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -190,7 +190,11 @@ export function PastRoundMap({
   // tee ?? courseCenter ?? ball): a hole with a round-pin but no surveyed tee
   // would otherwise resolve center == pin and re-collapse the heading. When no
   // tee resolves, courseCenter still gives a non-coincident origin.
-  const center = tee ?? courseCenter ?? OKC_FALLBACK
+  // effectivePin trails as a last resort BEFORE the OKC fallback — for a
+  // manually-added course with no tee and null lat/lng, framing on the pin
+  // (north-up, but on the hole) beats dropping the camera on Oklahoma. Pin is
+  // last, so it never wins over tee/courseCenter and can't recollapse a real hole.
+  const center = tee ?? courseCenter ?? effectivePin ?? OKC_FALLBACK
 
   const [placed, setPlaced] = useState<PlacedShot[]>([])
   const [activeIdx, setActiveIdx] = useState(0)


### PR DESCRIPTION
Two one-liners from the #692 pre-release 3-agent review (both LOW severity):

- **Learn chip tap target** (~26px → ~44pt via `hitSlop`; visual unchanged).
- **PastRoundMap OKC edge:** append `effectivePin` as the last-resort center so a manually-added course with no tee + null lat/lng frames on the pin, not Oklahoma. Pin stays *after* tee/courseCenter, so it can't reintroduce the #686 heading collapse.

Merges to `dev` so it rides into the #692 release. Mobile typecheck clean.