### PR TITLE
chore: lift shot-summary formatting into @oga/core

### DIFF
--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -7,11 +7,11 @@ import {
   bearingDegrees,
   destinationYards,
   formatClubLabel,
-  formatDistance,
   isPuttShot,
+  summarizePuttParts,
+  summarizeShotParts,
   type DistanceUnit,
   type LieType,
-  type ShotResult,
 } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
@@ -40,48 +40,25 @@ const KICKER: import('react-native').TextStyle = {
 // tracking the finger locally and only write the settled position.
 const AIM_PERSIST_DEBOUNCE_MS = 500
 
-// Short result labels for the review stepper's summary line. Kept app-local
-// rather than in @oga/core because summarizeShot/SHOT_RESULT_SHORT emit a
-// display-specific, abbreviated UI string tuned for this narrow stepper — web
-// has its own formatShotSummary (ShotEntryModal) with a different shape.
-// Unifying shot-summary formatting into core is real cross-surface debt
-// (tracked separately) — the package-boundary call here is "too view-specific
-// to lift yet," not the 3-caller rule.
-const SHOT_RESULT_SHORT: Record<ShotResult, string> = {
-  solid: 'Solid',
-  push_right: 'Push R',
-  pull_left: 'Pull L',
-  fat: 'Fat',
-  thin: 'Thin',
-  shank: 'Shank',
-  topped: 'Topped',
-  penalty: 'Penalty',
-  ob: 'OB',
-}
-
 // One-line summary of the selected shot for the review stepper. Putts read
 // "Putt · 12 ft · Made"; full shots read "7i · Fairway · 152 yd · Solid".
-function summarizeShot(row: ShotRow | null, unit: DistanceUnit): string {
+// Distance/result formatting lives in @oga/core (summarizePuttParts /
+// summarizeShotParts, shared with web's ShotEntryModal); this wrapper adds
+// the club·lie prefix (web shows those on their own row line) and the
+// empty-state text.
+function summarizeShot(
+  row: ShotRow | null,
+  next: ShotRow | null,
+  unit: DistanceUnit,
+): string {
   if (!row) return 'No details yet — tap Edit to add them'
-  const isPutt = isPuttShot(row.lie_type)
-  if (isPutt) {
-    const miss = [row.putt_distance_result, row.putt_direction_result]
-      .filter(Boolean)
-      .join(' ')
-    return [
-      'Putt',
-      row.putt_distance_ft != null ? `${row.putt_distance_ft} ft` : null,
-      row.putt_result === 'made' ? 'Made' : miss || null,
-    ]
-      .filter(Boolean)
-      .join(' · ')
-  }
-  const parts = [
-    row.club ? formatClubLabel({ club_type: row.club }) : null,
-    row.lie_type ? LIE_TYPE_LABELS[row.lie_type as LieType] : null,
-    row.distance_to_target != null ? formatDistance(row.distance_to_target, unit) : null,
-    row.shot_result ? SHOT_RESULT_SHORT[row.shot_result as ShotResult] : null,
-  ].filter(Boolean)
+  const parts = isPuttShot(row.lie_type)
+    ? ['Putt', ...summarizePuttParts(row, unit)]
+    : ([
+        row.club ? formatClubLabel({ club_type: row.club }) : null,
+        row.lie_type ? LIE_TYPE_LABELS[row.lie_type as LieType] : null,
+        ...summarizeShotParts(row, next, unit),
+      ].filter(Boolean) as string[])
   return parts.length ? parts.join(' · ') : 'No details yet — tap Edit to add them'
 }
 
@@ -274,6 +251,21 @@ export function PastRoundMap({
   const activeShotRow = useMemo(
     () => (active?.id ? shots.find((s) => s.id === active.id) ?? null : null),
     [shots, active?.id],
+  )
+  // Next shot after the active one — its start is the active shot's end, so
+  // core's summarizeShotParts can haversine a distance when
+  // distance_to_target is null.
+  const activeShotNext = useMemo(
+    () =>
+      activeShotRow
+        ? shots.find(
+            (s) =>
+              // `shots` is round-wide; shot_number restarts per hole.
+              s.hole_score_id === activeShotRow.hole_score_id &&
+              s.shot_number === activeShotRow.shot_number + 1,
+          ) ?? null
+        : null,
+    [shots, activeShotRow],
   )
 
   // The actually-placed shots, paired with their index in `placed`. The
@@ -833,7 +825,7 @@ export function PastRoundMap({
                   }]}
                   numberOfLines={1}
                 >
-                  {summarizeShot(activeShotRow, unit)}
+                  {summarizeShot(activeShotRow, activeShotNext, unit)}
                 </Text>
               </View>
               <Pressable

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -3,20 +3,17 @@ import {
   DEFAULT_BAG,
   LIE_TYPES,
   LIE_TYPE_LABELS,
-  PUTT_RESULT_LABELS,
-  SHOT_RESULT_LABELS,
   combinedBreakDirection,
   combinedPuttResult,
   formatClubLabel,
   horizontalBreakFromAim,
-  formatDistance,
-  formatPuttDistance,
   haversineYards,
   isPuttShot,
+  summarizePuttParts,
+  summarizeShotParts,
   type Club,
   type DistanceUnit,
   type LieType,
-  type ShotResult,
 } from '@oga/core'
 import { useUserBag } from '../../hooks/useUserBag'
 import type { Database } from '@oga/supabase'
@@ -633,44 +630,17 @@ export function ShotEntryModal({
   )
 }
 
-// Build the second line on each shot row in the side panel. Putts get
-// putt distance (feet/cm/in/m via formatPuttDistance) plus the
-// putt_result label. Other shots get distance_to_target with a
-// haversine fallback to the next shot's start coords, plus the
-// shot_result label. Only renders '—' when there's truly no signal —
-// stored distance, coords, and result columns all null.
+// Build the second line on each shot row in the side panel. Formatting
+// lives in @oga/core (summarizePuttParts / summarizeShotParts, shared with
+// mobile's review stepper); this wrapper only picks the branch and the
+// '—' empty state.
 function formatShotSummary(
   s: ShotRow,
   next: ShotRow | undefined,
   unit: DistanceUnit,
 ): string {
-  if (isPuttShot(s.lie_type)) {
-    const result =
-      (s.putt_result &&
-        PUTT_RESULT_LABELS[s.putt_result as keyof typeof PUTT_RESULT_LABELS]) ??
-      s.putt_result ??
-      null
-    const feet = s.putt_distance_ft ?? s.distance_to_target ?? null
-    const distance = feet != null ? formatPuttDistance(feet, unit) : null
-    const parts = [distance, result].filter(Boolean) as string[]
-    return parts.length ? parts.join(' · ') : '—'
-  }
-  let yards: number | null = s.distance_to_target ?? null
-  if (
-    yards == null &&
-    s.start_lat != null &&
-    s.start_lng != null &&
-    next?.start_lat != null &&
-    next?.start_lng != null
-  ) {
-    yards = Math.round(
-      haversineYards(s.start_lat, s.start_lng, next.start_lat, next.start_lng),
-    )
-  }
-  const distance = yards != null ? formatDistance(yards, unit) : null
-  const result = s.shot_result
-    ? SHOT_RESULT_LABELS[s.shot_result as ShotResult] ?? s.shot_result
-    : null
-  const parts = [distance, result].filter(Boolean) as string[]
+  const parts = isPuttShot(s.lie_type)
+    ? summarizePuttParts(s, unit)
+    : summarizeShotParts(s, next, unit)
   return parts.length ? parts.join(' · ') : '—'
 }

--- a/packages/core/src/__tests__/round.test.ts
+++ b/packages/core/src/__tests__/round.test.ts
@@ -5,7 +5,10 @@ import {
   isPuttShot,
   legacySlopeToAxes,
   playedRowsForDifferential,
+  summarizePuttParts,
+  summarizeShotParts,
   type PlacedPoint,
+  type ShotSummaryFields,
 } from '../round'
 import { decombinedPuttResult } from '../types'
 
@@ -130,6 +133,115 @@ describe('isPuttShot', () => {
   it('null/undefined lie is NOT a putt', () => {
     expect(isPuttShot(null)).toBe(false)
     expect(isPuttShot(undefined)).toBe(false)
+  })
+})
+
+function summaryFields(
+  overrides: Partial<ShotSummaryFields> = {},
+): ShotSummaryFields {
+  return {
+    distance_to_target: null,
+    shot_result: null,
+    start_lat: null,
+    start_lng: null,
+    putt_distance_ft: null,
+    putt_result: null,
+    putt_distance_result: null,
+    putt_direction_result: null,
+    ...overrides,
+  }
+}
+
+describe('summarizePuttParts', () => {
+  it('made putt: distance + Made', () => {
+    expect(
+      summarizePuttParts(
+        summaryFields({ putt_distance_ft: 4, putt_result: 'made' }),
+        'yards',
+      ),
+    ).toEqual(['4 ft', 'Made'])
+  })
+  it('miss derives axes-first with capitalized labels', () => {
+    expect(
+      summarizePuttParts(
+        summaryFields({
+          putt_distance_ft: 12,
+          putt_result: 'short',
+          putt_distance_result: 'short',
+          putt_direction_result: 'left',
+        }),
+        'yards',
+      ),
+    ).toEqual(['12 ft', 'Short Left'])
+  })
+  it('single-axis miss', () => {
+    expect(
+      summarizePuttParts(
+        summaryFields({ putt_distance_ft: 12, putt_direction_result: 'right' }),
+        'yards',
+      ),
+    ).toEqual(['12 ft', 'Right'])
+  })
+  it('legacy putt_result is the fallback when axes are null', () => {
+    expect(
+      summarizePuttParts(
+        summaryFields({ putt_distance_ft: 8, putt_result: 'missed_left' }),
+        'yards',
+      ),
+    ).toEqual(['8 ft', 'Missed left'])
+  })
+  it('meters mode is unit-aware', () => {
+    expect(
+      summarizePuttParts(
+        summaryFields({ putt_distance_ft: 12, putt_result: 'made' }),
+        'meters',
+      ),
+    ).toEqual(['3.7 m', 'Made'])
+  })
+  it('falls back to distance_to_target for feet', () => {
+    expect(
+      summarizePuttParts(
+        summaryFields({ distance_to_target: 6, putt_result: 'made' }),
+        'yards',
+      ),
+    ).toEqual(['6 ft', 'Made'])
+  })
+  it('no signal → empty parts', () => {
+    expect(summarizePuttParts(summaryFields(), 'yards')).toEqual([])
+  })
+})
+
+describe('summarizeShotParts', () => {
+  it('distance + full result label', () => {
+    expect(
+      summarizeShotParts(
+        summaryFields({ distance_to_target: 152, shot_result: 'solid' }),
+        null,
+        'yards',
+      ),
+    ).toEqual(['152 yd', 'Solid'])
+  })
+  it('full label set (not abbreviated)', () => {
+    expect(
+      summarizeShotParts(
+        summaryFields({ distance_to_target: 152, shot_result: 'push_right' }),
+        null,
+        'yards',
+      ),
+    ).toEqual(['152 yd', 'Push right'])
+  })
+  it('haversines to the next shot start when distance_to_target is null', () => {
+    const parts = summarizeShotParts(
+      summaryFields({ start_lat: 35.0, start_lng: -97.0 }),
+      summaryFields({ start_lat: 35.001, start_lng: -97.0 }),
+      'yards',
+    )
+    // ~0.001° latitude ≈ 111 m ≈ 122 yd
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatch(/^12[0-3] yd$/)
+  })
+  it('no signal → empty parts', () => {
+    expect(summarizeShotParts(summaryFields(), null, 'yards')).toEqual([])
   })
 })
 

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -4,10 +4,13 @@
 
 import { inferShot, type InferredShot, type PlacedShot } from './shotInference'
 import type { Club, LieType, LieSlope, LieSlopeForward, LieSlopeSide, ShotResult } from './constants'
+import { PUTT_RESULT_LABELS, SHOT_RESULT_LABELS } from './constants'
+import { formatDistance, formatPuttDistance, haversineYards } from './units'
 import type {
   BreakDirection,
   BreakDirectionHorizontal,
   BreakDirectionVertical,
+  DistanceUnit,
   GreenSpeed,
   LegacyPuttResult,
   PuttDirectionResult,
@@ -109,6 +112,80 @@ export function playedRowsForDifferential<T extends { score: number }>(
 // snake_case DB rows share it.
 export function isPuttShot(lieType: string | null | undefined): boolean {
   return lieType === 'green'
+}
+
+// Structural subset of a snake_case shots row that the shot-summary
+// formatters read — web and mobile pass their own DB Row types.
+export interface ShotSummaryFields {
+  distance_to_target: number | null
+  shot_result: string | null
+  start_lat: number | null
+  start_lng: number | null
+  putt_distance_ft: number | null
+  putt_result: string | null
+  putt_distance_result: string | null
+  putt_direction_result: string | null
+}
+
+const cap = (s: string) => s.charAt(0).toUpperCase() + s.slice(1)
+
+// One-line putt summary parts — unit-aware distance + result, e.g.
+// ["4 ft", "Made"] or ["12 ft", "Short Left"]. The miss is derived
+// axes-first (putt_distance_result / putt_direction_result are the canonical
+// columns; legacy combined putt_result is the back-compat fallback) so web
+// and mobile can't drift on derivation again (#601). Callers join with ' · '
+// and pick their own empty-state text.
+export function summarizePuttParts(
+  shot: ShotSummaryFields,
+  unit: DistanceUnit,
+): string[] {
+  const feet = shot.putt_distance_ft ?? shot.distance_to_target
+  const distance = feet != null ? formatPuttDistance(feet, unit) : null
+  let result: string | null
+  if (shot.putt_result === 'made') {
+    result = 'Made'
+  } else {
+    const miss = [shot.putt_distance_result, shot.putt_direction_result]
+      .filter((v): v is string => Boolean(v))
+      .map(cap)
+      .join(' ')
+    result =
+      miss ||
+      (shot.putt_result
+        ? PUTT_RESULT_LABELS[
+            shot.putt_result as keyof typeof PUTT_RESULT_LABELS
+          ] ?? shot.putt_result
+        : null)
+  }
+  return [distance, result].filter((v): v is string => Boolean(v))
+}
+
+// Non-putt summary parts — distance + full result label, e.g.
+// ["152 yd", "Solid"]. distance_to_target falls back to the haversine to the
+// next shot's start (end of shot N IS the start of shot N+1) so rows saved
+// without a pin distance still read a yardage.
+export function summarizeShotParts(
+  shot: ShotSummaryFields,
+  next: ShotSummaryFields | null | undefined,
+  unit: DistanceUnit,
+): string[] {
+  let yards = shot.distance_to_target
+  if (
+    yards == null &&
+    shot.start_lat != null &&
+    shot.start_lng != null &&
+    next?.start_lat != null &&
+    next?.start_lng != null
+  ) {
+    yards = Math.round(
+      haversineYards(shot.start_lat, shot.start_lng, next.start_lat, next.start_lng),
+    )
+  }
+  const distance = yards != null ? formatDistance(yards, unit) : null
+  const result = shot.shot_result
+    ? SHOT_RESULT_LABELS[shot.shot_result as ShotResult] ?? shot.shot_result
+    : null
+  return [distance, result].filter((v): v is string => Boolean(v))
 }
 
 export function buildInitialRows(


### PR DESCRIPTION
Closes #601 (second half; the is-putt half shipped in #732).

## What
Web `formatShotSummary` (ShotEntryModal) and mobile `summarizeShot` (PastRoundMap) were independently built formatters for the same shot-summary line. This lifts the shared derivation into `@oga/core`:

- **`summarizePuttParts(shot, unit)`** — unit-aware putt distance (`formatPuttDistance`) + result. Miss derives **axes-first** (`putt_distance_result`/`putt_direction_result` are the canonical columns) with legacy `putt_result` as the back-compat fallback.
- **`summarizeShotParts(shot, next, unit)`** — distance + full result label, with a haversine fallback to the next shot's start when `distance_to_target` is null.

Apps keep thin wrappers for what genuinely differs: mobile prepends `Putt`/club·lie (its stepper is a single line; web shows club·lie on its own row line) and each picks its empty-state text.

## Visible diffs (canonicalization — all richer, per #691/#601 decision)
- mobile putt line: `12 ft` → unit-aware (`3.7 m` in meters mode); raw lowercase axis values → `Short Left`
- mobile shot line: gains a yardage via haversine fallback where `distance_to_target` is null (also recovers a distance for the pre-#732 Texas-wedge rows flagged in #732's review)
- mobile result labels: `Push R` → `Push right` (app-local `SHOT_RESULT_SHORT` deleted)
- web putt line: axes-first miss (`Short Left`) instead of the flattened legacy label (`Short`)

## Notes
- Mobile's next-shot lookup matches on `hole_score_id` **and** `shot_number + 1` — the `shots` prop is round-wide and `shot_number` restarts per hole.
- 11 new core tests (589 total); direct `tsc --noEmit` clean on web and mobile.