### PR TITLE
fix(mobile): email confirmation round-trip — PKCE, never-hanging callback, self-clearing check-email screen

### DIFF
--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -45,19 +45,29 @@ export default function Signup() {
   const captchaTokenRef = useRef<string | null>(null)
   const attemptInFlightRef = useRef(false)
   const wantAttemptRef = useRef(false)
+  // Auto attempts (foreground returns) keep a minimum spacing so a user
+  // fidgeting between apps can't burn GoTrue's auth rate budget on
+  // speculative pre-confirmation attempts — getting rate-limited on the
+  // REAL attempt would reproduce the stuck screen this exists to fix.
+  // The manual button is exempt (explicit user intent).
+  const lastAutoAttemptAtRef = useRef(0)
 
   const captchaEnabled = Boolean(TURNSTILE_SITE_KEY)
   const canSubmit = !loading && (!captchaEnabled || captchaToken !== null)
 
   async function tryConfirmSignIn(manual: boolean) {
     if (attemptInFlightRef.current) return
+    if (!manual && Date.now() - lastAutoAttemptAtRef.current < 20_000) return
     const token = captchaTokenRef.current
     if (captchaEnabled && !token) {
       // No token yet (widget still minting after the last attempt consumed
       // one) — remember the intent; the token-arrival effect fires us.
+      // Deliberately NOT stamped as an attempt — the queued retry must not
+      // be suppressed by the auto-attempt interval.
       wantAttemptRef.current = true
       return
     }
+    if (!manual) lastAutoAttemptAtRef.current = Date.now()
     attemptInFlightRef.current = true
     wantAttemptRef.current = false
     if (manual) setChecking(true)
@@ -81,10 +91,14 @@ export default function Signup() {
       return
     }
     // "Email not confirmed" is the expected pre-confirmation result; stay
-    // quiet on auto attempts, give feedback on the button.
+    // quiet on auto attempts, give feedback on the button. Other failures
+    // (network, captcha, rate limit) show their real message — masking
+    // them as "not confirmed" would misdirect the user.
     if (manual) {
       setConfirmHint(
-        'Not confirmed yet — tap the link in your email, then try again.',
+        signInError.message.toLowerCase().includes('not confirmed')
+          ? 'Not confirmed yet — tap the link in your email, then try again.'
+          : signInError.message,
       )
     }
   }
@@ -97,6 +111,10 @@ export default function Signup() {
       if (s === 'active') void tryConfirmSignIn(false)
     })
     return () => sub.remove()
+    // tryConfirmSignIn is redefined every render; listing it would
+    // re-subscribe the listener per render. Its mutable inputs are refs;
+    // the state it reads (email/password) can't change once submitted —
+    // the form is unmounted — so the captured closure stays correct.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [submitted])
 
@@ -106,6 +124,9 @@ export default function Signup() {
     if (submitted && captchaToken && wantAttemptRef.current) {
       void tryConfirmSignIn(false)
     }
+    // tryConfirmSignIn omitted for the same reason as the AppState effect
+    // above — per-render identity, and its closure inputs are stable
+    // after submit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [submitted, captchaToken])
 

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import {
+  AppState,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -8,7 +9,7 @@ import {
   TextInput,
   View,
 } from 'react-native'
-import { Link } from 'expo-router'
+import { Link, useRouter } from 'expo-router'
 import * as Linking from 'expo-linking'
 import { WebView } from 'react-native-webview'
 import { supabase } from '../../lib/supabase'
@@ -17,6 +18,7 @@ import { TYPE } from '../../lib/typography'
 const TURNSTILE_SITE_KEY = process.env.EXPO_PUBLIC_TURNSTILE_SITE_KEY
 
 export default function Signup() {
+  const router = useRouter()
   const [username, setUsername] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
@@ -24,9 +26,88 @@ export default function Signup() {
   const [loading, setLoading] = useState(false)
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const [submitted, setSubmitted] = useState(false)
+  // Self-clearing "check your email" state (#509 field report): the deep
+  // link back into the app is the happy path, but it dies in in-app mail
+  // browsers and can't fire at all when the user confirms on another
+  // device — GoTrue confirms server-side either way, so the account works
+  // while this screen sits forever. Fallback: silently try
+  // signInWithPassword (we still hold both credentials) whenever the app
+  // returns to foreground — the natural "just confirmed in Mail" moment —
+  // plus a manual "I've confirmed it" button. Fails "Email not confirmed"
+  // until the link is tapped, succeeds right after.
+  const [checking, setChecking] = useState(false)
+  const [confirmHint, setConfirmHint] = useState<string | null>(null)
+  // Turnstile tokens are single-use; remounting the widget (key bump)
+  // mints the next one for the next attempt.
+  const [captchaNonce, setCaptchaNonce] = useState(0)
+  // Refs so the AppState listener and attempt logic never read stale
+  // closure state.
+  const captchaTokenRef = useRef<string | null>(null)
+  const attemptInFlightRef = useRef(false)
+  const wantAttemptRef = useRef(false)
 
   const captchaEnabled = Boolean(TURNSTILE_SITE_KEY)
   const canSubmit = !loading && (!captchaEnabled || captchaToken !== null)
+
+  async function tryConfirmSignIn(manual: boolean) {
+    if (attemptInFlightRef.current) return
+    const token = captchaTokenRef.current
+    if (captchaEnabled && !token) {
+      // No token yet (widget still minting after the last attempt consumed
+      // one) — remember the intent; the token-arrival effect fires us.
+      wantAttemptRef.current = true
+      return
+    }
+    attemptInFlightRef.current = true
+    wantAttemptRef.current = false
+    if (manual) setChecking(true)
+    // Consume the token up front — single-use either way — and remount the
+    // widget so the next attempt has a fresh one.
+    captchaTokenRef.current = null
+    setCaptchaToken(null)
+    setCaptchaNonce((n) => n + 1)
+    const { error: signInError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+      options: {
+        ...(token ? { captchaToken: token } : {}),
+      },
+    })
+    attemptInFlightRef.current = false
+    setChecking(false)
+    if (!signInError) {
+      // Confirmed — same hand-off as login (#500 splash route).
+      router.replace('/(auth)/welcome')
+      return
+    }
+    // "Email not confirmed" is the expected pre-confirmation result; stay
+    // quiet on auto attempts, give feedback on the button.
+    if (manual) {
+      setConfirmHint(
+        'Not confirmed yet — tap the link in your email, then try again.',
+      )
+    }
+  }
+
+  // Foreground return is the natural "I just confirmed in my mail app"
+  // moment — attempt (or queue) a silent sign-in.
+  useEffect(() => {
+    if (!submitted) return
+    const sub = AppState.addEventListener('change', (s) => {
+      if (s === 'active') void tryConfirmSignIn(false)
+    })
+    return () => sub.remove()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [submitted])
+
+  // A queued attempt (foreground arrived before the widget minted a token)
+  // fires as soon as the fresh token lands.
+  useEffect(() => {
+    if (submitted && captchaToken && wantAttemptRef.current) {
+      void tryConfirmSignIn(false)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [submitted, captchaToken])
 
   async function handleSubmit() {
     setLoading(true)
@@ -46,12 +127,18 @@ export default function Signup() {
     setLoading(false)
     if (signUpError) {
       setError(signUpError.message)
+      captchaTokenRef.current = null
       setCaptchaToken(null)
       return
     }
     // Email confirmation is required, so signUp returns no session yet. Show a
     // "check your email" state rather than routing into the app; the link
-    // deep-links back in via app/auth-callback.tsx once tapped.
+    // deep-links back in via app/auth-callback.tsx once tapped, and the
+    // foreground/button sign-in fallback above covers a dead deep link.
+    // The signup token was consumed by signUp — drop it so the check-email
+    // widget mints a fresh one for the first sign-in attempt.
+    captchaTokenRef.current = null
+    setCaptchaToken(null)
     setSubmitted(true)
   }
 
@@ -73,11 +160,59 @@ export default function Signup() {
             className="text-oga-text-muted"
           >
             We sent a confirmation link to {email}. Open it on this device to
-            finish setting up your account.
+            finish setting up your account — or confirm anywhere and come back
+            here.
           </Text>
+          {captchaEnabled && (
+            <WebView
+              key={captchaNonce}
+              source={{ uri: `https://oga.golf/captcha.html?siteKey=${encodeURIComponent(TURNSTILE_SITE_KEY ?? '')}` }}
+              originWhitelist={['https://*', 'http://*', 'about:blank', 'about:srcdoc']}
+              onMessage={(event) => {
+                try {
+                  const msg = JSON.parse(event.nativeEvent.data)
+                  if (msg.type === 'success') {
+                    captchaTokenRef.current = msg.token
+                    setCaptchaToken(msg.token)
+                  } else {
+                    captchaTokenRef.current = null
+                    setCaptchaToken(null)
+                  }
+                } catch {
+                  // ignore non-JSON WebView messages
+                }
+              }}
+              style={{ height: 65, marginTop: 16 }}
+              scrollEnabled={false}
+            />
+          )}
+          {confirmHint && (
+            <Text
+              style={[TYPE.body, { fontSize: 13, marginTop: 12 }]}
+              className="text-oga-text-muted"
+            >
+              {confirmHint}
+            </Text>
+          )}
+          <Pressable
+            onPress={() => void tryConfirmSignIn(true)}
+            disabled={checking || (captchaEnabled && !captchaToken)}
+            className="bg-oga-black"
+            style={{
+              borderRadius: 10,
+              paddingVertical: 13,
+              alignItems: 'center',
+              marginTop: 16,
+              opacity: checking || (captchaEnabled && !captchaToken) ? 0.5 : 1,
+            }}
+          >
+            <Text style={[TYPE.bodyBold, { fontSize: 13 }]} className="text-white">
+              {checking ? 'Checking…' : "I've confirmed it"}
+            </Text>
+          </Pressable>
           <Link href="/(auth)/login" asChild>
             <Text
-              style={[TYPE.body, { fontSize: 13, marginTop: 18 }]}
+              style={[TYPE.body, { fontSize: 13, marginTop: 14, textAlign: 'center' }]}
               className="text-oga-green"
             >
               Back to sign in
@@ -148,8 +283,13 @@ export default function Signup() {
             onMessage={(event) => {
               try {
                 const msg = JSON.parse(event.nativeEvent.data)
-                if (msg.type === 'success') setCaptchaToken(msg.token)
-                else setCaptchaToken(null)
+                if (msg.type === 'success') {
+                  captchaTokenRef.current = msg.token
+                  setCaptchaToken(msg.token)
+                } else {
+                  captchaTokenRef.current = null
+                  setCaptchaToken(null)
+                }
               } catch {
                 // ignore non-JSON WebView messages
               }

--- a/apps/mobile/app/auth-callback.tsx
+++ b/apps/mobile/app/auth-callback.tsx
@@ -7,46 +7,97 @@ import { TYPE } from '../lib/typography'
 
 // Deep-link target for email confirmation (signup sends
 // `emailRedirectTo: oga://auth-callback`). GoTrue verifies the token
-// server-side, then redirects here with the session in the URL *fragment*
-// (implicit flow — the native client is `detectSessionInUrl: false`, and
-// expo-router only surfaces query params, never the `#` fragment). So we
-// parse the fragment by hand, set the session, then hand off to the same
-// post-login splash every other sign-in uses.
+// server-side, then redirects here. Two payload shapes:
+//
+//  • PKCE (current, flowType 'pkce' in lib/supabase.ts): `?code=` in the
+//    QUERY string → exchangeCodeForSession. Query params survive the
+//    mail-app → browser → oga:// handoff that strips URL fragments on
+//    some iOS chains (#509 field reports).
+//  • Implicit (legacy links from signups before the PKCE switch): the
+//    session rides the `#` fragment → parse by hand (the native client is
+//    `detectSessionInUrl: false`, and expo-router never surfaces
+//    fragments) and setSession.
+//
+// Either way GoTrue confirmed the email BEFORE redirecting, so if neither
+// payload arrives (the observed stuck case) the account almost certainly
+// works — the fallback UI sends the user to sign in normally rather than
+// hanging on "Confirming…" forever.
 export default function AuthCallback() {
   const url = Linking.useURL()
   const handled = useRef(false)
   const [error, setError] = useState<string | null>(null)
+  // Payload never arrived (or the URL itself never arrived) — offer the
+  // manual sign-in path instead of spinning forever.
+  const [fallback, setFallback] = useState(false)
+
+  // Watchdog for the url-never-arrives case; any handled outcome wins the
+  // render over it via the message precedence below.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      if (!handled.current) setFallback(true)
+    }, 8000)
+    return () => clearTimeout(t)
+  }, [])
 
   useEffect(() => {
     if (!url || handled.current) return
-    const fragment = url.split('#')[1]
-    if (!fragment) return
-    handled.current = true
+    const [base, fragment] = url.split('#')
+    const queryStart = base!.indexOf('?')
+    const query = new URLSearchParams(queryStart >= 0 ? base!.slice(queryStart + 1) : '')
+    const frag = new URLSearchParams(fragment ?? '')
 
-    const params = new URLSearchParams(fragment)
-    const accessToken = params.get('access_token')
-    const refreshToken = params.get('refresh_token')
+    const code = query.get('code')
+    const accessToken = frag.get('access_token')
+    const refreshToken = frag.get('refresh_token')
+    const errDescription =
+      query.get('error_description') ?? frag.get('error_description')
 
-    if (!accessToken || !refreshToken) {
-      setError(
-        params.get('error_description') ??
-          'This confirmation link is invalid or has expired.',
-      )
-      return
-    }
-
-    supabase.auth
-      .setSession({ access_token: accessToken, refresh_token: refreshToken })
-      .then(({ error: sessionError }) => {
-        if (sessionError) {
-          // Terminal: the effect only re-runs on a new `url`, so a retry must
-          // come from re-requesting confirmation (the "Back to sign in" link).
-          setError(sessionError.message)
+    if (code) {
+      handled.current = true
+      supabase.auth.exchangeCodeForSession(code).then(({ error: exchangeError }) => {
+        if (exchangeError) {
+          // Most common cause: the code_verifier isn't on this install
+          // (link tapped after a reinstall, or minted pre-PKCE). The email
+          // is verified regardless — steer to a normal sign-in.
+          setError(exchangeError.message)
           return
         }
         router.replace('/(auth)/welcome')
       })
+      return
+    }
+
+    if (accessToken && refreshToken) {
+      handled.current = true
+      supabase.auth
+        .setSession({ access_token: accessToken, refresh_token: refreshToken })
+        .then(({ error: sessionError }) => {
+          if (sessionError) {
+            setError(sessionError.message)
+            return
+          }
+          router.replace('/(auth)/welcome')
+        })
+      return
+    }
+
+    if (errDescription) {
+      handled.current = true
+      setError(errDescription)
+      return
+    }
+
+    // URL arrived carrying neither a code, tokens, nor an error — the
+    // stuck-at-"Confirming…" case from the field. Go straight to the
+    // manual path.
+    setFallback(true)
   }, [url])
+
+  const message = error
+    ? error
+    : fallback
+      ? 'This is taking longer than expected. Your email is most likely already confirmed — go back and sign in with your email and password.'
+      : 'Confirming your account…'
 
   return (
     <View className="flex-1 items-center justify-center bg-oga-bg-page px-6">
@@ -54,9 +105,9 @@ export default function AuthCallback() {
         style={TYPE.body}
         className="text-oga-text-muted text-sm text-center"
       >
-        {error ?? 'Confirming your account…'}
+        {message}
       </Text>
-      {error && (
+      {(error || fallback) && (
         <Pressable onPress={() => router.replace('/(auth)/login')}>
           <Text
             style={[TYPE.body, { fontSize: 13, marginTop: 16 }]}

--- a/apps/mobile/lib/supabase.ts
+++ b/apps/mobile/lib/supabase.ts
@@ -114,4 +114,13 @@ export const supabase = createOgaClient({
   anonKey,
   storage: SecureStoreAdapter,
   detectSessionInUrl: false,
+  // PKCE: the email-confirm redirect carries ?code= in the QUERY string,
+  // which survives the mail-app → browser → oga:// handoff that strips
+  // URL fragments on some iOS chains (#509 field reports — users stuck on
+  // "Confirming your account…" because the implicit-flow tokens never
+  // arrived in the fragment). auth-callback exchanges the code locally;
+  // the code_verifier lives in this SecureStore adapter, so the exchange
+  // only works on the device that signed up — which is also the Android
+  // scheme-hijack hardening #509 tracked.
+  flowType: 'pkce',
 })

--- a/packages/supabase/src/client.ts
+++ b/packages/supabase/src/client.ts
@@ -14,6 +14,11 @@ export interface CreateClientOptions {
   autoRefreshToken?: boolean
   persistSession?: boolean
   detectSessionInUrl?: boolean
+  /** Auth flow. Mobile uses 'pkce' so email-confirm links return a
+   *  ?code= query param instead of a URL fragment — fragments get
+   *  stripped in some iOS mail→browser→app redirect chains (#509).
+   *  Omitted = supabase-js default (implicit), which web stays on. */
+  flowType?: 'implicit' | 'pkce'
 }
 
 export function createOgaClient(opts: CreateClientOptions): OgaSupabaseClient {
@@ -34,6 +39,7 @@ export function createOgaClient(opts: CreateClientOptions): OgaSupabaseClient {
       // injection foothold. Flip back to true (or pass explicitly) when
       // an OAuth callback route is wired up.
       detectSessionInUrl: opts.detectSessionInUrl ?? false,
+      ...(opts.flowType ? { flowType: opts.flowType } : {}),
     },
   })
 }


### PR DESCRIPTION
Fixes the #509 field failures (two real iPhone users, production build). Closes #509.

## The two reports
1. Signed up → confirmed → **'Check your email' screen never cleared** (account created fine).
2. Signed up → tapped the link → **stuck at 'Confirming your account…'** — this one pinned the root cause: the deep link FIRES (the callback screen mounted), but the implicit-flow **token fragment didn't survive** the mail-app → browser → `oga://` handoff. The callback's `if (!fragment) return` then sat on the spinner forever.

## Fix, three layers
**1. PKCE flow (root cause).** Mobile client switches to `flowType: 'pkce'` (new `createOgaClient` option; web untouched — omitted = implicit default). The confirm redirect now carries `?code=` in the **query string**, which survives redirect chains that strip fragments. `exchangeCodeForSession` uses the `code_verifier` in SecureStore — the exchange only works on the signup device, which is also the Android scheme-hijack hardening #509 tracked as pre-launch work.

**2. `auth-callback` can no longer hang.** Handles `?code=` (PKCE), keeps the fragment path for legacy links minted pre-switch, surfaces `error_description` from query OR fragment, and adds a no-payload fallback + 8s watchdog: GoTrue verifies the email server-side BEFORE redirecting, so the fallback says so and offers 'Back to sign in' instead of spinning.

**3. Self-clearing 'Check your email' screen.** Covers the deep-link-never-fires modes (confirmed on another device, in-app mail browsers, dismissed open-in-app prompt): the screen still holds the just-entered credentials, so it silently attempts `signInWithPassword` on every app-foreground return (the natural just-confirmed-in-Mail moment) plus a manual 'I've confirmed it' button. Fails 'Email not confirmed' until the link is tapped; succeeds right after → same welcome-splash route as login. Turnstile-aware (prod captcha ON): the card mounts its own widget, tokens consumed per attempt + widget remounted for the next mint, queued attempts fire on token arrival, stale signup token dropped on submit.

## For currently-stuck users
Their accounts ARE confirmed — force-quit, reopen, sign in normally. This ships OTA (pure JS).

## Verification
- Mobile + web `tsc --noEmit` clean (direct), 589 core tests pass.
- Needs on-device iOS verification: same-device confirm (PKCE round-trip), other-device confirm (button path), foreground auto-clear, and a legacy pre-PKCE link (fragment path).

Related: #509's dashboard config (done) and PR #510 (the original deep-link wiring).