### PR TITLE
fix(mobile): round-detail delete no longer wedges on "Deleting…"

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -416,13 +416,16 @@ export default function RoundIndex() {
           style: 'destructive',
           onPress: async () => {
             setDeleting(true)
-            const { error: delErr } = await deleteRound(supabase, round.id, user.id)
-            if (delErr) {
+            try {
+              const { error: delErr } = await deleteRound(supabase, round.id, user.id)
+              if (delErr) throw delErr
+              router.replace('/(app)')
+            } catch (e) {
+              // Reset so the `deleting` guard can't wedge the button on retry;
+              // surface the reason instead of hanging on "Deleting…" forever.
               setDeleting(false)
-              Alert.alert('Delete failed', delErr.message)
-              return
+              Alert.alert('Delete failed', (e as Error).message)
             }
-            router.replace('/(app)')
           },
         },
       ],


### PR DESCRIPTION
Fixes #701.

## Problem
Deleting a round from the round-detail/summary page hangs on "Deleting…" and never completes; the home-list swipe-delete works.

## Root cause
The detail handler (`app/(app)/round/[id]/index.tsx`) had no try/catch — its only exits were success→`router.replace('/(app)')` or a *returned* error→reset. If `await deleteRound` **rejects** (thrown fetch failure), neither branch runs: `deleting` stays `true` forever, no error surfaces, and the top-of-handler `if (… || deleting) return` guard then wedges the button so every subsequent tap no-ops (reads as "delete never works"). The list swipe (`rounds.tsx`) calls the same `deleteRound` but survives via `try/finally`.

## Fix
Wrap in try/catch: navigate only on confirmed success, otherwise reset `deleting` and surface the error via `Alert`. Clears the button-wedge, gives the user a retry, and reveals the reject cause if it recurs. Mirrors the working list handler.

## Testing
- `npm run typecheck` (mobile) clean.
- Structural defect + symptom confirmed by inspection; exact first-reject trigger not reproduced on-device — fix is resilience + error-surfacing, not a pinned network root cause (per repro-before-fix convention).