### PR TITLE
fix(learn): strokes-gained + benchmarks corrections

### DIFF
--- a/apps/mobile/components/learn/articles/Benchmarks.tsx
+++ b/apps/mobile/components/learn/articles/Benchmarks.tsx
@@ -7,7 +7,7 @@ import {
   type DetailedStats,
 } from '@oga/core'
 import { getProfile, getRoundsWithDetails } from '@oga/supabase'
-import { ArticleHeader, C, P, Subhead } from '../primitives'
+import { ArticleHeader, C, Link, P, Sources, Subhead } from '../primitives'
 import { FONT } from '../../../lib/typography'
 import { supabase } from '../../../lib/supabase'
 import { useAuth } from '../../../hooks/useAuth'
@@ -77,8 +77,11 @@ export function BenchmarksArticle() {
   }, [user?.id])
 
   const me: DetailedStats | null = useMemo(
-    () => (rounds.length > 0 ? computeDetailedStats(rounds, DEFAULT_HANDICAP) : null),
-    [rounds],
+    () =>
+      rounds.length > 0
+        ? computeDetailedStats(rounds, handicap ?? DEFAULT_HANDICAP)
+        : null,
+    [rounds, handicap],
   )
 
   const sg = me?.sg
@@ -137,7 +140,7 @@ export function BenchmarksArticle() {
     {
       key: 'avg_score',
       label: 'Avg score',
-      values: [69.5, 72, 77, 82, 87, 92, 99],
+      values: [71.0, 72, 77, 82, 87, 92, 99],
       format: (v) => v.toFixed(1),
       lowerIsBetter: true,
       meValue: scoring?.avgScore ?? null,
@@ -178,14 +181,14 @@ export function BenchmarksArticle() {
     {
       key: 'make_5ft',
       label: 'Make % from 5 ft / 152 cm',
-      values: [96, 85, 75, 63, 52, 42, 33],
+      values: [77, 65, 58, 50, 45, 40, 35],
       format: (v) => `${v.toFixed(0)}%`,
       meValue: null,
     },
     {
       key: 'make_10ft',
       label: 'Make % from 10 ft / 305 cm',
-      values: [55, 38, 28, 20, 14, 10, 7],
+      values: [40, 30, 25, 20, 16, 13, 10],
       format: (v) => `${v.toFixed(0)}%`,
       meValue: null,
     },
@@ -195,14 +198,14 @@ export function BenchmarksArticle() {
     {
       key: 'driving',
       label: 'Driving distance',
-      values: [294, 250, 235, 220, 205, 190, 175],
+      values: [300, 262, 255, 247, 238, 227, 212],
       format: (v) => toDisplay(v),
       meValue: ball?.drivingDistanceAvg ?? null,
     },
     {
       key: 'proximity',
-      label: 'Proximity to pin',
-      values: [25, 42, 52, 65, 82, 105, 130],
+      label: 'Proximity to pin (all approaches)',
+      values: [37, 55, 65, 75, 88, 105, 125],
       format: (v) => toDisplayFt(v),
       lowerIsBetter: true,
       meValue: ball?.proximityAvg != null ? ball.proximityAvg * 3 : null,
@@ -220,10 +223,9 @@ export function BenchmarksArticle() {
 
       <P>
         These bars show where each stat lands across the bell curve, from a
-        25-handicap weekend round all the way up to the PGA Tour. Your average
-        for the last ten rounds is plotted as a burnt-amber dot — when one is
-        missing it is because the app does not have enough rounds to compute it
-        yet.
+        25-handicap weekend round all the way up to the PGA Tour. If you track
+        rounds in OGA, your ten-round average appears as an amber dot on each
+        scale.
       </P>
 
       <ViewTabs value={view} onChange={setView} />
@@ -246,6 +248,36 @@ export function BenchmarksArticle() {
           userBracketIndex={userBracketIndex}
         />
       )}
+
+      <Sources
+        items={[
+          {
+            name: 'PGA Tour benchmarks',
+            note: (
+              <Text>
+                Mark Broadie's "Every Shot Counts" (2014) and PGA Tour
+                ShotLink-era season averages — scoring average, driving
+                distance, putting make rates by distance, and approach
+                proximity.
+              </Text>
+            ),
+          },
+          {
+            name: 'Amateur ladders',
+            note: (
+              <Text>
+                Shot Scope's handicap benchmark data, built from millions of
+                tracked amateur shots (summarized at{' '}
+                <Link href="https://practical-golf.com/shotscope-handicap-data">
+                  practical-golf.com
+                </Link>
+                ). Values are rounded and smoothed so each row steps
+                consistently across brackets.
+              </Text>
+            ),
+          },
+        ]}
+      />
     </View>
   )
 }

--- a/apps/mobile/components/learn/articles/StrokesGained.tsx
+++ b/apps/mobile/components/learn/articles/StrokesGained.tsx
@@ -8,6 +8,7 @@ import {
   GlanceBox,
   KICKER,
   P,
+  Sources,
   Subhead,
 } from '../primitives'
 
@@ -20,11 +21,12 @@ export function StrokesGainedArticle() {
       />
 
       <P>
-        <Em>Strokes gained</Em> measures every shot against an expectation. Hit
-        a shot from the same lie and distance as a pro might, beat the expected
-        outcome, and you gained strokes; come up short, you lost some. Sum the
-        deltas across a round and you get a precise read on where your strokes
-        are actually coming from — or going.
+        <Em>Strokes gained</Em> measures every shot against an expectation.
+        From every lie and distance there's an expected outcome — what a player
+        at your level typically does from there. Beat it and you gained
+        strokes; come up short, you lost some. Sum the deltas across a round
+        and you get a precise read on where your strokes are actually coming
+        from — or going.
       </P>
       <P>
         Score alone tells you the result. Strokes gained tells you <Em>why</Em>.
@@ -40,12 +42,13 @@ export function StrokesGainedArticle() {
           Tee shots on par 4s and par 5s. Your driver swing, essentially.
         </DefRow>
         <DefRow term="Approach">
-          Shots from outside 30 yards that aren't tee shots — the bulk of your
-          iron and hybrid play.
+          Shots from more than 30 yards out (measured to the edge of the green)
+          that aren't par-4 or par-5 tee shots — a par-3 tee shot counts as
+          approach.
         </DefRow>
         <DefRow term="Around the green">
-          Shots from within 30 yards that are not on the green — chips, pitches,
-          bunker shots.
+          Shots from within 30 yards of the green's edge that are not on the
+          putting surface — chips, pitches, bunker shots.
         </DefRow>
         <DefRow term="Putting">Every shot taken from the green.</DefRow>
       </GlanceBox>
@@ -61,13 +64,30 @@ export function StrokesGainedArticle() {
         means your irons are leaking 1.4 strokes a round.
       </P>
       <P>
-        The forest in this app is always positive territory. The brick is where
-        strokes leak. If a category sits at zero you are the average for your
-        bracket — fine, not a leak.
+        Green numbers are gained strokes; red is where they leak. If a category
+        sits at zero you are the average for your bracket — fine, not a leak.
       </P>
 
       <Subhead>What counts where</Subhead>
       <SGCategoriesTable />
+
+      <Sources
+        items={[
+          {
+            name: 'Strokes-gained framework and baselines',
+            note: (
+              <Text>
+                Mark Broadie's "Every Shot Counts" (2014) and the PGA Tour's
+                ShotLink-derived strokes-gained statistics define the
+                framework. The worked example uses OGA's 10-handicap bracket
+                baselines, which adapt Broadie's scratch tables with published
+                amateur shot data — so the expectations are for a player at
+                your level, not a tour pro.
+              </Text>
+            ),
+          },
+        ]}
+      />
     </View>
   )
 }
@@ -111,19 +131,19 @@ function WorkedExample() {
       >
         <ExampleStat
           label="Expected from 155 yd"
-          value="2.86"
+          value="3.67"
           note="Strokes a 10-handicap typically takes to hole out from there."
         />
         <ExampleStat
           label="Expected from 22 ft"
-          value="1.97"
-          note="What it usually takes to two-putt from that distance."
+          value="2.02"
+          note="What it usually takes to hole out from that distance — about a two-putt."
         />
         <ExampleStat
           label="Strokes gained"
-          value="−0.11"
-          note="2.86 − 1.97 − 1 (the shot you just hit)."
-          tone="neg"
+          value="+0.65"
+          note="3.67 − 2.02 − 1 (the shot you just hit)."
+          tone="pos"
         />
       </View>
       <Text
@@ -134,13 +154,16 @@ function WorkedExample() {
           lineHeight: 20,
         }}
       >
-        Slightly below baseline. Hit it to <Em>10 feet</Em> instead and the
-        number flips: 2.86 − 1.61 − 1 ={' '}
+        Well above baseline — for a 10-handicap, finding the green at all from
+        155 beats the expectation. Chunk the same swing 40 yards instead,
+        leaving <Em>115 in the fairway</Em>, and the sign flips: 3.67 − 3.39 −
+        1 ={' '}
         <Text style={{ fontFamily: FONT.serifItalic }}>
-          +0.25
+          −0.72
         </Text>{' '}
-        — a quarter of a stroke gained on a single approach. Stack eighteen of
-        those across a round and the difference is 4–5 strokes.
+        — nearly three-quarters of a stroke lost on one swing. Three of those
+        in a round and you have handed back more than two strokes before a putt
+        even drops.
       </Text>
     </GlanceBox>
   )
@@ -197,12 +220,12 @@ function SGCategoriesTable() {
     },
     {
       cat: 'Approach',
-      what: 'Anything outside 30 yd that isn’t a tee shot.',
+      what: 'Anything more than 30 yd from the green’s edge that isn’t a par-4 or par-5 tee shot.',
       example: '155 yd 7-iron from the fairway. Tee shot on a par-3.',
     },
     {
       cat: 'Around the green',
-      what: 'Inside 30 yd of the green, not on the putting surface.',
+      what: 'Inside 30 yd of the green’s edge, not on the putting surface.',
       example: 'Chip from the fringe; 20 yd flop from rough.',
     },
     {

--- a/apps/web/src/pages/learn/articles/ReadingStatsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/ReadingStatsArticle.tsx
@@ -3,7 +3,13 @@ import type { DetailedStats } from '@oga/core'
 import { useDetailedStats } from '../../../hooks/useDetailedStats'
 import { useProfile } from '../../../hooks/useProfile'
 import { useUnits } from '../../../hooks/useUnits'
-import { Lede, Subkicker, fmtSG } from '../components/ArticlePrimitives'
+import {
+  Lede,
+  SrcBody,
+  SrcLabel,
+  Subkicker,
+  fmtSG,
+} from '../components/ArticlePrimitives'
 
 const BRACKETS = ['PGA Tour', 'Scratch', '5', '10', '15', '20', '25+'] as const
 type BracketLabel = (typeof BRACKETS)[number]
@@ -46,7 +52,46 @@ export function ReadingStatsArticle() {
         Where you sit in the field.
       </h2>
       <BenchmarkBody me={me} />
+      <Sources />
     </article>
+  )
+}
+
+function Sources() {
+  return (
+    <section style={{ borderTop: '1px solid #D9D2BF', paddingTop: 18, marginTop: 22 }}>
+      <div className="kicker" style={{ marginBottom: 12 }}>
+        Sources
+      </div>
+      <div style={{ display: 'grid', gap: 14, maxWidth: 640 }}>
+        <div>
+          <SrcLabel>PGA Tour benchmarks</SrcLabel>
+          <SrcBody>
+            Mark Broadie's "Every Shot Counts" (2014) and PGA Tour
+            ShotLink-era season averages — scoring average, driving
+            distance, putting make rates by distance, and approach
+            proximity.
+          </SrcBody>
+        </div>
+        <div>
+          <SrcLabel>Amateur ladders</SrcLabel>
+          <SrcBody>
+            Shot Scope's handicap benchmark data, built from millions
+            of tracked amateur shots (summarized at{' '}
+            <a
+              href="https://practical-golf.com/shotscope-handicap-data"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: '#1F3D2C', textDecoration: 'underline' }}
+            >
+              practical-golf.com
+            </a>
+            ). Values are rounded and smoothed so each row steps
+            consistently across brackets.
+          </SrcBody>
+        </div>
+      </div>
+    </section>
   )
 }
 
@@ -108,7 +153,7 @@ function BenchmarkBody({ me }: { me: DetailedStats | null }) {
     {
       key: 'avg_score',
       label: 'Avg score',
-      values: [69.5, 72, 77, 82, 87, 92, 99],
+      values: [71.0, 72, 77, 82, 87, 92, 99],
       format: (v) => v.toFixed(1),
       lowerIsBetter: true,
       meValue: scoring?.avgScore ?? null,
@@ -149,14 +194,14 @@ function BenchmarkBody({ me }: { me: DetailedStats | null }) {
     {
       key: 'make_5ft',
       label: 'Make % from 5 ft / 152 cm',
-      values: [96, 85, 75, 63, 52, 42, 33],
+      values: [77, 65, 58, 50, 45, 40, 35],
       format: (v) => `${v.toFixed(0)}%`,
       meValue: null,
     },
     {
       key: 'make_10ft',
       label: 'Make % from 10 ft / 305 cm',
-      values: [55, 38, 28, 20, 14, 10, 7],
+      values: [40, 30, 25, 20, 16, 13, 10],
       format: (v) => `${v.toFixed(0)}%`,
       meValue: null,
     },
@@ -166,14 +211,14 @@ function BenchmarkBody({ me }: { me: DetailedStats | null }) {
     {
       key: 'driving',
       label: 'Driving distance',
-      values: [294, 250, 235, 220, 205, 190, 175],
+      values: [300, 262, 255, 247, 238, 227, 212],
       format: (v) => toDisplay(v),
       meValue: ball?.drivingDistanceAvg ?? null,
     },
     {
       key: 'proximity',
-      label: 'Proximity to pin',
-      values: [25, 42, 52, 65, 82, 105, 130],
+      label: 'Proximity to pin (all approaches)',
+      values: [37, 55, 65, 75, 88, 105, 125],
       format: (v) => toDisplayFt(v),
       lowerIsBetter: true,
       meValue: ball?.proximityAvg != null ? ball.proximityAvg * 3 : null,
@@ -191,9 +236,8 @@ function BenchmarkBody({ me }: { me: DetailedStats | null }) {
       <Lede>
         These bars show where each stat lands across the bell curve,
         from a 25-handicap weekend round all the way up to the PGA Tour.
-        Your average for the last ten rounds is plotted as a burnt-amber
-        dot — when one is missing it is because the app does not have
-        enough rounds to compute it yet.
+        If you track rounds in OGA, your ten-round average appears as an
+        amber dot on each scale.
       </Lede>
 
       <BenchmarkViewTabs value={view} onChange={setView} />

--- a/apps/web/src/pages/learn/articles/StrokesGainedArticle.tsx
+++ b/apps/web/src/pages/learn/articles/StrokesGainedArticle.tsx
@@ -2,6 +2,8 @@ import {
   Body,
   Bullet,
   Lede,
+  SrcBody,
+  SrcLabel,
   Subkicker,
 } from '../components/ArticlePrimitives'
 
@@ -34,11 +36,11 @@ export function StrokesGainedArticle() {
 
       <Lede>
         <em>Strokes gained</em> measures every shot against an
-        expectation. Hit a shot from the same lie and distance as a pro
-        might, beat the expected outcome, and you gained strokes; come
-        up short, you lost some. Sum the deltas across a round and you
-        get a precise read on where your strokes are actually coming
-        from — or going.
+        expectation. From every lie and distance there's an expected
+        outcome — what a player at your level typically does from
+        there. Beat it and you gained strokes; come up short, you lost
+        some. Sum the deltas across a round and you get a precise read
+        on where your strokes are actually coming from — or going.
       </Lede>
       <Body>
         Score alone tells you the result. Strokes gained tells you{' '}
@@ -56,12 +58,13 @@ export function StrokesGainedArticle() {
           essentially.
         </Bullet>
         <Bullet term="Approach">
-          Shots from outside 30 yards that aren't tee shots — the bulk
-          of your iron and hybrid play.
+          Shots from more than 30 yards out (measured to the edge of
+          the green) that aren't par-4 or par-5 tee shots — a par-3
+          tee shot counts as approach.
         </Bullet>
         <Bullet term="Around the green">
-          Shots from within 30 yards that are not on the green — chips,
-          pitches, bunker shots.
+          Shots from within 30 yards of the green's edge that are not
+          on the putting surface — chips, pitches, bunker shots.
         </Bullet>
         <Bullet term="Putting">
           Every shot taken from the green.
@@ -80,14 +83,39 @@ export function StrokesGainedArticle() {
         leaking 1.4 strokes a round.
       </Body>
       <Body>
-        The forest in this app is always positive territory. The brick
-        is where strokes leak. If a category sits at zero you are the
-        average for your bracket — fine, not a leak.
+        Green numbers are gained strokes; red is where they leak. If a
+        category sits at zero you are the average for your bracket —
+        fine, not a leak.
       </Body>
 
       <Subkicker>What counts where</Subkicker>
       <SGCategoriesTable />
+
+      <Sources />
     </article>
+  )
+}
+
+function Sources() {
+  return (
+    <section style={{ borderTop: '1px solid #D9D2BF', paddingTop: 18, marginTop: 22 }}>
+      <div className="kicker" style={{ marginBottom: 12 }}>
+        Sources
+      </div>
+      <div style={{ display: 'grid', gap: 14, maxWidth: 640 }}>
+        <div>
+          <SrcLabel>Strokes-gained framework and baselines</SrcLabel>
+          <SrcBody>
+            Mark Broadie's "Every Shot Counts" (2014) and the PGA
+            Tour's ShotLink-derived strokes-gained statistics define
+            the framework. The worked example uses OGA's 10-handicap
+            bracket baselines, which adapt Broadie's scratch tables
+            with published amateur shot data — so the expectations are
+            for a player at your level, not a tour pro.
+          </SrcBody>
+        </div>
+      </div>
+    </section>
   )
 }
 
@@ -118,33 +146,35 @@ function WorkedExample() {
       >
         <ExampleRow
           label="Expected from 155 yd"
-          value="2.86"
+          value="3.67"
           note="Strokes a 10-handicap typically takes to hole out from there."
         />
         <ExampleRow
           label="Expected from 22 ft"
-          value="1.97"
-          note="What it usually takes to two-putt from that distance."
+          value="2.02"
+          note="What it usually takes to hole out from that distance — about a two-putt."
         />
         <ExampleRow
           label="Strokes gained"
-          value="−0.11"
-          note="2.86 − 1.97 − 1 (the shot you just hit)."
-          tone="neg"
+          value="+0.65"
+          note="3.67 − 2.02 − 1 (the shot you just hit)."
+          tone="pos"
         />
       </div>
       <p
         className="text-caddie-ink-dim"
         style={{ fontSize: 13, lineHeight: 1.5 }}
       >
-        Slightly below baseline. Hit it to <em>10 feet</em> instead and
-        the number flips: 2.86 − 1.61 − 1 ={' '}
+        Well above baseline — for a 10-handicap, finding the green at
+        all from 155 beats the expectation. Chunk the same swing 40
+        yards instead, leaving <em>115 in the fairway</em>, and the
+        sign flips: 3.67 − 3.39 − 1 ={' '}
         <span className="font-serif" style={{ fontStyle: 'italic' }}>
-          +0.25
+          −0.72
         </span>{' '}
-        — a quarter of a stroke gained on a single approach. Stack
-        eighteen of those across a round and the difference is 4–5
-        strokes.
+        — nearly three-quarters of a stroke lost on one swing. Three
+        of those in a round and you have handed back more than two
+        strokes before a putt even drops.
       </p>
     </div>
   )
@@ -199,12 +229,12 @@ function SGCategoriesTable() {
     },
     {
       cat: 'Approach',
-      what: 'Anything outside 30 yd that isn’t a tee shot.',
+      what: 'Anything more than 30 yd from the green’s edge that isn’t a par-4 or par-5 tee shot.',
       example: '155 yd 7-iron from the fairway. Tee shot on a par-3.',
     },
     {
       cat: 'Around the green',
-      what: 'Inside 30 yd of the green, not on the putting surface.',
+      what: 'Inside 30 yd of the green’s edge, not on the putting surface.',
       example: 'Chip from the fringe; 20 yd flop from rough.',
     },
     {


### PR DESCRIPTION
Fixes the verified audit defects in the two stats-heavy Learn articles. All shipped numbers are either derived from `packages/core/src/sg-baselines.ts` (bracket 10) or sourced in the new Sources blocks. Web and mobile article text remains byte-identical for every edited passage.

## Strokes-gained article (#751, #757, #767 item 4)

- **Worked example recomputed from the app's own bracket-10 tables** (was Broadie's PGA Tour numbers mislabeled as a 10-handicap):
  - 155 yd fairway: `APPROACH_BASELINES[10]` 150→3.64, 175→3.80 ⇒ 3.64 + (5/25)·0.16 = **3.67**
  - 22 ft putt: `PUTTING_BASELINES[10]` 20→1.98, 30→2.18 ⇒ 1.98 + (2/10)·0.20 = **2.02**
  - SG = 3.67 − 2.02 − 1 = **+0.65** (tile now renders positive — the old −0.11 had the sign backwards vs the engine)
- **Losing-shot payoff rewritten.** The issue's "chunk to 40 ft" suggestion is still *positive* against bracket-10 baselines (40 ft putt = 2.32 ⇒ +0.35 — any green hit from 155 gains for a 10-handicap), so the below-baseline example is a chunk leaving **115 yd in the fairway**: `APPROACH_BASELINES[10]` 100→3.28, 125→3.46 ⇒ 3.28 + (15/25)·0.18 = **3.39**; SG = 3.67 − 3.39 − 1 = **−0.72**. "Stack eighteen of those" arithmetic replaced with "three of those ⇒ more than two strokes" (3 × 0.72 = 2.16).
- **Lede re-anchored** from "as a pro might" to "what a player at your level typically does" — matches the bracket-baseline framing the body (and the engine) actually uses.
- **Category definitions (#757):** Approach = ">30 yd measured to the edge of the green, not a par-4/par-5 tee shot — a par-3 tee shot counts as approach"; Around-the-green = "within 30 yd of the green's edge, not on the putting surface". The what-counts-where table cells got the same edge-of-green/par-3 qualifiers so the bullet no longer contradicts the table's own par-3 example.
- **Palette copy (#767 item 4):** "forest/brick" internal token names replaced with "Green numbers are gained strokes; red is where they leak."

## Benchmarks article (#752, #761, #767 item 5)

Tour column re-anchored, amateur ladders re-laddered monotonic:

| Row | Old | New |
|---|---|---|
| Make % from 5 ft | 96 / 85 / 75 / 63 / 52 / 42 / 33 | **77** / 65 / 58 / 50 / 45 / 40 / 35 |
| Make % from 10 ft | 55 / 38 / 28 / 20 / 14 / 10 / 7 | **40** / 30 / 25 / 20 / 16 / 13 / 10 |
| Avg score (tour) | 69.5 | **71.0** |
| Driving distance | 294 / 250 / 235 / 220 / 205 / 190 / 175 | **300** / 262 / 255 / 247 / 238 / 227 / 212 |
| Proximity | 25 / 42 / 52 / 65 / 82 / 105 / 130 | **37** / 55 / 65 / 75 / 88 / 105 / 125 |

- Driving ladder anchored on Shot Scope's 10-hcp ≈ 247 (per the Practical Golf roundup cited in the issue), smoothed monotonic; tour = 300.
- **Proximity row: chose the relabel-as-all-approach option** — `@oga/core`'s `proximityAvg` (which feeds the "You" dot) averages *all* approach-category shots, so a single-band label would mismatch the dot. Row is now "Proximity to pin (all approaches)", tour ≈ 37 ft (Broadie/ShotLink all-approach average), amateur ladder set plausibly above it and kept monotonic.
- **Sources blocks added to both articles on both platforms** (the only 2 of 20 articles without one): Mark Broadie, *Every Shot Counts* (2014) + PGA Tour ShotLink for tour numbers; Shot Scope handicap benchmarks (via practical-golf.com) for the amateur ladders, with an explicit rounded-and-smoothed note. Web uses the house `SrcLabel`/`SrcBody` local-`Sources()` pattern; mobile uses the `Sources` primitive.
- **#761:** mobile "You" dot now computed with the user's fetched handicap — `computeDetailedStats(rounds, handicap ?? DEFAULT_HANDICAP)` (+ `handicap` added to the memo deps) — matching web's `useDetailedStats`.
- **#767 item 5:** lede no longer promises a dot to readers without data: "If you track rounds in OGA, your ten-round average appears as an amber dot on each scale."

## Verification

- `pnpm typecheck` (web + packages) green; `npm run typecheck` in `apps/mobile` green (after per-package `npm install --legacy-peer-deps` in supabase/core/mobile).
- Text-parity probe over all edited passages: web ↔ mobile identical.

Closes #751
Closes #752
Closes #757
Closes #761
Part of #767 (items 4–5)
