### PR TITLE
fix(learn): swing-variations, understanding-your-swing, Operation 36 corrections

### DIFF
--- a/apps/mobile/components/learn/articles/Operation36.tsx
+++ b/apps/mobile/components/learn/articles/Operation36.tsx
@@ -23,6 +23,14 @@ export function Operation36Article() {
         title="The Operation 36 philosophy."
       />
 
+      <P>
+        Most golfers are taught to build a swing first and play golf later.
+        Operation 36 flips that: you start 25 yards from the hole, learn to
+        score, and earn your way back to the full tees one stage at a time.
+      </P>
+
+      <Hr />
+
       <H3>Most golfers learn in the wrong order</H3>
       <P>
         The traditional path into golf goes like this: stand on a mat at the
@@ -52,9 +60,9 @@ export function Operation36Article() {
         Clear it and you move back a stage; until then, you stay where you are.
         You begin in Division 1, playing nine holes from 25 yards out, where
         every hole is reachable and every score you write down is a real score.
-        Break 36 and you step back to 50 yards, then 75, and onward in stages
-        until, eventually, you're shooting par from the full tees — the same
-        game the rest of the course is playing.
+        Shoot 36 or better and you step back to 50 yards, then 100, 150, 200,
+        and finally your full tees — the same game the rest of the course is
+        playing.
       </P>
 
       <ProgressionLadder />
@@ -256,12 +264,13 @@ export function Operation36Article() {
       <Sources
         items={[
           {
-            name: 'Operation 36 Golf · How It Works',
-            href: 'https://operation36.golf/how-it-works/',
+            name: 'The program — distance progression and the "shoot 36" rule',
             note: (
               <Text>
-                The program — distance progression and the "shoot 36" rule:
-                start at 25 yards, shoot 36 or better for nine holes to level up,
+                <Link href="https://operation36.golf/how-it-works/">
+                  Operation 36 Golf · How It Works
+                </Link>{' '}
+                — start at 25 yards, shoot 36 or better for nine holes to level up,
                 and work back through stages to the full tees.{' '}
                 <Link href="https://www.pga.com/story/operation-36-helping-golfers-find-a-love-for-the-game-for-life">
                   PGA of America
@@ -273,9 +282,18 @@ export function Operation36Article() {
             ),
           },
           {
-            name: 'Keiser University College of Golf · Developing Confidence in Beginner Golfers',
-            href: 'https://collegeofgolf.keiseruniversity.edu/developing-confidence-in-beginner-golfers-thoughts-and-recommendations/',
-            note: 'Why achievable challenges build skill and confidence — on the optimal challenge point: learning is fastest when a task is neither too easy nor too hard, so difficulty should rise step by step as competence does.',
+            name: 'Why achievable challenges build skill and confidence',
+            note: (
+              <Text>
+                <Link href="https://collegeofgolf.keiseruniversity.edu/developing-confidence-in-beginner-golfers-thoughts-and-recommendations/">
+                  Keiser University College of Golf · Developing Confidence in
+                  Beginner Golfers
+                </Link>{' '}
+                — on the optimal challenge point: learning is fastest when a task
+                is neither too easy nor too hard, so difficulty should rise step
+                by step as competence does.
+              </Text>
+            ),
           },
         ]}
       />
@@ -295,11 +313,11 @@ function ProgressionLadder() {
       <Gate />
       <Rung distance="50 yd" caption="Division 2" />
       <Gate />
-      <Rung distance="75 yd" caption="and back a stage at a time" />
-      <Gate />
-      <Rung distance="100 yd" caption="" />
+      <Rung distance="100 yd" caption="and back a stage at a time" />
       <Gate />
       <Rung distance="150 yd" caption="" />
+      <Gate />
+      <Rung distance="200 yd" caption="" />
       <Gate />
       <Rung distance="Full tees" caption="par from the back — the goal" goal />
     </View>

--- a/apps/mobile/components/learn/articles/SwingVariations.tsx
+++ b/apps/mobile/components/learn/articles/SwingVariations.tsx
@@ -139,7 +139,7 @@ export function SwingVariationsArticle() {
       <PlaneSpectrum />
       <BulletList
         items={[
-          <Text>
+          <Text key="a">
             <Strong>The modern tour swing.</Strong> Big separation between the
             shoulders and hips at the top — what Jim McLean popularized in 1992 as
             the <Em>X-Factor</Em> — plus heavy use of the ground for speed. It's
@@ -149,7 +149,7 @@ export function SwingVariationsArticle() {
             lower-back stress for modest gain. Powerful, but not free, and not for
             every body.
           </Text>,
-          <Text>
+          <Text key="b">
             <Strong>The classic flatter plane (Hogan).</Strong> Ben Hogan's{' '}
             <Em>Five Lessons</Em> and its famous "pane of glass" image describe a
             flatter, on-plane move that's still hugely influential. Tellingly, even
@@ -158,7 +158,7 @@ export function SwingVariationsArticle() {
             that the most famous swing model in print still has to bend to the body
             using it.
           </Text>,
-          <Text>
+          <Text key="c">
             <Strong>The single-plane swing (Moe Norman / Graves).</Strong> Club,
             arms, and body set on essentially one plane at address and impact,
             stripping out moving parts. Moe Norman — whom Sam Snead and others
@@ -168,14 +168,14 @@ export function SwingVariationsArticle() {
             worth a look for players who fight conventional complexity or have back
             limitations.
           </Text>,
-          <Text>
+          <Text key="d">
             <Strong>Stack and Tilt.</Strong> Created by instructors Mike Bennett and
             Andy Plummer, it keeps the weight forward over the lead side throughout
             the swing to kill lateral sway. Controversial, but with real tour
             adherents over the years (Aaron Baddeley and Mike Weir among them), and
             potentially friendlier to limited hip mobility.
           </Text>,
-          <Text>
+          <Text key="e">
             <Strong>Rotary, body-driven methods.</Strong> A family of approaches
             that lead with body rotation over hand and arm manipulation, on the
             argument that fewer timing-dependent parts make the swing more
@@ -191,20 +191,20 @@ export function SwingVariationsArticle() {
       </P>
       <BulletList
         items={[
-          <Text>
+          <Text key="a">
             <Strong>Peak Performance (Don Trahan).</Strong> A short, vertical,
             limited-turn backswing — "a little turn, a lot of lift" — that Trahan
             built with orthopedic input to be easy on the back and friendly to
             players who've lost flexibility, while arguing it gives up little or no
             clubhead speed.
           </Text>,
-          <Text>
+          <Text key="b">
             <Strong>The A Swing (David Leadbetter).</Strong> An "alternative" that
             rebuilds the backswing to be simpler and more repeatable, so the
             downswing becomes mostly a reaction — aimed squarely at golfers who
             can't groove the conventional move.
           </Text>,
-          <Text>
+          <Text key="c">
             <Strong>Swing the clubhead (Manuel de la Torre).</Strong> A feel-first
             school in the Ernest Jones tradition: focus on swinging the club itself
             rather than choreographing body positions, trusting the body to follow a
@@ -228,38 +228,39 @@ export function SwingVariationsArticle() {
         <Text style={{ color: C.ink, fontFamily: FONT.body, fontSize: 14, lineHeight: 22 }}>
           <Strong>This is general information, not medical advice.</Strong> If you
           have any of the conditions below, get cleared by a medical professional
-          and work with a TPI-certified instructor <Em>before</Em> changing your
+          and work with a TPI-certified (Titleist Performance Institute)
+          instructor <Em>before</Em> changing your
           swing or starting intensive practice. The notes here are starting points
           for that conversation, not prescriptions.
         </Text>
       </Callout>
       <BulletList
         items={[
-          <Text>
+          <Text key="a">
             <Strong>Scoliosis.</Strong> Spinal curvature can make a high-torque
             rotational swing a poor fit; a flatter, more arms-based or single-plane
             motion may put less stress on the spine. This is exactly the case for a
             physical screening before any intensive change.
           </Text>,
-          <Text>
+          <Text key="b">
             <Strong>Hip replacement or hip limitations.</Strong> Weight shift and
             hip clearance are affected. Methods that reduce lateral movement (such
             as single-plane or weight-forward styles) and a wider, more stable
             stance can lower the demand on the hip.
           </Text>,
-          <Text>
+          <Text key="c">
             <Strong>Shoulder injury or limited shoulder mobility.</Strong> Backswing
             length and follow-through are the first things to give. A shorter, more
             controlled backswing that prioritizes solid contact usually beats
             forcing a full turn you don't have.
           </Text>,
-          <Text>
+          <Text key="d">
             <Strong>Back injury or fused vertebrae.</Strong> When rotation is
             restricted or gone, arms-dominant, minimal-rotation swings are the
             adaptation, and Moe Norman's low-stress single-plane motion is worth
             studying. Medical clearance first, always.
           </Text>,
-          <Text>
+          <Text key="e">
             <Strong>One-arm and adaptive golfers.</Strong> Competitive one-arm and
             adaptive players exist and thrive. The mechanics are genuinely different,
             not a tweak of the standard swing, and specialized adaptive instruction
@@ -377,10 +378,6 @@ export function SwingVariationsArticle() {
             name: 'The classic flatter plane (Hogan)',
             note: (
               <Text>
-                <Link href="https://www.usgtf.com/hogans-five-lessons-in-our-modern-game/">
-                  USGTF · Hogan's Five Lessons in the modern game
-                </Link>{' '}
-                and{' '}
                 <Link href="https://mygolfspy.com/news-opinion/ben-hogans-swing/">
                   MyGolfSpy · Ben Hogan's swing
                 </Link>{' '}
@@ -525,7 +522,7 @@ function HallOfFame() {
     },
     {
       name: 'Nancy Lopez',
-      quirk: 'A pronounced "flying" right elbow every textbook warns against.',
+      quirk: 'High hands and a slow, looping takeaway no textbook would draw.',
       result: '48 LPGA Tour wins and a Hall of Fame career.',
     },
     {
@@ -581,11 +578,11 @@ function BodyTypeTable() {
   const rows: { type: string; note: string }[] = [
     {
       type: 'Taller (6′2″+)',
-      note: 'Tend to stand more upright, with a flatter natural plane. Usually need longer clubs and flatter lie angles — off-the-rack clubs are built to a standard, not to you.',
+      note: 'Tend to stand more upright, with a flatter natural plane. Usually need longer clubs and more upright lie angles — off-the-rack clubs are built to a standard, not to you.',
     },
     {
       type: 'Shorter',
-      note: 'Stand closer to the ball with a more upright shaft angle; an upright plane is natural and correct here. Shorter clubs and more upright lie angles often fit better.',
+      note: 'Stand closer to the ball with a more upright shaft angle; an upright plane is natural and correct here. Shorter clubs and flatter lie angles often fit better.',
     },
     {
       type: 'Limited flexibility / older',
@@ -621,7 +618,9 @@ function BodyTypeTable() {
 
 // Editorial line-art: the shaft plane from upright to flat, with single-plane
 // shown as arms-and-shaft aligned. Same viewBox + coordinate data as the web
-// inline svg, re-authored in react-native-svg. Single plane in accent.
+// inline svg after its re-draw (all three lines are believable plane angles
+// fanning up from the ball — upright ~63°, flat ~45°, single plane ~33°),
+// re-authored in react-native-svg. Single plane in accent.
 function PlaneSpectrum() {
   return (
     <Figure caption='Roughly how the club travels — steep and upright through flat and rotary to a single plane. None is "correct"; each fits a different body.'>
@@ -629,19 +628,19 @@ function PlaneSpectrum() {
         {/* ground + ball, shared origin at lower right */}
         <Line x1={20} y1={100} x2={220} y2={100} stroke={C.mute} strokeWidth={1.5} />
         <Circle cx={190} cy={100} r={3} fill={C.ink} />
-        {/* upright (steep) plane */}
-        <Line x1={190} y1={100} x2={150} y2={14} stroke={C.mute} strokeWidth={2} />
-        {/* flat (Hogan) plane */}
-        <Line x1={190} y1={100} x2={78} y2={36} stroke={C.mute} strokeWidth={2} />
-        {/* single plane (accent) */}
-        <Line x1={190} y1={100} x2={40} y2={64} stroke={C.accent} strokeWidth={2.5} />
-        <SvgText x={138} y={12} fontSize={7} fontFamily={FONT.mono} letterSpacing={0.5} fill={C.mute}>
+        {/* upright (steep) plane ~63° */}
+        <Line x1={190} y1={100} x2={147} y2={16} stroke={C.mute} strokeWidth={2} />
+        {/* flat (Hogan) plane ~45° */}
+        <Line x1={190} y1={100} x2={108} y2={18} stroke={C.mute} strokeWidth={2} />
+        {/* single plane (accent), flattest ~33° */}
+        <Line x1={190} y1={100} x2={72} y2={24} stroke={C.accent} strokeWidth={2.5} />
+        <SvgText x={150} y={13} fontSize={7} fontFamily={FONT.mono} letterSpacing={0.5} fill={C.mute}>
           UPRIGHT
         </SvgText>
-        <SvgText x={62} y={32} fontSize={7} fontFamily={FONT.mono} letterSpacing={0.5} fill={C.mute}>
+        <SvgText x={86} y={13} fontSize={7} fontFamily={FONT.mono} letterSpacing={0.5} fill={C.mute}>
           FLAT
         </SvgText>
-        <SvgText x={20} y={60} fontSize={7} fontFamily={FONT.mono} letterSpacing={0.5} fill={C.accent}>
+        <SvgText x={14} y={22} fontSize={7} fontFamily={FONT.mono} letterSpacing={0.5} fill={C.accent}>
           SINGLE PLANE
         </SvgText>
       </Svg>

--- a/apps/mobile/components/learn/articles/UnderstandingYourSwing.tsx
+++ b/apps/mobile/components/learn/articles/UnderstandingYourSwing.tsx
@@ -47,7 +47,7 @@ export function UnderstandingYourSwingArticle() {
       <GlanceBox label="What writes the shot">
         <DefRow term="Face angle" first>
           Where the ball starts. At impact the face sets roughly three-quarters
-          of the start line — more at slower speeds.
+          of the start line with an iron — closer to 85% with the driver.
         </DefRow>
         <DefRow term="Face vs. path">
           How the ball curves. The gap between where the face points and where
@@ -60,8 +60,10 @@ export function UnderstandingYourSwingArticle() {
         is mostly your face. <Strong>How it curves</Strong> is the gap between
         face and path. A shot that starts left and slices back right, for
         instance, means the face was pointed left of the target but still open
-        relative to an even-more-leftward path — the classic out-to-in pull-slice.
-        The ball just told you both numbers; you only had to listen.
+        relative to an even-more-leftward path — the classic out-to-in pull-slice
+        (directions throughout are for a right-handed golfer — mirror them if you
+        play left-handed). The ball just told you both numbers; you only had to
+        listen.
       </P>
 
       <Figure caption="The ball starts where the face points, then bends by the gap between face and path. Two facts, read off one shot.">
@@ -79,20 +81,20 @@ export function UnderstandingYourSwingArticle() {
       </P>
       <BulletList
         items={[
-          <Text>
+          <Text key="a">
             <Strong>Direction.</Strong> A divot pointing left of target is the
             fingerprint of an out-to-in (over-the-top) path; one pointing right
             signals in-to-out. It should roughly agree with the curve you read off
             the ball.
           </Text>,
-          <Text>
+          <Text key="b">
             <Strong>Depth and evenness.</Strong> A deep, gouged divot says your low
             point is too far forward or your attack too steep; no divot at all
             usually means you're bottoming out behind the ball. A divot deeper on
             the toe or heel side points at how the club is delivered, not just where
             it lands.
           </Text>,
-          <Text>
+          <Text key="c">
             <Strong>Where it starts.</Strong> A divot that begins well behind the
             ball is the turf-side version of fat contact — the arc bottomed out
             early.

--- a/apps/web/src/pages/learn/articles/Operation36Article.tsx
+++ b/apps/web/src/pages/learn/articles/Operation36Article.tsx
@@ -28,6 +28,14 @@ export function Operation36Article() {
         The Operation 36 philosophy.
       </h2>
 
+      <P>
+        Most golfers are taught to build a swing first and play golf later.
+        Operation 36 flips that: you start 25 yards from the hole, learn to
+        score, and earn your way back to the full tees one stage at a time.
+      </P>
+
+      <Hr />
+
       <H3>Most golfers learn in the wrong order</H3>
       <P>
         The traditional path into golf goes like this: stand on a mat at the
@@ -57,9 +65,9 @@ export function Operation36Article() {
         Clear it and you move back a stage; until then, you stay where you are.
         You begin in Division 1, playing nine holes from 25 yards out, where
         every hole is reachable and every score you write down is a real score.
-        Break 36 and you step back to 50 yards, then 75, and onward in stages
-        until, eventually, you're shooting par from the full tees — the same
-        game the rest of the course is playing.
+        Shoot 36 or better and you step back to 50 yards, then 100, 150, 200,
+        and finally your full tees — the same game the rest of the course is
+        playing.
       </P>
 
       <ProgressionLadder />
@@ -341,11 +349,11 @@ function ProgressionLadder() {
       <Gate />
       <Rung distance="50 yd" caption="Division 2" />
       <Gate />
-      <Rung distance="75 yd" caption="and back a stage at a time" />
-      <Gate />
-      <Rung distance="100 yd" caption="" />
+      <Rung distance="100 yd" caption="and back a stage at a time" />
       <Gate />
       <Rung distance="150 yd" caption="" />
+      <Gate />
+      <Rung distance="200 yd" caption="" />
       <Gate />
       <Rung distance="Full tees" caption="par from the back — the goal" goal />
     </div>

--- a/apps/web/src/pages/learn/articles/SwingVariationsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/SwingVariationsArticle.tsx
@@ -225,7 +225,8 @@ export function SwingVariationsArticle() {
       <Callout>
         <strong>This is general information, not medical advice.</strong> If you
         have any of the conditions below, get cleared by a medical professional
-        and work with a TPI-certified instructor <em>before</em> changing your
+        and work with a TPI-certified (Titleist Performance Institute)
+        instructor <em>before</em> changing your
         swing or starting intensive practice. The notes here are starting points
         for that conversation, not prescriptions.
       </Callout>
@@ -422,7 +423,7 @@ function HallOfFame() {
     },
     {
       name: 'Nancy Lopez',
-      quirk: 'A pronounced "flying" right elbow every textbook warns against.',
+      quirk: 'High hands and a slow, looping takeaway no textbook would draw.',
       result: '48 LPGA Tour wins and a Hall of Fame career.',
     },
     {
@@ -487,11 +488,11 @@ function BodyTypeTable() {
   const rows: { type: string; note: string }[] = [
     {
       type: 'Taller (6′2″+)',
-      note: 'Tend to stand more upright, with a flatter natural plane. Usually need longer clubs and flatter lie angles — off-the-rack clubs are built to a standard, not to you.',
+      note: 'Tend to stand more upright, with a flatter natural plane. Usually need longer clubs and more upright lie angles — off-the-rack clubs are built to a standard, not to you.',
     },
     {
       type: 'Shorter',
-      note: 'Stand closer to the ball with a more upright shaft angle; an upright plane is natural and correct here. Shorter clubs and more upright lie angles often fit better.',
+      note: 'Stand closer to the ball with a more upright shaft angle; an upright plane is natural and correct here. Shorter clubs and flatter lie angles often fit better.',
     },
     {
       type: 'Limited flexibility / older',
@@ -655,10 +656,6 @@ function Sources() {
         <div>
           <SrcLabel>The classic flatter plane (Hogan)</SrcLabel>
           <SrcBody>
-            <Src href="https://www.usgtf.com/hogans-five-lessons-in-our-modern-game/">
-              USGTF · Hogan's Five Lessons in the modern game
-            </Src>{' '}
-            and{' '}
             <Src href="https://mygolfspy.com/news-opinion/ben-hogans-swing/">
               MyGolfSpy · Ben Hogan's swing
             </Src>{' '}

--- a/apps/web/src/pages/learn/articles/UnderstandingYourSwingArticle.tsx
+++ b/apps/web/src/pages/learn/articles/UnderstandingYourSwingArticle.tsx
@@ -52,8 +52,10 @@ export function UnderstandingYourSwingArticle() {
         is mostly your face. <strong>How it curves</strong> is the gap between
         face and path. A shot that starts left and slices back right, for
         instance, means the face was pointed left of the target but still open
-        relative to an even-more-leftward path — the classic out-to-in pull-slice.
-        The ball just told you both numbers; you only had to listen.
+        relative to an even-more-leftward path — the classic out-to-in pull-slice
+        (directions throughout are for a right-handed golfer — mirror them if you
+        play left-handed). The ball just told you both numbers; you only had to
+        listen.
       </P>
 
       <BallFlightDiagram />
@@ -184,7 +186,7 @@ function FlightReadout() {
     {
       factor: 'Face angle',
       writes:
-        'Where the ball starts. At impact the face sets roughly three-quarters of the start line — more at slower speeds.',
+        'Where the ball starts. At impact the face sets roughly three-quarters of the start line with an iron — closer to 85% with the driver.',
     },
     {
       factor: 'Face vs. path',


### PR DESCRIPTION
Verified audit defects across the swing/Op36 trio of Learn articles, web + mobile kept word-identical.

- **Operation 36 progression corrected** — prose now reads "Shoot 36 or better and you step back to 50 yards, then 100, 150, 200, and finally your full tees" (was "Break 36 … then 75"); ProgressionLadder rungs are now 25 / 50 / 100 / 150 / 200 / Full tees, matching the real program's divisions. Both platforms.
- **Body-type table lie-angle swap** — taller players now map to longer clubs + more upright lie angles, shorter players to shorter clubs + flatter lie angles (standard fitting; was inverted). Swing-plane halves of those rows untouched. Both platforms.
- **Mobile PlaneSpectrum figure re-synced with web** — ported the web re-draw's line endpoints (147,16)/(108,18)/(72,24) and label positions so all three plane lines are believable angles (~63°/~45°/~33°); corrected the stale "same coordinate data" comment.
- **Face-dominance claim un-inverted** — "the face sets roughly three-quarters of the start line with an iron — closer to 85% with the driver" (was "more at slower speeds", backwards). Both platforms.
- **Nancy Lopez quirk re-attributed** — "High hands and a slow, looping takeaway no textbook would draw" (the "flying right elbow" is Nicklaus/Barber lore, unsupported for Lopez). Result line unchanged. Both platforms.
- **Dead USGTF link dropped** from the Hogan Sources entry; the MyGolfSpy citation carries the claim. Both platforms.
- **Consistency polish (swing-section items)** — Operation 36 gains a lede matching the trio's opening shape; handedness parenthetical added at the pull-slice example in understanding-your-swing; "TPI-certified (Titleist Performance Institute)" expanded on first use in the swing-variations callout; missing `key` props added to mapped BulletList items in mobile UnderstandingYourSwing + SwingVariations; mobile Op36 Sources normalized to the claim-label style the other two mobile articles use.

Closes #753
Closes #754
Closes #760
Closes #763
Closes #765

Part of #769 (USGTF link), #770 (swing-section items).