### PR TITLE
fix(mobile): stamp distance_to_target on live-round shot saves

### DIFF
--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -131,6 +131,8 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
 
   function buildPayload(meta: ShotLoggerValue | null): ShotPayload | null {
     if (!user || !currentHoleScore || !ball) return null
+    const isPutt = meta?.club === 'putter' || meta?.lieType === 'green'
+    const pinTarget = roundPin ?? storedPin ?? null
     return {
       hole_score_id: currentHoleScore.id,
       user_id: user.id,
@@ -139,6 +141,10 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       start_lng: ball.lng,
       end_lat: null,
       end_lng: null,
+      // Putts leave this null to match the web save path — a putt's
+      // "distance to target" is putt_distance_ft, not this column.
+      distance_to_target:
+        !isPutt && pinTarget ? Math.round(distanceYards(ball, pinTarget)) : null,
       // Persist aim only if the player set/dragged it; an untouched auto-spawn
       // suggestion is dropped so it can't enter the dispersion dataset.
       aim_lat: aimTouched ? aim?.lat ?? null : null,

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -5,6 +5,7 @@ import type { User } from '@supabase/supabase-js'
 import {
   combinedBreakDirection,
   combinedPuttResult,
+  isPuttShot,
   type LieType,
 } from '@oga/core'
 import { deleteRound, getProfile } from '@oga/supabase'
@@ -131,7 +132,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
 
   function buildPayload(meta: ShotLoggerValue | null): ShotPayload | null {
     if (!user || !currentHoleScore || !ball) return null
-    const isPutt = meta?.club === 'putter' || meta?.lieType === 'green'
+    const isPutt = isPuttShot(meta?.lieType, meta?.club)
     const pinTarget = roundPin ?? storedPin ?? null
     return {
       hole_score_id: currentHoleScore.id,


### PR DESCRIPTION
Mobile live-round shot saves never wrote `distance_to_target` on the `shots` row, so `getExpectedStrokes(category, undefined)` returned null and the SG engine skipped scoring entirely — stamping `sg_off_tee`/`sg_approach`/`sg_around_green` at exactly 0.00 for every live round at completion. `buildPayload` in `useShotActions.ts` now computes it the same way `PastRoundMap.tsx` does: rounded yards from the shot-start (`ball`) to the resolved pin (`roundPin ?? storedPin`), for non-putt shots only. Putts keep `distance_to_target` null (parity with the web save path — a putt's distance lives in `putt_distance_ft`).

How verified: `npm run typecheck` in `apps/mobile` passes clean. Runtime/device verification (confirming SG values populate correctly on a live round at completion) is still pending.

Closes #709