### PR TITLE
fix(mobile): home rounds list refetches on focus — deleted rounds no longer linger (#705)

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useFocusEffect } from 'expo-router'
 import { Pressable, ScrollView, Text, View } from 'react-native'
 import { formatSG } from '@oga/core'
 import { deleteRound, getProfile, getRecentRounds } from '@oga/supabase'
@@ -86,31 +87,38 @@ export default function Home() {
     [user],
   )
 
-  useEffect(() => {
-    if (!user) return
-    let active = true
-    getProfile(supabase, user.id).then(({ data, error }) => {
-      if (!active) return
-      if (error) {
-        // eslint-disable-next-line no-console
-        console.error('[home/getProfile]', error.message)
-        return
+  // Focus effect, not a mount effect: router.replace('/(app)') after a
+  // delete can land on an already-mounted home instance, and a mount-only
+  // fetch then keeps showing the deleted round until the app restarts —
+  // the user swipe-deletes a ghost that's already gone server-side (#705).
+  // Same pattern as useActiveRound's banner query directly above.
+  useFocusEffect(
+    useCallback(() => {
+      if (!user) return
+      let active = true
+      getProfile(supabase, user.id).then(({ data, error }) => {
+        if (!active) return
+        if (error) {
+          // eslint-disable-next-line no-console
+          console.error('[home/getProfile]', error.message)
+          return
+        }
+        if (data) setProfile(data as unknown as Profile)
+      })
+      getRecentRounds(supabase, user.id, 20).then(({ data, error }) => {
+        if (!active) return
+        if (error) {
+          // eslint-disable-next-line no-console
+          console.error('[home/getRecentRounds]', error.message)
+          return
+        }
+        if (data) setRounds(data as RecentRound[])
+      })
+      return () => {
+        active = false
       }
-      if (data) setProfile(data as unknown as Profile)
-    })
-    getRecentRounds(supabase, user.id, 20).then(({ data, error }) => {
-      if (!active) return
-      if (error) {
-        // eslint-disable-next-line no-console
-        console.error('[home/getRecentRounds]', error.message)
-        return
-      }
-      if (data) setRounds(data as RecentRound[])
-    })
-    return () => {
-      active = false
-    }
-  }, [user?.id])
+    }, [user?.id]),
+  )
 
   useEffect(() => {
     pendingCount().then(setPending)


### PR DESCRIPTION
Fixes #705.

## Problem
Deleting a round, then landing on home via `router.replace('/(app)')`, can leave the deleted round visible in the recent-rounds list until app restart. Field repro: the user deleted a ghost twice — prod API logs show the second DELETE hitting zero rows. All server-side deletes verified working (204s + rows gone); the staleness is purely client render state.

## Root cause
The home data fetch (`getProfile` + `getRecentRounds`) ran in a mount-only `useEffect([user?.id])`. Whether `router.replace` remounts home varies by navigation path, so deletes appeared to work "sometimes." The resume banner directly above (`useActiveRound`) already refetches via `useFocusEffect` for exactly this reason.

## Fix
Convert the fetch to `useFocusEffect` with an identical body — every return to home refetches. Same pattern as `useActiveRound`.

Pure JS → OTA-shippable. Related: #701/#702 (summary-delete wedge) — the two bugs masked each other in field testing.

## Testing
Mobile typecheck clean. On-device: delete a round from any surface → land on home → round gone without restart.