### PR TITLE
feat(mobile): recenter button snaps the ball back to GPS during placement

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -111,6 +111,14 @@ interface HoleMapProps {
   aimCommitted?: boolean
   onSetAim: (loc: LatLng) => void
   onSetBall: (loc: LatLng) => void
+  /**
+   * Called with the current GPS fix when the recenter button is tapped
+   * during PLACE_BALL — a deliberate tap is explicit intent to put the
+   * ball back on the player, unlike the silent GPS clobber the manual-
+   * placement freeze exists to prevent (#713). Parent resumes GPS-driven
+   * ball tracking. Optional: past-round review passes nothing.
+   */
+  onRecenterBall?: (loc: LatLng) => void
   onPlacePin?: (loc: LatLng) => void
   /**
    * Whether to mount the Mapbox LocationPuck. The puck owns its own
@@ -203,6 +211,7 @@ export function HoleMap({
   holeNumber,
   onSetAim,
   onSetBall,
+  onRecenterBall,
   onPlacePin,
   showLocationPuck,
   tapToPlaceBall = true,
@@ -243,7 +252,10 @@ export function HoleMap({
       pitch: 0,
       animationDuration: 600,
     })
-  }, [gpsPosition, cameraRef])
+    // During ball placement the tap also snaps the ball back onto the
+    // player — the only way to resume GPS tracking after a manual drag.
+    if (isPlaceBallPhase) onRecenterBall?.(gpsPosition)
+  }, [gpsPosition, cameraRef, isPlaceBallPhase, onRecenterBall])
 
   const { aimGhosts, aimGhostFeatures } = useAimGhosts({
     ball,
@@ -921,7 +933,11 @@ export function HoleMap({
         {isPlaceBallPhase && (
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel="Center map on my location"
+            accessibilityLabel={
+              isPlaceBallPhase && onRecenterBall
+                ? 'Center map and ball on my location'
+                : 'Center map on my location'
+            }
             disabled={!gpsPosition}
             onPress={recenterOnGps}
             hitSlop={8}

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -559,6 +559,18 @@ export default function LiveRoundSession({
             }
             finalState.setBall(loc)
           }}
+          onRecenterBall={(loc) => {
+            // Deliberate recenter tap = "put the ball back on me": the
+            // inverse of onSetBall above. Lift the manual freeze, restart
+            // the Kalman filter from the next fresh fix, and snap the ball
+            // to GPS now for instant feedback. ballMoved=false restores
+            // the HUD's ball-from-GPS labeling.
+            if (isPastMode) return
+            finalState.manuallyPlacedRef.current = false
+            setBallMoved(false)
+            finalState.kalmanStateRef.current = null
+            finalState.setBall(loc)
+          }}
           onPlacePin={actions.persistRoundPin}
         />
         {finalState.aimHintVisible && (


### PR DESCRIPTION
Device-QA feedback: after manually dragging the ball marker there was no way to put it back on the player — the manual-placement freeze (correctly) blocks silent GPS clobbering, but nothing deliberately lifted it, and the recenter button was camera-only.

Now, during PLACE_BALL, tapping the recenter button recenters the camera AND resumes GPS-driven ball tracking: freeze lifted, Kalman restarted from the next fresh fix, ball snapped to the current fix immediately, `ballMoved` reset so the HUD's ball-from-GPS labeling returns. Outside placement (and in past-round review, which passes no handler) the button stays camera-only. A deliberate tap is explicit intent, so this doesn't conflict with the #713 anti-clobber protection. Accessibility label reflects the dual action in placement phase.

How verified: mobile typecheck clean; on-device via production-channel OTA after merge (pure JS).