### PR TITLE
fix(mobile): hole shot-count integrity — fetch-error guard, sync dedupe, reset-on-switch

### DIFF
--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -198,11 +198,28 @@ export function useHoleData(
             .select('id, club, lie_type, shot_number, start_lat, start_lng')
             .eq('hole_score_id', currentHoleScore.id)
             .order('shot_number')
-        const [shotsResInitial, local] = await Promise.all([
+        const [shotsResInitial, localInitial] = await Promise.all([
           fetchShots(),
-          pendingShotsForHoleScore(currentHoleScore.id),
+          // The SQLite read gets the same one-retry treatment as the remote
+          // fetch below — a transient rejection must not leave the neutral
+          // reset committed as a confident local=0 the save path could
+          // collide on (same class as the remote arm of #712).
+          pendingShotsForHoleScore(currentHoleScore.id).catch(() => null),
         ])
         if (myNonce !== fetchNonceRef.current) return
+        let local = localInitial
+        if (local === null) {
+          local = await pendingShotsForHoleScore(currentHoleScore.id).catch(
+            () => null,
+          )
+          if (myNonce !== fetchNonceRef.current) return
+          if (local === null) {
+            if (__DEV__) {
+              console.warn('[hole/pending-fetch] SQLite read failed twice')
+            }
+            return
+          }
+        }
         let shotsRes = shotsResInitial
         if (shotsRes.error) {
           // postgrest-js returns failures in-band ({data: null, error}) —

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -177,31 +177,89 @@ export function useHoleData(
   // resolve after a newer run started are silently dropped. (#284)
   const fetchNonceRef = useRef(0)
   useEffect(() => {
+    // Reset to the neutral "unknown" state synchronously, before the async
+    // fetch below resolves. Without this, a hole switch during the fetch
+    // RTT leaves the PREVIOUS hole's counts in state — e.g. `hasPriorShots`
+    // (LiveRoundSession) reads a stale true/false and the tee-default effect
+    // can place a ball marker on a hole the player is only reviewing (#720
+    // item 2). 0/[] also matches the true pre-fetch state of a fresh hole,
+    // so this isn't a behavior change for the common case.
+    setRemoteShotCount(0)
+    setRemotePuttCount(0)
+    setRemoteShotStarts([])
+    setPendingForHole([])
     if (!currentHoleScore) return
     const myNonce = ++fetchNonceRef.current
     ;(async () => {
-      const [shotsRes, local] = await Promise.all([
-        supabase
-          .from('shots')
-          .select('club, lie_type, shot_number, start_lat, start_lng')
-          .eq('hole_score_id', currentHoleScore.id)
-          .order('shot_number'),
-        pendingShotsForHoleScore(currentHoleScore.id),
-      ])
-      if (myNonce !== fetchNonceRef.current) return
-      const shots = shotsRes.data ?? []
-      setRemoteShotCount(shots.length)
-      setRemotePuttCount(
-        shots.filter((s) => s.club === 'putter' || s.lie_type === 'green').length,
-      )
-      const starts: LatLng[] = []
-      for (const r of shots) {
-        if (r.start_lat != null && r.start_lng != null) {
-          starts.push({ lat: r.start_lat, lng: r.start_lng })
+      try {
+        const fetchShots = () =>
+          supabase
+            .from('shots')
+            .select('id, club, lie_type, shot_number, start_lat, start_lng')
+            .eq('hole_score_id', currentHoleScore.id)
+            .order('shot_number')
+        const [shotsResInitial, local] = await Promise.all([
+          fetchShots(),
+          pendingShotsForHoleScore(currentHoleScore.id),
+        ])
+        if (myNonce !== fetchNonceRef.current) return
+        let shotsRes = shotsResInitial
+        if (shotsRes.error) {
+          // postgrest-js returns failures in-band ({data: null, error}) —
+          // the promise resolves normally, so this can't be caught by the
+          // outer try/catch. One retry covers most transient failures
+          // (mirrors the sync.ts chunk-upsert retry); if it fails twice,
+          // leave counts at the neutral reset above rather than committing
+          // a confident remote=0 that the save path could collide on.
+          shotsRes = await fetchShots()
+          if (myNonce !== fetchNonceRef.current) return
+          if (shotsRes.error) {
+            if (__DEV__) {
+              console.warn(
+                '[hole/shots-fetch]',
+                shotsRes.error.message,
+              )
+            }
+            return
+          }
+        }
+        const shots = shotsRes.data ?? []
+        // Dedupe the sync-in-flight window: a shot whose server row just
+        // committed can still be 'pending' locally for a beat before
+        // markShotSynced runs (lib/sync.ts marks rows synced one at a time
+        // after the chunk upsert). Both payload.id (client-generated, set
+        // before every insert) and the remote row's id are compared so a
+        // mid-sync shot counts once, not twice (#714).
+        const remoteIds = new Set(shots.map((s) => s.id))
+        const dedupedLocal = local.filter((p) => {
+          try {
+            const payload = JSON.parse(p.payload) as ShotPayload
+            return !payload.id || !remoteIds.has(payload.id)
+          } catch {
+            return true
+          }
+        })
+        setRemoteShotCount(shots.length)
+        setRemotePuttCount(
+          shots.filter((s) => s.club === 'putter' || s.lie_type === 'green').length,
+        )
+        const starts: LatLng[] = []
+        for (const r of shots) {
+          if (r.start_lat != null && r.start_lng != null) {
+            starts.push({ lat: r.start_lat, lng: r.start_lng })
+          }
+        }
+        setRemoteShotStarts(starts)
+        setPendingForHole(dedupedLocal)
+      } catch (err) {
+        if (myNonce !== fetchNonceRef.current) return
+        // SQLite (pendingShotsForHoleScore) rejection, or any other thrown
+        // error — leave counts at the neutral reset above rather than a
+        // stale previous-hole value.
+        if (__DEV__) {
+          console.warn('[hole/shots-fetch]', (err as Error).message)
         }
       }
-      setRemoteShotStarts(starts)
-      setPendingForHole(local)
     })()
   }, [currentHoleScore?.id])
 


### PR DESCRIPTION
## What

Three fixes to the counts-load effect in `useHoleData.ts` (~line 179), all inside the same `[currentHoleScore?.id]` effect:

**1. Fetch-error guard (#712).** `shotsRes.error` was never inspected — a transient failure resolved the promise normally (postgrest-js returns failures in-band as `{data: null, error}`), so `const shots = shotsRes.data ?? []` silently zeroed `remoteShotCount`. The next saved shot then computed `shot_number = 1`, collided with the existing shot 1 on `unique(hole_score_id, shot_number)`, and got quarantined `broken` by `lib/sync.ts` — invisible to every read including the end-round unsynced-shots warning.

**Design choice:** retry once (mirrors the existing chunk-upsert retry pattern in `lib/sync.ts:153-160`), then on persistent failure, DEV-warn and leave counts at the neutral reset state (see #3) rather than committing anything. I considered adding a `countsReliable` gate that `persistShot` could check before saving, but that would touch `useShotActions.ts` and the save UI — outside this file and larger than the fix warrants. The retry closes the common transient case; the residual "still failing after retry" window is the same class of problem the issue itself flags as longer-term hardening (server-side shot_number derivation). Noting this explicitly since it's a real, if narrow, trade-off.

**2. Sync-window dedupe (#714).** A shot mid-sync could count in both `remoteShotCount` (server row committed) and `pendingForHole` (not yet `markShotSynced`'d), inflating `shotNumber` and eventually `hole_scores.score` / `rounds.total_score`. Added `id` to the remote `shots` select and now filter pending rows whose `payload.id` (client-generated, always set before insert per the sync idempotency work in `lib/sync.ts`) appears in the remote result.

**3. Reset-on-hole-switch (Part of #720, item 2).** Counts were never reset when `currentHoleScore.id` changed, so during the refetch RTT, `hasPriorShots` (`LiveRoundSession.tsx:143`, `remoteShotCount + localShotCount > 0`) held the *previous* hole's answer — a swipe back from a shotless hole could let the tee-default effect place a ball marker on a hole the player was only reviewing. Now `remoteShotCount`/`remotePuttCount`/`remoteShotStarts`/`pendingForHole` reset to 0/[] synchronously at the top of the effect, before the async fetch — this also matches the true pre-fetch state of a fresh hole, so it's not a behavior change for the common path.

Also wrapped the async IIFE body in try/catch so a SQLite (`pendingShotsForHoleScore`) rejection warns (DEV-gated) and leaves counts at the neutral reset instead of stranding the previous hole's values.

## How verified

- `cd apps/mobile && npm run typecheck` — clean.
- Runtime verification pending (needs a device/simulator repro of a transient fetch failure or mid-sync navigation, per CLAUDE.md's "repro before fix" — these are audit-filed, mechanism-verified-in-code bugs; no live repro attempted this session).

Closes #712
Closes #714
Part of #720 (item 2)