### PR TITLE
fix(learn): on-course article corrections + registry description

### DIFF
--- a/apps/mobile/components/learn/articles/CourseManagement.tsx
+++ b/apps/mobile/components/learn/articles/CourseManagement.tsx
@@ -10,6 +10,7 @@ import {
   Link,
   P,
   Sources,
+  Strong,
 } from '../primitives'
 
 export function CourseManagementArticle() {
@@ -65,8 +66,8 @@ export function CourseManagementArticle() {
         ]}
       />
       <P>
-        Your OGA strokes gained data tells you this more clearly
-        than your gut does. If SG approach is -1.4 per round, your
+        If you track strokes gained, that data tells you this more
+        clearly than your gut does. If SG approach is -1.4 per round, your
         irons are leaking. If SG putting is +0.8, your putter is an
         asset. Play accordingly.
       </P>
@@ -88,7 +89,7 @@ export function CourseManagementArticle() {
         nervous — hit the other one. Every time.
       </P>
       <P>
-        Off the tee: hit the longest club you can confidently keep
+        <Strong>Off the tee:</Strong> hit the longest club you can confidently keep
         in play. That is it. You don't need a perfect drive. You
         need a ball in play. A 220-yard drive in the fairway beats a
         280-yard drive in the trees every single time. Driver is not
@@ -294,9 +295,9 @@ export function CourseManagementArticle() {
         The deeper power of this system is that it shifts your
         measure of success away from score and toward process. A
         player who reaches the Scoring Zone in two shots and
-        converts every time will shoot in the 80s almost regardless
-        of how their ball-striking looks. The system shows you what
-        actually matters hole by hole.
+        converts every time will shoot right around 90 or better
+        almost regardless of how their ball-striking looks. The
+        system shows you what actually matters hole by hole.
       </P>
       <DevNote variant="research">
         Will Robins — The Scoring Method. thescoringmethod.com and
@@ -349,7 +350,9 @@ export function CourseManagementArticle() {
         erase it. Just to get somewhere you can play a normal golf
         shot from.
       </P>
-      <P>Punch out. Accept the bogey. Move on.</P>
+      <P>
+        <Strong>Punch out. Accept the bogey. Move on.</Strong>
+      </P>
       <P>
         The double bogey that becomes a triple happens because the
         player tried to thread the needle through the trees instead

--- a/apps/mobile/components/learn/articles/MentalGame.tsx
+++ b/apps/mobile/components/learn/articles/MentalGame.tsx
@@ -198,8 +198,8 @@ export function MentalGameArticle() {
       </P>
       <P>
         At the 1992 U.S. Open at Pebble Beach, Tom Kite had been
-        0 for 20 in U.S. Opens. Wind gusts reached 35 miles per
-        hour on Sunday. Most players didn't break 80. Kite shot
+        0 for 20 in U.S. Opens. Wind gusts topped 40 miles per
+        hour on Sunday. A lot of players couldn't break 80. Kite shot
         even par and won by two. He did it by not getting flustered.
         By staying patient. By letting others beat themselves.
       </P>
@@ -333,15 +333,26 @@ export function MentalGameArticle() {
             note: (
               <Text>
                 <Link href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-                  International Review of Sport & Exercise Psychology (2018) ·
-                  choking interventions, a systematic review
-                </Link>{' '}
-                and{' '}
-                <Link href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2025.1435374/full">
-                  Frontiers in Psychology (2025) · performance under pressure
+                  Gröpel & Mesagno, International Review of Sport & Exercise
+                  Psychology (2019) · choking interventions, a systematic
+                  review
                 </Link>{' '}
                 — pre-performance routines and gradual exposure to stakes help
                 skills survive competitive anxiety.
+              </Text>
+            ),
+          },
+          {
+            name: "Rotella's ten rules",
+            note: (
+              <Text>
+                <Link href="https://www.golfwrx.com/5689/dr-bob-rotella-my-10-rules-on-mental-fitness/">
+                  Bob Rotella, "My 10 Rules on Mental Fitness" (Golf Digest,
+                  2009)
+                </Link>{' '}
+                — the rule numbering and the Immelman, Harrington, Kite,
+                Strange, and Hogan stories retold in this article come from
+                this piece.
               </Text>
             ),
           },

--- a/apps/mobile/components/learn/articles/PracticeVsScoringRound.tsx
+++ b/apps/mobile/components/learn/articles/PracticeVsScoringRound.tsx
@@ -99,7 +99,8 @@ export function PracticeVsScoringRoundArticle() {
         it goes into a yardage book built on top of the detailed base book the
         event supplies, until the player has a hole-by-hole plan: the club off
         each tee, the number to leave on each approach, and the side that can't
-        be short-sided. Crucially, they practice approaches to the actual hole
+        be short-sided — missed on the side the pin sits, leaving no green to
+        work with. Crucially, they practice approaches to the actual hole
         locations planned for the four tournament days — not to wherever the
         flag happens to sit that morning.
       </P>

--- a/apps/mobile/components/learn/articles/SelfDiagnosis.tsx
+++ b/apps/mobile/components/learn/articles/SelfDiagnosis.tsx
@@ -368,6 +368,7 @@ function DiagnosticFlow() {
       <Arrow />
       <FlowRow>
         <Chip label="Yes" sub="tempo, not technique" />
+        <Chip label="No" sub="keep reading the pattern" />
       </FlowRow>
       <Arrow />
       <FlowQ n="04" q="One club, or all of them?" />

--- a/apps/web/src/pages/learn/articles/CourseManagementArticle.tsx
+++ b/apps/web/src/pages/learn/articles/CourseManagementArticle.tsx
@@ -80,8 +80,8 @@ export function CourseManagementArticle() {
         <li>Where your game breaks down under pressure</li>
       </ul>
       <P>
-        Your OGA strokes gained data tells you this more clearly than
-        your gut does. If SG approach is -1.4 per round, your irons
+        If you track strokes gained, that data tells you this more clearly
+        than your gut does. If SG approach is -1.4 per round, your irons
         are leaking. If SG putting is +0.8, your putter is an asset.
         Play accordingly.
       </P>
@@ -320,9 +320,9 @@ export function CourseManagementArticle() {
         The deeper power of this system is that it shifts your
         measure of success away from score and toward process. A
         player who reaches the Scoring Zone in two shots and converts
-        every time will shoot in the 80s almost regardless of how
-        their ball-striking looks. The system shows you what actually
-        matters hole by hole.
+        every time will shoot right around 90 or better almost
+        regardless of how their ball-striking looks. The system shows
+        you what actually matters hole by hole.
       </P>
       <EditorialNote variant="research">
         Will Robins — The Scoring Method. thescoringmethod.com and

--- a/apps/web/src/pages/learn/articles/MentalGameArticle.tsx
+++ b/apps/web/src/pages/learn/articles/MentalGameArticle.tsx
@@ -272,8 +272,8 @@ export function MentalGameArticle() {
       </P>
       <P>
         At the 1992 U.S. Open at Pebble Beach, Tom Kite had been
-        0 for 20 in U.S. Opens. Wind gusts reached 35 miles per
-        hour on Sunday. Most players didn't break 80. Kite shot
+        0 for 20 in U.S. Opens. Wind gusts topped 40 miles per
+        hour on Sunday. A lot of players couldn't break 80. Kite shot
         even par and won by two. He did it by not getting flustered.
         By staying patient. By letting others beat themselves.
       </P>
@@ -545,15 +545,22 @@ function Sources() {
           <SrcLabel>The science of performing under pressure</SrcLabel>
           <SrcBody>
             <Src href="https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134">
-              International Review of Sport &amp; Exercise Psychology (2018) ·
-              choking interventions, a systematic review
-            </Src>{' '}
-            and{' '}
-            <Src href="https://www.frontiersin.org/journals/psychology/articles/10.3389/fpsyg.2025.1435374/full">
-              Frontiers in Psychology (2025) · performance under pressure
+              Gröpel &amp; Mesagno, International Review of Sport &amp;
+              Exercise Psychology (2019) · choking interventions, a systematic
+              review
             </Src>{' '}
             — pre-performance routines and gradual exposure to stakes help
             skills survive competitive anxiety.
+          </SrcBody>
+        </div>
+        <div>
+          <SrcLabel>Rotella's ten rules</SrcLabel>
+          <SrcBody>
+            <Src href="https://www.golfwrx.com/5689/dr-bob-rotella-my-10-rules-on-mental-fitness/">
+              Bob Rotella, "My 10 Rules on Mental Fitness" (Golf Digest, 2009)
+            </Src>{' '}
+            — the rule numbering and the Immelman, Harrington, Kite, Strange,
+            and Hogan stories retold in this article come from this piece.
           </SrcBody>
         </div>
         <div>

--- a/apps/web/src/pages/learn/articles/PracticeVsScoringRoundArticle.tsx
+++ b/apps/web/src/pages/learn/articles/PracticeVsScoringRoundArticle.tsx
@@ -101,7 +101,8 @@ export function PracticeVsScoringRoundArticle() {
         it goes into a yardage book built on top of the detailed base book the
         event supplies, until the player has a hole-by-hole plan: the club off
         each tee, the number to leave on each approach, and the side that can't
-        be short-sided. Crucially, they practice approaches to the actual hole
+        be short-sided — missed on the side the pin sits, leaving no green to
+        work with. Crucially, they practice approaches to the actual hole
         locations planned for the four tournament days — not to wherever the flag
         happens to sit that morning.
       </P>

--- a/apps/web/src/pages/learn/articles/SelfDiagnosisArticle.tsx
+++ b/apps/web/src/pages/learn/articles/SelfDiagnosisArticle.tsx
@@ -359,6 +359,7 @@ function DiagnosticFlow() {
       <Arrow />
       <FlowRow>
         <Chip label="Yes" sub="tempo, not technique" />
+        <Chip label="No" sub="keep reading the pattern" />
       </FlowRow>
       <Arrow />
       <FlowQ n="04" q="One club, or all of them?" />

--- a/docs/learn/course-management.md
+++ b/docs/learn/course-management.md
@@ -1,24 +1,12 @@
 ---
 title: Course Management
 section: On the Course
-status: draft
+status: published
 last_reviewed: 2026-05
 contributors: []
-content_warning: |
-  This article is a work in progress. The structure and core
-  ideas are established but individual sections need deeper
-  research, better resource links, and review by a qualified
-  golf instructor before being considered complete.
-  Do not treat any specific technique advice as authoritative
-  until this notice is removed.
 ---
 
 # Course Management
-
-> **Work in progress.** This article is being developed.
-> Core structure is in place but content needs review,
-> additional research, and input from qualified instructors.
-> Resource links are placeholders — verify before using.
 
 ## You are not on the range anymore
 
@@ -44,7 +32,7 @@ Before you play, know:
 - How far you actually carry the ball — not your best carry, your reliable carry
 - Where your game breaks down under pressure
 
-Your OGA strokes gained data tells you this more clearly than your gut does. If SG approach is -1.4 per round, your irons are leaking. If SG putting is +0.8, your putter is an asset. Play accordingly.
+If you track strokes gained, that data tells you this more clearly than your gut does. If SG approach is -1.4 per round, your irons are leaking. If SG putting is +0.8, your putter is an asset. Play accordingly.
 
 ---
 
@@ -141,7 +129,7 @@ Once inside your zone, did you convert? Or did you take 4 from there?
 
 Track these two numbers for a few rounds and patterns emerge fast. Most amateurs discover they're actually reaching the Scoring Zone regularly — the problem is converting once they get there. That tells you exactly where to practice.
 
-The deeper power of this system is that it shifts your measure of success away from score and toward process. A player who reaches the Scoring Zone in two shots and converts every time will shoot in the 80s almost regardless of how their ball-striking looks. The system shows you what actually matters hole by hole.
+The deeper power of this system is that it shifts your measure of success away from score and toward process. A player who reaches the Scoring Zone in two shots and converts every time will shoot right around 90 or better almost regardless of how their ball-striking looks. The system shows you what actually matters hole by hole.
 
 > 📚 *Will Robins — The Scoring Method. thescoringmethod.com and YouTube @thescoringmethod*
 
@@ -228,17 +216,11 @@ The Way of the Playa is not a swing philosophy. It's a mindset. And it's availab
 
 ---
 
-## Resources
+## Sources
 
-> ⚠️ *Verify all links before publishing*
-
-- **Golf Sidekick** — YouTube. Search "Way of the Playa." Ego-free, score-focused course management for amateurs.
-- **The Upbeat Golfer (Manu)** — YouTube. Process-driven mental approach and target commitment.
-- **Will Robins — The Scoring Method** — thescoringmethod.com and YouTube @thescoringmethod. The Scoring Zone framework and modified scorecard system.
-- **"Golf Is Not a Game of Perfect"** — Bob Rotella. The standard text on playing with what you have that day.
+- **Course-management approaches this article draws on** — Golf Sidekick's "Way of the Playa"; Will Robins' Scoring Method ([thescoringmethod.com](https://thescoringmethod.com)), the Scoring Zone framework and modified scorecard; and Bob Rotella's "Golf Is Not a Game of Perfect" — practitioner frameworks for ego-free, score-first decision making.
 
 ---
 
 *Last reviewed: May 2026*
-*Status: Draft — needs instructor review before publishing*
 *To contribute: open a PR editing docs/learn/course-management.md*

--- a/docs/learn/mental-game.md
+++ b/docs/learn/mental-game.md
@@ -1,23 +1,12 @@
 ---
 title: The Mental Game
 section: On the Course
-status: draft
+status: published
 last_reviewed: 2026-05
 contributors: []
-content_warning: |
-  This article is a work in progress. The structure and core
-  ideas are established but individual sections need deeper
-  research, better resource links, and review before
-  being considered complete. Do not treat any specific
-  advice as authoritative until this notice is removed.
 ---
 
 # The Mental Game
-
-> **Work in progress.** This article is being developed.
-> Core structure is in place but content needs review
-> and additional research.
-> Resource links are placeholders — verify before using.
 
 ## Golf is you versus you
 
@@ -185,7 +174,6 @@ swing thoughts, not with mechanical checkpoints. The image.
 > 📚 *Research basis: mental imagery and motor performance.
 > See Guillot & Collet (2008) on mental simulation of
 > motor actions.*
-> ⚠️ *TODO: Add more specific research citations*
 
 ---
 
@@ -236,8 +224,8 @@ make an aggressive play, go with the more conservative
 one. You will always be okay.
 
 At the 1992 U.S. Open at Pebble Beach, Tom Kite had been
-0 for 20 in U.S. Opens. Wind gusts reached 35 miles per
-hour on Sunday. Most players didn't break 80. Kite shot
+0 for 20 in U.S. Opens. Wind gusts topped 40 miles per
+hour on Sunday. A lot of players couldn't break 80. Kite shot
 even par and won by two. He did it by not getting flustered.
 By staying patient. By letting others beat themselves.
 
@@ -416,33 +404,24 @@ absence of difficulty. The speed of return.
 
 ---
 
-## Resources
+## Sources
 
-> ⚠️ *Verify all links before publishing*
-
-- **"Golf Is Not a Game of Perfect"** — Bob Rotella.
-  The gold standard in golf psychology. Essential reading.
-- **"Golf Is a Game of Confidence"** — Bob Rotella.
-  The follow-up, equally valuable.
-- **Bob Rotella — "My 10 Rules on Mental Fitness"**
-  GolfWRX. The ten rules referenced throughout this
-  article.
-  https://www.golfwrx.com/5689/dr-bob-rotella-my-10-rules-on-mental-fitness/
-- **"Zen Golf"** — Joseph Parent. Buddhist-influenced
-  approach to present-moment play.
-- **The Upbeat Golfer (Manu)** — YouTube. Process-driven
-  mental approach, target commitment, playing without fear.
-- **"The Inner Game of Tennis"** — Tim Gallwey. Not
-  golf-specific but the foundational text on getting out
-  of your own way in sport. Directly applicable.
-- **"Choke"** — Sian Beilock. The neuroscience of why
-  we perform poorly under pressure and what to do about it.
-
-> ⚠️ *TODO: Add sports psychology research citations
-> on visualization and motor performance*
+- **The science of performing under pressure** —
+  [Gröpel & Mesagno, International Review of Sport & Exercise Psychology (2019) · choking interventions, a systematic review](https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134)
+  — pre-performance routines and gradual exposure to stakes
+  help skills survive competitive anxiety.
+- **Rotella's ten rules** —
+  [Bob Rotella, "My 10 Rules on Mental Fitness" (Golf Digest, 2009)](https://www.golfwrx.com/5689/dr-bob-rotella-my-10-rules-on-mental-fitness/)
+  — the rule numbering and the Immelman, Harrington, Kite,
+  Strange, and Hogan stories retold in this article come
+  from this piece.
+- **Foundational texts on the mental game** — Bob Rotella,
+  "Golf Is Not a Game of Perfect" and "Golf Is a Game of
+  Confidence"; Sian Beilock, "Choke"; Tim Gallwey, "The
+  Inner Game of Tennis"; Joseph Parent, "Zen Golf." These
+  are the works this article draws on.
 
 ---
 
 *Last reviewed: May 2026*
-*Status: Draft — needs review before publishing*
 *To contribute: open a PR editing docs/learn/mental-game.md*

--- a/packages/core/src/learn.ts
+++ b/packages/core/src/learn.ts
@@ -146,7 +146,7 @@ export const LEARN_SECTIONS: LearnSection[] = [
         id: 'course-management',
         title: 'Course management guide',
         description:
-          'Way of the Playa, the Scoring Zone, planning a hole backwards. The mental side of shooting your number.',
+          'Way of the Playa, the Scoring Zone, planning a hole backwards — shooting your number with the swing you have today.',
         status: 'published',
         words: 2200,
       },


### PR DESCRIPTION
Verified audit defects in the four "On the course" Learn articles, their docs mirrors, and the course-management registry description.

- **1992 U.S. Open claim fixed** (MentalGame, web + mobile + docs mirror): "Wind gusts reached 35 mph… Most players didn't break 80" → "Wind gusts topped 40 mph… A lot of players couldn't break 80" — 46 of 66 players broke 80 in the final round; the original escalation flipped Rotella's line false.
- **Rotella's 10-rules source added** (MentalGame Sources, web + mobile + docs mirror): the article's rule numbering and the Immelman/Harrington/Kite/Strange/Hogan anecdotes all trace to "My 10 Rules on Mental Fitness" (Golf Digest, 2009; GolfWRX reprint linked), which was missing from Sources.
- **Citation fixes** (MentalGame Sources, both platforms): choking-interventions review attributed as "Gröpel & Mesagno (2019)" (was an unattributed "(2018)"); the Frontiers in Psychology (2025) entry — glossed with its neighbor's findings — dropped, letting the Gröpel & Mesagno review carry the claim.
- **General-audience copy** (CourseManagement, web + mobile + docs mirror): "Your OGA strokes gained data tells you this…" → conditional "If you track strokes gained, that data tells you this…"; SG-approach/SG-putting examples kept.
- **Scoring Zone math honesty** (CourseManagement, all three copies): reaching the zone in 2 and converting in 3 is exactly 90, so "will shoot in the 80s almost regardless" → "will shoot right around 90 or better almost regardless".
- **Docs mirrors published**: removed the "Work in progress / do not treat as authoritative" banners and trailing draft markers from docs/learn/course-management.md and mental-game.md (the registry ships both as published); ported the app's post-edit Sources blocks into both mirrors, replacing the placeholder Resources lists.
- **Polish**: mobile CourseManagement restores web's bold on "Off the tee:" and "Punch out. Accept the bogey. Move on." (Strong primitive); SelfDiagnosis flowchart's "Only under pressure?" gains its missing No branch chip ("keep reading the pattern"), both platforms; "short-sided" glossed at first use in PracticeVsScoringRound, both platforms; registry description for course-management no longer claims "The mental side…" — now "shooting your number with the swing you have today."

Note: the audit listed "short-sided" as undefined in SelfDiagnosis too, but that article contains no such usage — only PracticeVsScoringRound does; gloss applied there only.

Verified: pnpm typecheck, pnpm test (589 passing), mobile npm run typecheck — all green.

Closes #762
Part of #755 (MentalGame sites), #767 (item 2), #768 (item 4), #770 (on-course items)