### PR TITLE
feat(mobile): surface the web companion (Profile copy + Stats rider)

### DIFF
--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -447,7 +447,9 @@ export default function ProfileTab() {
                   marginBottom: 14,
                 }]}
               >
-                OGA is free and open source. Learn more at oga.golf.
+                Your rounds sync to a free web dashboard. Sign in at oga.golf
+                with the same account for bigger stats, strokes gained, and
+                shot-pattern charts.
               </Text>
               <Pressable
                 accessibilityRole="link"

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
+import { Linking, Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native'
 import { VictoryAxis, VictoryChart, VictoryLine } from 'victory-native'
 import Svg, { Line as SvgLine } from 'react-native-svg'
 import {
@@ -184,13 +184,29 @@ export default function Stats() {
         eyebrow="Performance"
         title="Strokes Gained"
         right={
-          <View
-            style={{
-              flexDirection: 'row',
-              borderWidth: 1,
-              borderColor: 'rgba(242,238,229,0.25)',
-            }}
-          >
+          <View style={{ alignItems: 'flex-end', gap: 7 }}>
+            <Pressable
+              accessibilityRole="link"
+              accessibilityLabel="Open the full dashboard on the web at oga.golf"
+              onPress={() => Linking.openURL('https://oga.golf')}
+              hitSlop={8}
+            >
+              <Text
+                style={[TYPE.body, {
+                  color: 'rgba(242,238,229,0.4)',
+                  fontSize: 11,
+                }]}
+              >
+                oga.golf ↗
+              </Text>
+            </Pressable>
+            <View
+              style={{
+                flexDirection: 'row',
+                borderWidth: 1,
+                borderColor: 'rgba(242,238,229,0.25)',
+              }}
+            >
             {N_OPTIONS.map((opt, i) => {
               const active = n === opt
               return (
@@ -218,6 +234,7 @@ export default function Stats() {
                 </Pressable>
               )
             })}
+            </View>
           </View>
         }
       />


### PR DESCRIPTION
Mobile users installing from the App Store had no cue that oga.golf is the same account with a fuller dashboard. Two low-key in-app pointers:

- **Profile 'OGA on the web' card** — reframed copy: *'Your rounds sync to a free web dashboard. Sign in at oga.golf with the same account for bigger stats, strokes gained, and shot-pattern charts.'* (was the open-source line). Feature framing only — stays clear of App Review 3.1.1 (no payment).
- **Stats top bar rider** — a muted `oga.golf ↗` above the L5/L10/L20 round buttons, opens the site. Deliberately subtle (40% opacity).

Also (not in this diff — gitignored): a one-line web-companion sentence added to `store-submission.md` §2 for the next App Store / Play listing edit. The Marketing URL already points to oga.golf; the description just never mentioned it.

Pure JS — rides the next OTA. Mobile `tsc --noEmit` clean.