### PR TITLE
perf(mobile): screen cache kills refetch-on-revisit spinners

### DIFF
--- a/apps/mobile/app/(app)/index.tsx
+++ b/apps/mobile/app/(app)/index.tsx
@@ -9,6 +9,7 @@ import { useAuth } from '../../hooks/useAuth'
 import { useActiveRound } from '../../hooks/useActiveRound'
 import { syncPendingShots } from '../../lib/sync'
 import { pendingCount } from '../../lib/db'
+import { clearScreenCache, getCached, setCached } from '../../lib/screenCache'
 import { AppBar } from '../../components/ui/AppBar'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { Entrance } from '../../components/ui/Entrance'
@@ -52,8 +53,14 @@ const KICKER: import('react-native').TextStyle = {
 
 export default function Home() {
   const { user } = useAuth()
-  const [profile, setProfile] = useState<Profile | null>(null)
-  const [rounds, setRounds] = useState<RecentRound[]>([])
+  // Seed from the screen cache so a revisit renders instantly; the focus
+  // fetch below always re-runs and replaces this (#599).
+  const [profile, setProfile] = useState<Profile | null>(
+    () => getCached<Profile>('home:profile') ?? null,
+  )
+  const [rounds, setRounds] = useState<RecentRound[]>(
+    () => getCached<RecentRound[]>('home:rounds') ?? [],
+  )
   const activeRound = useActiveRound()
   const [pending, setPending] = useState(0)
   const [pendingDelete, setPendingDelete] = useState<{
@@ -78,6 +85,9 @@ export default function Home() {
       try {
         const { error } = await deleteRound(supabase, id, user.id)
         if (error) throw error
+        // Wipe ALL cached screens — a stale rounds-list or round-detail
+        // cache would resurrect the deleted round as a ghost (#705 redux).
+        clearScreenCache()
         setRounds((prev) => prev.filter((r) => r.id !== id))
       } finally {
         setDeleting(false)
@@ -103,7 +113,10 @@ export default function Home() {
           console.error('[home/getProfile]', error.message)
           return
         }
-        if (data) setProfile(data as unknown as Profile)
+        if (data) {
+          setProfile(data as unknown as Profile)
+          setCached('home:profile', data)
+        }
       })
       getRecentRounds(supabase, user.id, 20).then(({ data, error }) => {
         if (!active) return
@@ -112,7 +125,10 @@ export default function Home() {
           console.error('[home/getRecentRounds]', error.message)
           return
         }
-        if (data) setRounds(data as RecentRound[])
+        if (data) {
+          setRounds(data as RecentRound[])
+          setCached('home:rounds', data)
+        }
       })
       return () => {
         active = false

--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -22,6 +22,7 @@ import { getProfile, updateProfile } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { clearScreenCache } from '../../lib/screenCache'
 import { AppBar } from '../../components/ui/AppBar'
 import { TYPE } from '../../lib/typography'
 
@@ -97,6 +98,7 @@ export default function ProfileTab() {
     // release the modal — otherwise the user is stranded in a disabled
     // "Deleting…" dialog after an irreversible delete. On success the auth
     // listener unmounts this screen and redirects to login.
+    clearScreenCache()
     const { error: signOutError } = await supabase.auth.signOut()
     if (signOutError) {
       setDeleting(false)
@@ -544,7 +546,11 @@ export default function ProfileTab() {
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Sign out"
-          onPress={() => supabase.auth.signOut()}
+          onPress={() => {
+            // Next sign-in must not render this account's cached screens.
+            clearScreenCache()
+            supabase.auth.signOut()
+          }}
           style={{
             marginTop: 22,
             paddingVertical: 12,

--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -31,6 +31,11 @@ import {
 import type { Database } from '@oga/supabase'
 import { supabase } from '../../../../lib/supabase'
 import { completeRound } from '../../../../lib/completeRound'
+import {
+  clearScreenCache,
+  getCached,
+  setCached,
+} from '../../../../lib/screenCache'
 import { ShareableScorecardCard } from '../../../../components/round/ShareableScorecardCard'
 import { RoundTeeSelector } from '../../../../components/round/RoundTeeSelector'
 import { PastHoleShotsSheet } from '../../../../components/round/PastHoleShotsSheet'
@@ -48,6 +53,17 @@ type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
 type ShotRow = Database['public']['Tables']['shots']['Row']
 type DrillRow = Database['public']['Tables']['drills']['Row']
 type CourseTeeRow = Database['public']['Tables']['course_tees']['Row']
+
+// Everything the summary view needs for a first paint, bundled under one
+// `round:${id}` screen-cache key (#599).
+interface RoundDetailCache {
+  round: RoundRow
+  courseName: string
+  courseCenter: LatLng | null
+  holes: HoleRow[]
+  holeScores: HoleScoreRow[]
+  shots: ShotRow[]
+}
 
 const KICKER: import('react-native').TextStyle = {
   color: '#8A8B7E',
@@ -132,7 +148,21 @@ export default function RoundIndex() {
     // live-redirect can't leak onto the next one — e.g. after the active round
     // is deleted from the home list, the stale `error` would otherwise keep the
     // `if (error || !round)` guard tripped for every round opened afterward.
-    setLoading(true)
+    // Seed from the screen cache when we have this round — instant render,
+    // and the fetch below still runs and replaces everything (#599).
+    // Unfinished rounds are never cached (they redirect to the live session).
+    const cached = getCached<RoundDetailCache>(`round:${id}`)
+    if (cached) {
+      setRound(cached.round)
+      setCourseName(cached.courseName)
+      setCourseCenter(cached.courseCenter)
+      setHoles(cached.holes)
+      setHoleScores(cached.holeScores)
+      setShots(cached.shots)
+      setLoading(false)
+    } else {
+      setLoading(true)
+    }
     setError(null)
     setRedirectToLive(false)
     ;(async () => {
@@ -282,6 +312,32 @@ export default function RoundIndex() {
     }, [holeScores]),
   )
 
+  // Mirror the settled screen state into the cache — covers both the fetch
+  // AND local edits (scorecard/sheet mutations setState here), so a revisit
+  // seeds post-edit data instead of a stale flash (#599).
+  useEffect(() => {
+    if (!id || loading || error || redirectToLive || !round) return
+    setCached(`round:${id}`, {
+      round,
+      courseName,
+      courseCenter,
+      holes,
+      holeScores,
+      shots,
+    } satisfies RoundDetailCache)
+  }, [
+    id,
+    loading,
+    error,
+    redirectToLive,
+    round,
+    courseName,
+    courseCenter,
+    holes,
+    holeScores,
+    shots,
+  ])
+
   // Stable across renders — passing an inline arrow caused
   // LiveRoundSession's onHoleChange-keyed effect to re-fire on every
   // parent render, looping with router.setParams.
@@ -419,6 +475,9 @@ export default function RoundIndex() {
             try {
               const { error: delErr } = await deleteRound(supabase, round.id, user.id)
               if (delErr) throw delErr
+              // Wipe ALL cached screens — home/list/detail caches would
+              // resurrect the deleted round as a ghost (#705 redux).
+              clearScreenCache()
               router.replace('/(app)')
             } catch (e) {
               // Reset so the `deleting` guard can't wedge the button on retry;

--- a/apps/mobile/app/(app)/rounds.tsx
+++ b/apps/mobile/app/(app)/rounds.tsx
@@ -12,6 +12,7 @@ import { formatSG } from '@oga/core'
 import { deleteRound, getRoundsList } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { clearScreenCache, getCached, setCached } from '../../lib/screenCache'
 import { AppBar } from '../../components/ui/AppBar'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { Entrance } from '../../components/ui/Entrance'
@@ -45,7 +46,11 @@ function buildA11yLabel(r: RoundRow): string {
 
 export default function RoundsList() {
   const { user } = useAuth()
-  const [rounds, setRounds] = useState<RoundRow[]>([])
+  // Seed from the screen cache for an instant render on revisit; the mount
+  // fetch below re-runs every visit and replaces it (#599).
+  const [rounds, setRounds] = useState<RoundRow[]>(
+    () => getCached<RoundRow[]>('roundsList') ?? [],
+  )
   const [pendingDelete, setPendingDelete] = useState<{
     id: string
     name: string
@@ -63,7 +68,10 @@ export default function RoundsList() {
         console.error('[rounds/getRecentRounds]', error.message)
         return
       }
-      if (data) setRounds(data as RoundRow[])
+      if (data) {
+        setRounds(data as RoundRow[])
+        setCached('roundsList', data)
+      }
     })
     return () => {
       active = false
@@ -77,6 +85,9 @@ export default function RoundsList() {
       try {
         const { error } = await deleteRound(supabase, id, user.id)
         if (error) throw error
+        // Wipe ALL cached screens — a stale home/round-detail cache would
+        // resurrect the deleted round as a ghost (#705 redux).
+        clearScreenCache()
         setRounds((prev) => prev.filter((r) => r.id !== id))
         // Delay so VoiceOver doesn't swallow the announce while focus
         // shifts from the dismissing ConfirmDialog.

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -19,6 +19,7 @@ import {
 import { getProfile, getRoundsWithDetails } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { getCached, setCached } from '../../lib/screenCache'
 import { useUnits } from '../../hooks/useUnits'
 import { AppBar } from '../../components/ui/AppBar'
 import { Entrance } from '../../components/ui/Entrance'
@@ -56,8 +57,15 @@ const KICKER: import('react-native').TextStyle = {
 export default function Stats() {
   const { user } = useAuth()
   const [n, setN] = useState<number>(10)
-  const [rounds, setRounds] = useState<DetailedRound[]>([])
-  const [loading, setLoading] = useState(true)
+  // Fetch the max window (L20) once and slice client-side per toggle — the
+  // L5/L10/L20 chips used to refire the whole nested query (#599). Seeded
+  // from the screen cache so a revisit renders instantly.
+  const [allRounds, setAllRounds] = useState<DetailedRound[]>(
+    () => getCached<DetailedRound[]>('stats:rounds') ?? [],
+  )
+  const [loading, setLoading] = useState(
+    () => getCached<DetailedRound[]>('stats:rounds') == null,
+  )
   // Player's handicap for SG baselines. Web (useDetailedStats) already uses
   // the profile value; hardcoding DEFAULT_HANDICAP here benchmarked every
   // player against the default bracket and made mobile disagree with web on
@@ -88,20 +96,27 @@ export default function Stats() {
   useEffect(() => {
     if (!user) return
     let active = true
-    setLoading(true)
-    getRoundsWithDetails(supabase, user.id, n).then(({ data, error }) => {
+    // Spinner only on a cold cache — a cached render revalidates silently.
+    if (getCached<DetailedRound[]>('stats:rounds') == null) setLoading(true)
+    getRoundsWithDetails(supabase, user.id, 20).then(({ data, error }) => {
       if (!active) return
       if (error) {
         // eslint-disable-next-line no-console
         console.error('[stats/getRoundsWithDetails]', error.message)
       }
-      setRounds((data as unknown as DetailedRound[] | null) ?? [])
+      const rows = (data as unknown as DetailedRound[] | null) ?? []
+      setAllRounds(rows)
+      if (!error) setCached('stats:rounds', rows)
       setLoading(false)
     })
     return () => {
       active = false
     }
-  }, [user?.id, n])
+  }, [user?.id])
+
+  // The visible window. getRoundsWithDetails orders played_at desc, so
+  // slice(0, n) is exactly what a limit-n fetch returned.
+  const rounds = useMemo(() => allRounds.slice(0, n), [allRounds, n])
 
   const avgs = useMemo(
     () =>

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -19,6 +19,7 @@ import {
 import type { Database } from '@oga/supabase'
 import { supabase } from './supabase'
 import { syncPendingShots } from './sync'
+import { clearScreenCache } from './screenCache'
 
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
 type ShotRow = Database['public']['Tables']['shots']['Row']
@@ -265,6 +266,9 @@ export async function completeRound({
     userId,
   )
   if (roundError) throw roundError
+  // The finalize rewrites totals/SG that home, list, and stats render —
+  // drop every cached screen so none serves the pre-finalize version (#599).
+  clearScreenCache()
 
   // ---- Handicap index recompute --------------------------------------
   // Once this round contributes a differential, re-derive the WHS index

--- a/apps/mobile/lib/screenCache.ts
+++ b/apps/mobile/lib/screenCache.ts
@@ -8,7 +8,14 @@
 // clearScreenCache() is the only invalidation: called on round delete,
 // round finalize, and sign-out — the mutations where even a one-fetch
 // stale flash is wrong (ghost deleted round, cross-account leak).
-// ponytail: coarse full-clear; per-key invalidation only if this thrashes.
+// Coarse full-clear on purpose; add per-key invalidation only if the
+// full clear demonstrably thrashes.
+//
+// Deliberately app-local rather than @oga/core: the safety of serving
+// cached data hinges on every consumer being a mobile stack screen that
+// re-fetches on mount/focus (the always-revalidate above). Web's screens
+// don't share that lifecycle contract, so lifting the Map alone would
+// export the mechanism without the invariant that makes it safe.
 const store = new Map<string, unknown>()
 
 export function getCached<T>(key: string): T | undefined {

--- a/apps/mobile/lib/screenCache.ts
+++ b/apps/mobile/lib/screenCache.ts
@@ -1,0 +1,24 @@
+// In-memory stale-while-revalidate store for screen data (#599). Screens
+// seed their state from here to render instantly on revisit; every consumer
+// is a stack screen whose fetch effect re-runs on mount (or focus), so the
+// network refetch always races behind and replaces the cached render —
+// staleness is bounded by one fetch latency. No TTL, no persistence: the
+// store lives for the JS session only.
+//
+// clearScreenCache() is the only invalidation: called on round delete,
+// round finalize, and sign-out — the mutations where even a one-fetch
+// stale flash is wrong (ghost deleted round, cross-account leak).
+// ponytail: coarse full-clear; per-key invalidation only if this thrashes.
+const store = new Map<string, unknown>()
+
+export function getCached<T>(key: string): T | undefined {
+  return store.get(key) as T | undefined
+}
+
+export function setCached(key: string, value: unknown): void {
+  store.set(key, value)
+}
+
+export function clearScreenCache(): void {
+  store.clear()
+}


### PR DESCRIPTION
Closes #599.

## Design: stale-while-revalidate, always-revalidate
New `lib/screenCache.ts` — a session-lifetime in-memory `Map`. Screens seed their state from it so a revisit renders instantly instead of spinning; every consumer is a stack screen whose existing fetch re-runs on mount (or focus), so the network response always races behind and replaces the cached render. **Staleness is bounded by one fetch latency and self-corrects** — no TTLs, no persistence.

## Wired screens
- **Home** — profile + recent rounds seed from cache; the existing focus-refetch (#705/#707) is the revalidate.
- **All-rounds list** — same, on its mount fetch.
- **Round detail** — `{round, courseName, courseCenter, holes, holeScores, shots}` bundled per `round:${id}`. Seeded inside the fetch effect (works across param changes between rounds), and **mirror-written from state** so in-screen scorecard/sheet edits re-cache — a revisit seeds post-edit data. Unfinished rounds are never cached (they redirect to the live session before the summary fetch).
- **Stats** — also fixes the issue's second item: the L5/L10/L20 chips used to refire the whole nested rounds query. Now fetch L20 once + `slice(0, n)` client-side (query orders `played_at` desc, so the slice is exactly what a limit-n fetch returned). Toggle is instant.

## Invalidation
Coarse `clearScreenCache()` at the four places where even a one-fetch stale flash is wrong:
- round **delete** — home, list, and detail handlers (a stale cache would resurrect the deleted round as a ghost, #705 redux)
- round **finalize** — `completeRound` after the successful rounds write (totals/SG/handicap all change)
- **sign-out** — both profile paths (account switching must not leak cached screens)

Everything else rides the always-revalidate. Per-key invalidation deliberately skipped until coarse-clear demonstrably thrashes.

## Verification
- Mobile `tsc --noEmit` clean (direct, not turbo).
- Needs on-device QA for feel: revisit home/stats/round detail (no spinner, instant paint), L-window toggle (instant), delete → home (no ghost), finalize → home (fresh totals), sign-out → sign-in (no stale screens).