### PR TITLE
fix(core): formatSG rounds before picking sign — no more signed zero

### DIFF
--- a/packages/core/src/__tests__/units.test.ts
+++ b/packages/core/src/__tests__/units.test.ts
@@ -111,11 +111,13 @@ describe('formatSG', () => {
     expect(formatSG(-1.23999)).toBe('-1.24')
   })
 
-  it('values that round to 0 keep their pre-rounding sign', () => {
-    // 0.001 is positive → renders as +0.00 even though it rounds to
-    // zero. The plus survives because it's set before toFixed.
-    expect(formatSG(0.001)).toBe('+0.00')
-    expect(formatSG(-0.001)).toBe('-0.00')
+  it('values that round to 0 render unsigned (no "-0.00"/"+0.00") (#672)', () => {
+    // Sign is picked AFTER rounding, so anything that rounds to zero shows
+    // a clean "0.00" — a −0.004 round no longer displays a signed zero.
+    expect(formatSG(0.001)).toBe('0.00')
+    expect(formatSG(-0.001)).toBe('0.00')
+    expect(formatSG(-0.004)).toBe('0.00')
+    expect(formatSG(0.004)).toBe('0.00')
   })
 
   it('handles large magnitudes', () => {

--- a/packages/core/src/units.ts
+++ b/packages/core/src/units.ts
@@ -52,8 +52,12 @@ export function bearingDegrees(
 }
 
 export function formatSG(n: number): string {
-  const sign = n > 0 ? '+' : ''
-  return `${sign}${n.toFixed(2)}`
+  // Round to 2dp BEFORE picking the sign so a value that rounds to zero
+  // (e.g. -0.004) renders "0.00", not a signed "-0.00" (#672). Number()
+  // collapses the rounded -0.00 to 0, and (-0).toFixed(2) drops the sign.
+  const rounded = Number(n.toFixed(2))
+  const sign = rounded > 0 ? '+' : ''
+  return `${sign}${rounded.toFixed(2)}`
 }
 
 export function formatToPar(diff: number): string {


### PR DESCRIPTION
Closes #672.

`formatSG(-0.004)` rendered **'-0.00'** (and +0.004 → '+0.00') because the sign was picked from the raw value before `toFixed` rounded it to zero. A round with a near-zero SG showed a signed zero anywhere SG is displayed (home, stats, round detail — both platforms).

Fix: round to 2dp first (`Number(n.toFixed(2))` — collapses the rounded −0.00 to 0), then pick the sign, so anything that rounds to zero shows a clean '0.00'. Non-zero values are unchanged.

Test updated: the case that pinned the old '+0.00'/'-0.00' now asserts '0.00' for ±0.001/±0.004. 589 core tests pass.