### PR TITLE
fix(mobile): ShotLogger re-seeds lie from initial on open

### DIFF
--- a/apps/mobile/components/round/ShotLogger.tsx
+++ b/apps/mobile/components/round/ShotLogger.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Modal, Pressable, ScrollView, Text, TextInput, View } from 'react-native'
 import Svg, { Circle, Line as SvgLine } from 'react-native-svg'
 import {
@@ -112,6 +112,25 @@ export function ShotLogger({
   })
   const set = <K extends keyof ShotLoggerValue>(key: K, v: ShotLoggerValue[K]) =>
     setValue((prev) => ({ ...prev, [key]: prev[key] === v ? undefined : v }))
+
+  // Re-seed `value` from `initial` each time the sheet opens. ShotLogger only
+  // remounts when shotEntryKey changes (save / hole change), but the "not
+  // putting" flows seed loggerInitial mid-cycle AFTER this instance mounted —
+  // handleOnGreenNo sets { lieType: 'rough' }, swapPuttingToShot sets the
+  // chosen lie. Without this re-seed the mounted instance never reads that
+  // prop and the shot stores lie_type null, silently degrading SG (#654).
+  useEffect(() => {
+    if (!visible) return
+    setValue({
+      ...initial,
+      lieType: isPutt ? 'green' : initial?.lieType,
+      club: isPutt ? 'putter' : initial?.club,
+    })
+    // Re-seed on open only. initial/isPutt are stable while the sheet is open
+    // (loggerInitial is set before it opens and not mutated during), and
+    // listing them would wipe in-progress edits on any identity change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible])
 
   // Source the club picker from the user's bag. Fall back to DEFAULT_BAG
   // while the bag is loading or if the user trimmed it to nothing — never


### PR DESCRIPTION
Closes #654.

## Bug
Answering 'No' to the on-green prompt (or 'Not a putt? Chip / bunker →') opened the shot logger with **no lie preselected**, so a player who skipped the picker stored `lie_type: null` where the flow intended `rough` — silently degrading SG categorization.

## Mechanism (regression from the #284 key change)
`ShotLogger` reads `initial` only in its `useState` initializer, and only remounts when `shotEntryKey` changes (save / hole change). But `handleOnGreenNo` (`setLoggerInitial({ lieType: 'rough' })`) and `swapPuttingToShot` set `loggerInitial` **mid-cycle**, after this instance already mounted — so the seeded lie was set on a prop the mounted instance never re-reads.

## Fix
An effect keyed on `visible` re-seeds `value` from `initial` each time the sheet opens (mirrors the useState initializer exactly). Re-seeds on open only — deps are `[visible]` because `loggerInitial` is set before the sheet opens and isn't mutated while it's open, so in-progress edits are never wiped.

Mobile `tsc --noEmit` clean.