### PR TITLE
fix(mobile): convert two dropped function-styles to PressableTouch

### DIFF
--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -24,6 +24,7 @@ import {
 } from '@oga/core'
 import { getShotsByClub } from '@oga/supabase'
 import { MaterialCommunityIcons } from '@expo/vector-icons'
+import { PressableTouch } from '../../components/ui/PressableTouch'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useUnits } from '../../hooks/useUnits'
@@ -210,14 +211,15 @@ export default function Patterns() {
               <DispersionPlot points={points} stats={stats} />
               <PatternLegend hasStats={!!stats} />
               {stats && (
-                <Pressable
+                <PressableTouch
                   accessibilityRole="button"
                   accessibilityLabel="Export shot pattern image"
                   accessibilityState={{ disabled: sharing }}
                   onPress={handleShare}
                   disabled={sharing}
                   hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                  style={({ pressed }) => ({
+                  android_ripple={{ color: 'rgba(31,61,44,0.12)' }}
+                  style={{
                     alignSelf: 'flex-start',
                     flexDirection: 'row',
                     alignItems: 'center',
@@ -230,8 +232,10 @@ export default function Patterns() {
                     borderWidth: 1,
                     borderColor: '#1F3D2C',
                     borderRadius: 2,
-                    opacity: pressed || sharing ? 0.6 : 1,
-                  })}
+                    // Disabled-while-sharing dim; PressableTouch adds the
+                    // iOS press dim on top.
+                    opacity: sharing ? 0.6 : 1,
+                  }}
                 >
                   <MaterialCommunityIcons
                     name="tray-arrow-down"
@@ -243,7 +247,7 @@ export default function Patterns() {
                   <Text style={{ ...KICKER, color: '#1F3D2C', fontSize: 11 }}>
                     {sharing ? 'Rendering…' : 'Export image'}
                   </Text>
-                </Pressable>
+                </PressableTouch>
               )}
             </>
           )}

--- a/apps/mobile/app/(app)/rounds.tsx
+++ b/apps/mobile/app/(app)/rounds.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native'
 import { Link } from 'expo-router'
 import { Swipeable } from 'react-native-gesture-handler'
+import { PressableTouch } from '../../components/ui/PressableTouch'
 import { formatSG } from '@oga/core'
 import { deleteRound, getRoundsList } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
@@ -163,7 +164,7 @@ export default function RoundsList() {
                 overshootRight={false}
               >
                 <Link href={`/(app)/round/${r.id}`} asChild>
-                  <Pressable
+                  <PressableTouch
                     onLongPress={() => openDeleteFor(r)}
                     accessibilityLabel={buildA11yLabel(r)}
                     accessibilityHint="Opens round detail"
@@ -174,7 +175,8 @@ export default function RoundsList() {
                       if (e.nativeEvent.actionName === 'delete')
                         openDeleteFor(r)
                     }}
-                    style={({ pressed }) => ({
+                    android_ripple={{ color: 'rgba(31,61,44,0.10)' }}
+                    style={{
                       flexDirection: 'row',
                       justifyContent: 'space-between',
                       alignItems: 'center',
@@ -183,8 +185,7 @@ export default function RoundsList() {
                       borderBottomWidth: 1,
                       borderColor: '#D9D2BF',
                       backgroundColor: '#F2EEE5',
-                      opacity: pressed ? 0.7 : 1,
-                    })}
+                    }}
                   >
                     <View style={{ flex: 1, paddingRight: 12 }}>
                       <Text style={{ ...KICKER, marginBottom: 4 }}>
@@ -232,7 +233,7 @@ export default function RoundsList() {
                         {r.sg_total == null ? '—' : formatSG(r.sg_total)}
                       </Text>
                     </View>
-                  </Pressable>
+                  </PressableTouch>
                 </Link>
               </Swipeable>
             ))}


### PR DESCRIPTION
Closes #655.

## Bug (#303 class)
NativeWind/css-interop silently drops function `style` props on wrapped RN components. Two sites still used `style={({ pressed }) => ...}`:
- `rounds.tsx` — the rounds-list row (padding, dividers, background, press opacity all inside the dropped function) → row loses its layout.
- `patterns.tsx` — the shot-pattern export button (background, border, press/sharing opacity) → renders as bare text.

## Fix
Both now use `PressableTouch` (static style + iOS press dim via onPressIn/out) with `android_ripple` for Android feedback — matching the already-fixed sites (MapBottomChrome, HoleMapOverlays). The rounds row keeps its `Link asChild` wrapper (onPress flows through). The export button keeps its `disabled-while-sharing` dim in the static style (`opacity: sharing ? 0.6 : 1`); PressableTouch layers the press dim on top.

Mobile `tsc --noEmit` clean. Needs an on-device glance to confirm the rows render with dividers and the export button shows its chrome (the audit flagged the rule violation; visual damage was unconfirmed).