### PR TITLE
fix(mobile): Shot Patterns lie-slope filter — two-axis multi-select

### DIFF
--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -5,7 +5,8 @@ import { captureRef } from 'react-native-view-shot'
 import * as Sharing from 'expo-sharing'
 import {
   CLUBS,
-  LIE_SLOPES,
+  LIE_SLOPES_FORWARD,
+  LIE_SLOPES_SIDE,
   LIE_TYPES,
   YARDS_TO_METERS,
   clubDistanceStats,
@@ -19,6 +20,8 @@ import {
   type DispersionStats,
   type DistanceUnit,
   type LieSlope,
+  type LieSlopeForward,
+  type LieSlopeSide,
   type LieType,
   type Shot,
 } from '@oga/core'
@@ -56,6 +59,8 @@ interface ShotRowMin {
   club: string | null
   lie_type: LieType | null
   lie_slope: LieSlope | null
+  lie_slope_forward: LieSlopeForward | null
+  lie_slope_side: LieSlopeSide | null
   shot_result: string | null
   penalty: boolean
   ob: boolean
@@ -77,6 +82,8 @@ function rowToShot(r: ShotRowMin): Shot {
     club: (r.club as Shot['club']) ?? undefined,
     lieType: r.lie_type ?? undefined,
     lieSlope: r.lie_slope ?? undefined,
+    lieSlopeForward: r.lie_slope_forward ?? undefined,
+    lieSlopeSide: r.lie_slope_side ?? undefined,
     shotResult: (r.shot_result as Shot['shotResult']) ?? undefined,
     penalty: r.penalty,
     ob: r.ob,
@@ -90,7 +97,12 @@ export default function Patterns() {
   const { unit, toDisplay } = useUnits()
   const [club, setClub] = useState<Club>('7i')
   const [lieType, setLieType] = useState<LieType | typeof ANY>(ANY)
-  const [lieSlope, setLieSlope] = useState<LieSlope | typeof ANY>(ANY)
+  // Two-axis slope filter, multi-select. Empty array on an axis = "any"
+  // (no constraint). Replaces the old single-select LIE_SLOPES chip row,
+  // which filtered the legacy lie_slope column (null on every shot logged
+  // since the two-axis migration → matched nothing) (#746).
+  const [forwardSel, setForwardSel] = useState<LieSlopeForward[]>([])
+  const [sideSel, setSideSel] = useState<LieSlopeSide[]>([])
   const [shots, setShots] = useState<ShotRowMin[]>([])
   const [loading, setLoading] = useState(false)
 
@@ -114,14 +126,23 @@ export default function Patterns() {
 
   const points = useMemo(() => {
     let pts = computeDispersion(shots.map(rowToShot))
-    if (lieType !== ANY || lieSlope !== ANY) {
-      pts = filterDispersionByLie(pts, {
-        lieSlope: lieSlope === ANY ? undefined : lieSlope,
-        lieType: lieType === ANY ? undefined : lieType,
-      })
+    if (lieType !== ANY) {
+      pts = filterDispersionByLie(pts, { lieType })
+    }
+    // Multi-select per axis: a point passes when the axis has no selection
+    // (any) OR its value is among the selected. The two axes AND together.
+    if (forwardSel.length > 0) {
+      pts = pts.filter(
+        (p) => p.lieSlopeForward != null && forwardSel.includes(p.lieSlopeForward),
+      )
+    }
+    if (sideSel.length > 0) {
+      pts = pts.filter(
+        (p) => p.lieSlopeSide != null && sideSel.includes(p.lieSlopeSide),
+      )
     }
     return pts
-  }, [shots, lieType, lieSlope])
+  }, [shots, lieType, forwardSel, sideSel])
 
   const stats = useMemo(() => computeDispersionStats(points), [points])
 
@@ -187,12 +208,24 @@ export default function Patterns() {
 
         <Entrance index={2}>
         <Section kicker="Lie slope">
-          <ChipRow
-            value={lieSlope}
-            options={[ANY, ...LIE_SLOPES] as const}
-            onChange={(v) => setLieSlope(v as LieSlope | typeof ANY)}
-            labelFor={(v) => (v === ANY ? 'any' : (v as string).replace(/_/g, ' '))}
-          />
+          {/* Two independent axes, each multi-select (tap several to see
+              them together). No selection on an axis = any. Fixes the old
+              single-select filter that read the always-null legacy column
+              (#746). */}
+          <View style={{ gap: 8 }}>
+            <MultiChipRow
+              options={LIE_SLOPES_FORWARD}
+              selected={forwardSel}
+              onToggle={(v) => setForwardSel(toggleSel(forwardSel, v))}
+              labelFor={slopeLabel}
+            />
+            <MultiChipRow
+              options={LIE_SLOPES_SIDE}
+              selected={sideSel}
+              onToggle={(v) => setSideSel(toggleSel(sideSel, v))}
+              labelFor={slopeLabel}
+            />
+          </View>
         </Section>
         </Entrance>
 
@@ -204,7 +237,10 @@ export default function Patterns() {
             <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 13 }]}>
               No shots yet for {club}
               {lieType !== ANY ? ` (${lieType})` : ''}
-              {lieSlope !== ANY ? ` (${lieSlope})` : ''}.
+              {forwardSel.length + sideSel.length > 0
+                ? ` (${[...forwardSel, ...sideSel].map(slopeLabel).join(', ')})`
+                : ''}
+              .
             </Text>
           ) : (
             <>
@@ -614,6 +650,64 @@ function ChipRow<T extends string>({ value, options, onChange, labelFor }: ChipR
             </Pressable>
           )
         })}
+    </View>
+  )
+}
+
+// Toggle a value in/out of a multi-select array.
+function toggleSel<T>(arr: T[], v: T): T[] {
+  return arr.includes(v) ? arr.filter((x) => x !== v) : [...arr, v]
+}
+
+// 'ball_above' → 'ball above'. Shared by the slope chips + empty-state text.
+function slopeLabel(v: string): string {
+  return v.replace(/_/g, ' ')
+}
+
+interface MultiChipRowProps<T extends string> {
+  options: readonly T[]
+  selected: T[]
+  onToggle: (v: T) => void
+  labelFor?: (v: T) => string
+}
+
+// Like ChipRow but multi-select: every chip in `selected` is highlighted,
+// tapping toggles. No "any" chip — an empty selection IS "any".
+function MultiChipRow<T extends string>({
+  options,
+  selected,
+  onToggle,
+  labelFor,
+}: MultiChipRowProps<T>) {
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+      {options.map((opt) => {
+        const active = selected.includes(opt)
+        return (
+          <Pressable
+            key={opt}
+            accessibilityRole="checkbox"
+            accessibilityState={{ checked: active }}
+            onPress={() => onToggle(opt)}
+            style={{
+              paddingHorizontal: 10,
+              paddingVertical: 8,
+              borderRadius: 2,
+              backgroundColor: active ? '#1F3D2C' : '#EBE5D6',
+            }}
+          >
+            <Text
+              style={[TYPE.body, {
+                color: active ? '#F2EEE5' : '#1C211C',
+                fontSize: 12,
+                fontWeight: active ? '500' : '400',
+              }]}
+            >
+              {labelFor ? labelFor(opt) : opt}
+            </Text>
+          </Pressable>
+        )
+      })}
     </View>
   )
 }


### PR DESCRIPTION
Closes #746.

## Bug
The Shot Patterns lie-slope filter read the legacy `lie_slope` column, which the app stopped writing at the two-axis migration — it's null on every shot logged since. So selecting any slope matched **zero shots**. It was also the old flat single-select chip row, inconsistent with the two-axis slope model used in shot logging.

## Fix
- `ShotRowMin` + `rowToShot` now carry `lie_slope_forward` / `lie_slope_side` onto the `Shot` (the query already selected them; only the mapping was missing). Legacy `lie_slope` mapping kept, harmless.
- Filter state is two axes, each **multi-select**: forward (uphill / level / downhill) + side (ball above / below). Empty selection on an axis = *any*; the two axes AND together. Tap several within an axis to see them together.
- New `MultiChipRow` (co-located — 2 callers here) mirrors `ChipRow`'s wrapping-chip style with checkbox semantics.
- `filterDispersionByLie` (core) already supported the two axes — no core change needed; slope multi-select is filtered inline since the core helper takes single values per axis.

Mobile `tsc --noEmit` clean. Needs an on-device check that selecting slopes now actually narrows the dispersion set.