### PR TITLE
fix(learn): glossary audit corrections

### DIFF
--- a/apps/mobile/components/learn/articles/Glossary.tsx
+++ b/apps/mobile/components/learn/articles/Glossary.tsx
@@ -9,10 +9,9 @@ export function GlossaryArticle() {
         title="Glossary of golf terms."
       />
       <P>
-        The basics — birdie, bogey, par, handicap, GIR — are covered
-        in the app's stat reference section. This glossary focuses
-        on the terms that come up once you start playing regularly
-        and trying to improve.
+        The basics — birdie, bogey, par, handicap, GIR — are not
+        covered here. This glossary focuses on the terms that come
+        up once you start playing regularly and trying to improve.
       </P>
 
       {GLOSSARY_GROUPS.map((group) => (
@@ -68,11 +67,11 @@ const GLOSSARY_GROUPS: GlossaryGroup[] = [
       { name: 'Stinger', body: 'A low, penetrating shot hit with minimal loft, played into wind or under trees.' },
       { name: 'Punch shot', body: 'A low, controlled shot played with a shortened swing. Stays low, runs out after landing.' },
       { name: 'Flier', body: 'A shot that travels farther than expected because grass gets between face and ball, reducing backspin. Common from rough.' },
-      { name: 'Spinner', body: 'A wedge struck cleanly into a soft green that spins back toward the player after landing. Useful when the pin is at the back of the green.' },
+      { name: 'Spinner', body: 'A wedge struck cleanly into a soft green that spins back toward the player after landing. Useful when the pin is at the front — fly it past and let the spin bring it back.' },
       { name: 'Knuckleball', body: 'A shot with almost no spin — the ball flutters unpredictably. Often happens out of thick rough.' },
       { name: 'Texas Wedge', body: 'Using a putter from off the green — fringe, apron, or even light rough. Highest-percentage shot when the ground between ball and hole is firm and flat.' },
       { name: 'DOD (Driver Off the Deck)', body: 'Hitting a driver without a tee, from the fairway or rough. One of the hardest shots in golf.' },
-      { name: 'Thai Spinner', body: 'A low, high-spin shot popularized by Kiradech Aphibarnrat — steep outside-in lob wedge from a tight or grainy lie. Reached wider audiences when Keith Mitchell pulled it off at the 2025 Houston Open.' },
+      { name: 'Thai Spinner', body: 'A low, high-spin shot popularized by Kiradech Aphibarnrat — steep outside-in lob wedge from a tight or grainy lie. Reached wider audiences when Keith Mitchell pulled it off at the 2025 Texas Children\'s Houston Open.' },
     ],
   },
   {
@@ -91,7 +90,6 @@ const GLOSSARY_GROUPS: GlossaryGroup[] = [
     heading: 'Putting terms',
     terms: [
       { name: 'Pin high / Hole high', body: 'Approach finishes level with the pin (correct distance, off line). Generally a good miss — putting across slope, not up or down it.' },
-      { name: 'Spinner (putting)', body: 'A putt that lips out spinning — catches the edge, spins around the rim, comes back out. See also: lip out.' },
     ],
   },
   {
@@ -114,7 +112,7 @@ const GLOSSARY_GROUPS: GlossaryGroup[] = [
     terms: [
       { name: 'Divot', body: 'The chunk of turf displaced (or the hole left). Replace it, or fill with sand-mix where provided. Hitting from a divot is no relief — play it as it lies.' },
       { name: 'Pitch mark / Ball mark', body: 'The indentation an approach leaves on the green. Repair yours and any nearby. Push edges down and smooth — do not lift the center.' },
-      { name: 'Burn mark', body: 'Browning on one side of the cup where grain grows away from the cup edge. The healthy side is with the grain; the burned side is into it. Quick read for grain on Bermuda greens.' },
+      { name: 'Burn mark', body: 'Browning on one side of the cup — the burnt, ragged edge shows the direction the grain grows toward; the sharp, healthy edge is up-grain. Putts run faster and break toward the burnt side. Quick read for grain on Bermuda greens.' },
       { name: 'Divot tool / Pitch fork', body: 'Tool for repairing pitch marks. Insert tines at the edges, push inward. Never pry up from the center.' },
     ],
   },

--- a/apps/web/src/pages/learn/articles/GlossaryArticle.tsx
+++ b/apps/web/src/pages/learn/articles/GlossaryArticle.tsx
@@ -1,4 +1,4 @@
-import { SrcBody, SrcLabel } from '../components/ArticlePrimitives'
+import { Lede, SrcBody, SrcLabel } from '../components/ArticlePrimitives'
 export function GlossaryArticle() {
   return (
     <article
@@ -26,12 +26,11 @@ export function GlossaryArticle() {
         Glossary of golf terms.
       </h2>
 
-      <P>
-        The basics — birdie, bogey, par, handicap, GIR — are covered
-        in the app's stat reference section. This glossary focuses
-        on the terms that come up once you start playing regularly
-        and trying to improve.
-      </P>
+      <Lede>
+        The basics — birdie, bogey, par, handicap, GIR — are not
+        covered here. This glossary focuses on the terms that come
+        up once you start playing regularly and trying to improve.
+      </Lede>
 
       <Hr />
 
@@ -96,8 +95,8 @@ export function GlossaryArticle() {
         A shot hit with enough backspin that the ball spins back
         toward the player after landing on the green. Typically
         happens on clean contact with a wedge into a soft green. A
-        desirable shot when the pin is at the back of the green and
-        you need the ball to check up and release toward the hole.
+        desirable shot when the pin is at the front of the green —
+        fly the ball past the hole and let the spin bring it back.
       </Term>
       <Term name="Knuckleball">
         A shot with almost no spin — the ball flutters and moves
@@ -196,13 +195,6 @@ export function GlossaryArticle() {
         considered a good miss — you're putting across the slope
         rather than up or down it.
       </Term>
-      <Term name="Spinner (putting)">
-        In putting context, a spinner refers to a putt that lips
-        out spinning — the ball catches the edge of the cup, spins
-        around the rim and comes back out. One of the most
-        frustrating outcomes in golf. See also: lip out.
-      </Term>
-
       <Hr />
 
       <H3>Course and green terminology</H3>
@@ -288,14 +280,13 @@ export function GlossaryArticle() {
         down and smoothing, not by lifting the center up.
       </Term>
       <Term name="Burn mark">
-        The browning or dying of grass on one side of the hole cup,
-        caused by the grain growing away from that side and
-        exposing the roots. The burned side indicates where the
-        grain is running from — grain runs toward the healthy
-        green side of the cup. Reading burn marks is a quick way
-        to identify grain direction on Bermuda greens before
-        putting. The side with the burn is into the grain; the
-        healthy side is with the grain.
+        The browning or dying of grass on one side of the hole cup.
+        The blades on the down-grain edge hang over the hole and die
+        off, leaving a burnt, ragged edge — that side shows the
+        direction the grain grows toward. The sharp, healthy edge is
+        the up-grain side. Putts run faster and break toward the
+        burnt side. Reading burn marks is a quick way to identify
+        grain direction on Bermuda greens before putting.
       </Term>
       <Term name="Divot tool / Pitch fork">
         The small forked tool used to repair pitch marks on the

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -18,10 +18,9 @@ content_warning: |
 > docs/learn/glossary.md
 
 The basics — birdie, bogey, par, handicap, GIR —
-are covered in the app's stat reference section.
-This glossary focuses on the terms that come up
-once you start playing regularly and trying to
-improve.
+are not covered here. This glossary focuses on the
+terms that come up once you start playing regularly
+and trying to improve.
 
 ---
 
@@ -90,8 +89,8 @@ A shot hit with enough backspin that the ball spins
 back toward the player after landing on the green.
 Typically happens on clean contact with a wedge into
 a soft green. A desirable shot when the pin is at
-the back of the green and you need the ball to check
-up and release toward the hole.
+the front of the green — fly the ball past the hole
+and let the spin bring it back.
 
 **Knuckleball**
 A shot with almost no spin — the ball flutters and
@@ -199,13 +198,6 @@ direction was off. Generally considered a good miss
 — you're putting across the slope rather than up
 or down it.
 
-**Spinner (putting)**
-In putting context, a spinner refers to a putt that
-lips out spinning — the ball catches the edge of
-the cup, spins around the rim and comes back out.
-One of the most frustrating outcomes in golf. See
-also: lip out.
-
 ---
 
 ## Course and green terminology
@@ -299,7 +291,7 @@ for everyone. Repair by pushing the edges down and
 smoothing, not by lifting the center up.
 
 **Burn mark**
-The browning or dying of grass on one side of the hole cup, caused by the grain growing away from that side and exposing the roots. The burned side indicates where the grain is running from — grain runs toward the healthy green side of the cup. Reading burn marks is a quick way to identify grain direction on Bermuda greens before putting. The side with the burn is into the grain; the healthy side is with the grain.
+The browning or dying of grass on one side of the hole cup. The blades on the down-grain edge hang over the hole and die off, leaving a burnt, ragged edge — that side shows the direction the grain grows toward. The sharp, healthy edge is the up-grain side. Putts run faster and break toward the burnt side. Reading burn marks is a quick way to identify grain direction on Bermuda greens before putting.
 
 **Divot tool / Pitch fork**
 The small forked tool used to repair pitch marks on
@@ -309,12 +301,6 @@ to level it out. Do not pry up from the center —
 this damages the roots. A ball marker (usually a
 coin) is used alongside the divot tool to mark your
 ball position on the green.
-
-**Scalp**
-To hit the top of the ball (same as thin or blade).
-Also used as a noun: "He left a big scalp on the
-fairway" — meaning a divot cut so shallow it's
-more of a skin than a proper divot.
 
 ---
 
@@ -348,8 +334,7 @@ the hole outright — no ties — wins the skin. If
 two or more players tie, the skin carries over to
 the next hole, making it worth more. Skins can
 stack up over several holes and create exciting
-swings. A popular format for casual gambling rounds
-and some professional made-for-TV events.
+swings.
 
 **Match play**
 A format where the score is tracked hole by hole
@@ -446,9 +431,6 @@ even with a good swing. Can be adjusted by a fitter.
 ---
 
 ## Slang and culture
-
-**Flush**
-See short game section above.
 
 **Worm burner**
 A shot that never gets airborne, rolling along the
@@ -586,14 +568,6 @@ had to play around or over it. Eliminated from the
 rules in 1952 when ball marking became standard.
 Still used figuratively in everyday English — "I'm
 in a bit of a stymie" — meaning blocked or stuck.
-
-**Dormie**
-While still used today in match play (see scoring
-section), dormie has its roots in early golf
-language. Some historians believe it derives from
-the French "dormir" (to sleep) — the leading player
-could sleep easy knowing the worst outcome was a
-tie. Others dispute this etymology.
 
 **Fore**
 Still very much in use — the warning shout when a


### PR DESCRIPTION
Verified audit corrections to the Glossary article across all three copies (web, mobile, docs mirror).

- **Burn mark grain read inverted** — rewritten in all three files: the burnt, ragged edge of the cup shows the direction the grain grows toward (down-grain); the sharp, healthy edge is up-grain; putts run faster and break toward the burnt side. The "roots exposed" causal story replaced with the correct mechanism (down-grain blades hang over the hole and die off).
- **Spinner (shot) pin advice** — a spin-back shot suits a front pin, not a back pin: "fly the ball past the hole and let the spin bring it back." All three files.
- **Spinner (putting) deleted** — unsourced as a lip-out term and a second, conflicting definition of Spinner in the same article; Lip out already exists in Slang. All three files.
- **Lede no longer assumes the reader uses OGA** — "are covered in the app's stat reference section" → "are not covered here." All three files.
- **docs mirror drift** (docs/learn/glossary.md only): deleted the docs-only Scalp entry under Divots (contradicted the article's own Scalp/Thin/Blade definition), the duplicate Dormie in Historical, the stray "Flush — See short game section above" cross-ref, and the extra Skins sentence about made-for-TV events.
- **Consistency polish**: web intro now uses the shared `Lede` primitive instead of the local body `P` (mobile primitives have no Lede equivalent — left as-is); mobile Thai Spinner aligned to "2025 Texas Children's Houston Open."

Typechecks pass locally (web `pnpm typecheck`, mobile `npm run typecheck`).

Closes #750
Closes #758
Part of #767, #768, #770 (glossary items)