### PR TITLE
fix(mobile): bump version to 1.0.1 for App Store resubmission

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -8,7 +8,7 @@ const config: ExpoConfig = {
   name: 'OGA',
   slug: 'oga',
   scheme: 'oga',
-  version: '1.0.0',
+  version: '1.0.1',
   // EAS Update (OTA). Ships JS/asset-only fixes to installed builds WITHOUT an
   // App Store / Play review — Apple/Google permit interpreted-code updates that
   // don't add native code or change the app's purpose. Native changes (SDK/RN


### PR DESCRIPTION
App Store Connect rejected iOS build `1.0.0 (8)`:

- **90186** — the `1.0.0` pre-release train is closed for new submissions.
- **90062** — `CFBundleShortVersionString` must exceed the approved `1.0.0`.

Bumps the mobile marketing `version` to `1.0.1` so iOS accepts a new build. iOS production build already re-kicked at 1.0.1 (build e99812ab).

Android is untouched — its in-flight `1.0.0` build (versionCode 4) is valid for Play. The runtimeVersion (appVersion policy) moves to 1.0.1 on iOS only, which is fine per-platform.

Merge to keep `main` in sync with the shipped iOS binary.