### PR TITLE
fix: display batch — 9-hole share card, sentinel score renders, hole clamp, styledata listener

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -142,17 +142,20 @@ export default function Home() {
       const avg = values.length === 0 ? 0 : values.reduce((a, b) => a + b, 0) / values.length
       return { ...c, value: Number(avg.toFixed(2)) }
     })
-    const scoreRounds = rounds.filter((r) => r.total_score !== null)
-    const avgScore = scoreRounds.length > 0
-      ? scoreRounds.reduce((s, r) => s + (r.total_score ?? 0), 0) / scoreRounds.length
-      : null
     // total_score === 0 is the past-round-logger sentinel for "no score
-    // entered" (map-created rounds), so exclude it from the best-round min —
-    // otherwise a single unscored round always reads as a best of 0.
-    const realScores = rounds
-      .map((r) => r.total_score)
-      .filter((s): s is number => s != null && s > 0)
-    const bestScore = realScores.length > 0 ? Math.min(...realScores) : null
+    // entered" (map-created rounds), so exclude it from avg + best-round min —
+    // otherwise an abandoned log skews the average and a single unscored
+    // round always reads as a best of 0.
+    const realScoreRounds = rounds.filter(
+      (r): r is typeof r & { total_score: number } =>
+        r.total_score != null && r.total_score > 0,
+    )
+    const avgScore = realScoreRounds.length > 0
+      ? realScoreRounds.reduce((s, r) => s + r.total_score, 0) / realScoreRounds.length
+      : null
+    const bestScore = realScoreRounds.length > 0
+      ? Math.min(...realScoreRounds.map((r) => r.total_score))
+      : null
     const totalSG = avgs.reduce((s, a) => s + a.value, 0)
     const sorted = [...avgs].sort((a, b) => b.value - a.value)
     return { avgScore, bestScore, totalSG, weakest: sorted[sorted.length - 1]!, strongest: sorted[0]! }

--- a/apps/mobile/app/(app)/rounds.tsx
+++ b/apps/mobile/app/(app)/rounds.tsx
@@ -203,7 +203,7 @@ export default function RoundsList() {
                           fontVariant: ['tabular-nums'],
                         }]}
                       >
-                        {r.total_score ?? '—'}
+                        {r.total_score ? r.total_score : '—'}
                       </Text>
                       <Text
                         style={[TYPE.serifUpright, {

--- a/apps/mobile/components/home/RecentRoundsList.tsx
+++ b/apps/mobile/components/home/RecentRoundsList.tsx
@@ -136,7 +136,7 @@ export function RecentRoundsList({
                         },
                       ]}
                     >
-                      {r.total_score ?? '—'}
+                      {r.total_score ? r.total_score : '—'}
                     </Text>
                     <SGValue value={r.sg_total} />
                   </View>

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -133,6 +133,15 @@ export default function LiveRoundSession({
   }, [initialHoleNumber])
 
   const data = useHoleData(roundId, holeNumber)
+  // Deep-link / refresh clamp (#718): ?hole= can name a hole past the
+  // round's actual count (e.g. hole=10 on a 9-hole round) — the
+  // Resume-banner path (useActiveRound) already clamps to the round's
+  // real hole count, this mirrors it here once data.holeCount is known,
+  // instead of stranding the player on the "isn't set up" error branch.
+  useEffect(() => {
+    if (data.loading) return
+    if (holeNumber > data.holeCount) setHoleNumber(data.holeCount)
+  }, [data.loading, data.holeCount, holeNumber])
   const finalState = useHoleState({
     currentHoleId: data.currentHole?.id ?? null,
     currentHoleScoreId: data.currentHoleScore?.id ?? null,

--- a/apps/web/src/components/round/ShareableScorecardCard.tsx
+++ b/apps/web/src/components/round/ShareableScorecardCard.tsx
@@ -1,5 +1,5 @@
 import type { Database } from '@oga/supabase'
-import { formatSG, formatToPar } from '@oga/core'
+import { formatSG, formatToPar, inferHoleCount } from '@oga/core'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
@@ -79,12 +79,12 @@ export function ShareableScorecardCard({
   const c = COLORS[tone]
   const courseName = round.courses?.name ?? 'Round'
 
-  // Stable 1..18 layout regardless of how many holes the array carries.
-  // Synthetic holes still get rendered with par 4 placeholders if needed
-  // — keeps the card visually balanced for partial rounds.
+  // Match the round's actual size (#715) — a 9-hole round shows one grid,
+  // not nine empty "In" cells. Empty/old rounds fall back to 18.
   const holesByNumber = new Map<number, HoleRow>()
   for (const h of holes) holesByNumber.set(h.number, h)
-  const holeNumbers = Array.from({ length: 18 }, (_, i) => i + 1)
+  const holeCount = inferHoleCount(holes.map((h) => h.number))
+  const holeNumbers = Array.from({ length: holeCount }, (_, i) => i + 1)
 
   const totalPar = holeNumbers.reduce((sum, n) => {
     const h = holesByNumber.get(n)
@@ -170,14 +170,18 @@ export function ShareableScorecardCard({
         colors={c}
         rangeLabel="Out"
       />
-      <div style={{ height: 14 }} />
-      <ScoreGrid
-        holeNumbers={holeNumbers.slice(9)}
-        holesByNumber={holesByNumber}
-        scoresByHoleId={scoresByHoleId}
-        colors={c}
-        rangeLabel="In"
-      />
+      {holeNumbers.length > 9 && (
+        <>
+          <div style={{ height: 14 }} />
+          <ScoreGrid
+            holeNumbers={holeNumbers.slice(9)}
+            holesByNumber={holesByNumber}
+            scoresByHoleId={scoresByHoleId}
+            colors={c}
+            rangeLabel="In"
+          />
+        </>
+      )}
 
       <section
         style={{

--- a/apps/web/src/components/round/map/useMapLayers.ts
+++ b/apps/web/src/components/round/map/useMapLayers.ts
@@ -582,8 +582,14 @@ export function useMapLayers({
     if (!map) return
     // Wait for style.
     if (!map.isStyleLoaded()) {
-      map.once('styledata', () => renderLayers())
-      return
+      const handler = () => renderLayers()
+      map.once('styledata', handler)
+      // Replace, don't stack (#719) — without this teardown, each effect
+      // re-run during the load window queues another once-listener with a
+      // stale renderLayers closure that fires after the fresh render.
+      return () => {
+        map.off('styledata', handler)
+      }
     }
     renderLayers()
   }, [mapRef, renderLayers])

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -11,7 +11,7 @@ import { ShareableScorecardCard } from '../../components/round/ShareableScorecar
 import { HoleReviewSheet } from '../../components/round/HoleReviewSheet'
 import { WebPuttingSheet } from '../../components/round/WebPuttingSheet'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
-import { DEFAULT_HANDICAP, haversineYards } from '@oga/core'
+import { DEFAULT_HANDICAP, haversineYards, inferHoleCount } from '@oga/core'
 import { useAuth } from '../../hooks/useAuth'
 import { useProfile } from '../../hooks/useProfile'
 import { toUserMessage } from '../../lib/errors'
@@ -209,6 +209,7 @@ export function RoundDetailPage() {
   }
 
   const holesPlayed = holeScores.length
+  const holeCount = inferHoleCount(holes.map((h) => h.number))
   const totalRoundsLogged = allRounds.data?.length ?? 0
   // The played tee (by id, then by colour) supplies rating/slope/yardage for
   // the share card — same match RoundHeader uses.
@@ -229,6 +230,7 @@ export function RoundDetailPage() {
         round={round.data as unknown as RoundRow & { courses?: { name?: string | null } | null }}
         tees={teesQuery.data ?? []}
         holesPlayed={holesPlayed}
+        holeCount={holeCount}
         shareTone={shareTone}
         sharing={sharing}
         completePending={completeMutation.isPending}

--- a/apps/web/src/pages/rounds/RoundsPage.tsx
+++ b/apps/web/src/pages/rounds/RoundsPage.tsx
@@ -169,7 +169,7 @@ export function RoundsPage() {
                       className="font-serif tabular text-caddie-ink"
                       style={{ fontSize: 28, fontWeight: 500, lineHeight: 1 }}
                     >
-                      {r.total_score ?? '—'}
+                      {r.total_score ? r.total_score : '—'}
                     </div>
                   </div>
                   <div className="text-right hidden sm:block" style={{ minWidth: 80 }}>

--- a/apps/web/src/pages/rounds/components/RoundHeader.tsx
+++ b/apps/web/src/pages/rounds/components/RoundHeader.tsx
@@ -7,6 +7,7 @@ interface RoundHeaderProps {
   round: RoundRow & { courses?: { name?: string | null } | null }
   tees: CourseTeeRow[]
   holesPlayed: number
+  holeCount: number
   shareTone: 'light' | 'dark'
   sharing: boolean
   completePending: boolean
@@ -22,6 +23,7 @@ export function RoundHeader({
   round,
   tees,
   holesPlayed,
+  holeCount,
   shareTone,
   sharing,
   completePending,
@@ -71,7 +73,7 @@ export function RoundHeader({
           >
             {round.played_at}
             {round.tee_color ? ` · ${round.tee_color} tees` : ''} ·{' '}
-            {holesPlayed}/18 holes scored
+            {holesPlayed}/{holeCount} holes scored
           </div>
           <RoundRatingLine round={round} tees={tees} />
         </div>


### PR DESCRIPTION
- **#715** — Web share card and round header hardcoded 18 holes. `ShareableScorecardCard.tsx` now uses `inferHoleCount` (mirroring the mobile card) to size `holeNumbers`/`totalPar` and only renders the back-nine grid when `holeCount > 9`. `RoundDetailPage.tsx` computes `holeCount` from the round's `holes` array and passes it to `RoundHeader.tsx`, which now shows `{holesPlayed}/{holeCount} holes scored` instead of the hardcoded `/18`.
- **#716** — Mobile home `avgScore` counted `total_score = 0` sentinel rounds (abandoned past-round logs), skewing the average indefinitely; `bestScore` already excluded them. Unified both into a single `realScoreRounds` filter (`total_score != null && total_score > 0`) in `app/(app)/index.tsx`. Also fixed three literal-`0` score renders that `?? '—'` didn't catch: `app/(app)/rounds.tsx`, `components/home/RecentRoundsList.tsx`, and web's `pages/rounds/RoundsPage.tsx`.
- **#718** — Deep-linking `round/[id]?hole=10+` on a 9-hole round hit the "Hole N isn't set up" dead-end. Added a clamp effect in `LiveRoundSession.tsx` right after `data = useHoleData(...)`: once `data.loading` is false, if `holeNumber > data.holeCount` it clamps `holeNumber` down to `data.holeCount`, mirroring the existing `useActiveRound` resume-banner clamp pattern.
- **#719** — `useMapLayers.ts`'s `styledata` wait-for-style branch registered `map.once('styledata', ...)` with no teardown, so repeated effect re-runs during the load window could stack stale-closure listeners that redraw old markers. Now uses a named handler and returns `() => map.off('styledata', handler)`.

**How verified:** `pnpm typecheck` (root) and `cd apps/mobile && npm run typecheck` both pass clean. Visual verification (9-hole share card render, avg-score display, hole-clamp deep link, map marker drag) is pending — not yet manually tested in-app.

Closes #715
Closes #716
Closes #718
Closes #719