### PR TITLE
fix: completeRound no longer finalizes totals/differential from unplayed score-0 holes (#711, #717)

### DIFF
--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -1,8 +1,10 @@
 import {
+  DEFAULT_HANDICAP,
   adjustedScore,
   calculateDifferential,
   calculateHandicapIndex,
   computeRoundSG,
+  inferHoleCount,
   inferHoleStats,
 } from '@oga/core'
 import {
@@ -78,6 +80,21 @@ export async function completeRound({
   const tees: CourseTeeRow[] = teesRes.data ?? []
   const roundTee = roundRes.data ?? null
 
+  // Self-repair stale stamped zeros (#711). Round creation pre-inserts
+  // every hole_scores row with score 0; live play updates it per shot via
+  // a direct online write that is never queued, so an offline stretch
+  // loses the score even though the shots themselves sync later. Live
+  // stamping defines score = shot count, so a score-0 hole that HAS
+  // synced shots recovers exactly the value the online path would have
+  // written. Patched in place so every downstream reader (computeRoundSG
+  // totals, holedOut, the SG upsert's carried score, the differential)
+  // sees the repaired value; the SG/infer upserts below persist it.
+  for (const hs of holeScores) {
+    if (hs.score !== 0) continue
+    const shotCount = shots.filter((s) => s.hole_score_id === hs.id).length
+    if (shotCount > 0) hs.score = shotCount
+  }
+
   // Infer fairway_hit + gir for any hole where the player didn't set
   // them manually. Mobile live mode never writes those columns
   // per-shot, so without this round-level fairwaysHit/gir totals stay
@@ -135,7 +152,7 @@ export async function completeRound({
     holes,
     holeScores,
     shots,
-    handicap: handicap ?? 18,
+    handicap: handicap ?? DEFAULT_HANDICAP,
   })
 
   // Per-hole SG upsert. Mirrors useCompleteRound.ts: carry round_id /
@@ -193,8 +210,15 @@ export async function completeRound({
         return { score: hs.score, par: h.par }
       })
       .filter((x): x is { score: number; par: number } => !!x)
-    if (holeRows.length > 0) {
-      const adjusted = adjustedScore(holeRows, handicap ?? 18)
+    // Only a complete round produces a differential (#711). Score-0 rows
+    // are unplayed holes (early End round / unlogged holes / lost offline
+    // updates with no synced shots); adjustedScore adds 0 strokes per
+    // unplayed hole, yielding an impossible negative differential that
+    // then permanently dominates the last-20 handicap recompute.
+    const playedRows = holeRows.filter((r) => r.score > 0)
+    const holeCount = inferHoleCount(holes.map((h) => h.number))
+    if (playedRows.length === holeCount) {
+      const adjusted = adjustedScore(playedRows, handicap ?? DEFAULT_HANDICAP)
       differential = round2(
         calculateDifferential(adjusted, tee.course_rating, tee.slope_rating),
       )
@@ -243,7 +267,15 @@ export async function completeRound({
       .not('score_differential', 'is', null)
       .order('played_at', { ascending: false })
       .limit(20)
-    if (diffsError) throw diffsError
+    // The round is already finalized above — a failure in the index
+    // recompute must not surface as "End round failed" (#711 secondary
+    // bug: a corrupt differential could push the index past the profiles
+    // CHECK floor and throw here). Warn and move on; the next completed
+    // round recomputes over the same data.
+    if (diffsError) {
+      if (__DEV__) console.warn('[completeRound] differentials fetch failed', diffsError)
+      return
+    }
     const diffs = (recentDiffs ?? [])
       .map((r) => r.score_differential)
       .filter((d): d is number => d != null)
@@ -252,7 +284,9 @@ export async function completeRound({
       const { error: profileError } = await updateProfile(supabase, userId, {
         handicap_index: newIndex,
       })
-      if (profileError) throw profileError
+      if (profileError && __DEV__) {
+        console.warn('[completeRound] handicap index update failed', profileError)
+      }
     }
   }
 }

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -6,6 +6,7 @@ import {
   computeRoundSG,
   inferHoleCount,
   inferHoleStats,
+  playedRowsForDifferential,
 } from '@oga/core'
 import {
   getCourseTees,
@@ -210,14 +211,13 @@ export async function completeRound({
         return { score: hs.score, par: h.par }
       })
       .filter((x): x is { score: number; par: number } => !!x)
-    // Only a complete round produces a differential (#711). Score-0 rows
-    // are unplayed holes (early End round / unlogged holes / lost offline
-    // updates with no synced shots); adjustedScore adds 0 strokes per
-    // unplayed hole, yielding an impossible negative differential that
-    // then permanently dominates the last-20 handicap recompute.
-    const playedRows = holeRows.filter((r) => r.score > 0)
-    const holeCount = inferHoleCount(holes.map((h) => h.number))
-    if (playedRows.length === holeCount) {
+    // Only a complete round produces a differential (#711) — see
+    // playedRowsForDifferential for the sentinel/coverage contract.
+    const playedRows = playedRowsForDifferential(
+      holeRows,
+      inferHoleCount(holes.map((h) => h.number)),
+    )
+    if (playedRows) {
       const adjusted = adjustedScore(playedRows, handicap ?? DEFAULT_HANDICAP)
       differential = round2(
         calculateDifferential(adjusted, tee.course_rating, tee.slope_rating),

--- a/apps/web/src/hooks/useCompleteRound.ts
+++ b/apps/web/src/hooks/useCompleteRound.ts
@@ -5,6 +5,7 @@ import {
   calculateHandicapIndex,
   computeRoundSG,
   inferHoleCount,
+  playedRowsForDifferential,
 } from '@oga/core'
 import type { RoundSGResult } from '@oga/core'
 import {
@@ -130,15 +131,13 @@ export function useCompleteRound() {
             return { score: hs.score, par: h.par }
           })
           .filter((x): x is { score: number; par: number } => !!x)
-        // Only a complete round produces a differential (#711). Web
-        // creates hole_scores lazily, so a partial round shows up as
-        // fewer scored rows than the course's hole count; adjustedScore
-        // over a partial round sits far below the course rating and
-        // yields an impossible negative differential that then dominates
-        // the last-20 handicap recompute.
-        const playedRows = holeRows.filter((r) => r.score > 0)
-        const holeCount = inferHoleCount(holes.map((h) => h.number))
-        if (playedRows.length === holeCount) {
+        // Only a complete round produces a differential (#711) — see
+        // playedRowsForDifferential for the sentinel/coverage contract.
+        const playedRows = playedRowsForDifferential(
+          holeRows,
+          inferHoleCount(holes.map((h) => h.number)),
+        )
+        if (playedRows) {
           const adjusted = adjustedScore(playedRows, handicap)
           differential = round2(
             calculateDifferential(adjusted, tee.course_rating, tee.slope_rating),

--- a/apps/web/src/hooks/useCompleteRound.ts
+++ b/apps/web/src/hooks/useCompleteRound.ts
@@ -4,6 +4,7 @@ import {
   calculateDifferential,
   calculateHandicapIndex,
   computeRoundSG,
+  inferHoleCount,
 } from '@oga/core'
 import type { RoundSGResult } from '@oga/core'
 import {
@@ -129,8 +130,16 @@ export function useCompleteRound() {
             return { score: hs.score, par: h.par }
           })
           .filter((x): x is { score: number; par: number } => !!x)
-        if (holeRows.length > 0) {
-          const adjusted = adjustedScore(holeRows, handicap)
+        // Only a complete round produces a differential (#711). Web
+        // creates hole_scores lazily, so a partial round shows up as
+        // fewer scored rows than the course's hole count; adjustedScore
+        // over a partial round sits far below the course rating and
+        // yields an impossible negative differential that then dominates
+        // the last-20 handicap recompute.
+        const playedRows = holeRows.filter((r) => r.score > 0)
+        const holeCount = inferHoleCount(holes.map((h) => h.number))
+        if (playedRows.length === holeCount) {
+          const adjusted = adjustedScore(playedRows, handicap)
           differential = round2(
             calculateDifferential(adjusted, tee.course_rating, tee.slope_rating),
           )

--- a/packages/core/src/__tests__/round.test.ts
+++ b/packages/core/src/__tests__/round.test.ts
@@ -4,6 +4,7 @@ import {
   inferHoleCount,
   isPuttShot,
   legacySlopeToAxes,
+  playedRowsForDifferential,
   type PlacedPoint,
 } from '../round'
 import { decombinedPuttResult } from '../types'
@@ -220,5 +221,35 @@ describe('inferHoleCount', () => {
 
   it('a single mapped hole 10 already implies 18', () => {
     expect(inferHoleCount([10])).toBe(18)
+  })
+})
+
+describe('playedRowsForDifferential', () => {
+  const rows = (scores: number[]) => scores.map((score) => ({ score }))
+
+  it('returns the played rows when they cover every hole', () => {
+    expect(playedRowsForDifferential(rows([4, 5, 3]), 3)).toEqual(
+      rows([4, 5, 3]),
+    )
+  })
+
+  it('null when any hole is unplayed — score-0 sentinel rows (mobile pre-creation)', () => {
+    expect(playedRowsForDifferential(rows([4, 0, 3]), 3)).toBeNull()
+  })
+
+  it('null on a partial round — fewer scored rows than holes (web lazy creation)', () => {
+    expect(playedRowsForDifferential(rows([4, 5]), 3)).toBeNull()
+  })
+
+  it('null on an early-ended 18 — 9 played of 18 pre-created rows', () => {
+    expect(
+      playedRowsForDifferential(rows([...Array(9).fill(4), ...Array(9).fill(0)]), 18),
+    ).toBeNull()
+  })
+
+  it('sentinel rows are excluded from the returned set, not just tolerated', () => {
+    expect(playedRowsForDifferential(rows([4, 5, 3, 0]), 3)).toEqual(
+      rows([4, 5, 3]),
+    )
   })
 })

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -79,6 +79,25 @@ export function inferHoleCount(holeNumbers: number[]): 9 | 18 {
   return Math.max(...holeNumbers) <= 9 ? 9 : 18
 }
 
+// Gate for computing a WHS-style score differential: only a fully-played
+// round qualifies. Returns the played (score > 0) rows when they cover every
+// hole of the round, else null — a partial round must produce NO differential,
+// because adjustedScore adds 0 strokes per unplayed hole and yields an
+// impossible negative value that then dominates the last-20 handicap
+// recompute (#711). Score 0 is the "not played" sentinel on both platforms.
+// Implicit contract: callers pass holeCount = inferHoleCount(course hole
+// numbers), and both materialization paths (mobile round creation's gap-fill,
+// web's ensureRealHole) create holes rows up to that same inferred count — if
+// a materialization path ever changes, this gate fails CLOSED (differential
+// stays null on a fully-played round) rather than corrupting the index.
+export function playedRowsForDifferential<T extends { score: number }>(
+  holeRows: T[],
+  holeCount: number,
+): T[] | null {
+  const played = holeRows.filter((r) => r.score > 0)
+  return played.length === holeCount ? played : null
+}
+
 // Single source of truth for putt classification: a shot is a putt when its
 // lie is the green or its club is the putter. Feeds putt counts, the putt-only
 // persisted columns, and SG putting, so every surface must agree. Distance to


### PR DESCRIPTION
## Mechanism

Mobile round creation pre-inserts a `hole_scores` row with `score: 0` for every hole, and per-shot score stamping is a direct online write that is never queued — so offline stretches, early End-round, or unlogged holes leave score-0 rows that `completeRound` trusted everywhere: totals, `holedOut` GIR inference, and the WHS differential. `adjustedScore` adds 0 strokes per unplayed hole, producing impossible negative differentials (≈ −23..−65) that permanently dominate the last-20 handicap recompute; past the profiles CHECK floor the profile write then threw **after** the round had already finalized ("End round failed"). Separately, mobile's no-handicap fallback was a hardcoded `18` while web uses `DEFAULT_HANDICAP` (15) — different SG brackets per platform (#717).

## Changes

**`apps/mobile/lib/completeRound.ts`**
- Self-repair stale stamped zeros: a score-0 hole that HAS synced shots is patched in place to `score = shot count` (the exact value live stamping would have written online) before totals/SG/holedOut/differential read it; the existing SG + infer upserts persist the repaired value server-side.
- Differential is computed only when played rows (effective score > 0) cover the round's full hole count (`inferHoleCount` over the course's hole numbers); otherwise `score_differential` stays null — never partially computed.
- Both `?? 18` handicap fallbacks replaced with `DEFAULT_HANDICAP` from `@oga/core` (#717).
- Handicap-index recompute is now non-fatal: the round is already finalized at that point, so a diffs-fetch or profile-update error DEV-warns and continues instead of surfacing "End round failed".

**`apps/web/src/hooks/useCompleteRound.ts`**
- Same differential guard: filter to score > 0 rows and require full coverage of `inferHoleCount(holes)` before computing; null otherwise. (Web creates `hole_scores` lazily, so the partial-round arm shows up as missing rows rather than score-0 rows — the coverage requirement handles both.)

## How verified

- `cd apps/mobile && npm run typecheck` — clean
- `pnpm typecheck` (workspace: core, web) — clean
- No `@oga/core` changes, so no new tests. Device/runtime QA pending (offline stretch + early End-round repro).

Closes #711
Closes #717