### PR TITLE
fix(learn): practice-article corrections + docs mirrors resync

### DIFF
--- a/apps/mobile/components/learn/articles/HowToPractice.tsx
+++ b/apps/mobile/components/learn/articles/HowToPractice.tsx
@@ -340,7 +340,8 @@ export function HowToPracticeArticle() {
             note: (
               <Text>
                 <Link href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-                  Gröpel & Mesagno (2019) · choking interventions, a systematic
+                  Gröpel & Mesagno, International Review of Sport & Exercise
+                  Psychology (2019) · choking interventions, a systematic
                   review
                 </Link>{' '}
                 — acclimatization and pre-performance routines help skills

--- a/apps/mobile/components/learn/articles/HowToPractice.tsx
+++ b/apps/mobile/components/learn/articles/HowToPractice.tsx
@@ -20,6 +20,12 @@ export function HowToPracticeArticle() {
     <View>
       <ArticleHeader kicker="Improving your game · How to practice" title="How to practice." />
 
+      <P>
+        Hitting balls and getting better are two different activities. This is
+        the difference — and how to structure range time so the work actually
+        shows up on the course.
+      </P>
+
       <H3>The uncomfortable truth</H3>
       <P>
         Most golfers practice in a way that feels productive but isn't. They
@@ -197,9 +203,10 @@ export function HowToPracticeArticle() {
         achieved your goal, it wasn't a goal — it was a vague intention.
       </P>
       <P>
-        Your OGA strokes gained data tells you exactly where to focus. If
-        you're losing 1.2 strokes per round on approach shots, that's your
-        focus area. Your practice goal should be specific to that weakness.
+        If you track strokes gained (OGA computes this for you), it tells you
+        exactly where to focus. If you're losing 1.2 strokes per round on
+        approach shots, that's your focus area. Your practice goal should be
+        specific to that weakness.
       </P>
       <H4>How to quantify your practice</H4>
       <BulletList
@@ -290,7 +297,7 @@ export function HowToPracticeArticle() {
                 </Link>{' '}
                 confirms high contextual interference improves retention, and{' '}
                 <Link href="https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285">
-                  Magill & Hall, Quest (1998)
+                  Brady, Quest (1998)
                 </Link>{' '}
                 reviews the effect first shown by Shea & Morgan (1979): random
                 order hurts practice, helps learning.
@@ -333,12 +340,8 @@ export function HowToPracticeArticle() {
             note: (
               <Text>
                 <Link href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-                  International Review of Sport & Exercise Psychology (2018) ·
-                  choking interventions, a systematic review
-                </Link>{' '}
-                and{' '}
-                <Link href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2025.1435374/full">
-                  Frontiers in Psychology (2025) · performance under pressure
+                  Gröpel & Mesagno (2019) · choking interventions, a systematic
+                  review
                 </Link>{' '}
                 — acclimatization and pre-performance routines help skills
                 survive competitive anxiety.
@@ -350,7 +353,7 @@ export function HowToPracticeArticle() {
             note: (
               <Text>
                 <Link href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6731745/">
-                  Macnamara & Hambrick, revisiting Ericsson, Krampe &
+                  Macnamara & Maitra, revisiting Ericsson, Krampe &
                   Tesch-Römer (1993)
                 </Link>{' '}
                 — practice quality matters enormously, though the strong claim

--- a/apps/mobile/components/learn/articles/PracticeModes.tsx
+++ b/apps/mobile/components/learn/articles/PracticeModes.tsx
@@ -162,7 +162,7 @@ export function PracticeModesArticle() {
                 </Link>{' '}
                 confirms high contextual interference improves retention, and{' '}
                 <Link href="https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285">
-                  Magill & Hall, Quest (1998)
+                  Brady, Quest (1998)
                 </Link>{' '}
                 reviews the effect first shown by Shea & Morgan (1979): random
                 order hurts practice, helps learning.
@@ -206,12 +206,8 @@ export function PracticeModesArticle() {
             note: (
               <Text>
                 <Link href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-                  International Review of Sport & Exercise Psychology (2018) ·
-                  choking interventions, a systematic review
-                </Link>{' '}
-                and{' '}
-                <Link href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2025.1435374/full">
-                  Frontiers in Psychology (2025) · performance under pressure
+                  Gröpel & Mesagno (2019) · choking interventions, a systematic
+                  review
                 </Link>{' '}
                 — acclimatization and pre-performance routines help skills survive
                 competitive anxiety.
@@ -223,7 +219,7 @@ export function PracticeModesArticle() {
             note: (
               <Text>
                 <Link href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6731745/">
-                  Macnamara & Hambrick, revisiting Ericsson, Krampe &
+                  Macnamara & Maitra, revisiting Ericsson, Krampe &
                   Tesch-Römer (1993)
                 </Link>{' '}
                 — practice quality matters enormously, though the strong claim that
@@ -269,7 +265,7 @@ function ScheduleDiagram() {
   const order = (seq: ('c' | 's' | 't')[]): Mark[] =>
     seq.map((t, i) => ({ t, x: xs[i] ?? 0 }))
   const blocked = order(['c', 'c', 'c', 's', 's', 's', 't', 't', 't'])
-  const random = order(['c', 's', 't', 's', 'c', 't', 't', 'c', 's'])
+  const random = order(['c', 's', 't', 's', 'c', 't', 'c', 't', 's'])
   return (
     <Svg width="100%" height={90} viewBox="0 0 160 90">
       {blocked.map((m, i) => (

--- a/apps/mobile/components/learn/articles/PracticeModes.tsx
+++ b/apps/mobile/components/learn/articles/PracticeModes.tsx
@@ -206,7 +206,8 @@ export function PracticeModesArticle() {
             note: (
               <Text>
                 <Link href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-                  Gröpel & Mesagno (2019) · choking interventions, a systematic
+                  Gröpel & Mesagno, International Review of Sport & Exercise
+                  Psychology (2019) · choking interventions, a systematic
                   review
                 </Link>{' '}
                 — acclimatization and pre-performance routines help skills survive

--- a/apps/mobile/components/learn/articles/SkillGames.tsx
+++ b/apps/mobile/components/learn/articles/SkillGames.tsx
@@ -20,6 +20,12 @@ export function SkillGamesArticle() {
         title="Skill games and pressure games."
       />
 
+      <P>
+        A target, a score, and something at stake turn a pile of range balls
+        into practice that transfers. These are the games — putting, short
+        game, and full swing.
+      </P>
+
       <H3>Why games beat mindless repetition</H3>
       <P>
         Hitting the same shot over and over until you run out of
@@ -79,9 +85,9 @@ export function SkillGamesArticle() {
         the line.
       </P>
       <P>
-        Move to four feet, then five. Tour players do this from
-        six feet as a warm-up. Make all twelve from six and your
-        short putting is tour-level.
+        Move to four feet, then five, then six. Even tour players
+        make only about 70% from six feet — they'd miss several of
+        twelve. Treat a clean dozen from six as elite.
       </P>
       <Kv label="Variation">
         Use one ball. Walk around the clock, replace after each
@@ -277,7 +283,7 @@ export function SkillGamesArticle() {
                 </Link>{' '}
                 confirms high contextual interference improves retention, and{' '}
                 <Link href="https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285">
-                  Magill & Hall, Quest (1998)
+                  Brady, Quest (1998)
                 </Link>{' '}
                 reviews the effect first shown by Shea & Morgan (1979): mixed,
                 scored practice transfers better than rote repetition.
@@ -304,12 +310,8 @@ export function SkillGamesArticle() {
             note: (
               <Text>
                 <Link href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-                  International Review of Sport & Exercise Psychology (2018) ·
-                  choking interventions, a systematic review
-                </Link>{' '}
-                and{' '}
-                <Link href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2025.1435374/full">
-                  Frontiers in Psychology (2025) · performance under pressure
+                  Gröpel & Mesagno (2019) · choking interventions, a systematic
+                  review
                 </Link>{' '}
                 — rehearsing with consequences helps skills survive competitive
                 anxiety.

--- a/apps/mobile/components/learn/articles/SkillGames.tsx
+++ b/apps/mobile/components/learn/articles/SkillGames.tsx
@@ -310,7 +310,8 @@ export function SkillGamesArticle() {
             note: (
               <Text>
                 <Link href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-                  Gröpel & Mesagno (2019) · choking interventions, a systematic
+                  Gröpel & Mesagno, International Review of Sport & Exercise
+                  Psychology (2019) · choking interventions, a systematic
                   review
                 </Link>{' '}
                 — rehearsing with consequences helps skills survive competitive

--- a/apps/web/src/pages/learn/articles/HowToPracticeArticle.tsx
+++ b/apps/web/src/pages/learn/articles/HowToPracticeArticle.tsx
@@ -516,7 +516,8 @@ function Sources() {
           <SrcLabel>Practicing under pressure</SrcLabel>
           <SrcBody>
             <Src href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-              Gröpel &amp; Mesagno (2019) · choking interventions, a systematic
+              Gröpel &amp; Mesagno, International Review of Sport &amp;
+              Exercise Psychology (2019) · choking interventions, a systematic
               review
             </Src>{' '}
             — acclimatization and pre-performance routines help skills survive

--- a/apps/web/src/pages/learn/articles/HowToPracticeArticle.tsx
+++ b/apps/web/src/pages/learn/articles/HowToPracticeArticle.tsx
@@ -28,6 +28,12 @@ export function HowToPracticeArticle() {
         How to practice.
       </h2>
 
+      <P>
+        Hitting balls and getting better are two different activities. This is
+        the difference — and how to structure range time so the work actually
+        shows up on the course.
+      </P>
+
       <H3>The uncomfortable truth</H3>
       <P>
         Most golfers practice in a way that feels productive but
@@ -224,8 +230,8 @@ export function HowToPracticeArticle() {
         intention.
       </P>
       <P>
-        Your OGA strokes gained data tells you exactly where to
-        focus. If you're losing 1.2 strokes per round on approach
+        If you track strokes gained (OGA computes this for you), it
+        tells you exactly where to focus. If you're losing 1.2 strokes per round on approach
         shots, that's your focus area. Your practice goal should be
         specific to that weakness.
       </P>
@@ -473,7 +479,7 @@ function Sources() {
             </Src>{' '}
             confirms high contextual interference improves retention, and{' '}
             <Src href="https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285">
-              Magill &amp; Hall, Quest (1998)
+              Brady, Quest (1998)
             </Src>{' '}
             reviews the effect first shown by Shea &amp; Morgan (1979): random
             order hurts practice, helps learning.
@@ -510,12 +516,8 @@ function Sources() {
           <SrcLabel>Practicing under pressure</SrcLabel>
           <SrcBody>
             <Src href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-              International Review of Sport &amp; Exercise Psychology (2018) ·
-              choking interventions, a systematic review
-            </Src>{' '}
-            and{' '}
-            <Src href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2025.1435374/full">
-              Frontiers in Psychology (2025) · performance under pressure
+              Gröpel &amp; Mesagno (2019) · choking interventions, a systematic
+              review
             </Src>{' '}
             — acclimatization and pre-performance routines help skills survive
             competitive anxiety.
@@ -525,7 +527,7 @@ function Sources() {
           <SrcLabel>Deliberate practice, and its limits</SrcLabel>
           <SrcBody>
             <Src href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6731745/">
-              Macnamara &amp; Hambrick, revisiting Ericsson, Krampe &amp;
+              Macnamara &amp; Maitra, revisiting Ericsson, Krampe &amp;
               Tesch-Römer (1993)
             </Src>{' '}
             — practice quality matters enormously, though the strong claim that

--- a/apps/web/src/pages/learn/articles/PracticeModesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/PracticeModesArticle.tsx
@@ -299,18 +299,24 @@ function ScheduleDiagram() {
   const order = (seq: ('c' | 's' | 't')[]): Mark[] =>
     seq.map((t, i) => ({ t, x: xs[i] ?? 0 }))
   const blocked = order(['c', 'c', 'c', 's', 's', 's', 't', 't', 't'])
-  const random = order(['c', 's', 't', 's', 'c', 't', 't', 'c', 's'])
+  const random = order(['c', 's', 't', 's', 'c', 't', 'c', 't', 's'])
   return (
-    <SvgPanel>
-      <svg width="100%" viewBox="0 0 160 90" aria-hidden="true" style={{ display: 'block' }}>
-        {blocked.map((m, i) => (
-          <Shape key={`b-${i}`} type={m.t} x={m.x} y={28} />
-        ))}
-        {random.map((m, i) => (
-          <Shape key={`r-${i}`} type={m.t} x={m.x} y={64} />
-        ))}
-      </svg>
-    </SvgPanel>
+    <div>
+      <SvgPanel>
+        <svg width="100%" viewBox="0 0 160 90" aria-hidden="true" style={{ display: 'block' }}>
+          {blocked.map((m, i) => (
+            <Shape key={`b-${i}`} type={m.t} x={m.x} y={28} />
+          ))}
+          {random.map((m, i) => (
+            <Shape key={`r-${i}`} type={m.t} x={m.x} y={64} />
+          ))}
+        </svg>
+      </SvgPanel>
+      <div className="text-caddie-ink-mute" style={{ fontSize: 12, lineHeight: 1.5, marginTop: 6 }}>
+        Top row: blocked practice groups the same shot together. Bottom row:
+        random practice interleaves club and target every ball.
+      </div>
+    </div>
   )
 }
 
@@ -402,7 +408,7 @@ function Sources() {
             </Src>{' '}
             confirms high contextual interference improves retention, and{' '}
             <Src href="https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285">
-              Magill &amp; Hall, Quest (1998)
+              Brady, Quest (1998)
             </Src>{' '}
             reviews the effect first shown by Shea &amp; Morgan (1979): random
             order hurts practice, helps learning.
@@ -440,12 +446,8 @@ function Sources() {
           <SrcLabel>Practicing under pressure</SrcLabel>
           <SrcBody>
             <Src href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-              International Review of Sport &amp; Exercise Psychology (2018) ·
-              choking interventions, a systematic review
-            </Src>{' '}
-            and{' '}
-            <Src href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2025.1435374/full">
-              Frontiers in Psychology (2025) · performance under pressure
+              Gröpel &amp; Mesagno (2019) · choking interventions, a systematic
+              review
             </Src>{' '}
             — acclimatization and pre-performance routines help skills survive
             competitive anxiety.
@@ -455,7 +457,7 @@ function Sources() {
           <SrcLabel>Deliberate practice, and its limits</SrcLabel>
           <SrcBody>
             <Src href="https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6731745/">
-              Macnamara &amp; Hambrick, revisiting Ericsson, Krampe &amp;
+              Macnamara &amp; Maitra, revisiting Ericsson, Krampe &amp;
               Tesch-Römer (1993)
             </Src>{' '}
             — practice quality matters enormously, though the strong claim that

--- a/apps/web/src/pages/learn/articles/PracticeModesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/PracticeModesArticle.tsx
@@ -446,7 +446,8 @@ function Sources() {
           <SrcLabel>Practicing under pressure</SrcLabel>
           <SrcBody>
             <Src href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-              Gröpel &amp; Mesagno (2019) · choking interventions, a systematic
+              Gröpel &amp; Mesagno, International Review of Sport &amp;
+              Exercise Psychology (2019) · choking interventions, a systematic
               review
             </Src>{' '}
             — acclimatization and pre-performance routines help skills survive

--- a/apps/web/src/pages/learn/articles/SkillGamesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/SkillGamesArticle.tsx
@@ -533,7 +533,8 @@ function Sources() {
           <SrcLabel>Why the stakes matter — practicing under pressure</SrcLabel>
           <SrcBody>
             <Src href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-              Gröpel &amp; Mesagno (2019) · choking interventions, a systematic
+              Gröpel &amp; Mesagno, International Review of Sport &amp;
+              Exercise Psychology (2019) · choking interventions, a systematic
               review
             </Src>{' '}
             — rehearsing with consequences helps skills survive competitive

--- a/apps/web/src/pages/learn/articles/SkillGamesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/SkillGamesArticle.tsx
@@ -26,6 +26,12 @@ export function SkillGamesArticle() {
         Skill games and pressure games.
       </h2>
 
+      <P>
+        A target, a score, and something at stake turn a pile of range balls
+        into practice that transfers. These are the games — putting, short
+        game, and full swing.
+      </P>
+
       <H3>Why games beat mindless repetition</H3>
       <P>
         Hitting the same shot over and over until you run out of
@@ -103,10 +109,11 @@ export function SkillGamesArticle() {
         of needing to make a putt with something on the line.
       </P>
       <P>
-        As you improve, move to four feet, then five. PGA Tour
-        players do this drill from six feet as a standard warm-up.
-        If you can make all twelve from six feet without missing,
-        your short putting is tour-level.
+        As you improve, move to four feet, then five, then six.
+        Don't expect six feet to ever feel routine — tour players
+        make only about 70% from that distance, so even they would
+        miss several of twelve. Treat a clean dozen from six feet
+        as elite.
       </P>
       <Kv label="Variation">
         Do it with only one ball. Walk around the clock, replace
@@ -503,7 +510,7 @@ function Sources() {
             </Src>{' '}
             confirms high contextual interference improves retention, and{' '}
             <Src href="https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285">
-              Magill &amp; Hall, Quest (1998)
+              Brady, Quest (1998)
             </Src>{' '}
             reviews the effect first shown by Shea &amp; Morgan (1979): mixed,
             scored practice transfers better than rote repetition.
@@ -526,12 +533,8 @@ function Sources() {
           <SrcLabel>Why the stakes matter — practicing under pressure</SrcLabel>
           <SrcBody>
             <Src href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-              International Review of Sport &amp; Exercise Psychology (2018) ·
-              choking interventions, a systematic review
-            </Src>{' '}
-            and{' '}
-            <Src href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2025.1435374/full">
-              Frontiers in Psychology (2025) · performance under pressure
+              Gröpel &amp; Mesagno (2019) · choking interventions, a systematic
+              review
             </Src>{' '}
             — rehearsing with consequences helps skills survive competitive
             anxiety.

--- a/docs/learn/how-to-practice.md
+++ b/docs/learn/how-to-practice.md
@@ -254,7 +254,7 @@ commit to it fully.
   — variable, interleaved practice is a "desirable
   difficulty" that builds more general, robust skill.
 - **Practicing under pressure** —
-  [Gröpel & Mesagno (2019) · choking interventions, a systematic review](https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134)
+  [Gröpel & Mesagno, International Review of Sport & Exercise Psychology (2019) · choking interventions, a systematic review](https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134)
   — acclimatization and pre-performance routines help
   skills survive competitive anxiety.
 - **Deliberate practice, and its limits** —

--- a/docs/learn/how-to-practice.md
+++ b/docs/learn/how-to-practice.md
@@ -1,24 +1,16 @@
 ---
 title: How to Practice
 section: Improving Your Game
-status: draft
+status: published
 last_reviewed: 2026-05
 contributors: []
-content_warning: |
-  This article is a work in progress. The structure and core
-  ideas are established but individual sections need deeper
-  research, better resource links, and review by a qualified
-  golf instructor before being considered complete.
-  Do not treat any specific technique advice as authoritative
-  until this notice is removed.
 ---
 
 # How to Practice
 
-> **Work in progress.** This article is being developed.
-> Core structure is in place but content needs review,
-> additional research, and input from qualified instructors.
-> Resource links are placeholders — verify before using.
+Hitting balls and getting better are two different
+activities. This is the difference — and how to structure
+range time so the work actually shows up on the course.
 
 ## The uncomfortable truth
 
@@ -72,11 +64,6 @@ you do get better within the session. That feeling is
 misleading. It is one of the most well-replicated findings
 in motor learning research.
 
-> 📚 *Research basis: Robert Bjork (UCLA) — contextual
-> interference effect. See also: "Make It Stick" by Brown,
-> Roediger, McDaniel.*
-> ⚠️ *TODO: Add specific study citations*
-
 ---
 
 ### Random practice
@@ -94,27 +81,36 @@ your brain has to fully reconstruct the motor pattern from
 scratch. That reconstruction process is where learning
 happens.
 
+**Vary the conditions too:** Don't just change clubs —
+change distance, lie, wind, and slope. Golf never gives
+you the same shot twice, so practice that never repeats a
+shot transfers best.
+
 **Not good for:** Learning a brand new movement. Don't
 randomize before you have a basic pattern to work with.
 
-> 📚 *Research basis: Contextual interference effect,
-> Battig (1979), confirmed in many subsequent studies.*
-> ⚠️ *TODO: Verify whether the beginner exception is
-> well-established or still debated*
-
 ---
 
-### Variable practice
+### Skill games
 
-**What it is:** Same club, different conditions. 9-iron
-from 100 yards, then 90, then uphill, then into wind,
-then from a downslope.
+**What it is:** Turning a drill into a scored challenge.
+Make 7 of 10 from 8 feet. Get up-and-down 6 times out of
+10. Land 5 wedges inside a 15-foot circle. Every game has
+a number you can pass or fail.
 
-**Good for:** Building adaptability. Golf never gives you
-the same shot twice. Variable practice trains you for
-that reality.
+**Good for:** Feedback and tracking. A score tells you
+instantly whether a shot was good enough, and the same
+game repeated over weeks shows whether you're actually
+improving — not just whether today felt good.
 
-**Combine it with:** Random practice for maximum transfer.
+**Why it works:** A target and a score force a real result
+on every ball. That's the line between practice and just
+hitting. It also makes practice competitive, which is what
+keeps you coming back.
+
+**Combine it with:** Pressure. Add a consequence to a
+skill game — start over on a miss — and you've trained
+scoring and nerves at the same time.
 
 ---
 
@@ -136,11 +132,6 @@ under pressure. If you've never practiced with
 consequences, your body hasn't learned how to handle them
 on the course.
 
-> 📚 *Research basis: Dr. Sian Beilock — "Choke" (2010).
-> Bob Rotella — "Golf Is Not a Game of Perfect" (1995).*
-> ⚠️ *TODO: Add more specific pressure practice examples
-> from tour player documented routines*
-
 ---
 
 ## How to structure a session
@@ -156,11 +147,6 @@ your time and current focus area.
 | Pressure games | 10-15 min | Consequences on every shot. Keep score. |
 | Short game | 15-20 min | Chipping and pitching. Don't skip. |
 | Putting | 10-15 min | Always end on the green. End by holing putts. |
-
-> ⚠️ *TODO: Review these time allocations with a teaching
-> professional. The short game / full swing split in
-> particular (Dave Pelz suggests ~60% short game) needs
-> more exploration.*
 
 ---
 
@@ -178,10 +164,11 @@ The difference is measurability. If you can't tell whether
 you achieved your goal, it wasn't a goal — it was a
 vague intention.
 
-Your OGA strokes gained data tells you exactly where to
-focus. If you're losing 1.2 strokes per round on approach
-shots, that's your focus area. Your practice goal should
-be specific to that weakness.
+If you track strokes gained (OGA computes this for you),
+it tells you exactly where to focus. If you're losing 1.2
+strokes per round on approach shots, that's your focus
+area. Your practice goal should be specific to that
+weakness.
 
 **How to quantify your practice:**
 - Track your success rate on pressure games over time
@@ -247,45 +234,36 @@ commit to it fully.
 
 ---
 
-## Resources
+## Sources
 
-> ⚠️ *These are starting points for further research,
-> not endorsements. Verify all links are current before
-> publishing.*
-
-### Books
-- **"Make It Stick"** — Brown, Roediger, McDaniel.
-  Best plain-language summary of learning science.
-  Not golf-specific but directly applicable.
-- **"Golf Is Not a Game of Perfect"** — Bob Rotella.
-  Standard text on golf psychology and performance.
-- **"Dave Pelz's Short Game Bible"** — Research-based
-  approach to practice from inside 100 yards.
-- **"Harvey Penick's Little Red Book"** — The most
-  beloved golf instruction book ever written.
-  Simple, wise, feel-based.
-- **"Peak"** — Anders Ericsson. His own account of
-  deliberate practice research. Better than the
-  Gladwell version.
-- **"Choke"** — Sian Beilock. Accessible neuroscience
-  of performance under pressure.
-
-### Research worth knowing
-- Robert Bjork — contextual interference, desirable
-  difficulties (UCLA)
-- Anders Ericsson — deliberate practice and expert
-  performance
-- Gabriele Wulf — attentional focus research showing
-  external focus cues outperform internal focus cues
-- Sian Beilock — choking under pressure
-
-### Online resources
-- TPI (Titleist Performance Institute): https://mytpi.com
-- Robert Bjork's lab: https://bjorklab.psych.ucla.edu
-  ⚠️ *TODO: Verify this URL is current*
+- **Block vs random practice (contextual interference)** —
+  [Scientific Reports (2024) · meta-analysis](https://www.nature.com/articles/s41598-024-65753-3)
+  confirms high contextual interference improves retention,
+  and [Brady, Quest (1998)](https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285)
+  reviews the effect first shown by Shea & Morgan (1979):
+  random order hurts practice, helps learning.
+- **Random practice in golf specifically** —
+  [Frontiers · motor learning in golf, a systematic review](https://www.frontiersin.org/journals/sports-and-active-living/articles/10.3389/fspor.2024.1324615/full)
+  and [Fazeli et al. (2017) · random vs blocked in golf putting](https://pubmed.ncbi.nlm.nih.gov/28449601/)
+  — random groups putt worse in practice, better in
+  retention.
+- **Varying conditions — variability and desirable
+  difficulty** —
+  [Memory & Cognition (2021) · interleaving and transfer](https://link.springer.com/article/10.3758/s13421-021-01168-z)
+  and [Sherwood & Lee (2003) · schema theory review](https://pubmed.ncbi.nlm.nih.gov/14768838/)
+  — variable, interleaved practice is a "desirable
+  difficulty" that builds more general, robust skill.
+- **Practicing under pressure** —
+  [Gröpel & Mesagno (2019) · choking interventions, a systematic review](https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134)
+  — acclimatization and pre-performance routines help
+  skills survive competitive anxiety.
+- **Deliberate practice, and its limits** —
+  [Macnamara & Maitra, revisiting Ericsson, Krampe & Tesch-Römer (1993)](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6731745/)
+  — practice quality matters enormously, though the strong
+  claim that hours alone explain expertise has not fully
+  replicated.
 
 ---
 
 *Last reviewed: May 2026*
-*Status: Draft — needs instructor review before publishing*
 *To contribute: open a PR editing docs/learn/how-to-practice.md*

--- a/docs/learn/skill-games-pressure-games.md
+++ b/docs/learn/skill-games-pressure-games.md
@@ -345,7 +345,7 @@ over months is genuinely motivating.
   — varied, game-like practice builds a more skilled
   mental model.
 - **Why the stakes matter — practicing under pressure** —
-  [Gröpel & Mesagno (2019) · choking interventions, a systematic review](https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134)
+  [Gröpel & Mesagno, International Review of Sport & Exercise Psychology (2019) · choking interventions, a systematic review](https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134)
   — rehearsing with consequences helps skills survive
   competitive anxiety.
 

--- a/docs/learn/skill-games-pressure-games.md
+++ b/docs/learn/skill-games-pressure-games.md
@@ -1,21 +1,16 @@
 ---
 title: Skill Games and Pressure Games
 section: Improving Your Game
-status: draft
+status: published
 last_reviewed: 2026-05
 contributors: []
-content_warning: |
-  This article is a work in progress. Content is drawn from
-  established practice methodology and personal experience.
-  Games and drills are well-documented but individual results
-  vary. Do not treat any specific advice as authoritative
-  until this notice is removed.
 ---
 
 # Skill Games and Pressure Games
 
-> **Work in progress.** This article is being developed.
-> Core structure is in place but content needs review.
+A target, a score, and something at stake turn a pile of
+range balls into practice that transfers. These are the
+games — putting, short game, and full swing.
 
 ## Why games beat mindless repetition
 
@@ -84,10 +79,11 @@ painful. That pain is the point — it simulates the
 pressure of needing to make a putt with something on the
 line.
 
-As you improve, move to four feet, then five. PGA Tour
-players do this drill from six feet as a standard warm-up.
-If you can make all twelve from six feet without missing,
-your short putting is tour-level.
+As you improve, move to four feet, then five, then six.
+Don't expect six feet to ever feel routine — tour players
+make only about 70% from that distance, so even they would
+miss several of twelve. Treat a clean dozen from six feet
+as elite.
 
 **Variation:** Do it with only one ball. Walk around the
 clock, replace the ball after each putt, make all twelve
@@ -333,29 +329,28 @@ over months is genuinely motivating.
 
 ---
 
-## Resources
+## Sources
 
-> ⚠️ *Verify all links before publishing*
-
-- **Golf Digest — 15 Best Golf Practice Games**
-  golfdigest.com. Good overview of range and
-  putting green games.
-- **Practical Golf — 5 Games That Build Real Skills**
-  practical-golf.com. Solid collection of pressure
-  games with scoring systems.
-- **"Dave Pelz's Short Game Bible"** — The research-based
-  approach to short game practice. Specific drills
-  backed by data.
-- **The Upbeat Golfer (Manu)** — YouTube. Process under
-  pressure, routine under stakes.
-
-> ⚠️ *TODO: Add research citations on pressure practice
-> and performance transfer (see Sian Beilock's work
-> on choking and practice under pressure)*
+- **Why scored, varied games transfer (contextual
+  interference)** —
+  [Scientific Reports (2024) · meta-analysis](https://www.nature.com/articles/s41598-024-65753-3)
+  confirms high contextual interference improves retention,
+  and [Brady, Quest (1998)](https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285)
+  reviews the effect first shown by Shea & Morgan (1979):
+  mixed, scored practice transfers better than rote
+  repetition.
+- **In golf specifically** —
+  [Frontiers · motor learning in golf, a systematic review](https://www.frontiersin.org/journals/sports-and-active-living/articles/10.3389/fspor.2024.1324615/full)
+  and [Fazeli et al. (2017) · random vs blocked in golf putting](https://pubmed.ncbi.nlm.nih.gov/28449601/)
+  — varied, game-like practice builds a more skilled
+  mental model.
+- **Why the stakes matter — practicing under pressure** —
+  [Gröpel & Mesagno (2019) · choking interventions, a systematic review](https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134)
+  — rehearsing with consequences helps skills survive
+  competitive anxiety.
 
 ---
 
 *Last reviewed: May 2026*
-*Status: Draft — needs review before publishing*
 *To contribute: open a PR editing
 docs/learn/skill-games-pressure-games.md*


### PR DESCRIPTION
Verified audit defects in the four practice Learn articles (web + mobile) and their two docs mirrors.

- **Citations (#755, practice-article sites):** "Magill & Hall, Quest (1998)" → "Brady, Quest (1998)" (6 sites — DOI resolves to Brady); "Macnamara & Hambrick" → "Macnamara & Maitra" (4 sites — PMC6731745 is Macnamara & Maitra 2019); choking review re-labeled "Gröpel & Mesagno (2019)"; the Frontiers in Psychology (2025) entry dropped (it was glossed with its neighbor's findings — the Gröpel & Mesagno review carries the claim). MentalGame's sites are handled separately.
- **Random-practice diagram (#759):** ScheduleDiagram random row now has no adjacent repeats (`c s t s c t c t s`), matching the "never the same shot twice in a row" prose, both platforms; web figure gains the mobile caption (blocked vs random rows) in the existing muted-caption style.
- **Clock drill (#764):** removed the unsourced "PGA Tour standard warm-up from six feet" and "12/12 from six = tour-level" claims; replaced with honest framing (~70% tour make rate from 6 ft — a clean dozen is beyond tour-level, treat it as elite). Web, mobile, and docs mirror.
- **General-audience copy (#767 item 1):** "Your OGA strokes gained data tells you…" → conditional "If you track strokes gained (OGA computes this for you)…" in HowToPractice, both platforms + mirror.
- **Docs mirrors resynced (#768 items 1–2):** `docs/learn/how-to-practice.md` regenerated from the current app copy — four types are now block / random / skill games / pressure (variable-practice material folded into random as "vary the conditions too"), the verified Sources block ported as a markdown section, WIP banner / placeholder Resources removed, status → published (matches registry). `docs/learn/skill-games-pressure-games.md`: placeholder Resources + satisfied research-citations TODO replaced with the app's 3-entry Sources, draft markers removed.
- **Ledes (#770, practice items):** HowToPractice and SkillGames now open with a one-to-two-sentence lede after the title (both platforms, mirrored into both docs files), matching the MeasurableGoals/PracticeModes shape.

`pnpm typecheck` and mobile `npm run typecheck` pass.

Closes #759
Closes #764
Part of #755 (MentalGame sites remain), #767 (item 1), #768 (items 1–2), #770 (practice ledes)