### PR TITLE
fix(learn): equipment + coaching article corrections

### DIFF
--- a/apps/mobile/components/learn/articles/BuildingYourBag.tsx
+++ b/apps/mobile/components/learn/articles/BuildingYourBag.tsx
@@ -94,8 +94,8 @@ export function BuildingYourBagArticle() {
       <P style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>
         The bottom of the bag is where most amateurs quietly leak strokes.
         Pitching-wedge lofts have crept stronger over the years — a
-        game-improvement set may run 41–43°, where a traditional one sat at
-        45–46° — and that opens a big hole right below it, in the 30-to-50-yard
+        strong-lofted set may run 41–44°, where a traditional one sat at
+        46–48° — and that opens a big hole right below it, in the 30-to-50-yard
         range where you score.
       </P>
       <P style={{ color: C.inkDim, fontSize: 14, lineHeight: 22 }}>

--- a/apps/mobile/components/learn/articles/BuildingYourBag.tsx
+++ b/apps/mobile/components/learn/articles/BuildingYourBag.tsx
@@ -145,29 +145,48 @@ export function BuildingYourBagArticle() {
       <Sources
         items={[
           {
-            name: "USGA · Rule 4, the player's equipment",
-            href: 'https://www.usga.org/content/usga/home-page/rules/rules-2019/rules-of-golf/rule-4.html',
-            note: "The fourteen-club limit — you may carry no more than fourteen clubs, but no minimum and no restriction on type.",
+            name: 'The fourteen-club limit',
+            note: (
+              <Text>
+                <Link href="https://www.usga.org/content/usga/home-page/rules/rules-2019/rules-of-golf/rule-4.html">
+                  USGA · Rule 4, the player's equipment
+                </Link>{' '}
+                — you may carry no more than fourteen clubs, but no minimum and
+                no restriction on type.
+              </Text>
+            ),
           },
           {
-            name: 'Bobby Walia Golf · club gapping guide',
-            href: 'https://www.bobbywaliagolf.com/club-gapping-guide/',
-            note: 'Distance gapping and finding the holes — aim for even 10–15 yard steps; long irons that bunch within ten yards are better replaced with hybrids.',
+            name: 'Distance gapping and finding the holes',
+            note: (
+              <Text>
+                <Link href="https://www.bobbywaliagolf.com/club-gapping-guide/">
+                  Bobby Walia Golf · club gapping guide
+                </Link>{' '}
+                and{' '}
+                <Link href="https://www.hirekogolf.com/blog/post/guide-to-gapping-your-irons-correctly-solving-iron-distance-gaps">
+                  Hireko Golf · gapping your irons
+                </Link>{' '}
+                — aim for even 10–15 yard steps; long irons that bunch within
+                ten yards are better replaced with hybrids.
+              </Text>
+            ),
           },
           {
-            name: 'Hireko Golf · gapping your irons',
-            href: 'https://www.hirekogolf.com/blog/post/guide-to-gapping-your-irons-correctly-solving-iron-distance-gaps',
-            note: 'Companion gapping reference — even steps between full clubs, no bunched long irons.',
-          },
-          {
-            name: 'Golf Digest · everything to know about wedge lofts',
-            href: 'https://www.golfdigest.com/story/everything-you-need-to-know-about-wedge-lofts',
-            note: 'Wedge lofts and the gap below the pitching wedge — strong pitching-wedge lofts open a gap; space wedges about 4–6° apart to close it.',
-          },
-          {
-            name: 'MyGolfSpy · wedge gapping by handicap',
-            href: 'https://mygolfspy.com/news-opinion/instruction/wedge-gapping-chart-by-handicap-distance-lofts-and-trends/',
-            note: 'Wedge distances and lofts by handicap — even spacing keeps the scoring range covered.',
+            name: 'Wedge lofts and the gap below the pitching wedge',
+            note: (
+              <Text>
+                <Link href="https://www.golfdigest.com/story/everything-you-need-to-know-about-wedge-lofts">
+                  Golf Digest · everything to know about wedge lofts
+                </Link>{' '}
+                and{' '}
+                <Link href="https://mygolfspy.com/news-opinion/instruction/wedge-gapping-chart-by-handicap-distance-lofts-and-trends/">
+                  MyGolfSpy · wedge gapping by handicap
+                </Link>{' '}
+                — strong pitching-wedge lofts open a gap; space wedges about
+                4–6° apart to close it.
+              </Text>
+            ),
           },
         ]}
       />

--- a/apps/mobile/components/learn/articles/FittingsWithCoaches.tsx
+++ b/apps/mobile/components/learn/articles/FittingsWithCoaches.tsx
@@ -188,12 +188,8 @@ export function FittingsWithCoachesArticle() {
             name: 'Coach and fitter should be aligned',
             note: (
               <Text>
-                <Link href="https://www.mytpi.com/certification">
+                <Link href="https://www.titleist.com/learning-lab/performance/tpi-team-approach">
                   Titleist Performance Institute · the team approach
-                </Link>{' '}
-                and{' '}
-                <Link href="https://www.dennissalesgolf.com/golf-drills-and-practice-blogs/2025/3/18/why-you-should-get-fit-by-your-instructor-not-just-a-club-fitter">
-                  why getting fit by your instructor matters
                 </Link>{' '}
                 — most fitters, left alone, don't know your coach's plan; the player
                 has to connect them.

--- a/apps/mobile/components/learn/articles/GuideToFittings.tsx
+++ b/apps/mobile/components/learn/articles/GuideToFittings.tsx
@@ -73,8 +73,8 @@ export function GuideToFittingsArticle() {
       />
       <Fit
         name="Ball"
-        measures="how compression and cover suit your speed and short game"
-        adjusts="which ball you play. Compression is matched to swing speed; the cover — soft urethane versus a firmer ionomer — trades greenside spin and feel against durability and distance. The ball is a fitting too, and the cheapest one to test."
+        measures="how the ball launches, spins, and behaves around the green with your clubs"
+        adjusts="which ball you play. Balls are marketed by compression, but fit by flight and spin — find the launch-and-spin window your clubs actually produce, not a number matched to your swing speed. The cover — soft urethane versus a firmer ionomer — trades greenside spin and feel against durability and distance. The ball is a fitting too, and the cheapest one to test."
       />
 
       <Hr />
@@ -272,11 +272,7 @@ export function GuideToFittingsArticle() {
             href: 'https://www.globalgolf.com/articles/pro-tip-110/',
             note: (
               <Text>
-                <Text style={{ ...KICKER, color: C.inkDim }}>
-                  Lie angle and iron fitting
-                </Text>
-                {'  '}
-                Paired with{' '}
+                Lie angle and iron fitting — paired with{' '}
                 <Link href="https://mygolfspy.com/news-opinion/historys-mysteries-the-birth-of-pings-color-code-system/">
                   MyGolfSpy on PING's color-code system
                 </Link>{' '}
@@ -290,11 +286,7 @@ export function GuideToFittingsArticle() {
             href: 'https://www.vokey.com/explained/wedge-bounce',
             note: (
               <Text>
-                <Text style={{ ...KICKER, color: C.inkDim }}>
-                  Wedge bounce and grind
-                </Text>
-                {'  '}
-                Paired with{' '}
+                Wedge bounce and grind — paired with{' '}
                 <Link href="https://www.golfdigest.com/story/wedge-bounce-versus-wedge-grind-explained">
                   Golf Digest · bounce vs grind
                 </Link>{' '}
@@ -308,17 +300,13 @@ export function GuideToFittingsArticle() {
             href: 'https://mygolfspy.com/news-opinion/instruction/golf-driver-shaft-flex-chart-find-the-right-flex-for-your-swing-speed/',
             note: (
               <Text>
-                <Text style={{ ...KICKER, color: C.inkDim }}>
-                  Shaft flex and ball, matched to swing speed
-                </Text>
-                {'  '}
-                Paired with{' '}
+                Shaft flex and the ball — paired with{' '}
                 <Link href="https://www.pgatoursuperstore.com/learning-center/ultimate-golf-club-shaft-flex-guide.html">
                   PGA Tour Superstore · shaft flex guide
                 </Link>{' '}
                 — flex changes where the face points at impact, and isn't
-                standard across brands; compression pairs to the same
-                swing-speed logic.
+                standard across brands; the ball is marketed by compression but
+                fit by flight, spin, and greenside cover.
               </Text>
             ),
           },
@@ -327,11 +315,7 @@ export function GuideToFittingsArticle() {
             href: 'https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know',
             note: (
               <Text>
-                <Text style={{ ...KICKER, color: C.inkDim }}>
-                  What the fitter's numbers mean
-                </Text>
-                {'  '}
-                Paired with{' '}
+                What the fitter's numbers mean — paired with{' '}
                 <Link href="https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman">
                   the ultimate guide to TrackMan data
                 </Link>{' '}

--- a/apps/mobile/components/learn/articles/GuideToFittings.tsx
+++ b/apps/mobile/components/learn/articles/GuideToFittings.tsx
@@ -268,11 +268,13 @@ export function GuideToFittingsArticle() {
       <Sources
         items={[
           {
-            name: 'Understanding the PING fitting charts',
-            href: 'https://www.globalgolf.com/articles/pro-tip-110/',
+            name: 'Lie angle and iron fitting',
             note: (
               <Text>
-                Lie angle and iron fitting — paired with{' '}
+                <Link href="https://www.globalgolf.com/articles/pro-tip-110/">
+                  Understanding the PING fitting charts
+                </Link>{' '}
+                and{' '}
                 <Link href="https://mygolfspy.com/news-opinion/historys-mysteries-the-birth-of-pings-color-code-system/">
                   MyGolfSpy on PING's color-code system
                 </Link>{' '}
@@ -282,11 +284,13 @@ export function GuideToFittingsArticle() {
             ),
           },
           {
-            name: 'Titleist Vokey · Wedge Bounce',
-            href: 'https://www.vokey.com/explained/wedge-bounce',
+            name: 'Wedge bounce and grind',
             note: (
               <Text>
-                Wedge bounce and grind — paired with{' '}
+                <Link href="https://www.vokey.com/explained/wedge-bounce">
+                  Titleist Vokey · Wedge Bounce
+                </Link>{' '}
+                and{' '}
                 <Link href="https://www.golfdigest.com/story/wedge-bounce-versus-wedge-grind-explained">
                   Golf Digest · bounce vs grind
                 </Link>{' '}
@@ -296,11 +300,13 @@ export function GuideToFittingsArticle() {
             ),
           },
           {
-            name: 'MyGolfSpy · shaft flex by swing speed',
-            href: 'https://mygolfspy.com/news-opinion/instruction/golf-driver-shaft-flex-chart-find-the-right-flex-for-your-swing-speed/',
+            name: 'Shaft flex and the ball',
             note: (
               <Text>
-                Shaft flex and the ball — paired with{' '}
+                <Link href="https://mygolfspy.com/news-opinion/instruction/golf-driver-shaft-flex-chart-find-the-right-flex-for-your-swing-speed/">
+                  MyGolfSpy · shaft flex by swing speed
+                </Link>{' '}
+                and{' '}
                 <Link href="https://www.pgatoursuperstore.com/learning-center/ultimate-golf-club-shaft-flex-guide.html">
                   PGA Tour Superstore · shaft flex guide
                 </Link>{' '}
@@ -311,11 +317,13 @@ export function GuideToFittingsArticle() {
             ),
           },
           {
-            name: 'TrackMan · 6 numbers every amateur should know',
-            href: 'https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know',
+            name: "What the fitter's numbers mean",
             note: (
               <Text>
-                What the fitter's numbers mean — paired with{' '}
+                <Link href="https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know">
+                  TrackMan · 6 numbers every amateur should know
+                </Link>{' '}
+                and{' '}
                 <Link href="https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman">
                   the ultimate guide to TrackMan data
                 </Link>{' '}

--- a/apps/mobile/components/learn/articles/LessonsAndCoaching.tsx
+++ b/apps/mobile/components/learn/articles/LessonsAndCoaching.tsx
@@ -25,6 +25,14 @@ export function LessonsAndCoachingArticle() {
         title="Lessons and coaching."
       />
 
+      <P>
+        Good instruction is the fastest way to get better — and the easiest
+        thing in golf to waste. What you do around the lesson counts for as much
+        as the lesson itself.
+      </P>
+
+      <Hr />
+
       <H3>Most golfers waste the lesson hour</H3>
       <P>
         A golf lesson is one of the highest-leverage hours you can spend on your
@@ -256,22 +264,33 @@ export function LessonsAndCoachingArticle() {
       <Sources
         items={[
           {
-            name: 'Titleist Performance Institute · About Certification',
-            href: 'https://www.mytpi.com/certification/about',
+            name: 'What the certifications mean',
             note: (
               <Text>
+                <Link href="https://www.mytpi.com/certification/about">
+                  Titleist Performance Institute · About Certification
+                </Link>{' '}
                 on the body-swing-connection approach and physical screening;{' '}
-                <Link href="https://www.pga.com/things-to-do/coaches">
-                  PGA of America · Coaches
+                <Link href="https://www.pga.com/coaches">
+                  PGA of America · Find a Coach
                 </Link>{' '}
                 for what a PGA teaching professional is and how to find one.
               </Text>
             ),
           },
           {
-            name: 'HackMotion · Worse After Golf Lessons?',
-            href: 'https://hackmotion.com/worse-after-golf-lessons/',
-            note: '— the temporary performance dip is a normal stage of overwriting a grooved motor pattern: the old swing fades before the new one takes hold, so contact gets clumsy in the middle. Expected, not a failure.',
+            name: 'Why a swing change feels worse before it feels better',
+            note: (
+              <Text>
+                <Link href="https://hackmotion.com/worse-after-golf-lessons/">
+                  HackMotion · Worse After Golf Lessons?
+                </Link>{' '}
+                — the temporary performance dip is a normal stage of overwriting
+                a grooved motor pattern: the old swing fades before the new one
+                takes hold, so contact gets clumsy in the middle. Expected, not
+                a failure.
+              </Text>
+            ),
           },
         ]}
       />
@@ -284,7 +303,8 @@ export function LessonsAndCoachingArticle() {
 // Side-by-side "look for / walk away from" cards. Single-column stacked on
 // phone. Palette stays in the house earth tones — the accent green marks the
 // column you want, a muted ink marks the one you don't. No red; the labels
-// carry the meaning. Keeps the ✓ / · glyphs and the green/amber accent split.
+// carry the meaning. Keeps the ✓ / · glyphs and the green-accent vs muted-ink
+// split.
 function FlagColumns() {
   return (
     <View style={{ marginBottom: 14, gap: 12 }}>

--- a/apps/mobile/components/learn/articles/QuestionsForCoach.tsx
+++ b/apps/mobile/components/learn/articles/QuestionsForCoach.tsx
@@ -63,8 +63,7 @@ export function QuestionsForCoachArticle() {
             change tied to an outcome you can see, not just a body position.
             Research on where golfers aim their attention is unusually consistent:
             focusing on the <Em>effect</Em> of a movement — what the ball does —
-            produces better and more durable results than focusing on the body
-            part making it. If the answer is only "get your hands here," ask what
+            produces better results than focusing on the body part making it. If the answer is only "get your hands here," ask what
             "here" is supposed to <Em>produce</Em>.
           </P>,
           <P style={{ marginBottom: 0 }}>
@@ -186,11 +185,6 @@ export function QuestionsForCoachArticle() {
                 the body part making it.
               </P>
             ),
-          },
-          {
-            name: 'And it holds up over days',
-            href: 'https://pmc.ncbi.nlm.nih.gov/articles/PMC11246618/',
-            note: 'Internal vs external focus on golf putting accuracy over multiple days (2024) — the external-focus advantage persists on delayed retention, not just in the moment.',
           },
           {
             name: 'Space the practice you’re given',

--- a/apps/mobile/components/learn/articles/TrainingAids.tsx
+++ b/apps/mobile/components/learn/articles/TrainingAids.tsx
@@ -308,11 +308,13 @@ export function TrainingAidsArticle() {
       <Sources
         items={[
           {
-            name: 'PGA of America · 4 alignment mistakes',
-            href: 'https://www.pga.com/story/4-alignment-mistakes-killing-your-golf-game-and-how-to-fix-them',
+            name: 'Why alignment is foundational',
             note: (
               <Text>
-                Why alignment is foundational — paired with{' '}
+                <Link href="https://www.pga.com/story/4-alignment-mistakes-killing-your-golf-game-and-how-to-fix-them">
+                  PGA of America · 4 alignment mistakes
+                </Link>{' '}
+                and{' '}
                 <Link href="https://golf.com/instruction/why-aim-alignment-poor-how-fix/">
                   Golf.com · why your aim is poor
                 </Link>{' '}
@@ -322,11 +324,13 @@ export function TrainingAidsArticle() {
             ),
           },
           {
-            name: 'TrackMan · what is face angle',
-            href: 'https://www.trackman.com/blog/golf/what-is-face-angle',
+            name: 'Face angle sets the start line',
             note: (
               <Text>
-                Face angle sets the start line — paired with{' '}
+                <Link href="https://www.trackman.com/blog/golf/what-is-face-angle">
+                  TrackMan · what is face angle
+                </Link>{' '}
+                and{' '}
                 <Link href="https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know">
                   6 numbers every amateur should know
                 </Link>{' '}
@@ -337,12 +341,13 @@ export function TrainingAidsArticle() {
             ),
           },
           {
-            name: 'Tour Tempo',
-            href: 'https://tourtempo.com/pages/tour-tempo-app',
+            name: 'Tempo — the three-to-one ratio',
             note: (
               <Text>
-                Tempo, the three-to-one ratio — the 3:1 backswing-to-downswing
-                finding, paired with{' '}
+                <Link href="https://tourtempo.com/pages/tour-tempo-app">
+                  Tour Tempo
+                </Link>{' '}
+                on the 3:1 backswing-to-downswing finding, and{' '}
                 <Link href="https://www.pga.com/story/find-a-rhythm-and-tempo-that-fits-your-game">
                   PGA of America · rhythm and tempo
                 </Link>{' '}
@@ -352,11 +357,13 @@ export function TrainingAidsArticle() {
             ),
           },
           {
-            name: 'TrackMan · the ultimate guide to the data',
-            href: 'https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman',
+            name: 'Launch monitors — which numbers, and what they cost',
             note: (
               <Text>
-                Launch monitors, which numbers and what they cost — paired with{' '}
+                <Link href="https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman">
+                  TrackMan · the ultimate guide to the data
+                </Link>{' '}
+                and{' '}
                 <Link href="https://mygolfspy.com/buyers-guide/we-tested-12-launch-monitors-ranging-from-500-to-5000-whats-the-real-difference/">
                   MyGolfSpy · $500 to $5,000 tested
                 </Link>{' '}

--- a/apps/mobile/components/learn/articles/TrainingAids.tsx
+++ b/apps/mobile/components/learn/articles/TrainingAids.tsx
@@ -308,13 +308,11 @@ export function TrainingAidsArticle() {
       <Sources
         items={[
           {
-            name: 'Why alignment is foundational',
+            name: 'PGA of America · 4 alignment mistakes',
+            href: 'https://www.pga.com/story/4-alignment-mistakes-killing-your-golf-game-and-how-to-fix-them',
             note: (
               <Text>
-                <Link href="https://www.pga.com/story/4-alignment-mistakes-killing-your-golf-game-and-how-to-fix-them">
-                  PGA of America · 4 alignment mistakes
-                </Link>{' '}
-                and{' '}
+                Why alignment is foundational — paired with{' '}
                 <Link href="https://golf.com/instruction/why-aim-alignment-poor-how-fix/">
                   Golf.com · why your aim is poor
                 </Link>{' '}
@@ -324,29 +322,27 @@ export function TrainingAidsArticle() {
             ),
           },
           {
-            name: 'Face angle sets the start line',
+            name: 'TrackMan · what is face angle',
+            href: 'https://www.trackman.com/blog/golf/what-is-face-angle',
             note: (
               <Text>
-                <Link href="https://www.trackman.com/blog/golf/what-is-face-angle">
-                  TrackMan · what is face angle
-                </Link>{' '}
-                and{' '}
+                Face angle sets the start line — paired with{' '}
                 <Link href="https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know">
                   6 numbers every amateur should know
                 </Link>{' '}
-                — the clubface controls roughly 85% of where the ball starts, which
-                is why putting and impact aids train a square strike.
+                — the clubface controls roughly 75–85% of where the ball starts
+                (most with the driver), which is why putting and impact aids
+                train a square strike.
               </Text>
             ),
           },
           {
-            name: 'Tempo — the three-to-one ratio',
+            name: 'Tour Tempo',
+            href: 'https://tourtempo.com/pages/tour-tempo-app',
             note: (
               <Text>
-                <Link href="https://tourtempo.com/pages/tour-tempo-app">
-                  Tour Tempo
-                </Link>{' '}
-                on the 3:1 backswing-to-downswing finding, and{' '}
+                Tempo, the three-to-one ratio — the 3:1 backswing-to-downswing
+                finding, paired with{' '}
                 <Link href="https://www.pga.com/story/find-a-rhythm-and-tempo-that-fits-your-game">
                   PGA of America · rhythm and tempo
                 </Link>{' '}
@@ -356,13 +352,11 @@ export function TrainingAidsArticle() {
             ),
           },
           {
-            name: 'Launch monitors — which numbers, and what they cost',
+            name: 'TrackMan · the ultimate guide to the data',
+            href: 'https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman',
             note: (
               <Text>
-                <Link href="https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman">
-                  TrackMan · the ultimate guide to the data
-                </Link>{' '}
-                and{' '}
+                Launch monitors, which numbers and what they cost — paired with{' '}
                 <Link href="https://mygolfspy.com/buyers-guide/we-tested-12-launch-monitors-ranging-from-500-to-5000-whats-the-real-difference/">
                   MyGolfSpy · $500 to $5,000 tested
                 </Link>{' '}
@@ -453,7 +447,7 @@ function NumbersTable() {
     },
     {
       num: 'Path & face angle',
-      who: 'Coaches and better players. Face angle alone sets about 85% of your start line — worth knowing, hard to change without help.',
+      who: 'Coaches and better players. Face angle alone sets about 75–85% of your start line (most with the driver) — worth knowing, hard to change without help.',
     },
   ]
   return (

--- a/apps/web/src/pages/learn/articles/BuildingYourBagArticle.tsx
+++ b/apps/web/src/pages/learn/articles/BuildingYourBagArticle.tsx
@@ -90,8 +90,8 @@ export function BuildingYourBagArticle() {
         <AidBody>
           The bottom of the bag is where most amateurs quietly leak strokes.
           Pitching-wedge lofts have crept stronger over the years — a
-          game-improvement set may run 41–43°, where a traditional one sat at
-          45–46° — and that opens a big hole right below it, in the 30-to-50-yard
+          strong-lofted set may run 41–44°, where a traditional one sat at
+          46–48° — and that opens a big hole right below it, in the 30-to-50-yard
           range where you score.
         </AidBody>
         <AidBody>

--- a/apps/web/src/pages/learn/articles/FittingsWithCoachesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/FittingsWithCoachesArticle.tsx
@@ -349,12 +349,8 @@ function Sources() {
         <div>
           <SrcLabel>Coach and fitter should be aligned</SrcLabel>
           <SrcBody>
-            <Src href="https://www.mytpi.com/certification">
+            <Src href="https://www.titleist.com/learning-lab/performance/tpi-team-approach">
               Titleist Performance Institute · the team approach
-            </Src>{' '}
-            and{' '}
-            <Src href="https://www.dennissalesgolf.com/golf-drills-and-practice-blogs/2025/3/18/why-you-should-get-fit-by-your-instructor-not-just-a-club-fitter">
-              why getting fit by your instructor matters
             </Src>{' '}
             — most fitters, left alone, don't know your coach's plan; the player
             has to connect them.

--- a/apps/web/src/pages/learn/articles/GuideToFittingsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/GuideToFittingsArticle.tsx
@@ -72,8 +72,8 @@ export function GuideToFittingsArticle() {
       />
       <Fit
         name="Ball"
-        measures="how compression and cover suit your speed and short game"
-        adjusts="which ball you play. Compression is matched to swing speed; the cover — soft urethane versus a firmer ionomer — trades greenside spin and feel against durability and distance. The ball is a fitting too, and the cheapest one to test."
+        measures="how the ball launches, spins, and behaves around the green with your clubs"
+        adjusts="which ball you play. Balls are marketed by compression, but fit by flight and spin — find the launch-and-spin window your clubs actually produce, not a number matched to your swing speed. The cover — soft urethane versus a firmer ionomer — trades greenside spin and feel against durability and distance. The ball is a fitting too, and the cheapest one to test."
       />
 
       <Hr />
@@ -478,7 +478,7 @@ function Sources() {
           </SrcBody>
         </div>
         <div>
-          <SrcLabel>Shaft flex and ball, matched to swing speed</SrcLabel>
+          <SrcLabel>Shaft flex and the ball</SrcLabel>
           <SrcBody>
             <Src href="https://mygolfspy.com/news-opinion/instruction/golf-driver-shaft-flex-chart-find-the-right-flex-for-your-swing-speed/">
               MyGolfSpy · shaft flex by swing speed
@@ -488,7 +488,8 @@ function Sources() {
               PGA Tour Superstore · shaft flex guide
             </Src>{' '}
             — flex changes where the face points at impact, and isn't standard
-            across brands; compression pairs to the same swing-speed logic.
+            across brands; the ball is marketed by compression but fit by
+            flight, spin, and greenside cover.
           </SrcBody>
         </div>
         <div>

--- a/apps/web/src/pages/learn/articles/LessonsAndCoachingArticle.tsx
+++ b/apps/web/src/pages/learn/articles/LessonsAndCoachingArticle.tsx
@@ -28,6 +28,14 @@ export function LessonsAndCoachingArticle() {
         Lessons and coaching.
       </h2>
 
+      <P>
+        Good instruction is the fastest way to get better — and the easiest
+        thing in golf to waste. What you do around the lesson counts for as much
+        as the lesson itself.
+      </P>
+
+      <Hr />
+
       <H3>Most golfers waste the lesson hour</H3>
       <P>
         A golf lesson is one of the highest-leverage hours you can spend on your
@@ -436,8 +444,8 @@ function Sources() {
               Titleist Performance Institute · About Certification
             </Src>{' '}
             on the body-swing-connection approach and physical screening;{' '}
-            <Src href="https://www.pga.com/things-to-do/coaches">
-              PGA of America · Coaches
+            <Src href="https://www.pga.com/coaches">
+              PGA of America · Find a Coach
             </Src>{' '}
             for what a PGA teaching professional is and how to find one.
           </SrcBody>

--- a/apps/web/src/pages/learn/articles/QuestionsForCoachArticle.tsx
+++ b/apps/web/src/pages/learn/articles/QuestionsForCoachArticle.tsx
@@ -54,8 +54,7 @@ export function QuestionsForCoachArticle() {
           change tied to an outcome you can see, not just a body position.
           Research on where golfers aim their attention is unusually consistent:
           focusing on the <em>effect</em> of a movement — what the ball does —
-          produces better and more durable results than focusing on the body part
-          making it. If the answer is only "get your hands here," ask what "here"
+          produces better results than focusing on the body part making it. If the answer is only "get your hands here," ask what "here"
           is supposed to <em>produce</em>.
         </li>
         <li>
@@ -300,17 +299,6 @@ function Sources() {
             </Src>{' '}
             — focusing on the movement's effect (the ball) beats focusing on the
             body part making it.
-          </SrcBody>
-        </div>
-        <div>
-          <SrcLabel>And it holds up over days</SrcLabel>
-          <SrcBody>
-            <Src href="https://pmc.ncbi.nlm.nih.gov/articles/PMC11246618/">
-              Internal vs external focus on golf putting accuracy over multiple
-              days (2024)
-            </Src>{' '}
-            — the external-focus advantage persists on delayed retention, not just
-            in the moment.
           </SrcBody>
         </div>
         <div>

--- a/apps/web/src/pages/learn/articles/TrainingAidsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/TrainingAidsArticle.tsx
@@ -564,7 +564,7 @@ function NumbersTable() {
     },
     {
       num: 'Path & face angle',
-      who: 'Coaches and better players. Face angle alone sets about 85% of your start line — worth knowing, hard to change without help.',
+      who: 'Coaches and better players. Face angle alone sets about 75–85% of your start line (most with the driver) — worth knowing, hard to change without help.',
     },
   ]
   return (
@@ -673,8 +673,9 @@ function Sources() {
             <Src href="https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know">
               6 numbers every amateur should know
             </Src>{' '}
-            — the clubface controls roughly 85% of where the ball starts, which
-            is why putting and impact aids train a square strike.
+            — the clubface controls roughly 75–85% of where the ball starts
+            (most with the driver), which is why putting and impact aids train a
+            square strike.
           </SrcBody>
         </div>
         <div>


### PR DESCRIPTION
Verified audit defects across the six equipment + coaching Learn articles, web and mobile kept in sync throughout.

**Ball-fitting framing (#766)**
- GuideToFittings: the Ball fit no longer teaches compression-matched-to-swing-speed (the source house the article cites calls that a myth). Reframed around flight/spin windows — "marketed by compression, but fit by flight and spin" — with the accurate urethane-vs-ionomer cover half kept. Sources note and label fixed to match.
- BuildingYourBag: PW loft brackets corrected — "a strong-lofted set may run 41–44°, where a traditional one sat at 46–48°" (was 41–43° attributed to game-improvement vs 45–46° traditional).

**PeerJ citation (#756)**
- QuestionsForCoach: deleted the "And it holds up over days" Sources entry citing the 2024 multi-day putting study — the paper found the external-focus advantage did NOT persist past day 1, the opposite of the note. The Wulf 2013 review + JMLD 2013 entries stay and carry the claim.
- Body bullet softened: "produces better results" (dropped "and more durable").

**Citation link fixes (part of #769, items 2–4)**
- LessonsAndCoaching: PGA citation repointed to https://www.pga.com/coaches (verified: 200, resolves to PGA's Find-a-Coach page describing the PGA Coach program). Link text updated to "PGA of America · Find a Coach".
- FittingsWithCoaches: TPI team-approach source now points at https://www.titleist.com/learning-lab/performance/tpi-team-approach, which actually states the coach/fitness/fitting team claim. Note: titleist.com 403s all non-browser requests site-wide (Akamai bot-blocking — the article's existing titleist.com citation 403s identically), so this was verified as bot-blocking rather than a dead page.
- Dropped the dennissalesgolf.com source entry (single pro's marketing blog); the corrected TPI link carries the block.

**Face-angle figure (part of #763, training-aids rider)**
- TrainingAids: "sets about 85% of your start line" → "about 75–85% of your start line (most with the driver)" in both the launch-monitor numbers table and the Sources gloss.

**Consistency polish (part of #770, coaching/equipment items)**
- Mobile Sources normalized across the equipment trio (GuideToFittings, TrainingAids, BuildingYourBag) to the repo-wide claim-label arrangement: item name = claim category from the web SrcLabel, source names as links inside the note. Substance unchanged.
- Mobile LessonsAndCoaching Sources restores web's claim-category labels ("What the certifications mean" / "Why a swing change feels worse before it feels better") as the item labels.
- LessonsAndCoaching gets a lede after the title on both platforms (its two siblings already have one).
- Fixed a mobile comment claiming a "green/amber accent split" that doesn't exist (code is green accent vs muted ink).

Verified: `pnpm typecheck` and mobile `npm run typecheck` both green.

Closes #766
Closes #756

Part of #769 (items 2–4), #763 (training-aids rider), #770 (coaching/equipment items)
