### PR TITLE
fix(mobile): chip rows wrap instead of scrolling horizontally

### DIFF
--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -582,9 +582,10 @@ interface ChipRowProps<T extends string> {
 
 function ChipRow<T extends string>({ value, options, onChange, labelFor }: ChipRowProps<T>) {
   return (
-    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-      <View style={{ flexDirection: 'row', gap: 6 }}>
-        {options.map((opt) => {
+    // Wrap rather than scroll horizontally — the club list is long enough
+    // that off-screen chips read as the end of the list (#740).
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+      {options.map((opt) => {
           const active = value === opt
           return (
             <Pressable
@@ -609,8 +610,7 @@ function ChipRow<T extends string>({ value, options, onChange, labelFor }: ChipR
             </Pressable>
           )
         })}
-      </View>
-    </ScrollView>
+    </View>
   )
 }
 

--- a/apps/mobile/components/round/PastHoleShotsSheet.tsx
+++ b/apps/mobile/components/round/PastHoleShotsSheet.tsx
@@ -357,29 +357,29 @@ function ChipRow<T extends string>({
   return (
     <View style={{ marginBottom: 18 }}>
       <Text style={{ ...KICKER, marginBottom: 8 }}>{label}</Text>
-      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-        <View style={{ flexDirection: 'row', gap: 6 }}>
-          {options.map((o) => {
-            const active = value === o.value
-            return (
-              <Pressable
-                key={o.value}
-                onPress={() => onSelect(o.value)}
-                style={{
-                  paddingHorizontal: 10,
-                  paddingVertical: 8,
-                  borderRadius: 2,
-                  backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
-                }}
-              >
-                <Text style={[TYPE.body, { color: active ? '#F2EEE5' : '#1C211C', fontSize: 12 }]}>
-                  {o.label}
-                </Text>
-              </Pressable>
-            )
-          })}
-        </View>
-      </ScrollView>
+      {/* Wrap rather than scroll horizontally — off-screen chips read as
+          the end of the list in the edit sheet (#740). */}
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+        {options.map((o) => {
+          const active = value === o.value
+          return (
+            <Pressable
+              key={o.value}
+              onPress={() => onSelect(o.value)}
+              style={{
+                paddingHorizontal: 10,
+                paddingVertical: 8,
+                borderRadius: 2,
+                backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
+              }}
+            >
+              <Text style={[TYPE.body, { color: active ? '#F2EEE5' : '#1C211C', fontSize: 12 }]}>
+                {o.label}
+              </Text>
+            </Pressable>
+          )
+        })}
+      </View>
     </View>
   )
 }

--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -599,9 +599,10 @@ interface ChipRowProps<T extends string> {
 
 function ChipRow<T extends string>({ value, options, onChange }: ChipRowProps<T>) {
   return (
-    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-      <View style={{ flexDirection: 'row', gap: 6 }}>
-        {options.map(({ value: optValue, label }) => {
+    // Wrap to multiple rows rather than scroll horizontally — a hidden
+    // off-screen club/lie chip reads as "the list ends here" (#740).
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+      {options.map(({ value: optValue, label }) => {
           const active = value === optValue
           return (
             <Pressable
@@ -632,7 +633,6 @@ function ChipRow<T extends string>({ value, options, onChange }: ChipRowProps<T>
             </Pressable>
           )
         })}
-      </View>
-    </ScrollView>
+    </View>
   )
 }


### PR DESCRIPTION
Closes #740. Tester UX feedback.

## Problem
The shot-detail logging modal (and the Shot Patterns page) laid out club / lie-type / filter chips in a **horizontal ScrollView**, so options past the screen edge were hidden behind a scroll — they read as "the list ends here," which feels bad and hides valid choices.

## Fix
Swap the `<ScrollView horizontal>` for a `<View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>` in all three `ChipRow`/`ChipSelector` variants:
- `ShotLogger.tsx` — live-round shot logger (club, lie type)
- `PastHoleShotsSheet.tsx` — past-round shot editor (~10 selectors)
- `patterns.tsx` — Shot Patterns filters (club / lie / slope)

RN `gap` spaces the wrapped rows too, so no extra row-gap needed.

## Scope
- **Excluded** `Scorecard.tsx`'s hole-number strip — a scorecard is meant to scroll horizontally; wrapping it would be wrong.
- **Design-compatible:** DESIGN.md specifies chip styling, not a horizontal-scroll requirement; the lie-slope / putt-result `DO NOT CHANGE` grids are separate wrapping components, untouched here.

## Verification
- Mobile `tsc --noEmit` clean.
- Needs an on-device glance to confirm the wrapped rows look right in the modal (pure layout change; ships OTA).