### PR TITLE
fix: putt classification is green-lie only — putter off the green is a normal shot

### DIFF
--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -18,6 +18,7 @@ import {
   combinedPuttResult,
   formatClubLabel,
   formatDistance,
+  isPuttShot,
   type BreakDirectionHorizontal,
   type BreakDirectionVertical,
   type DistanceUnit,
@@ -276,7 +277,7 @@ function ShotRowView({
   unit: DistanceUnit
   onPress: () => void
 }) {
-  const isPutt = shot.lie_type === 'green' || shot.club === 'putter'
+  const isPutt = isPuttShot(shot.lie_type)
   const clubLabel = isPutt
     ? 'Putt'
     : shot.club
@@ -426,7 +427,7 @@ function EditShotSheet({
     (shot.break_direction_horizontal as BreakDirectionHorizontal | null) ?? null,
   )
 
-  const isPutt = lieType === 'green'
+  const isPutt = isPuttShot(lieType)
 
   const idx = allShots.findIndex((s) => s.id === shot.id)
   const prevShot = idx > 0 ? allShots[idx - 1]! : null

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -8,6 +8,7 @@ import {
   destinationYards,
   formatClubLabel,
   formatDistance,
+  isPuttShot,
   type DistanceUnit,
   type LieType,
   type ShotResult,
@@ -62,7 +63,7 @@ const SHOT_RESULT_SHORT: Record<ShotResult, string> = {
 // "Putt · 12 ft · Made"; full shots read "7i · Fairway · 152 yd · Solid".
 function summarizeShot(row: ShotRow | null, unit: DistanceUnit): string {
   if (!row) return 'No details yet — tap Edit to add them'
-  const isPutt = row.lie_type === 'green' || row.club === 'putter'
+  const isPutt = isPuttShot(row.lie_type)
   if (isPutt) {
     const miss = [row.putt_distance_result, row.putt_direction_result]
       .filter(Boolean)

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { inferHoleCount } from '@oga/core'
+import { inferHoleCount, isPuttShot } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import {
   pendingShotsForHoleScore,
@@ -257,9 +257,7 @@ export function useHoleData(
           }
         })
         setRemoteShotCount(shots.length)
-        setRemotePuttCount(
-          shots.filter((s) => s.club === 'putter' || s.lie_type === 'green').length,
-        )
+        setRemotePuttCount(shots.filter((s) => isPuttShot(s.lie_type)).length)
         const starts: LatLng[] = []
         for (const r of shots) {
           if (r.start_lat != null && r.start_lng != null) {
@@ -282,7 +280,7 @@ export function useHoleData(
 
   // Derive local shot/putt counts from the pending array — single source
   // of truth, never out of sync with the underlying queue. Putts are
-  // counted as shots where club='putter' OR lie_type='green'.
+  // counted via @oga/core isPuttShot (lie_type='green').
   const localShotCount = pendingForHole.length
 
   // Shot waypoints rendered on the map: synced shot starts followed by
@@ -316,7 +314,7 @@ export function useHoleData(
     for (const r of pendingForHole) {
       try {
         const p = JSON.parse(r.payload) as ShotPayload
-        if (p.club === 'putter' || p.lie_type === 'green') n++
+        if (isPuttShot(p.lie_type)) n++
       } catch {
         // skip malformed pending payload
       }

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -133,7 +133,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
 
   function buildPayload(meta: ShotLoggerValue | null): ShotPayload | null {
     if (!user || !currentHoleScore || !ball) return null
-    const isPutt = isPuttShot(meta?.lieType, meta?.club)
+    const isPutt = isPuttShot(meta?.lieType)
     const pinTarget = roundPin ?? storedPin ?? null
     return {
       hole_score_id: currentHoleScore.id,
@@ -196,7 +196,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     try {
       const localId = await insertPendingShot(payload)
       lastSavedShotLocalIdRef.current = localId
-      const isPutt = payload.club === 'putter' || payload.lie_type === 'green'
+      const isPutt = isPuttShot(payload.lie_type)
       setPendingForHole((prev) => [
         ...prev,
         {

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -348,10 +348,10 @@ function ShotRow({
   // Mirror mobile's PUTTING_RADIUS_YARDS — any shot starting within 30 yd
   // of the pin gets the putt entry surface (made/short/long, miss left/
   // right, distance in feet) rather than the standard club + lie row.
-  // Putt-ness is user intent only — lie 'green' (set when a putt is placed)
-  // or club 'putter'. Raw distance must NOT classify: a chip/bunker inside
-  // 30 yd is not a putt, and unmapped rows read distanceToPin 0 (#660).
-  const isPutt = isPuttShot(row.lieType, row.club)
+  // Putt-ness is the green lie only (set when a putt is placed). Raw
+  // distance must NOT classify: a chip/bunker inside 30 yd is not a putt,
+  // and unmapped rows read distanceToPin 0 (#660).
+  const isPutt = isPuttShot(row.lieType)
   const { toDisplay, toDisplayFt } = useUnits()
   const { bag } = useUserBag()
   // Source the club options from the user's bag, falling back to

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -164,7 +164,7 @@ export function ShotEntryModal({
     const shotNumber = editing
       ? draft.shotNumber
       : Math.max(freshMax, lastIssuedNumberRef.current) + 1
-    const isPuttSave = draft.lieType === 'green'
+    const isPuttSave = isPuttShot(draft.lieType)
     const made =
       opts?.madeOverride === true
         ? true
@@ -250,7 +250,7 @@ export function ShotEntryModal({
     setPendingDeleteId(null)
   }
 
-  const isPutt = draft.lieType === 'green'
+  const isPutt = isPuttShot(draft.lieType)
 
   // Source shot row + its successor for the mini-map. Mini-map shows
   // only when editing a saved shot with start coords; new-shot drafts
@@ -265,7 +265,7 @@ export function ShotEntryModal({
     // the pin so SG for this shot stays accurate. Skipped for putts
     // (distance_to_target stays null; putt_distance_ft tracks that flow
     // and isn't auto-recalculated on drag).
-    const editIsPutt = isPuttShot(editingRow.lie_type, editingRow.club)
+    const editIsPutt = isPuttShot(editingRow.lie_type)
     const newDistance =
       !editIsPutt && pinLat != null && pinLng != null
         ? Math.round(haversineYards(point.lat, point.lng, pinLat, pinLng))
@@ -644,7 +644,7 @@ function formatShotSummary(
   next: ShotRow | undefined,
   unit: DistanceUnit,
 ): string {
-  if (isPuttShot(s.lie_type, s.club)) {
+  if (isPuttShot(s.lie_type)) {
     const result =
       (s.putt_result &&
         PUTT_RESULT_LABELS[s.putt_result as keyof typeof PUTT_RESULT_LABELS]) ??

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -580,12 +580,10 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         // derived from the rows so the scorecard reflects what was placed
         // without needing a manual entry.
         const existing = scoresByHoleId.get(activeHole.id)
-        // Match HoleReviewSheet's isPutt — putt-ness is user intent (lie
-        // 'green', set when a putt is placed, or club 'putter'), never raw
-        // distance (a near-green chip isn't a putt; unmapped rows read 0).
-        const puttCount = rows.filter((r) =>
-          isPuttShot(r.lieType, r.club),
-        ).length
+        // Match HoleReviewSheet's isPutt — putt-ness is the green lie (set
+        // when a putt is placed), never club or raw distance (a near-green
+        // chip isn't a putt; unmapped rows read 0).
+        const puttCount = rows.filter((r) => isPuttShot(r.lieType)).length
         // Materialize the synthetic hole if needed before upserting the
         // hole_score (FK to holes.id). The RPC inserts only (course_id,
         // number, par, stroke_index) — per-round tee/pin overrides
@@ -642,7 +640,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         if (delErr) throw delErr
 
         for (const row of rows) {
-          const isPuttRow = isPuttShot(row.lieType, row.club)
+          const isPuttRow = isPuttShot(row.lieType)
           // Persist the aim only if the player actually set/dragged it — an
           // untouched auto-spawn suggestion is dropped so it can't enter the
           // dispersion dataset (aim must be explicit to count).

--- a/packages/core/src/__tests__/round.test.ts
+++ b/packages/core/src/__tests__/round.test.ts
@@ -115,20 +115,21 @@ describe('buildInitialRows', () => {
 
 describe('isPuttShot', () => {
   it('green lie is a putt', () => {
-    expect(isPuttShot('green', 'driver')).toBe(true)
+    expect(isPuttShot('green')).toBe(true)
   })
-  it('putter club is a putt', () => {
-    expect(isPuttShot('fairway', 'putter')).toBe(true)
+  it('putter off the green (Texas wedge) is NOT a putt (#691)', () => {
+    expect(isPuttShot('fairway')).toBe(false)
+    expect(isPuttShot('fringe')).toBe(false)
   })
-  it('near-green chip (rough/wedge) is NOT a putt', () => {
-    expect(isPuttShot('rough', 'gap-wedge')).toBe(false)
+  it('near-green chip is NOT a putt', () => {
+    expect(isPuttShot('rough')).toBe(false)
   })
   it('sand shot is NOT a putt', () => {
-    expect(isPuttShot('sand', '56')).toBe(false)
+    expect(isPuttShot('sand')).toBe(false)
   })
-  it('null/undefined fields are NOT a putt', () => {
-    expect(isPuttShot(null, null)).toBe(false)
-    expect(isPuttShot(undefined, undefined)).toBe(false)
+  it('null/undefined lie is NOT a putt', () => {
+    expect(isPuttShot(null)).toBe(false)
+    expect(isPuttShot(undefined)).toBe(false)
   })
 })
 

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -98,18 +98,17 @@ export function playedRowsForDifferential<T extends { score: number }>(
   return played.length === holeCount ? played : null
 }
 
-// Single source of truth for putt classification: a shot is a putt when its
-// lie is the green or its club is the putter. Feeds putt counts, the putt-only
-// persisted columns, and SG putting, so every surface must agree. Distance to
-// the pin must NOT factor in — a near-green chip isn't a putt, and unmapped
-// rows read distanceToPin 0 (#660, which was a drift between hand-copied
-// predicates). Takes raw fields (not a shaped row) so camelCase ReviewedShotRow
-// and snake_case DB rows share it.
-export function isPuttShot(
-  lieType: string | null | undefined,
-  club: string | null | undefined,
-): boolean {
-  return lieType === 'green' || club === 'putter'
+// Single source of truth for putt classification: a shot is a putt exactly
+// when its lie is the green. A putter played from off the green (Texas wedge)
+// is a normal shot — yards, SG around-green — matching what the save paths
+// write (#691; club used to be an OR term, which made reads disagree with
+// writes). Feeds putt counts, the putt-only persisted columns, and SG putting,
+// so every surface must agree. Distance to the pin must NOT factor in — a
+// near-green chip isn't a putt, and unmapped rows read distanceToPin 0 (#660).
+// Takes the raw field (not a shaped row) so camelCase ReviewedShotRow and
+// snake_case DB rows share it.
+export function isPuttShot(lieType: string | null | undefined): boolean {
+  return lieType === 'green'
 }
 
 export function buildInitialRows(


### PR DESCRIPTION
Closes #691.

## Problem
Write paths classified putts by `lie === 'green'` only, but read paths (core `isPuttShot`, mobile putt counts, past-round display) used `lie === 'green' || club === 'putter'`. A putter played from off the green (Texas wedge) was therefore **written** as a normal shot (`distance_to_target` in yards, no putt fields) but **read back** as a putt — rendering the yards value as feet (~3× wrong) and inflating putt counts.

## Decision (product)
**Option B from #691: putt = green lie only.** A putter off the green is a normal shot (yards, SG around-green) — matches what the save paths already write and how the SG engine (`sg-calculator`, lie-only since inception) already scores it. No UI changes needed.

## Changes
- `@oga/core` `isPuttShot(lieType)` — drops the `club === 'putter'` OR term and the club param; comment records the #691 decision. Tests updated (Texas wedge case pinned).
- Migrates every remaining hand-rolled copy of the predicate onto `isPuttShot` (the is-putt half of #601):
  - mobile: `useHoleData` remote/local putt counts, `useShotActions` persist path, `PastHoleShotsSheet` row + editor, `PastRoundMap.summarizeShot`
  - web: `ShotEntryModal` `isPuttSave`/`isPutt` (were inline lie checks)
- Intentionally untouched: `stats.ts` putter exclusions in club-distance/accuracy tables (club-based exclusion, not putt classification).

#601's other half (reconciling `summarizeShot`/`formatShotSummary` into one core formatter) is a separate no-behavior consolidation PR.

## Verification
- `pnpm test` green (isPuttShot suite re-pinned for lie-only).
- Direct `tsc --noEmit` clean on web and mobile (not turbo-cached).