### PR TITLE
fix(db): per-round par override + authorized tee RPC — hole writes silently no-op'd with no UPDATE policy (#710, #721)

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -545,7 +545,9 @@ export default function RoundIndex() {
     const hs = scoresByHoleId.get(h.id)
     if (hs?.score != null && hs.score > 0) {
       runningScore += hs.score
-      runningPar += h.par
+      // Per-round par override (#710) — hole_scores.par wins over the
+      // course hole's par when the player corrected it.
+      runningPar += hs.par ?? h.par
     }
   }
   const diff = runningScore - runningPar
@@ -796,14 +798,17 @@ export default function RoundIndex() {
             const hs = scoresByHoleId.get(h.id)
             const score = hs?.score ?? 0
             const putts = hs?.putts ?? null
-            const d = score > 0 ? score - h.par : null
+            // Per-round par override (#710) — hole_scores.par wins over
+            // the course hole's par when the player corrected it.
+            const par = hs?.par ?? h.par
+            const d = score > 0 ? score - par : null
             const shotCount = hs ? holeScoreShotCount.get(hs.id) ?? 0 : 0
             // FIR/GIR: prefer the persisted hole_scores columns — web parity,
             // a manual/web-set value wins (apps/web useRoundActions) — else
             // infer from the hole's placed shots. par-3 fairway → null (blank).
             const inferred = inferHoleStats(
               hs ? shotsByHoleScoreId.get(hs.id) ?? [] : [],
-              h.par,
+              par,
             )
             const fairway = hs?.fairway_hit ?? inferred.fairway
             const gir = hs?.gir ?? inferred.gir
@@ -838,7 +843,7 @@ export default function RoundIndex() {
                     fontVariant: ['tabular-nums'],
                   }]}
                 >
-                  {h.par}
+                  {par}
                 </Text>
                 <ScoreCell
                   value={score}

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -661,16 +661,21 @@ export default function LiveRoundSession({
         routerReplace={(href) => router.replace(href as Parameters<typeof router.replace>[0])}
         id={roundId}
         onChangePar={async (holeId, newPar) => {
+          if (!roundId) return
           // Optimistic update so the cell reflects the tap immediately.
           // Roll back if the DB write fails so the UI doesn't lie.
+          // `holes` has no UPDATE RLS policy — a direct .update() filters
+          // to 0 rows and reports success (#710) — so the write goes
+          // through the authorized RPC, scoped to this round.
           const prev = data.holes.find((h) => h.id === holeId)?.par ?? 4
           data.setHoles((cur) =>
             cur.map((h) => (h.id === holeId ? { ...h, par: newPar } : h)),
           )
-          const { error: parErr } = await supabase
-            .from('holes')
-            .update({ par: newPar })
-            .eq('id', holeId)
+          const { error: parErr } = await supabase.rpc('update_hole_curation', {
+            p_hole_id: holeId,
+            p_round_id: roundId,
+            p_par: newPar,
+          })
           if (parErr) {
             data.setHoles((cur) =>
               cur.map((h) => (h.id === holeId ? { ...h, par: prev } : h)),

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -464,7 +464,7 @@ export default function LiveRoundSession({
               },
             ]}
           >
-            Par {data.currentHole.par}
+            Par {data.currentHoleScore?.par ?? data.currentHole.par}
             {data.currentHole.yards ? ` · ${toDisplay(data.currentHole.yards)}` : ''}
           </Text>
         </View>
@@ -612,7 +612,7 @@ export default function LiveRoundSession({
           totalShotsThisHole={totalShotsThisHole}
           holeNumber={holeNumber}
           holeCount={data.holeCount}
-          par={data.currentHole.par}
+          par={data.currentHoleScore?.par ?? data.currentHole.par}
           yardsLabel={data.currentHole.yards ? toDisplay(data.currentHole.yards) : null}
           onCancelPinPlacement={() => setPinPlacementOpen(false)}
           onClearRoundPin={actions.clearRoundPin}
@@ -661,24 +661,28 @@ export default function LiveRoundSession({
         routerReplace={(href) => router.replace(href as Parameters<typeof router.replace>[0])}
         id={roundId}
         onChangePar={async (holeId, newPar) => {
-          if (!roundId) return
+          // Par is a per-round override on hole_scores.par (#710) — this
+          // round's opinion, not global course curation (holes has no
+          // UPDATE policy; the old direct update silently no-op'd). The
+          // hole's hole_scores row is batch-created at round start.
+          const hs = data.holeScores.find((s) => s.hole_id === holeId)
+          if (!hs) return
           // Optimistic update so the cell reflects the tap immediately.
           // Roll back if the DB write fails so the UI doesn't lie.
-          // `holes` has no UPDATE RLS policy — a direct .update() filters
-          // to 0 rows and reports success (#710) — so the write goes
-          // through the authorized RPC, scoped to this round.
-          const prev = data.holes.find((h) => h.id === holeId)?.par ?? 4
-          data.setHoles((cur) =>
-            cur.map((h) => (h.id === holeId ? { ...h, par: newPar } : h)),
+          const prev = hs.par
+          data.setHoleScores((cur) =>
+            cur.map((s) => (s.id === hs.id ? { ...s, par: newPar } : s)),
           )
-          const { error: parErr } = await supabase.rpc('update_hole_curation', {
-            p_hole_id: holeId,
-            p_round_id: roundId,
-            p_par: newPar,
-          })
-          if (parErr) {
-            data.setHoles((cur) =>
-              cur.map((h) => (h.id === holeId ? { ...h, par: prev } : h)),
+          const { data: updated, error: parErr } = await supabase
+            .from('hole_scores')
+            .update({ par: newPar })
+            .eq('id', hs.id)
+            .select('id')
+          // 0 returned rows = RLS filtered the write while reporting
+          // success — the exact failure mode from #710. Treat as failure.
+          if (parErr || !updated || updated.length === 0) {
+            data.setHoleScores((cur) =>
+              cur.map((s) => (s.id === hs.id ? { ...s, par: prev } : s)),
             )
           }
         }}

--- a/apps/mobile/components/round/Scorecard.tsx
+++ b/apps/mobile/components/round/Scorecard.tsx
@@ -157,11 +157,14 @@ export function ScorecardModal({
             // -71 after hole 1).
             const rawScore = hs?.score
             const score = rawScore != null && rawScore > 0 ? rawScore : null
+            // Per-round par override (#710) — hole_scores.par wins over
+            // the course hole's par when the player corrected it.
+            const par = hs?.par ?? h.par
             if (score != null) {
               runningTotal += score
-              runningPar += h.par
+              runningPar += par
             }
-            const diff = score != null ? score - h.par : null
+            const diff = score != null ? score - par : null
             const active = h.number === currentHoleNumber
             // Editable par only for holes that came back without any
             // layout data — for OSM-mapped holes par is authoritative
@@ -172,7 +175,7 @@ export function ScorecardModal({
               <Pressable
                 key={h.id}
                 accessibilityRole="button"
-                accessibilityLabel={`Jump to hole ${h.number}, par ${h.par}${score != null ? `, score ${score}` : ''}`}
+                accessibilityLabel={`Jump to hole ${h.number}, par ${par}${score != null ? `, score ${score}` : ''}`}
                 accessibilityState={{ selected: active }}
                 onPress={() => onJumpToHole(h.number)}
                 style={{
@@ -198,9 +201,9 @@ export function ScorecardModal({
                 {parEditable ? (
                   <Pressable
                     accessibilityRole="button"
-                    accessibilityLabel={`Par ${h.par}, tap to change`}
+                    accessibilityLabel={`Par ${par}, tap to change`}
                     onPress={() => {
-                      const next = h.par === 3 ? 4 : h.par === 4 ? 5 : 3
+                      const next = par === 3 ? 4 : par === 4 ? 5 : 3
                       onChangePar?.(h.id, next)
                     }}
                     hitSlop={6}
@@ -221,7 +224,7 @@ export function ScorecardModal({
                         textDecorationColor: '#9F9580',
                       }]}
                     >
-                      {h.par}
+                      {par}
                     </Text>
                   </Pressable>
                 ) : (
@@ -234,7 +237,7 @@ export function ScorecardModal({
                       fontVariant: ['tabular-nums'],
                     }]}
                   >
-                    {h.par}
+                    {par}
                   </Text>
                 )}
                 <Text
@@ -373,7 +376,7 @@ export function ScorecardPreview({
           const hs = scoresByHoleId.get(h.id)
           const active = h.number === currentHoleNumber
           const score = hs?.score && hs.score > 0 ? hs.score : null
-          const diff = score != null ? score - h.par : null
+          const diff = score != null ? score - (hs?.par ?? h.par) : null
           const isCircle = diff != null && diff <= -1
           const isSquare = diff != null && diff >= 1
           const hasDecoration = isCircle || isSquare

--- a/apps/mobile/components/round/ShareableScorecardCard.tsx
+++ b/apps/mobile/components/round/ShareableScorecardCard.tsx
@@ -85,7 +85,10 @@ export function ShareableScorecardCard({
 
   const totalPar = holeNumbers.reduce((sum, n) => {
     const h = holesByNumber.get(n)
-    return sum + (h?.par ?? 4)
+    // Per-round par override (#710) — hole_scores.par wins over the
+    // course hole's par when the player corrected it.
+    const hs = h ? scoresByHoleId.get(h.id) : null
+    return sum + (hs?.par ?? h?.par ?? 4)
   }, 0)
   const total = round.total_score ?? null
   const toPar = total != null ? total - totalPar : null
@@ -288,13 +291,13 @@ function ScoreGrid({
   let anyScore = false
   for (const n of holeNumbers) {
     const h = holesByNumber.get(n)
-    parSum += h?.par ?? 4
-    if (h) {
-      const hs = scoresByHoleId.get(h.id)
-      if (hs?.score != null && hs.score > 0) {
-        scoreSum += hs.score
-        anyScore = true
-      }
+    const hs = h ? scoresByHoleId.get(h.id) : null
+    // Per-round par override (#710) — hole_scores.par wins over the
+    // course hole's par when the player corrected it.
+    parSum += hs?.par ?? h?.par ?? 4
+    if (hs?.score != null && hs.score > 0) {
+      scoreSum += hs.score
+      anyScore = true
     }
   }
 
@@ -375,9 +378,10 @@ function ScoreGrid({
         <Text style={labelStyle}>Par</Text>
         {holeNumbers.map((n) => {
           const h = holesByNumber.get(n)
+          const hs = h ? scoresByHoleId.get(h.id) : null
           return (
             <Text key={`p-${n}`} style={{ ...cellNum, color: colors.inkDim }}>
-              {h?.par ?? 4}
+              {hs?.par ?? h?.par ?? 4}
             </Text>
           )
         })}
@@ -404,7 +408,7 @@ function ScoreGrid({
               key={`s-${n}`}
               cellStyle={cellNum}
               colors={colors}
-              par={h?.par ?? 4}
+              par={hs?.par ?? h?.par ?? 4}
               score={score}
             />
           )

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -326,7 +326,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     // 0 rows and reports success (#710) — so the write goes through the
     // authorized RPC, scoped to this round. Still background enrichment:
     // the shot already saved, so a failure warns rather than alerting.
-    const { error: updateErr } = await supabase.rpc('update_hole_curation', {
+    const { error: updateErr } = await supabase.rpc('update_hole_tee', {
       p_hole_id: currentHole.id,
       p_round_id: id,
       p_tee_lat: loc.lat,

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -313,7 +313,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   // light up without a manual placement step. Background + non-blocking: the
   // shot already saved, so a failure warns rather than alerting.
   async function writeTee(loc: LatLng) {
-    if (!currentHole) return
+    if (!currentHole || !id) return
     if (!Number.isFinite(loc.lat) || !Number.isFinite(loc.lng)) return
     setHoles((prev) =>
       prev.map((h) =>
@@ -322,10 +322,16 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
           : h,
       ),
     )
-    const { error: updateErr } = await supabase
-      .from('holes')
-      .update({ tee_lat: loc.lat, tee_lng: loc.lng })
-      .eq('id', currentHole.id)
+    // `holes` has no UPDATE RLS policy — a direct .update() filters to
+    // 0 rows and reports success (#710) — so the write goes through the
+    // authorized RPC, scoped to this round. Still background enrichment:
+    // the shot already saved, so a failure warns rather than alerting.
+    const { error: updateErr } = await supabase.rpc('update_hole_curation', {
+      p_hole_id: currentHole.id,
+      p_round_id: id,
+      p_tee_lat: loc.lat,
+      p_tee_lng: loc.lng,
+    })
     if (updateErr) {
       // eslint-disable-next-line no-console
       console.warn('[hole/tee-auto-persist]', updateErr.message)

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -66,13 +66,26 @@ export async function completeRound({
   if (holeScoresRes.error) throw holeScoresRes.error
   if (shotsRes.error) throw shotsRes.error
 
-  const holes: HoleRow[] = holesRes.data ?? []
   const holeScoreRows = (holeScoresRes.data ?? []) as Array<
     HoleScoreRow & { holes?: HoleRow | null }
   >
   const holeScores: HoleScoreRow[] = holeScoreRows.map((row) => {
     const { holes: _h, ...rest } = row
     return rest
+  })
+  // Per-round par override (#710): a hole_scores.par set during the round
+  // wins over the course hole's par for everything stamped at completion —
+  // stat inference, SG categorization, and the differential. Patching the
+  // holes array here is safe: unique (round_id, hole_id) means each hole
+  // has at most one override in this round.
+  const parOverrides = new Map(
+    holeScores
+      .filter((hs) => hs.par != null)
+      .map((hs) => [hs.hole_id, hs.par as number]),
+  )
+  const holes: HoleRow[] = (holesRes.data ?? []).map((h) => {
+    const par = parOverrides.get(h.id)
+    return par != null && par !== h.par ? { ...h, par } : h
   })
   const shots = (shotsRes.data ?? []) as unknown as ShotRow[]
   const tees: CourseTeeRow[] = teesRes.data ?? []

--- a/apps/web/src/components/rounds/HoleScoreCard.tsx
+++ b/apps/web/src/components/rounds/HoleScoreCard.tsx
@@ -114,23 +114,28 @@ export function HoleScoreCard({
   }, [holeScore])
 
   // Cycle par 3 → 4 → 5 → 3. Synthetic placeholders are materialized via
-  // ensureRealHole so the UPDATE has a real id to target; real holes
-  // short-circuit to a plain UPDATE. Either way the change is permanent
-  // course curation — every par tap improves the dataset over time.
+  // ensureRealHole so the write has a real id to target. `holes` has no
+  // UPDATE RLS policy — a direct .update() filters to 0 rows and reports
+  // success (#710) — so curation goes through the authorized RPC, scoped
+  // to a round the caller owns on the hole's course.
   async function setPar(newPar: number) {
     setParOverride(newPar)
-    const realHoleId = await ensureRealHole({ ...hole, par: newPar })
-    const { error } = await supabase
-      .from('holes')
-      .update({ par: newPar })
-      .eq('id', realHoleId)
-    if (error) {
+    try {
+      const realHoleId = await ensureRealHole({ ...hole, par: newPar })
+      const { error } = await supabase.rpc('update_hole_curation', {
+        p_hole_id: realHoleId,
+        p_round_id: roundId,
+        p_par: newPar,
+      })
+      if (error) throw error
+    } catch (err) {
       // Roll back the optimistic override so the UI doesn't lie about
       // what's persisted. The user re-tries by tapping again.
       setParOverride(null)
+      setSaveError(toUserMessage(err))
       if (import.meta.env.DEV) {
         // eslint-disable-next-line no-console
-        console.error('[HoleScoreCard/setPar]', error)
+        console.error('[HoleScoreCard/setPar]', err)
       }
       return
     }

--- a/apps/web/src/components/rounds/HoleScoreCard.tsx
+++ b/apps/web/src/components/rounds/HoleScoreCard.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
 import type { Database } from '@oga/supabase'
 import { useUpsertHoleScore } from '../../hooks/useHoleScores'
 import { useUnits } from '../../hooks/useUnits'
-import { supabase } from '../../lib/supabase'
 import { toUserMessage } from '../../lib/errors'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
@@ -85,7 +83,6 @@ export function HoleScoreCard({
   onEditShots,
 }: HoleScoreCardProps) {
   const upsert = useUpsertHoleScore(roundId)
-  const queryClient = useQueryClient()
   const { toDisplay } = useUnits()
   const [score, setScore] = useState<string>(holeScore?.score?.toString() ?? '')
   const [putts, setPutts] = useState<string>(holeScore?.putts?.toString() ?? '')
@@ -94,9 +91,11 @@ export function HoleScoreCard({
   // Par is always editable on the scorecard — synthetic-fallback courses
   // need it (par-4 default is wrong for the par 3s and 5s) and real
   // courses occasionally have stale data the player wants to correct.
+  // Persisted as hole_scores.par (per-round override, #710); the course
+  // hole's par is the fallback.
   const [parOverride, setParOverride] = useState<number | null>(null)
   const [saveError, setSaveError] = useState<string | null>(null)
-  const effectivePar = parOverride ?? hole.par
+  const effectivePar = parOverride ?? holeScore?.par ?? hole.par
 
   // Hydrate the form from server state once per holeScore.id. Subsequent
   // refetches (after our own save, or another tab) must not clobber what
@@ -113,21 +112,26 @@ export function HoleScoreCard({
     setGir(holeScore.gir ?? null)
   }, [holeScore])
 
-  // Cycle par 3 → 4 → 5 → 3. Synthetic placeholders are materialized via
-  // ensureRealHole so the write has a real id to target. `holes` has no
-  // UPDATE RLS policy — a direct .update() filters to 0 rows and reports
-  // success (#710) — so curation goes through the authorized RPC, scoped
-  // to a round the caller owns on the hole's course.
+  // Cycle par 3 → 4 → 5 → 3. Par is a per-round override on
+  // hole_scores.par (#710) — this round's opinion, not global course
+  // curation (holes has no UPDATE policy; the old direct update silently
+  // no-op'd). With no score yet there's no hole_scores row to hold it
+  // (score is NOT NULL), so the override stays local and persist()
+  // carries it with the first score save.
   async function setPar(newPar: number) {
     setParOverride(newPar)
+    const existingScore = holeScore?.score ?? (score ? Number(score) : null)
+    if (!existingScore) return
+    setSaveError(null)
     try {
       const realHoleId = await ensureRealHole({ ...hole, par: newPar })
-      const { error } = await supabase.rpc('update_hole_curation', {
-        p_hole_id: realHoleId,
-        p_round_id: roundId,
-        p_par: newPar,
+      await upsert.mutateAsync({
+        id: holeScore?.id,
+        round_id: roundId,
+        hole_id: realHoleId,
+        score: existingScore,
+        par: newPar,
       })
-      if (error) throw error
     } catch (err) {
       // Roll back the optimistic override so the UI doesn't lie about
       // what's persisted. The user re-tries by tapping again.
@@ -137,9 +141,7 @@ export function HoleScoreCard({
         // eslint-disable-next-line no-console
         console.error('[HoleScoreCard/setPar]', err)
       }
-      return
     }
-    queryClient.invalidateQueries({ queryKey: ['holes', hole.course_id] })
   }
 
   async function persist(next: {
@@ -167,6 +169,9 @@ export function HoleScoreCard({
         round_id: roundId,
         hole_id: realHoleId,
         score: numericScore,
+        // Carry a locally-held par override (tapped before any score
+        // existed) so it lands with the row's first save.
+        par: parOverride ?? undefined,
         putts:
           next.putts !== undefined
             ? next.putts

--- a/apps/web/src/components/rounds/RoundSummary.tsx
+++ b/apps/web/src/components/rounds/RoundSummary.tsx
@@ -44,7 +44,9 @@ function bestWorstHole(
   for (const hs of holeScores) {
     const hole = byHoleId.get(hs.hole_id)
     if (!hole) continue
-    const diff = hs.score - hole.par
+    // Per-round par override (#710) — hole_scores.par wins over the
+    // course hole's par when the player corrected it.
+    const diff = hs.score - (hs.par ?? hole.par)
     if (!best || diff < best.diff) best = { number: hole.number, diff }
     if (!worst || diff > worst.diff) worst = { number: hole.number, diff }
   }
@@ -57,7 +59,11 @@ export function RoundSummary({
   holeScores,
   totalRoundsLogged,
 }: RoundSummaryProps) {
-  const par = holes.reduce((sum, h) => sum + h.par, 0)
+  // Per-round par override (#710) folded into the round's total par.
+  const parByHoleId = new Map(
+    holeScores.filter((hs) => hs.par != null).map((hs) => [hs.hole_id, hs.par!]),
+  )
+  const par = holes.reduce((sum, h) => sum + (parByHoleId.get(h.id) ?? h.par), 0)
   const score = round.total_score ?? holeScores.reduce((s, hs) => s + hs.score, 0)
   const toPar = score && par ? score - par : null
   const { best, worst } = bestWorstHole(holeScores, holes)

--- a/apps/web/src/hooks/useCompleteRound.ts
+++ b/apps/web/src/hooks/useCompleteRound.ts
@@ -61,13 +61,26 @@ export function useCompleteRound() {
       // needed. The holeScoreRows annotation carries the nested holes()
       // join shape that the typed select doesn't expose; that's the one
       // place a narrowing assertion still earns its keep.
-      const holes: HoleRow[] = holesRes.data ?? []
       const holeScoreRows = (holeScoresRes.data ?? []) as Array<
         HoleScoreRow & { holes?: HoleRow | null }
       >
       const holeScores: HoleScoreRow[] = holeScoreRows.map((row) => {
         const { holes: _holes, ...rest } = row
         return rest
+      })
+      // Per-round par override (#710): a hole_scores.par set during the
+      // round wins over the course hole's par for everything stamped at
+      // completion — SG categorization and the differential. Patching the
+      // holes array here is safe: unique (round_id, hole_id) means each
+      // hole has at most one override in this round.
+      const parOverrides = new Map(
+        holeScores
+          .filter((hs) => hs.par != null)
+          .map((hs) => [hs.hole_id, hs.par as number]),
+      )
+      const holes: HoleRow[] = (holesRes.data ?? []).map((h) => {
+        const par = parOverrides.get(h.id)
+        return par != null && par !== h.par ? { ...h, par } : h
       })
       // `as unknown as ShotRow[]` because getShotsForRound now narrows the
       // select to the columns the SG calc actually reads — created_at is

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -416,8 +416,13 @@ export function RoundDetailPage() {
                 <HoleReviewSheet
                   open={reviewOpen}
                   holeNumber={activeHole.number}
-                  par={activeHole.par}
-                  totalPar={holes.reduce((s, h) => s + h.par, 0)}
+                  // Per-round par override (#710) — hole_scores.par wins
+                  // over the course hole's par when the player corrected it.
+                  par={scoresByHoleId.get(activeHole.id)?.par ?? activeHole.par}
+                  totalPar={holes.reduce(
+                    (s, h) => s + (scoresByHoleId.get(h.id)?.par ?? h.par),
+                    0,
+                  )}
                   pinLat={effectivePin?.lat ?? null}
                   pinLng={effectivePin?.lng ?? null}
                   placedPoints={placedPoints}

--- a/apps/web/src/pages/rounds/components/ScorecardView.tsx
+++ b/apps/web/src/pages/rounds/components/ScorecardView.tsx
@@ -113,7 +113,8 @@ export function ScorecardView({
                 onEditShots({
                   holeScoreId,
                   holeNumber: h.number,
-                  holePar: h.par,
+                  // Per-round par override (#710) — hole_scores.par wins.
+                  holePar: hs?.par ?? h.par,
                 })
               }
             />

--- a/packages/core/src/__tests__/sg.test.ts
+++ b/packages/core/src/__tests__/sg.test.ts
@@ -232,6 +232,7 @@ describe('computeRoundSG (sg.ts) — DB row → result adapter', () => {
       round_id: overrides.round_id ?? 'r',
       hole_id: overrides.hole_id ?? 'h1',
       score: overrides.score ?? 4,
+      par: overrides.par ?? null,
       putts: overrides.putts ?? null,
       fairway_hit: overrides.fairway_hit ?? null,
       gir: overrides.gir ?? null,

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -734,6 +734,16 @@ export type Database = {
         Args: { p_club_ids: string[]; p_orders: number[]; p_user_id: string }
         Returns: undefined
       }
+      update_hole_curation: {
+        Args: {
+          p_hole_id: string
+          p_par?: number
+          p_round_id: string
+          p_tee_lat?: number
+          p_tee_lng?: number
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -238,6 +238,7 @@ export type Database = {
           gir: boolean | null
           hole_id: string
           id: string
+          par: number | null
           pin_lat: number | null
           pin_lng: number | null
           putts: number | null
@@ -253,6 +254,7 @@ export type Database = {
           gir?: boolean | null
           hole_id: string
           id?: string
+          par?: number | null
           pin_lat?: number | null
           pin_lng?: number | null
           putts?: number | null
@@ -268,6 +270,7 @@ export type Database = {
           gir?: boolean | null
           hole_id?: string
           id?: string
+          par?: number | null
           pin_lat?: number | null
           pin_lng?: number | null
           putts?: number | null
@@ -734,13 +737,12 @@ export type Database = {
         Args: { p_club_ids: string[]; p_orders: number[]; p_user_id: string }
         Returns: undefined
       }
-      update_hole_curation: {
+      update_hole_tee: {
         Args: {
           p_hole_id: string
-          p_par?: number
           p_round_id: string
-          p_tee_lat?: number
-          p_tee_lng?: number
+          p_tee_lat: number
+          p_tee_lng: number
         }
         Returns: undefined
       }

--- a/supabase/migrations/0040_hole_curation_rpc.sql
+++ b/supabase/migrations/0040_hole_curation_rpc.sql
@@ -1,0 +1,127 @@
+-- Hole curation writes go through an authorized RPC (closes #710, #721).
+--
+-- `holes` has RLS with only SELECT + INSERT policies — no UPDATE policy
+-- exists in 0001–0039. An UPDATE under RLS with zero policies filters to
+-- 0 rows and PostgREST returns success with `error: null`, so every par
+-- correction and auto-persisted tee coordinate silently no-op'd for every
+-- user, including the course creator.
+--
+-- Rather than an open UPDATE policy on a shared table, curation goes
+-- through `update_hole_curation(...)` (SECURITY DEFINER, matching the
+-- `insert_synthetic_hole` ownership shape): only the crowd-curation
+-- columns (par, tee_lat, tee_lng) are writable, and the caller must own
+-- a round on the hole's course — round-scoped authorization, same
+-- auditable trail the INSERT path requires.
+
+create or replace function public.update_hole_curation(
+  p_hole_id uuid,
+  p_round_id uuid,
+  p_par integer default null,
+  p_tee_lat double precision default null,
+  p_tee_lng double precision default null
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'not authenticated';
+  end if;
+
+  -- Cap par to the table's CHECK range so a malformed payload returns
+  -- a clean error instead of tripping the constraint deep in the function.
+  if p_par is not null and (p_par < 3 or p_par > 6) then
+    raise exception 'par must be between 3 and 6';
+  end if;
+
+  -- Caller must own a round on the same course as the hole they're
+  -- curating. Stops a malicious client from editing arbitrary holes by
+  -- passing any owned round id — the round has to reference the hole's
+  -- course, and rounds.user_id is RLS-scoped.
+  if not exists (
+    select 1 from public.rounds r
+    join public.holes h on h.id = p_hole_id and h.course_id = r.course_id
+    where r.id = p_round_id
+      and r.user_id = v_user_id
+  ) then
+    raise exception 'not authorized';
+  end if;
+
+  update public.holes set
+    par = coalesce(p_par, par),
+    tee_lat = coalesce(p_tee_lat, tee_lat),
+    tee_lng = coalesce(p_tee_lng, tee_lng)
+  where id = p_hole_id;
+end;
+$$;
+
+revoke all on function public.update_hole_curation(uuid, uuid, integer, double precision, double precision) from public;
+grant execute on function public.update_hole_curation(uuid, uuid, integer, double precision, double precision) to authenticated;
+
+-- #721: insert_synthetic_hole's own comment claims the round must be on
+-- the target course, but the check was never implemented — any owned
+-- round authorized hole inserts on any public course. Add the one-line
+-- `r.course_id = p_course_id` predicate; body otherwise identical to 0026.
+
+create or replace function public.insert_synthetic_hole(
+  p_course_id uuid,
+  p_number integer,
+  p_par integer,
+  p_round_id uuid
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_hole_id uuid;
+  v_user_id uuid := auth.uid();
+begin
+  if v_user_id is null then
+    raise exception 'not authenticated';
+  end if;
+
+  -- Caller must own the round they're materializing the hole for.
+  -- Stops a malicious client from inserting holes for arbitrary courses
+  -- by passing a course_id they don't own — they'd still need a round
+  -- on that course, and rounds.user_id is RLS-scoped.
+  if not exists (
+    select 1 from public.rounds r
+    where r.id = p_round_id
+      and r.user_id = v_user_id
+      and r.course_id = p_course_id
+  ) then
+    raise exception 'not authorized';
+  end if;
+
+  -- Cap par to the table's CHECK range so a malformed payload returns
+  -- a clean error instead of tripping the constraint deep in the function.
+  if p_par < 3 or p_par > 6 then
+    raise exception 'par must be between 3 and 6';
+  end if;
+  if p_number < 1 or p_number > 18 then
+    raise exception 'number must be between 1 and 18';
+  end if;
+
+  insert into public.holes (course_id, number, par, stroke_index)
+  values (p_course_id, p_number, p_par, p_number)
+  on conflict (course_id, number) do nothing
+  returning id into v_hole_id;
+
+  -- ON CONFLICT DO NOTHING returns NULL on conflict — fetch the
+  -- existing row so the caller always gets a real id.
+  if v_hole_id is null then
+    select id into v_hole_id
+    from public.holes
+    where course_id = p_course_id
+      and number = p_number;
+  end if;
+
+  return v_hole_id;
+end;
+$$;

--- a/supabase/migrations/0040_round_par_override_and_tee_rpc.sql
+++ b/supabase/migrations/0040_round_par_override_and_tee_rpc.sql
@@ -38,6 +38,14 @@ begin
     raise exception 'not authenticated';
   end if;
 
+  -- Bound the coordinates like par is bounded below — holes is shared
+  -- crowd data, and a direct RPC caller bypasses the client-side
+  -- Number.isFinite guard. NaN fails all comparisons, so this also
+  -- rejects non-finite input with a clean error.
+  if not (p_tee_lat between -90 and 90) or not (p_tee_lng between -180 and 180) then
+    raise exception 'tee coordinates out of range';
+  end if;
+
   -- Caller must own a round on the same course as the hole whose tee
   -- they're capturing. Stops a malicious client from editing arbitrary
   -- holes by passing any owned round id — the round has to reference the

--- a/supabase/migrations/0040_round_par_override_and_tee_rpc.sql
+++ b/supabase/migrations/0040_round_par_override_and_tee_rpc.sql
@@ -1,4 +1,4 @@
--- Hole curation writes go through an authorized RPC (closes #710, #721).
+-- Per-round par override + authorized tee RPC (closes #710, #721).
 --
 -- `holes` has RLS with only SELECT + INSERT policies — no UPDATE policy
 -- exists in 0001–0039. An UPDATE under RLS with zero policies filters to
@@ -6,19 +6,25 @@
 -- correction and auto-persisted tee coordinate silently no-op'd for every
 -- user, including the course creator.
 --
--- Rather than an open UPDATE policy on a shared table, curation goes
--- through `update_hole_curation(...)` (SECURITY DEFINER, matching the
--- `insert_synthetic_hole` ownership shape): only the crowd-curation
--- columns (par, tee_lat, tee_lng) are writable, and the caller must own
--- a round on the hole's course — round-scoped authorization, same
--- auditable trail the INSERT path requires.
+-- The fix splits by what the data IS:
+--   * Par corrections are the player's per-round opinion, not global
+--     course curation — they land on `hole_scores.par` (nullable; null =
+--     use the course hole's par). `hole_scores` already has the
+--     owner-scoped FOR ALL policy from 0001, so no policy work needed.
+--   * Tee coordinates are factual GPS capture and stay global on
+--     `holes`, but writes go through `update_hole_tee(...)` (SECURITY
+--     DEFINER, matching the `insert_synthetic_hole` ownership shape):
+--     only tee_lat/tee_lng are writable, and the caller must own a round
+--     on the hole's course — round-scoped, auditable authorization.
 
-create or replace function public.update_hole_curation(
+alter table public.hole_scores
+  add column par smallint check (par between 3 and 6);
+
+create or replace function public.update_hole_tee(
   p_hole_id uuid,
   p_round_id uuid,
-  p_par integer default null,
-  p_tee_lat double precision default null,
-  p_tee_lng double precision default null
+  p_tee_lat double precision,
+  p_tee_lng double precision
 )
 returns void
 language plpgsql
@@ -32,16 +38,10 @@ begin
     raise exception 'not authenticated';
   end if;
 
-  -- Cap par to the table's CHECK range so a malformed payload returns
-  -- a clean error instead of tripping the constraint deep in the function.
-  if p_par is not null and (p_par < 3 or p_par > 6) then
-    raise exception 'par must be between 3 and 6';
-  end if;
-
-  -- Caller must own a round on the same course as the hole they're
-  -- curating. Stops a malicious client from editing arbitrary holes by
-  -- passing any owned round id — the round has to reference the hole's
-  -- course, and rounds.user_id is RLS-scoped.
+  -- Caller must own a round on the same course as the hole whose tee
+  -- they're capturing. Stops a malicious client from editing arbitrary
+  -- holes by passing any owned round id — the round has to reference the
+  -- hole's course, and rounds.user_id is RLS-scoped.
   if not exists (
     select 1 from public.rounds r
     join public.holes h on h.id = p_hole_id and h.course_id = r.course_id
@@ -52,15 +52,14 @@ begin
   end if;
 
   update public.holes set
-    par = coalesce(p_par, par),
-    tee_lat = coalesce(p_tee_lat, tee_lat),
-    tee_lng = coalesce(p_tee_lng, tee_lng)
+    tee_lat = p_tee_lat,
+    tee_lng = p_tee_lng
   where id = p_hole_id;
 end;
 $$;
 
-revoke all on function public.update_hole_curation(uuid, uuid, integer, double precision, double precision) from public;
-grant execute on function public.update_hole_curation(uuid, uuid, integer, double precision, double precision) to authenticated;
+revoke all on function public.update_hole_tee(uuid, uuid, double precision, double precision) from public;
+grant execute on function public.update_hole_tee(uuid, uuid, double precision, double precision) to authenticated;
 
 -- #721: insert_synthetic_hole's own comment claims the round must be on
 -- the target course, but the check was never implemented — any owned


### PR DESCRIPTION
## Mechanism

`holes` has RLS enabled with only SELECT + INSERT policies — no UPDATE policy exists in any migration 0001–0039 (verified against live prod + dev `pg_policy`). An UPDATE under RLS with zero policies filters to 0 rows, and PostgREST reports success with `error: null`. All three client call sites checked only `error`, so par corrections and auto-captured tee coordinates **silently never persisted for any user**, and every rollback/warn branch was structurally unreachable.

## Design (per maintainer decision on the #710 open question)

- **Par is a per-round override, not global crowd curation** — new nullable `hole_scores.par` (null = use the course hole's par). `hole_scores` already carries the owner-scoped FOR ALL policy from 0001, so no policy work needed.
- **Tee auto-capture stays global** (GPS tee coords are factual data) — writes go through a narrow SECURITY DEFINER RPC.

## Migration `0040_round_par_override_and_tee_rpc.sql`

- `alter table hole_scores add column par smallint check (par between 3 and 6)` (nullable).
- New `update_hole_tee(p_hole_id, p_round_id, p_tee_lat, p_tee_lng)` — SECURITY DEFINER, `set search_path = public`, auth check, authorization = caller owns a round whose `course_id` matches the hole's course; updates only `tee_lat`/`tee_lng`. `revoke all from public` + `grant execute to authenticated`.
- **#721:** `create or replace` of `insert_synthetic_hole` adding the one-line `and r.course_id = p_course_id` predicate its own comment always claimed — body otherwise copied verbatim from 0026.

## `types.ts` hand-edit

Added `par` to the `hole_scores` Row/Insert/Update types and an `update_hole_tee` Functions entry in `packages/supabase/src/types.ts`. Types are normally generated — these entries will be reconciled at the next `gen types` run after the migration is applied.

## Call-site changes

- **web `HoleScoreCard.tsx` (setPar):** par now persists through the component's existing `hole_scores` upsert path (`ensureRealHole` + `useUpsertHoleScore`). `effectivePar` chain is `parOverride ?? holeScore?.par ?? hole.par`. Because `hole_scores.score` is NOT NULL, a par tap before any score stays a local override and `persist()` carries it with the first score save. On failure: rolls back the optimistic override AND surfaces via the card's existing `saveError` affordance.
- **mobile `LiveRoundSession.tsx` (onChangePar):** writes `hole_scores.par` by the hole's `hole_scores` row id (rows are batch-created at round start), chaining `.select('id')` and **treating 0 returned rows as failure** — the #710 lesson. The previously-unreachable optimistic-rollback branch is now reachable and rolls back `holeScores` state.
- **mobile `useShotActions.ts` (writeTee):** `.update()` → `update_hole_tee` RPC. Keeps its fire-and-forget background-enrichment character — real errors `console.warn`, never user-blocking.

## Effective-par reads (`hs.par ?? hole.par`, inline — no helper)

- **Completion boundary (both apps):** `apps/mobile/lib/completeRound.ts` and `apps/web/src/hooks/useCompleteRound.ts` patch the fetched `holes` array with per-round overrides before `computeRoundSG` / `inferHoleStats` / the WHS differential — one boundary covers SG categorization, stat inference, and to-par stamped at round completion.
- **Mobile displays:** live HUD par (LiveRoundSession ×2), `Scorecard.tsx` modal (display, running par, diff, cycle base, a11y labels) + `ScorecardPreview` diff, past-round detail scorecard (`round/[id]/index.tsx`: running totals, per-hole diff, FIR/GIR inference, par cell), `ShareableScorecardCard` (total par, grid par sums, par row, score-cell par).
- **Web displays:** `RoundSummary` (total par + best/worst hole diffs), `ScorecardView` (holePar passed to the shot editor), `RoundDetailPage` `HoleReviewSheet` (par + totalPar — `scoresByHoleId` already in scope).

**Deliberately left reading base par** (out of scope, no hole_scores fetched alongside or intentionally course-level): `@oga/core` stats aggregates, courses pages, web `MapView` hole-marker titles, web `useRoundData` internal shot-categorization pars, mobile `PastRoundMap` HUD par, `round/new.tsx` (round creation).

## How verified

- Root `pnpm typecheck` and `apps/mobile` `npm run typecheck` both pass.
- **Migration NOT applied to any live database** — needs `npx supabase db push` on dev, then prod, after merge.

Closes #710
Closes #721