### PR TITLE
docs(learn): mirror all 21 Learn articles into docs/learn

### DIFF
--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -1,0 +1,82 @@
+---
+title: Reading Your Stats
+section: Understanding the Game
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Reading Your Stats
+
+These tables show where each stat lands across the bell
+curve, from a 25-handicap weekend round all the way up
+to the PGA Tour.
+
+*[In the app, these render as graded scales with a
+chart/table toggle; if you track rounds in OGA, your
+ten-round average appears as an amber dot on each
+scale.]*
+
+---
+
+## Strokes gained
+
+Per round, versus a scratch baseline.
+
+| Stat | 25+ | 20 | 15 | 10 | 5 | Scratch | PGA Tour |
+|---|---|---|---|---|---|---|---|
+| SG · Off the tee | −1.6 | −1.2 | −0.9 | −0.6 | −0.3 | 0.0 | +1.0 |
+| SG · Approach | −3.0 | −2.3 | −1.7 | −1.1 | −0.5 | 0.0 | +1.4 |
+| SG · Around the green | −1.5 | −1.2 | −0.9 | −0.6 | −0.3 | 0.0 | +0.6 |
+| SG · Putting | −1.4 | −1.1 | −0.8 | −0.5 | −0.2 | 0.0 | +0.3 |
+| SG · Total | −7.5 | −5.8 | −4.3 | −2.8 | −1.3 | 0.0 | +3.3 |
+
+---
+
+## Scoring + ball striking
+
+| Stat | 25+ | 20 | 15 | 10 | 5 | Scratch | PGA Tour |
+|---|---|---|---|---|---|---|---|
+| Avg score | 99.0 | 92.0 | 87.0 | 82.0 | 77.0 | 72.0 | 71.0 |
+| GIR % | 9% | 15% | 22% | 30% | 40% | 50% | 67% |
+| Fairways hit | 26% | 32% | 38% | 44% | 50% | 55% | 62% |
+
+---
+
+## Putting
+
+| Stat | 25+ | 20 | 15 | 10 | 5 | Scratch | PGA Tour |
+|---|---|---|---|---|---|---|---|
+| Putts / round | 37.0 | 36.0 | 35.0 | 34.0 | 33.0 | 32.0 | 29.0 |
+| 3-putt rate | 28% | 22% | 17% | 12% | 8% | 5% | 2% |
+| Make % from 5 ft / 152 cm | 35% | 40% | 45% | 50% | 58% | 65% | 77% |
+| Make % from 10 ft / 305 cm | 10% | 13% | 16% | 20% | 25% | 30% | 40% |
+
+---
+
+## Ball striking
+
+| Stat | 25+ | 20 | 15 | 10 | 5 | Scratch | PGA Tour |
+|---|---|---|---|---|---|---|---|
+| Driving distance (yd) | 212 | 227 | 238 | 247 | 255 | 262 | 300 |
+| Proximity to pin, all approaches (ft) | 125 | 105 | 88 | 75 | 65 | 55 | 37 |
+
+---
+
+## Sources
+
+- **PGA Tour benchmarks** — Mark Broadie's "Every Shot
+  Counts" (2014) and PGA Tour ShotLink-era season
+  averages — scoring average, driving distance, putting
+  make rates by distance, and approach proximity.
+- **Amateur ladders** — Shot Scope's handicap benchmark
+  data, built from millions of tracked amateur shots
+  (summarized at
+  [practical-golf.com](https://practical-golf.com/shotscope-handicap-data)).
+  Values are rounded and smoothed so each row steps
+  consistently across brackets.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/benchmarks.md*

--- a/docs/learn/building-your-bag.md
+++ b/docs/learn/building-your-bag.md
@@ -1,0 +1,163 @@
+---
+title: Building Your Bag
+section: Your Equipment
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Building Your Bag
+
+## Fourteen clubs is a budget, not a checklist
+
+The rules let you carry fourteen clubs — no more. Most
+golfers fill that number out of habit: driver, 3-wood,
+irons down through the pitching wedge, a sand wedge, a
+putter, and whatever was in the box. Almost nobody asks
+the only question that matters — do these fourteen
+actually cover my distances? Usually they don't. The
+goal was never to own fourteen clubs. It's even gaps,
+top to bottom, with no dead zones.
+
+**The two dead zones**
+
+- **Overlap** — Two clubs that carry the same distance.
+  One of them is a wasted slot — a club you could have
+  spent covering a yardage you can't reach.
+- **Hole** — A distance you can't cover with any full
+  swing, so you're stuck guessing at a three-quarter
+  shot. Most often it sits just below the pitching
+  wedge.
+
+Fix both and the bag fits you instead of the rack it
+came off. Everything below is how to find and close
+those gaps.
+
+---
+
+## Start from your distances, not the set
+
+Build the bag backwards from carry numbers, not forwards
+from a set you bought. Hit five to ten balls with each
+club, average the carries — throw out the obvious duffs
+— and list them top to bottom. The picture shows up at
+once: where clubs bunch together, and where they spread.
+
+Aim for even steps of roughly 10 to 15 yards between
+full clubs. Two clubs landing within about 8 yards of
+each other is a wasted slot — one of them is doing
+nothing. A gap wider than 15 leaves you stranded between
+clubs, forced into a half-swing you'll never trust on
+the course.
+
+---
+
+## The top of the bag: driver down to your longest club
+
+This is where the most common dead zone hides. Modern
+lofts are strong, and a lot of amateurs find their 3-,
+4-, and 5-iron all carry within ten yards of each other
+— three slots doing one club's job. The fix is to
+replace the long irons you can't launch with hybrids or
+a higher-lofted fairway wood: they get the ball up more
+easily and restore real separation between clubs.
+
+Keep long irons only if you have the speed to flight
+them and a reason to hit it low. And check the very top:
+if your 3-wood off the deck goes nearly as far as a
+driver you rarely trust, that's a slot you could spend
+on a club you'll actually pull. Carry the longest club
+you can keep in play, not the longest one you own.
+
+---
+
+## The scoring clubs: wedges, where strokes are won and lost
+
+The bottom of the bag is where most amateurs quietly
+leak strokes. Pitching-wedge lofts have crept stronger
+over the years — a strong-lofted set may run 41–44°,
+where a traditional one sat at 46–48° — and that opens a
+big hole right below it, in the 30-to-50-yard range
+where you score.
+
+Space your wedges in even loft steps of about 4 to 6°. A
+common setup: pitching wedge around 45°, gap wedge near
+50°, sand wedge 54–56°, lob wedge 58–60°. If your
+pitching wedge is 45° or stronger, a gap wedge isn't
+optional — without it you've got a yawning hole exactly
+where touch matters most. For most players, pitching,
+gap, and sand wedges cover it; add a lob wedge only if
+you have the swing for it.
+
+Which bounce and grind to put on those wedges is a
+fitting question, not a gapping one — it's covered in
+the fittings guide. Here, the job is only to make sure
+no two of them go the same distance and nothing's
+missing below your pitching wedge.
+
+---
+
+## The putter — the club you use most
+
+Roughly 40% of the strokes in a round are putts, which
+makes the putter the one slot you should never treat as
+an afterthought or a hand-me-down. It doesn't need
+gapping, but it does need fitting — length, lie, and
+head style matched to your stroke — and that's the
+cheapest set of strokes on this page. One slot, used
+more than any other; spend it deliberately.
+
+---
+
+## Where the fourteen go
+
+There's no single correct bag, but a no-dead-zone build
+for most golfers lands close to this. The exact count
+flexes — drop a wedge to add a hybrid, or the reverse —
+as long as the gaps stay even.
+
+- **Off the tee** — Driver — one slot, the longest club
+  you can keep in play.
+- **Long approach** — A 3-wood, hybrids, or a
+  high-lofted fairway — whatever you actually hit off
+  the deck. Most amateurs gap better with hybrids than
+  3- and 4-irons.
+- **Mid & short irons** — Roughly 5-iron through
+  pitching wedge, in even 10–15 yard steps.
+- **Scoring** — Pitching, gap, and sand wedge cover most
+  players; add a lob wedge if you have the swing for it.
+  Even 4–6° loft gaps.
+- **On the green** — Putter — the club you use most. Fit
+  it, don't default it.
+
+Run the range test once a season and after any new club.
+A bag with even gaps and nothing you can't hit beats a
+bag full of the newest models — the fourteen slots are a
+budget, and the player who spends them on coverage
+instead of habit shoots lower without buying a thing.
+
+---
+
+## Sources
+
+- **The fourteen-club limit** —
+  [USGA · Rule 4, the player's equipment](https://www.usga.org/content/usga/home-page/rules/rules-2019/rules-of-golf/rule-4.html)
+  — you may carry no more than fourteen clubs, but no
+  minimum and no restriction on type.
+- **Distance gapping and finding the holes** —
+  [Bobby Walia Golf · club gapping guide](https://www.bobbywaliagolf.com/club-gapping-guide/)
+  and
+  [Hireko Golf · gapping your irons](https://www.hirekogolf.com/blog/post/guide-to-gapping-your-irons-correctly-solving-iron-distance-gaps)
+  — aim for even 10–15 yard steps; long irons that bunch
+  within ten yards are better replaced with hybrids.
+- **Wedge lofts and the gap below the pitching wedge** —
+  [Golf Digest · everything to know about wedge lofts](https://www.golfdigest.com/story/everything-you-need-to-know-about-wedge-lofts)
+  and
+  [MyGolfSpy · wedge gapping by handicap](https://mygolfspy.com/news-opinion/instruction/wedge-gapping-chart-by-handicap-distance-lofts-and-trends/)
+  — strong pitching-wedge lofts open a gap; space wedges
+  about 4–6° apart to close it.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/building-your-bag.md*

--- a/docs/learn/fittings-with-coaches.md
+++ b/docs/learn/fittings-with-coaches.md
@@ -1,0 +1,164 @@
+---
+title: Fittings and Your Coach
+section: Working with Coaches
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Fittings and Your Coach
+
+The equipment guide on *golf fittings* covers what each
+fitting measures and changes — driver, irons, wedges,
+putter, shaft, and ball — and when each one is worth the
+money. This is the companion question from the coaching
+side: who should fit you, how a fitting fits into working
+with a coach, and how to time it so you're not fitting
+expensive equipment to a swing you're about to change. The
+two appointments are easy to confuse, and treating them as
+one is how golfers waste both.
+
+| Who         | Context                 | Neutrality             | Best                        |
+|-------------|-------------------------|------------------------|-----------------------------|
+| Your coach  | Knows your swing & plan | Depends on their tools | When you're mid-change      |
+| Independent | Meets you cold          | Brand-neutral          | For an open comparison      |
+| Brand (OEM) | Meets you cold          | One brand only         | Once you've picked a brand  |
+
+---
+
+## Two different appointments
+
+A lesson tries to change your swing. A fitting fits clubs
+to the swing you actually have today — not the one you're
+hoping to build. That's the line that confuses people:
+they want to "fix the slice first, then get fit," and end
+up playing ill-fitting clubs for a year while they chase a
+swing change.
+
+The better order is usually the opposite. Properly fit
+equipment fits the swing you bring tomorrow, and when you
+stop compensating for the wrong gear, a coach's changes
+often come *faster*. Unless you are a brand new golfer
+with nothing stable to measure, "fix it first" is mostly
+backward — get fit to your current swing, then let lessons
+move it, and re-check the specs when the swing has
+genuinely changed.
+
+---
+
+## Who's actually fitting you
+
+Not all fittings come from the same chair, and the chair
+matters. Three people might fit you, and their incentives
+are not identical:
+
+- **Your coach or instructor.** Already knows your typical
+  miss, your goals, and the change you're in the middle
+  of. A fitting run by — or coordinated with — your coach
+  starts with all of that context instead of a blank
+  sheet. The catch: not every teaching pro is a trained
+  fitter, so ask what tools and data they actually use.
+- **An independent fitter.** Carries multiple brands and
+  gets paid for the fitting, not the badge on the head, so
+  the recommendation is brand-neutral. The catch: they
+  meet you cold and only see the swing you bring that hour
+  — tell them what you're working on so they don't fit you
+  to a temporary flaw.
+- **A brand (OEM) fitter.** Deep on one manufacturer's
+  lineup and often free, which is great if you already
+  want that brand. The catch: the answer will be that
+  brand, so treat it as fitting *within* a line you've
+  chosen, not an open comparison.
+
+The strongest setup is a team that talks. The Titleist
+Performance Institute model makes this explicit — coach,
+fitness, and fitting aligned on the same goals — and most
+club fitters, left alone, have no idea what your
+instructor is trying to build. You are the one who has to
+connect them.
+
+---
+
+## Time it around your swing, not against it
+
+The "fit the swing you have" rule has a wrinkle worth
+getting right. Real swing changes are usually incremental
+and ongoing, not a single overhaul on a Tuesday — so there
+is rarely a perfect "finished" moment to fit. Waiting for
+one mostly means playing bad gear forever.
+
+The actual danger is narrow: getting fit cold, in the
+middle of a major rebuild, to a swing you're about to
+abandon. Avoid it with coordination, not delay. Tell your
+coach before you book a fitting, and tell the fitter what
+you're working on — a degree of lie or a shaft profile can
+either support a change your coach is making or quietly
+fight it, and only the two of them together can tell
+which.
+
+---
+
+## The body comes first
+
+Before the launch monitor, the right spec depends on what
+your body can actually do. The textbook lie angle, shaft,
+and length assume a range of motion you may or may not
+have; a mobility limit in the hips or shoulders can make
+the "standard" recommendation wrong for you. This is the
+body-swing connection the Titleist Performance Institute
+built its certification around — a physical screen that
+correlates how you move with how you should be fit and
+coached. A good coach-led fitting starts there, not at the
+driver.
+
+> **The one move:** loop your coach in before you book the
+> fitting, and tell the fitter the exact change you're
+> working on. A fitting done in a vacuum optimizes launch
+> and spin for one hour's swing; a fitting that knows your
+> coach's plan optimizes for the player you're becoming.
+
+## Red flags
+
+A coach-coordinated fitting should make your equipment
+quieter, not your wallet lighter. Walk if you see these:
+
+- **A "fitting" that only ever lands on one brand** — or
+  one that never asks what you currently play or what
+  you're working on.
+- **Gear pushed in the middle of a lesson.** A purchase is
+  a separate appointment; your most expensive coaching
+  minutes shouldn't go to a sales pitch.
+- **"Buy these and your slice is gone."** Equipment can
+  remove a fight against your gear; it can't install a
+  swing change. If someone promises clubs will fix
+  mechanics, they're selling, not fitting.
+
+Get the order and the team right — body first, fit the
+swing you have, coach and fitter on the same page — and a
+fitting stops being a gamble on gear and becomes part of
+the same plan as your lessons.
+
+---
+
+## Sources
+
+- **Fit the swing you have, don't wait to "fix" it** —
+  [GOLF.com · why fixing your swing before a fitting is backward](https://golf.com/gear/fix-your-swing-club-fitting/)
+  and
+  [GolfTEC · fit vs fix](https://scramble.golftec.com/blog/2015/06/fit-vs-fix-should-i-get-fit-for-clubs-or-fix-my-swing/)
+  — fit to your current swing; properly fit gear tends to
+  speed a change up, not wait on it.
+- **Coach and fitter should be aligned** —
+  [Titleist Performance Institute · the team approach](https://www.titleist.com/learning-lab/performance/tpi-team-approach)
+  — most fitters, left alone, don't know your coach's
+  plan; the player has to connect them.
+- **Your body shapes the right spec** —
+  [Titleist Performance Institute · the body-swing connection](https://www.titleist.com/fitting/golf-club-fitting/titleist-performance-institute)
+  — a physical screen correlates how you move with how you
+  should be fit and coached, so the fitting starts with
+  the body, not the driver.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/fittings-with-coaches.md*

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -1,21 +1,12 @@
 ---
 title: Glossary of Golf Terms
 section: Understanding the Game
-status: draft
+status: published
 last_reviewed: 2026-05
 contributors: []
-content_warning: |
-  This article expands on the in-app glossary with
-  intermediate and advanced terms. Core definitions
-  are well-established. Some slang entries are
-  colloquial and may vary by region.
 ---
 
 # Glossary of Golf Terms
-
-> **Work in progress.** Being expanded over time.
-> Suggest missing terms by opening a PR editing
-> docs/learn/glossary.md
 
 The basics — birdie, bogey, par, handicap, GIR —
 are not covered here. This glossary focuses on the
@@ -577,12 +568,20 @@ walking ahead), possibly a military "beware before"
 command. One of golf's oldest surviving terms and
 one of its most important.
 
-> ⚠️ *TODO: Verify historical club equivalencies —
-> sources vary on exact loft comparisons between
-> hickory era clubs and modern equivalents.*
+---
+
+## Sources
+
+- **How these definitions are sourced** — definitions
+  follow the USGA & R&A Rules of Golf where a term is
+  formally defined there (stroke, hazard, out of bounds,
+  and so on), and otherwise reflect common golf usage.
+  Slang and historical entries are described as they're
+  actually used, not as official definitions. Historical
+  club equivalencies follow standard reference tables;
+  sources vary slightly on exact hickory-era lofts.
 
 ---
 
 *Last reviewed: May 2026*
-*Status: Draft — being expanded over time*
 *To contribute: open a PR editing docs/learn/glossary.md*

--- a/docs/learn/guide-to-fittings.md
+++ b/docs/learn/guide-to-fittings.md
@@ -1,0 +1,338 @@
+---
+title: Guide to Golf Fittings
+section: Your Equipment
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Guide to Golf Fittings
+
+## There is no such thing as "getting fit"
+
+Most golfers picture a fitting as one appointment that
+sorts out their clubs. It isn't. Driver, irons, wedges,
+putter, shaft, and ball are six different fittings
+measuring six different things, and being dialed in with
+one tells you nothing about the others.
+
+Knowing what each one actually changes is how you spend
+fitting money where it returns strokes instead of where
+it sells clubs. So before you book anything, here is
+what is on the table.
+
+---
+
+## The six fittings, and what each one changes
+
+### Driver
+
+**Measures** — launch angle, spin rate, club path, face
+angle, ball speed
+
+**Adjusts** — loft, shaft, and — on most modern heads —
+movable weights and an adjustable hosel. The goal is a
+launch-and-spin pairing that carries: too much spin
+balloons it, too little drops it out of the sky early.
+
+### Irons
+
+**Measures** — lie angle, length, shaft weight and flex,
+grip size
+
+**Adjusts** — mostly lie and length. Lie angle is the
+one that quietly costs accuracy — and most players are
+off. Across more than 100,000 fittings, Ping finds the
+majority of golfers don't match the standard lie, and a
+single degree off can push a wedge five to six yards
+offline.
+
+### Wedges
+
+**Measures** — bounce, grind, and the loft gaps between
+your wedges
+
+**Adjusts** — which bounce and grind suit your turf and
+swing. Bounce is the angle that keeps the sole from
+digging: high bounce (over 10°) suits soft turf, fluffy
+lies, and steep digger swings; low bounce (4–6°) suits
+firm turf and shallow, sweeping contact; mid bounce
+(7–10°) is the versatile middle. Grind is the shape of
+the sole around that bounce.
+
+### Putter
+
+**Measures** — length, lie, loft, and your stroke shape
+— how much it arcs
+
+**Adjusts** — length, lie, head style, and grip. A
+strong-arc stroke and a straight-back-straight-through
+stroke want different head designs. It is the club you
+use most and the one amateurs fit least.
+
+### Shaft
+
+**Measures** — how the shaft loads and delivers the head
+for your speed and tempo
+
+**Adjusts** — flex, weight, and bend profile. Flex is
+how much the shaft bends through the swing; too soft for
+your speed and the head lags behind your hands and the
+face arrives pointing offline. Flex is not standardized
+— one brand's stiff can play like another's regular.
+
+### Ball
+
+**Measures** — how the ball launches, spins, and behaves
+around the green with your clubs
+
+**Adjusts** — which ball you play. Balls are marketed by
+compression, but fit by flight and spin — find the
+launch-and-spin window your clubs actually produce, not
+a number matched to your swing speed. The cover — soft
+urethane versus a firmer ionomer — trades greenside spin
+and feel against durability and distance. The ball is a
+fitting too, and the cheapest one to test.
+
+---
+
+## When to get fitted — start where it pays
+
+You don't need every fitting at once, and a brand-new
+golfer doesn't need any yet — the swing has to repeat
+before there is anything stable to measure. After that,
+fit in the order that returns the most strokes for the
+money.
+
+- **New golfer** — Not yet. Get contact repeatable
+  first — there is nothing stable to fit.
+- **20+ handicap** — Putter first. The club you use
+  most, and the cheapest to fit.
+- **10–20** — Irons and wedges — lie angle, length, and
+  the loft gaps between wedges.
+- **Under 10** — Everything, ball included — small gains
+  are worth chasing now.
+
+The through-line: fit the club you use most and the
+swing you actually have, not the one you are hoping to
+build.
+
+---
+
+## Get the most out of the day
+
+A fitting is only as good as the swing you bring to it.
+A few habits separate data you can trust from a wasted
+hour:
+
+- **Bring the clubs you actually play.** The fitter
+  needs a baseline — every recommendation should be
+  measured against your current gamer, not against
+  nothing.
+- **Warm up like a round, not a long-drive contest.**
+  Fit the swing you play with, not the one that shows up
+  for three perfect balls.
+- **Come with a goal and your typical miss.** "I lose it
+  right off the tee" or "my wedges are gapping badly"
+  focuses the hour.
+- **Hit enough balls per option.** One good shot is
+  luck; a fitter should be reading a cluster, not a
+  highlight.
+- **Be honest about how often you play.** The best club
+  for a range hero who plays twice a year is not the
+  best club for you.
+
+---
+
+## A real fitting vs a sales pitch
+
+A fitting and a sale can look identical from the
+outside. The difference is whether the session is about
+your numbers or about the rack.
+
+### Signs it's a real fitting
+
+- A launch monitor is running and you are shown your
+  numbers
+- Several heads and shafts are tested back-to-back, not
+  just one
+- The fitter explains what each change did to the ball
+  flight
+- You are sometimes told a change isn't worth the money
+
+### Signs it's a sales pitch
+
+- One option is pushed hard from the start
+- No data is shown, or the numbers are kept on the
+  fitter's side
+- "This is what everyone's playing" stands in for your
+  results
+- Every session somehow ends in exactly one thing to buy
+
+Indoor fitting gives controlled launch-monitor data;
+outdoor lets you see real flight and roll. Both are
+valid — but either way the numbers should be explained
+to you, not just sold.
+
+---
+
+## Questions worth asking
+
+The fitter works for you for that hour, even when the
+bay is inside a shop. These turn a transaction back into
+a fitting — each one, and what you're listening for in
+the answer:
+
+**"What are we optimizing for?"**
+
+You want a clear target before the first ball — carry
+distance, tighter dispersion, better gapping. "Let's
+just hit some and see" is not a plan.
+
+**"Can I see the numbers for every option?"**
+
+A real fitting shows you the data for each club, not
+just announces a winner. If the screen only faces the
+fitter, ask them to turn it around.
+
+**"How does this compare to what I'm playing now?"**
+
+Every change should beat your current gamer by enough to
+matter — and "better" should be a number, not a feeling.
+
+**"Is this difference real, or is it inside my scatter?"**
+
+If an option averages five yards longer but your shots
+vary by twenty, that five yards is noise. A good fitter
+talks in averages and spread, not single shots.
+
+**"What would you change first — and what isn't worth it?"**
+
+A fitter willing to tell you something doesn't matter is
+one you can trust on the things that do.
+
+**"What are my yardage gaps?"**
+
+You want even gaps between clubs — no two going the same
+distance, and no big holes where you're stranded between
+clubs.
+
+---
+
+## Decoding what the fitter says
+
+Fitters talk in launch-monitor shorthand. Here is what
+the common phrases actually mean — and when one is a
+real signal versus a way to wave a weak number past you.
+
+**"You need more launch / less spin."**
+
+Your carry isn't matching your speed. With the driver,
+too much spin balloons the ball and costs distance; too
+little and it drops out of the sky early. The fix is
+launch and spin working together, usually through loft
+and shaft.
+
+**"Your smash factor is 1.4-something."**
+
+How much ball speed you got for your clubhead speed —
+basically, how flush you struck it. Around 1.50 with a
+driver is efficient; a low number usually means
+off-center contact, which can be the club or your
+strike, so make sure it's the club before you pay for
+it.
+
+**"Your dispersion tightened up."**
+
+Your shots are landing in a smaller area. This matters
+more than one extra-long drive — the tighter pattern is
+the one that keeps you in play. Reward dispersion over
+the occasional bomb.
+
+**"Your spin axis is tilted."**
+
+That's your curve: the ball fades or draws because the
+face and the path don't match. Same mechanism as a slice
+in any ball-flight explainer — the fitter is just
+reading it off the monitor.
+
+**"This shaft loads better for you."**
+
+A feel-and-timing claim. It can be real, but it should
+still show up in the data — better contact, tighter
+dispersion, more speed. If it only feels better and the
+numbers are flat, that's preference, not performance.
+
+**"Your attack angle is up / down."**
+
+Whether you're hitting up or down on the ball at impact.
+The driver likes a slightly upward strike for carry;
+irons want a downward strike that bottoms out just after
+the ball.
+
+**"The numbers don't tell the whole story."**
+
+Sometimes true for feel — but it's also the line used to
+sell you past data that doesn't support the upgrade.
+Make them tell you exactly what the numbers are missing.
+
+---
+
+## When you're ready, and how often
+
+You are ready when your contact is consistent enough
+that the fitter is measuring your swing and not your
+mishits — roughly, when most shots find the middle of
+the face. Get re-fit after a swing change, a real change
+in speed, or every few years as your body and the
+equipment move on. You don't need the newest model. You
+need clubs that match you.
+
+---
+
+## What it costs
+
+Big retailers often fit for free when you buy.
+Independent fittings run roughly $75–150 for a single
+club up to $300 and more for a full bag, sometimes
+credited back toward a purchase, with building the clubs
+billed separately. The fitting itself is cheap next to a
+set of irons — and a putter fitting is the cheapest
+stroke-saver on this page.
+
+---
+
+## Sources
+
+- **Lie angle and iron fitting** —
+  [Understanding the PING fitting charts](https://www.globalgolf.com/articles/pro-tip-110/)
+  and
+  [MyGolfSpy on PING's color-code system](https://mygolfspy.com/news-opinion/historys-mysteries-the-birth-of-pings-color-code-system/)
+  — over 100,000 fittings show most golfers don't match
+  the standard lie; a degree off moves a wedge several
+  yards offline.
+- **Wedge bounce and grind** —
+  [Titleist Vokey · Wedge Bounce](https://www.vokey.com/explained/wedge-bounce)
+  and
+  [Golf Digest · bounce vs grind](https://www.golfdigest.com/story/wedge-bounce-versus-wedge-grind-explained)
+  — high, mid, and low bounce, and which turf and swing
+  each suits.
+- **Shaft flex and the ball** —
+  [MyGolfSpy · shaft flex by swing speed](https://mygolfspy.com/news-opinion/instruction/golf-driver-shaft-flex-chart-find-the-right-flex-for-your-swing-speed/)
+  and
+  [PGA Tour Superstore · shaft flex guide](https://www.pgatoursuperstore.com/learning-center/ultimate-golf-club-shaft-flex-guide.html)
+  — flex changes where the face points at impact, and
+  isn't standard across brands; the ball is marketed by
+  compression but fit by flight, spin, and greenside
+  cover.
+- **What the fitter's numbers mean** —
+  [TrackMan · 6 numbers every amateur should know](https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know)
+  and
+  [the ultimate guide to TrackMan data](https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman)
+  — launch, spin, smash factor, attack angle, and
+  dispersion, in plain terms.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/guide-to-fittings.md*

--- a/docs/learn/lessons-and-coaching.md
+++ b/docs/learn/lessons-and-coaching.md
@@ -1,0 +1,260 @@
+---
+title: Guide to Lessons and Coaching
+section: Working with Coaches
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Guide to Lessons and Coaching
+
+Good instruction is the fastest way to get better — and
+the easiest thing in golf to waste. What you do around the
+lesson counts for as much as the lesson itself.
+
+---
+
+## Most golfers waste the lesson hour
+
+A golf lesson is one of the highest-leverage hours you can
+spend on your game — and most golfers either never book
+one or get almost nothing out of the ones they do. They
+show up cold, collect a tip, never practice it, slide back
+to their old swing within a week, and conclude that
+"lessons don't work for me." The lesson worked fine. The
+hour around it didn't. This guide is about both halves:
+choosing a teacher worth your money, and setting yourself
+up to actually keep what they give you.
+
+---
+
+## What the letters after a name mean — and don't
+
+Certifications tell you someone cleared a bar. They don't
+tell you whether that person is the right teacher for
+*you*.
+
+- **PGA / LPGA.** A PGA of America or LPGA teaching
+  professional has completed a long training and testing
+  program and knows the game deeply. It's a real
+  credential — and a broad one. It certifies competence
+  and seriousness, not that this particular coach
+  communicates in a way that clicks for you.
+- **TPI (Titleist Performance Institute).** A
+  TPI-certified instructor is trained in the "body-swing
+  connection" — they screen your physical mobility and
+  limitations first, so they're less likely to prescribe a
+  position your body literally cannot reach. Useful if
+  you've got an injury history or wonder why a textbook
+  move feels impossible.
+
+Treat any certification as a floor, not a ceiling. The
+best teacher you ever have might have a wall of letters or
+just a long line of students who got better. The
+credential gets them on your shortlist; the next few
+questions decide whether they make the cut.
+
+---
+
+## Questions worth asking before you book
+
+You're hiring someone. It's fair — and smart — to
+interview them first. A quick email or phone call answers
+most of this:
+
+- **What's your teaching philosophy?** A good teacher can
+  answer in a sentence or two. Vagueness here is a
+  warning.
+- **Do you use video and a launch monitor?** You want
+  someone who measures, not just eyeballs and guesses.
+- **How do you structure things — one-offs or a series?**
+  The honest answer is almost always a series, and you
+  want a coach who says so.
+- **Who do you mostly teach?** A coach who lives with
+  competitive players may not be the right fit for a
+  nervous beginner, and vice versa.
+
+---
+
+## Green flags and red flags
+
+Once you're in front of someone — or watching a few
+minutes of how they teach online — the difference between
+a teacher who'll help you and one who won't is usually
+obvious within a lesson:
+
+### Look for
+
+- Ties every change to ball flight — what it does, not
+  just how it looks
+- Gives you a feel AND a checkpoint you can verify on your
+  own
+- Sends you off with a clear practice plan
+- Explains the why, so you could re-teach it to a friend
+- Asks about your goals and your typical miss before
+  touching your swing
+
+### Walk away from
+
+- Only tells you what's wrong, never how to fix it
+- One identical swing prescribed to every student
+- No video, no launch monitor — all eyeball and opinion
+- Jargon with no translation into something you can do
+- Promises a quick, one-lesson fix
+
+---
+
+## Online or in person?
+
+In-person lessons give a coach hands-on feedback in real
+time — they can feel your grip, move you into a position,
+and react to a shot the second it happens. That's hard to
+beat for first-time fundamentals and anything kinesthetic.
+Online coaching — you send swing videos, they send back a
+breakdown — is cheaper, fits any schedule, and lets you
+work with a specialist who isn't within driving distance.
+It leans on you to film well and to self-apply between
+notes.
+
+For a lot of golfers the best answer is both: in person to
+set the direction and learn the feel, online to maintain
+it and stay accountable between range trips.
+
+---
+
+## Show up ready
+
+How much you get out of an hour is mostly decided before
+it starts.
+
+- **Bring your own clubs.** They're what you actually
+  play, fitted (or mis-fitted) to you. A coach learns a
+  lot from them.
+- **Bring your phone.** You'll want video to review later,
+  and your own footage of the feels they give you.
+- **Tell them the truth up front:** your goals, your
+  typical miss, what's been bothering you, and what you
+  actually shoot. The more specific, the faster they can
+  help.
+- **Take notes** — during the lesson or the moment it
+  ends. The clarity you feel walking off the range fades
+  startlingly fast by the next day.
+
+---
+
+## Feel isn't real
+
+This is the single most useful thing to understand about
+taking instruction: what a change *feels* like and what
+the camera actually shows are almost never the same. When
+a coach asks you to feel something that seems wildly
+exaggerated, they're usually using that gap on purpose —
+the feeling that produces the correct position often feels
+like a gross overcorrection. Don't argue with the feel and
+don't trust it either. Trust the checkpoint — the video,
+the launch-monitor number, the ball flight — and let the
+feel be whatever gets you there.
+
+---
+
+## Why you might get worse before you get better
+
+A genuine swing change means overwriting a motor pattern
+your brain has grooved over years. For a while the old
+pattern is fading and the new one hasn't taken hold, so
+you're caught in between — contact gets clumsy, the odd
+shot flies sideways, and your scores can dip. This is a
+normal, predictable stage of learning a new movement, not
+a sign the lesson failed or the teacher was wrong.
+
+> **So plan for the dip.** Commit to a set number of
+> practice sessions on the change before you judge it,
+> expect a rough patch in the middle, and don't carry a
+> half-built swing into a round that matters. The most
+> common way golfers waste a good lesson is bailing on the
+> change the first time it costs them a few shots.
+
+---
+
+## One lesson rarely fixes anything
+
+Skill change comes from reps and feedback loops, not a
+single revelation on a Tuesday. Going in expecting to be
+"fixed" in an hour is the surest way to be disappointed.
+Commit to a block instead — say three to five lessons over
+a couple of months — and judge the teacher on the block,
+not the first session.
+
+Between lessons, practice exactly what they gave you, not
+the new tip you stumbled onto on YouTube that week —
+mixing coaches mid-change is how you end up with no swing
+at all. At the end of the block, take stock: is my miss
+smaller, are my numbers or scores trending the right way,
+do I understand what I'm doing and why? If the answer is
+yes, keep going. If there's no plan, no progress after
+honest effort, or you simply never understand the language
+they teach in, it's fair to move on.
+
+---
+
+## Coaching yourself between lessons
+
+You can do a surprising amount of your own checking with a
+phone and a little honesty. Film two angles: **down the
+line** (camera directly behind you, on the target line)
+and **face on** (straight in front). They show different
+things — the down-the-line view reveals swing plane and
+path, the face-on view shows sway, weight, and ball
+position. Compare yourself to the checkpoints your coach
+gave you, not to a tour pro built nothing like you.
+
+Data does the same job for the parts you can't see. A
+launch monitor — Trackman, a Garmin unit, whatever you can
+borrow — or your own round-tracking turns "I think I'm
+better" into evidence you can act on. And the most useful
+thing you can carry into a lesson is a clear read on where
+you're actually losing shots.
+
+> **Walk in with a diagnosis, not a complaint.** "I'm
+> hitting it bad" burns the first ten minutes of the hour.
+> "My strokes gained data says I lose about 1.2 shots a
+> round on approach, and my miss is right" points the
+> lesson straight at the leak. If you track your rounds in
+> OGA, you arrive with that read already done — and the
+> coach spends the hour fixing instead of interviewing.
+
+---
+
+## The bottom line
+
+Pick a teacher who measures, explains the why, and sends
+you away with a plan. Show up with your clubs, your
+numbers, and the truth about your miss. Expect to get a
+little worse before you get better, and don't quit the
+change in the dip. Do that and a lesson stops being a tip
+you forget by Saturday and becomes the fastest way there
+is to actually get better.
+
+---
+
+## Sources
+
+- **What the certifications mean** —
+  [Titleist Performance Institute · About Certification](https://www.mytpi.com/certification/about)
+  on the body-swing-connection approach and physical
+  screening;
+  [PGA of America · Find a Coach](https://www.pga.com/coaches)
+  for what a PGA teaching professional is and how to find
+  one.
+- **Why a swing change feels worse before it feels
+  better** —
+  [HackMotion · Worse After Golf Lessons?](https://hackmotion.com/worse-after-golf-lessons/)
+  — the temporary performance dip is a normal stage of
+  overwriting a grooved motor pattern: the old swing fades
+  before the new one takes hold, so contact gets clumsy in
+  the middle. Expected, not a failure.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/lessons-and-coaching.md*

--- a/docs/learn/measurable-goals.md
+++ b/docs/learn/measurable-goals.md
@@ -1,0 +1,131 @@
+---
+title: Creating Measurable Practice Goals
+section: Improving Your Game
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Creating Measurable Practice Goals
+
+Most practice goals are wishes wearing a goal's clothes —
+work on my irons, get more consistent, fix the slice. None
+of them can be passed or failed, so none of them can tell
+you whether the session worked. A real goal has a number
+and a verdict: when you're done you either hit it or you
+didn't. This is how to build one.
+
+It starts with picking the right *kind* of goal — because
+not all of them are yours to control.
+
+## Three kinds of goal
+
+**From least to most controllable**
+
+| Kind | Example | How much you control |
+|---|---|---|
+| Outcome | Win the match. Beat Dave. | Depends on other people — you can play your best and still lose. |
+| Performance | Break 85. Hit 7 of 10 greens. | Your own number, measured against yourself, not the field. |
+| Process | Commit to the routine. Finish the swing. | The action itself — entirely under your control, every shot. |
+
+The trouble with outcome goals is that you don't fully own
+them: a clean round can still lose to someone putting out
+of their mind. Hang your sense of a good day on the outcome
+and you've imported anxiety you can't do anything about.
+Performance and process goals are the ones worth setting in
+practice — and of the two, process goals travel best under
+pressure. In a study of club golfers, the players trained
+to set process goals controlled their competitive anxiety
+and held their concentration better than players given no
+goals at all. Keep the outcome as the direction you're
+heading; score yourself on the performance and process
+steps that get you there.
+
+---
+
+## Start with a baseline
+
+You can't make a goal measurable until you know your
+current number. Before you set a target, measure where you
+stand: hit ten wedges from 60 yards, count how many finish
+within a flagstick's length — say four. Now the goal isn't
+a figure you invented out of optimism; it's "beat four." A
+baseline turns every later session into a comparison
+instead of a guess, and it keeps the target honest — pinned
+to your actual game rather than to what you wish your game
+looked like.
+
+---
+
+## Calibrate the difficulty
+
+Goal-setting research is consistent on one point: specific,
+hard goals beat vague or easy ones — but only up to the
+edge of what you can actually do. A goal you clear every
+single time just confirms what you already had. A goal you
+never reach only tells you, again, that you failed. Aim for
+the band in between — the target you make roughly half the
+time. That's the version that pulls your skill forward
+without snapping your commitment to chasing it, the same
+"harder on purpose" principle behind random and pressure
+practice.
+
+*[The app version includes a diagram of the success-rate
+band: clear the goal every time and it teaches nothing;
+never clear it and it only demoralizes. The target you make
+about half the time is the one that moves your skill.]*
+
+---
+
+## The anatomy of a testable goal
+
+Whatever the skill, a goal you can score has the same four
+parts. Leave any one of them vague and the verdict goes
+fuzzy with it.
+
+| Part | What it pins down |
+|---|---|
+| The shot | Exactly what you're hitting — 7-iron, 60-yard wedge, 6-foot putt. Not "irons." |
+| The standard | What counts as a success — inside 20 feet, on the green, holed. |
+| The sample | How many attempts — ten balls, so one lucky or unlucky swing can't decide it. |
+| The verdict | The number to beat — 6 of 10, up from last week's 4. |
+
+---
+
+## Then move it
+
+The whole point of a baseline is that you re-set it. Clear
+your target a few sessions running and it has gone too easy
+— raise it. A measurable goal isn't a finish line you cross
+once; it's a number you keep nudging upward as the skill
+comes in. What never changes is the test itself: at the end
+of every session you can say plainly whether you passed. A
+goal you can't score isn't a goal. It's a hope.
+
+---
+
+## Sources
+
+- **Specific, hard goals beat "do your best"** —
+  [Locke & Latham, American Psychologist (2002) · goal-setting theory, a 35-year review](https://doi.org/10.1037/0003-066X.57.9.705)
+  — specific and difficult goals consistently produce
+  higher performance than vague or easy ones, up to the
+  limit of ability.
+- **Process goals in golf — anxiety and concentration** —
+  [Kingston & Hardy, The Sport Psychologist (1997)](https://journals.humankinetics.com/view/journals/tsp/11/3/article-p277.xml)
+  — club golfers trained on process goals controlled
+  competitive anxiety and held concentration better than a
+  no-goal group.
+- **Which goal types actually help — the evidence base** —
+  [International Review of Sport & Exercise Psychology (2022) · systematic review and meta-analysis of goal setting in sport](https://www.tandfonline.com/doi/full/10.1080/1750984X.2022.2116723)
+  — pooled evidence that goal setting improves performance,
+  with process and performance goals carrying the effect.
+- **Process goals under pressure** —
+  [Psychology of Sport & Exercise (2015) · holistic process goals for learning and performance under pressure](https://www.sciencedirect.com/science/article/abs/pii/S1469029214001800)
+  — a process focus helps skills hold up when the pressure
+  is on.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/measurable-goals.md*

--- a/docs/learn/operation-36.md
+++ b/docs/learn/operation-36.md
@@ -1,0 +1,258 @@
+---
+title: The Operation 36 Philosophy
+section: Improving Your Game
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# The Operation 36 Philosophy
+
+Most golfers are taught to build a swing first and play
+golf later. Operation 36 flips that: you start 25 yards
+from the hole, learn to score, and earn your way back to
+the full tees one stage at a time.
+
+---
+
+## Most golfers learn in the wrong order
+
+The traditional path into golf goes like this: stand on a
+mat at the range, hit a full swing a few hundred times,
+chase a textbook position, and someday — once the swing
+"looks right" — take it to the course. The short game and
+the business of actually scoring get filed under *later*.
+The trouble is that the first real round usually arrives
+long before the swing does, and a beginner who can't yet
+finish a hole spends four hours confirming they're bad at
+golf. A lot of people quit right there.
+
+Operation 36 — a long-term development program created in
+2010 by the PGA coaches Matthew Reagan and Ryan Dailey —
+inverts the order. Instead of building a swing and hoping a
+game shows up, you start on the course, 25 yards from the
+hole, and you earn the right to move back only once you can
+post a score from where you stand. You learn to play golf
+by playing golf, at a distance where playing it is actually
+possible.
+
+---
+
+## How the progression works
+
+The whole system runs on one number you can pass or fail:
+**shoot 36 — par for nine holes — from your current
+distance.** Clear it and you move back a stage; until then,
+you stay where you are. You begin in Division 1, playing
+nine holes from 25 yards out, where every hole is reachable
+and every score you write down is a real score. Shoot 36 or
+better and you step back to 50 yards, then 100, 150, 200,
+and finally your full tees — the same game the rest of the
+course is playing.
+
+The ladder, with the same gate — shoot 36 to advance —
+between every stage:
+
+- **25 yd** — Division 1 · where you start
+- **50 yd** — Division 2
+- **100 yd** — and back a stage at a time
+- **150 yd**
+- **200 yd**
+- **Full tees** — par from the back — the goal
+
+Notice what the structure does: it never lets the challenge
+run too far ahead of the skill. You don't get launched to
+the back tees and told to survive. You face a version of
+golf you can complete today, and the course only grows when
+you've proven you've outgrown it. Moving back is something
+you *earn*, which makes each step feel like a promotion
+instead of a punishment.
+
+---
+
+## What "36" actually means
+
+The 36 is simply par for nine holes — four strokes a hole,
+nine holes, thirty-six. What makes it clever is that you're
+chasing that par on a course scaled to your ability instead
+of from the back tees. From 25 yards, giving yourself four
+shots to hole out is a target almost anyone can reach with
+a little practice. So par stops being the intimidating
+standard printed on the scorecard and becomes a personal,
+rolling benchmark: par for *your* distance, today.
+
+The number never changes — it's always 36 — but what it
+asks of you grows as you move back. Par from 25 yards and
+par from 150 are the same score and wildly different feats,
+and the gap between them is exactly the ground you've
+earned your way across. That's the quiet trick of it: a raw
+beginner and a single-digit handicap can both be "shooting
+par," each from the course that fits them, each with a real
+reason to be proud of the number they wrote down.
+
+---
+
+## Why starting near the hole works
+
+The instinct to "master the swing first" feels responsible,
+but it puts the hardest, least rewarding part of golf at
+the very front, before any sense of competence has had a
+chance to form. Starting near the hole flips the experience
+on its head:
+
+- **You learn to score, not just to swing.** From 25 yards
+  the job is to get the ball in the hole, which is the
+  actual game. Range golf measures whether a shot looked
+  good; on-course golf measures whether it counted.
+- **Confidence comes from finishing holes.** Completing a
+  nine and writing down a number you're proud of builds
+  belief in a way that striping range balls never quite
+  does.
+- **The short game is honest.** Did it go in or didn't it?
+  A chip and a putt give instant, unambiguous feedback —
+  far easier to judge than whether a full swing was "on
+  plane."
+- **It defuses the frustration spiral.** The beginner who
+  tops three off the tee and triple-bogeys the first hole
+  learns to dread the course. The one shooting 36 from 25
+  yards learns to look forward to it.
+
+There's a sound learning principle underneath all of this.
+Skills are built fastest when the challenge sits just at
+the edge of current ability — hard enough to demand effort,
+easy enough to succeed at often. Coaches call it the
+optimal challenge point, and it's why you don't start a
+basketball beginner at the three-point line. Operation 36
+is that idea wearing golf shoes: calibrate the distance to
+the player, then ratchet it up only as fast as they can
+handle.
+
+---
+
+## What it actually teaches
+
+Beyond getting beginners hooked, the inside-out order
+quietly teaches a few things the range-first path tends to
+leave out:
+
+- **Putting and chipping are the foundation, not an
+  afterthought.** They're the first thing you practice and
+  the last thing every hole comes down to.
+- **Scoring is its own skill.** Hitting it well and
+  shooting a number are related but not the same — and the
+  program trains the second one directly, from day one.
+- **Course management arrives naturally.** Playing real
+  holes, even short ones, forces real decisions: where to
+  leave the ball, when to play safe, how to think a hole
+  backward from the pin.
+
+---
+
+## What the program actually sells
+
+The distance ladder is the part that's easy to describe,
+but it isn't really what you pay for. Operation 36 is built
+around coaching: a structured curriculum that introduces a
+set of skills at each level, live group classes with a PGA
+coach, drills to work on between sessions, and an app that
+tracks where you sit in the progression. The "shoot 36 to
+move back" framework is the scaffold — the teaching, the
+drills, and the feedback are what actually carry you up it.
+
+That's a fair trade, and for a lot of people — especially
+kids in a junior program — it's some of the best money in
+golf. But it does mean the full experience comes with a
+price tag and a place you have to show up to. The framework
+rewards you for scoring; the coaching tells you *how* to
+score better. The two are worth separating, because the
+second part is the expensive part — and it's the part you
+can assemble in other ways.
+
+---
+
+## Borrowing the idea without joining the program
+
+You don't need to enroll anywhere to use the thinking. The
+philosophy survives perfectly well on its own, and any
+golfer — beginner or not — can fold it into how they
+practice and play:
+
+> **Start your sessions close and work outward.** Open with
+> wedges and chips from 25–50 yards before you ever pull
+> the driver. When you're learning a new club, begin with
+> partial swings at a short target and lengthen only once
+> contact is repeatable.
+
+> **Measure practice by "did I score," not "did I hit it
+> well."** Give yourself a pass/fail target — up-and-down
+> from 30 yards, two-putt from 20 feet — instead of grading
+> the look of the swing. Build the distance or the
+> difficulty back only when you're clearing the bar
+> consistently.
+
+---
+
+## A guided version you can build for free
+
+On the course, the same logic argues for playing the tees
+that fit your game today rather than the ones ego or habit
+picks for you. Move up, give yourself reachable holes, and
+make the round about completing it well instead of grinding
+through a course built for someone who hits it forty yards
+past you. As your scoring holds up, move back — the same
+earned progression, on a real card.
+
+The harder thing to replicate on your own is the guidance —
+the part that tells you what to work on and shows you
+you're improving. That's a lot of what OGA is built to do.
+Strokes gained analysis runs the diagnosis a coach would,
+pointing at the one part of your game quietly costing you
+the most shots; a practice plan turns that into specific
+things to go work on; and tracking your rounds gives you
+the rising line that tells you when you've earned the next
+step back. It's the same loop — diagnose, practice, prove
+it, move back — without a membership.
+
+None of that asks you to be a junior, to have grown up at a
+country club, or to pay for a coach you can't reach. An app
+doesn't replace a good teacher — the Operation 36 coaches
+are excellent at theirs — but the *shape* of the journey,
+start where you can win and earn your way back, is
+something any golfer can follow with honest tracking and
+practice that has a point to it.
+
+---
+
+## Credit where it's due
+
+The structured, distance-based progression described here
+was developed and popularized by
+[Operation 36 Golf](https://operation36.golf/), and the
+"shoot 36 to move back" framework is theirs. What's general
+— and free for anyone to borrow — is the underlying idea:
+start where you can succeed, measure by scoring, and earn
+your way back. You can apply that on any course, with any
+bag, without signing up for anything.
+
+---
+
+## Sources
+
+- **The program — distance progression and the "shoot 36" rule** —
+  [Operation 36 Golf · How It Works](https://operation36.golf/how-it-works/)
+  — start at 25 yards, shoot 36 or better for nine holes to
+  level up, and work back through stages to the full tees.
+  [PGA of America](https://www.pga.com/story/operation-36-helping-golfers-find-a-love-for-the-game-for-life)
+  on the program's founding (2010, Matthew Reagan and Ryan
+  Dailey) and why achievable milestones keep beginners
+  connected to the game.
+- **Why achievable challenges build skill and confidence** —
+  [Keiser University College of Golf · Developing Confidence in Beginner Golfers](https://collegeofgolf.keiseruniversity.edu/developing-confidence-in-beginner-golfers-thoughts-and-recommendations/)
+  — on the optimal challenge point: learning is fastest
+  when a task is neither too easy nor too hard, so
+  difficulty should rise step by step as competence does.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/operation-36.md*

--- a/docs/learn/practice-modes.md
+++ b/docs/learn/practice-modes.md
@@ -1,0 +1,171 @@
+---
+title: Block, Random, and Pressure Practice
+section: Improving Your Game
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Block, Random, and Pressure Practice
+
+## The practice that feels best teaches least
+
+The most satisfying practice — same club, same target, ball
+after ball until it grooves — is also the least durable.
+Half a century of motor-learning research keeps landing on
+the same uncomfortable result: how well you hit it on the
+range is a poor predictor of how well you'll learn. The
+practice that improves your score often feels worse while
+you're doing it.
+
+There are three modes worth understanding — blocked, random,
+and pressure. Each does a different job, and the mistake
+nearly every golfer makes is living entirely in the first
+one. This is what each mode is for, and how to put them
+together.
+
+**The three modes at a glance**
+
+| Mode | The job |
+|---|---|
+| Blocked | Same shot, repeated. Installs a new movement — fast gains, fragile. |
+| Random | A different shot every ball. Builds durable, transferable skill. |
+| Pressure | Consequence on the shot. Carries the skill to the first tee. |
+
+---
+
+## Blocked — building the movement
+
+Blocked practice is one shot repeated: the same club to the
+same target, over and over. It's the right tool for
+installing a brand-new movement or working through a swing
+change — repetition lets you feel the new pattern without
+anything else competing for attention, and you improve fast
+inside the session. That fast improvement is exactly the
+trap. The gains are fragile, and they tend not to follow
+you to the course. Use blocks to install a feel, not to
+finish it: a short blocked warm-up, then move on.
+
+---
+
+## Random — the mode that actually transfers
+
+Random practice mixes it up every ball — different club,
+different target, never the same shot twice in a row. It
+produces a strange, well-documented pattern called the
+contextual interference effect: random practice makes you
+*worse* during the session but *better* days later, on the
+tests that measure real learning — retention and transfer
+to new situations.
+
+The reason is that each ball forces you to build the shot
+from scratch, the way the course always will — you never
+hit the same putt twice in a round. Studies of golf putting
+and chipping show it directly: random groups putt worse in
+practice, then more accurately on a delayed retention test,
+and build a mental model of the stroke closer to a skilled
+player's.
+
+This is what the psychologist Robert Bjork named a
+*desirable difficulty* — a condition that slows you down
+now and pays off later. It feels like you're practicing
+badly, which is precisely why most people avoid it. Once a
+movement is roughly in place, the bulk of your practice
+should live here.
+
+*[The app version includes a chart of skill over time:
+blocked practice looks better on the range; random practice
+wins where it counts — days later, on the course.]*
+
+---
+
+## Pressure — closing the gap to the first tee
+
+The range swing that abandons you on the first tee is a
+transfer failure: you rehearsed the skill in a calm state
+you never actually compete in. Pressure practice fixes the
+mismatch by adding consequence — a putt you have to hole, a
+number to beat, one ball and one attempt — so the skill is
+trained alongside the nerves it will meet. Sport-psychology
+research on acclimatization shows that practicing under
+mild, manufactured pressure helps performance hold up when
+the real thing arrives, and is one of the better-supported
+defenses against choking.
+
+The companion article on skill games and pressure games is
+the how — the specific games that manufacture that
+consequence. The point here is only the why: a skill you've
+never tested under pressure is a skill you don't yet own on
+the course.
+
+---
+
+## How to combine them
+
+The modes aren't a menu to pick from; they're a
+progression. Match the mix to what you're trying to do, and
+shift it as a movement stabilizes.
+
+| Goal | The mix |
+|---|---|
+| Installing a new move | Mostly blocked. Repeat the shot until the new feel is reliable before adding any variety. |
+| Building durable skill | Mostly random. A different club and target every ball — this is where most practice should live. |
+| Getting ready to compete | Add pressure. Put consequence on the shot, woven into random practice rather than tacked on at the end. |
+
+Within a single session, the same shape works: a few
+minutes of blocks to find the feel, the bulk of the time in
+random practice with the club and target changing every
+ball, and a pressure game to finish. Across months, a new
+change starts blocked-heavy and tilts toward random and
+pressure as it holds up.
+
+---
+
+## Why it has to feel worse
+
+The through-line under all three modes is the same:
+performance during practice is a poor guide to learning,
+and the conditions that build durable, transferable skill
+are the ones that feel harder while you're in them. If your
+range sessions feel smooth and your scores aren't moving,
+that gap is the signal — not to practice more, but to
+practice in a way that makes the work harder in the right
+places.
+
+---
+
+## Sources
+
+- **The contextual interference effect (blocked vs random)** —
+  [Scientific Reports (2024) · meta-analysis](https://www.nature.com/articles/s41598-024-65753-3)
+  confirms high contextual interference improves retention,
+  and
+  [Brady, Quest (1998)](https://www.tandfonline.com/doi/abs/10.1080/00336297.1998.10484285)
+  reviews the effect first shown by Shea & Morgan (1979):
+  random order hurts practice, helps learning.
+- **Random practice in golf specifically** —
+  [Frontiers · motor learning in golf, a systematic review](https://www.frontiersin.org/journals/sports-and-active-living/articles/10.3389/fspor.2024.1324615/full)
+  and
+  [Fazeli et al. (2017) · random vs blocked in golf putting](https://pubmed.ncbi.nlm.nih.gov/28449601/)
+  — random groups putt worse in practice, better in
+  retention, with a more skilled mental model.
+- **Why harder practice helps — variability and desirable difficulty** —
+  [Memory & Cognition (2021) · interleaving and transfer](https://link.springer.com/article/10.3758/s13421-021-01168-z)
+  and
+  [Sherwood & Lee (2003) · schema theory review](https://pubmed.ncbi.nlm.nih.gov/14768838/)
+  — variable, interleaved practice is a "desirable
+  difficulty" that builds more general, robust skill.
+- **Practicing under pressure** —
+  [Gröpel & Mesagno, International Review of Sport & Exercise Psychology (2019) · choking interventions, a systematic review](https://www.tandfonline.com/doi/full/10.1080/1750984X.2017.1408134)
+  — acclimatization and pre-performance routines help
+  skills survive competitive anxiety.
+- **Deliberate practice, and its limits** —
+  [Macnamara & Maitra, revisiting Ericsson, Krampe & Tesch-Römer (1993)](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6731745/)
+  — practice quality matters enormously, though the strong
+  claim that hours alone explain expertise has not fully
+  replicated.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/practice-modes.md*

--- a/docs/learn/practice-vs-scoring-round.md
+++ b/docs/learn/practice-vs-scoring-round.md
@@ -1,0 +1,261 @@
+---
+title: Practice Round vs Scoring Round
+section: On the Course
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Practice Round vs Scoring Round
+
+A practice round and a scoring round use the same eighteen
+holes, but they are two different jobs — and trying to do
+both at once does neither well. The guide on *how to
+practice effectively* makes the distinction in a sentence:
+one is for information, the other is for performance. This
+is the on-course version — what each round is actually for,
+how to run a real practice round instead of just a casual
+one, and why the rounds that blur the line teach you the
+least.
+
+|            | Practice round                 | Scoring round              |
+|------------|--------------------------------|----------------------------|
+| The job    | Gather information             | Post a number              |
+| Balls      | Drop extras, experiment        | One ball, no mulligans     |
+| Routine    | Loose                          | Full, every shot           |
+| Risk       | Try the dangerous line         | Favor the safe miss        |
+| Score      | Don't keep it                  | Count everything           |
+| Success is | Walking off knowing the course | The lowest number you can  |
+
+---
+
+## What a practice round is actually for
+
+A practice round is reconnaissance. You are not trying to
+shoot a number — you are gathering the information that
+lets you commit on the day it counts. It's what tour
+players spend the days before a tournament doing — more on
+their method below — and you can get most of the value in
+a single honest loop.
+
+- **Hit driver off the tees you're unsure about.** You
+  learn whether your driver actually reaches the fairway
+  bunker or the dogleg trouble. You can always dial back
+  to a 3-wood in competition — but only if you know what
+  driver does first.
+- **Find where you can't miss.** On every approach, note
+  the side that leaves a dead chip or a ball in the water.
+  Course management is mostly knowing the one place the
+  ball can't go; the practice round is where you find it.
+- **Putt from the spots you'll actually face.** Roll a few
+  from each likely pin area to learn the speed and the big
+  breaks. The green is where rounds are won, and it reads
+  differently than it looks.
+- **Play a ball from the rough and a bunker.** A shot or
+  two from the conditions you'll meet tells you how this
+  course's turf and sand behave before they surprise you
+  under pressure.
+- **Don't keep score.** A score on a practice round sets
+  an expectation you'll carry to the first tee for no
+  reason. Drop a second ball, try the riskier line, hole
+  out for the read — the round is for learning, not for a
+  number.
+
+---
+
+## How the pros do it
+
+The gold standard for this lives on tour, and the logic
+scales down to any golfer. Pros don't see a tournament
+course cold on Thursday — they arrive days early and play
+practice rounds Monday and Tuesday, with Wednesday's
+pro-am often serving as one last relaxed look. By the time
+the first round counts, they've already made every
+decision the course is going to ask of them.
+
+Most of that work is reconnaissance, not swing practice.
+The caddie scouts the course — sometimes separately from
+the player — pacing off yardages to landing zones and to
+each pin area, logging the wind, and recording the club,
+speed, and spin from shots hit along the way. All of it
+goes into a yardage book built on top of the detailed base
+book the event supplies, until the player has a
+hole-by-hole plan: the club off each tee, the number to
+leave on each approach, and the side that can't be
+short-sided — missed on the side the pin sits, leaving no
+green to work with. Crucially, they practice approaches to
+the actual hole locations planned for the four tournament
+days — not to wherever the flag happens to sit that
+morning.
+
+Greens are the one place the rules recently pushed pros
+back toward doing their own homework. Since 2022, golf's
+governing bodies have let tournaments require an approved
+yardage book whose green diagrams show only minimal detail
+— major slopes and tiers, not a full contour map — and the
+only extra notes allowed are ones the player or caddie
+made from watching a ball actually roll. Even the best
+players in the world now have to earn their green reads in
+the practice round, which is exactly what you should be
+doing anyway.
+
+---
+
+## Borrow the method, skip the budget
+
+You don't have a caddie, four days, or a closed golf
+course — but the method shrinks to fit an ordinary tee
+time. The goal is unchanged: walk off knowing the course
+so that nothing in your next scoring round is a first-time
+surprise.
+
+- **Go when it's quiet.** An early or twilight tee time,
+  or a slow midweek afternoon, lets you drop a second ball
+  and experiment without a group breathing down your neck.
+  Reconnaissance needs room to fail.
+- **Keep a notebook.** A phone note or a cheap yardage
+  book is plenty. One line per hole: a stock layup number
+  and the one place the ball can't go — "7th: lay back to
+  110, water long-right, bail short-left." You'll have
+  forgotten it by next week otherwise.
+- **Rehearse the in-between yardages.** Every course keeps
+  handing you the same awkward numbers — a 40-yard pitch,
+  a 215-yard par 3, a layup that leaves three-quarter
+  wedge. Hit those on purpose so they're rehearsed instead
+  of improvised under pressure.
+- **Learn the big greens from every side.** Lag a putt
+  from the front, the back, and each edge of the largest
+  greens to feel the speed and the two or three breaks
+  that actually matter. Speed surprises cost more strokes
+  than misread line.
+- **Practice the misses, not the makes.** Chip and play
+  bunker shots from the spots you tend to short-side
+  yourself, not the comfortable ones — those are the shots
+  that wreck a scoring round, so meet them here first.
+- **No time for a full loop? Do it in reverse.** After an
+  ordinary round, jot three notes per nine while the holes
+  are fresh. A handful of rounds like that builds the same
+  course knowledge a dedicated practice round would, just
+  spread out over time.
+
+---
+
+## What a scoring round demands
+
+A scoring round is performance. One ball, every shot
+counts, and the only job is to post the lowest number you
+can with the game you brought. That means the opposite of
+the practice round on almost every count.
+
+- **Full routine on every shot.** The same pre-shot
+  sequence, even on the throwaway ones. A consistent
+  pre-shot routine is one of the most reliably effective
+  mental tools in the game — a meta-analysis across sports
+  found routines measurably improve performance, and they
+  help most precisely when the pressure is on and the mind
+  wants to wander.
+- **Commit, then accept.** Pick the shot, commit to it,
+  and take the result without relitigating it. The
+  experimenting was supposed to happen in the practice
+  round; here, a half-committed swing is the worst of both
+  worlds.
+- **One ball, no mulligans.** The score only means
+  something if it's the score you actually made. Play it
+  down, count everything, move on.
+- **Manage, don't experiment.** Aim at the fat of the
+  green, favor the safe miss, and save the new shot you've
+  been working on for the range. Even tour players aim at
+  the center, not the pin, for anything longer than a
+  short iron.
+
+---
+
+## Why mixing them costs you both
+
+The common mistake isn't choosing the wrong mode — it's
+failing to choose, and drifting through the round half in
+each. You take the round seriously enough to feel the
+nerves, but loosely enough to drop a second ball when one
+goes sideways. The result is the worst of both: the
+anxiety of performance without a real score to show for
+it, and the freedom of practice without any of the
+information.
+
+It also quietly ruins your data. If you track rounds to
+find where your game leaks strokes, a dropped second ball
+or a "let me just try the cut here" poisons the signal —
+the round no longer reflects the decisions and misses
+you'd actually make. A round is only worth measuring if it
+was played honestly: one ball, full commitment, every
+stroke counted.
+
+---
+
+## The casual round is neither — and that's the trap
+
+Most weekend rounds are neither a true practice round nor
+a true scoring round. That's completely fine — golf is
+supposed to be fun, and most of the time the goal is a
+good walk with friends. The trap is mistaking a steady
+diet of casual rounds for improvement work. A casual round
+gives you neither clean recon nor a trustworthy score; it
+just gives you a pleasant afternoon, which is its own
+reward but not a feedback loop.
+
+If you actually want to get better, some of your rounds
+have to be honestly one or the other: a recon loop where
+you experiment freely and keep notes, or a committed
+scoring round you track without fudging. The line between
+them is the whole point.
+
+> **The one habit:** before you hit the first tee shot,
+> decide out loud which round this is. "This is a practice
+> round" or "I'm playing this one for score" — said before
+> you start — is what keeps you from drifting into the
+> half-committed middle where neither version pays off.
+
+The skill in golf isn't only swinging the club; it's
+knowing which game you're playing on any given day and
+committing to it fully. Pick one before you tee off, and
+both your scores and your practice get sharper for it.
+
+---
+
+## Sources
+
+- **A practice round is recon, not a score** —
+  [PGA of America · preparing for a tournament](https://www.pga.com/story/prioritize-your-practice-sessions-to-prepare-for-a-big-golf-tournament)
+  and
+  [Golf State of Mind · course-management lessons from the PGA Tour](https://golfstateofmind.com/course-management-lessons-from-the-pga-tour/)
+  — hit driver to learn the trouble, find the no-go side,
+  default to the center of the green, and keep score out
+  of it.
+- **Pre-shot routines help most under pressure** —
+  [International Review of Sport & Exercise Psychology (2021) · meta-analysis of pre-performance routines](https://www.tandfonline.com/doi/full/10.1080/1750984X.2021.1944271)
+  — a consistent routine produces a measurable performance
+  benefit, and it matters most when the pressure invites
+  distraction.
+- **Why the practice mindset is a separate gear** —
+  [Golf Psychology (Dr. Patrick Cohn) · how to think about practice rounds](https://www.sportspsychologygolf.com/how-to-think-about-practice-rounds-in-golf/)
+  — treating a practice round as a performance is how
+  golfers carry scoring anxiety into a day that was
+  supposed to lower it.
+- **How tour players turn recon into a plan** —
+  [Golf Monthly · inside a tour player's yardage book](https://www.golfmonthly.com/features/5-secrets-of-the-players-open-yardage-book)
+  and
+  [Golfing Focus · what pros carry in their yardage books](https://golfingfocus.com/what-do-pros-have-in-their-yardage-books-things-have-changed/)
+  — caddies pace off pin-zone yardages and log wind, club,
+  and spin in practice rounds, building a hole-by-hole
+  game plan before round one.
+- **Even the pros earn their green reads in practice** —
+  [PGA TOUR · the green-reading-materials rule (Model Local Rule G-11, effective 2022)](https://www.pgatour.com/article/news/ground-rules/2021/11/02/new-rule-will-limit-information-players-can-use-for-reading-greens-yardage-book-pga-tour)
+  and
+  [Golf Digest · USGA and R&A on the limit](https://www.golfdigest.com/story/usga-randa-approve-model-local-rule-to-limit-use-of-green-reading-materials)
+  — approved books now show only minimal green detail, and
+  any extra notes must come from a player or caddie
+  watching a ball roll.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/practice-vs-scoring-round.md*

--- a/docs/learn/questions-for-coach.md
+++ b/docs/learn/questions-for-coach.md
@@ -1,0 +1,142 @@
+---
+title: Questions to Ask Your Coach
+section: Working with Coaches
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Questions to Ask Your Coach
+
+Most golfers treat a lesson as a download: stand there,
+collect the tip, nod, drive home. The ones who actually
+improve treat it as a conversation — and the questions
+they ask are what turn a good feeling on the range into a
+change they can still find next week. The companion guide
+on *lessons and coaching* covers choosing a teacher and
+the questions to ask *before* you book. This is the
+conversation once you're in the bay, and the handful of
+questions at the end that decide whether any of it
+survives the drive home.
+
+**When to ask what**
+
+| Moment           | What to ask                                                                                |
+|------------------|--------------------------------------------------------------------------------------------|
+| Before booking   | Who to hire — philosophy, video, series. Covered in the lessons-and-coaching guide.         |
+| While teaching   | What the change is for, the feel and its checkpoint, and how the miss shows up.              |
+| Before you leave | The exact drill and dose, what to ignore, the dip to expect, and when to check back.         |
+
+---
+
+## While they're teaching
+
+A tip you can't reproduce on your own is worthless by
+Tuesday. These three turn a position into something
+portable.
+
+- **"What is this doing to my ball flight?"** You want the
+  change tied to an outcome you can see, not just a body
+  position. Research on where golfers aim their attention
+  is unusually consistent: focusing on the *effect* of a
+  movement — what the ball does — produces better results
+  than focusing on the body part making it. If the answer
+  is only "get your hands here," ask what "here" is
+  supposed to *produce*.
+- **"What's the feel, and what's the checkpoint?"** Feel
+  and reality rarely match, so you want both — a feel to
+  chase in the moment, and an external checkpoint you can
+  verify alone: a video angle, a ball-flight window, a
+  launch number. The feel gets you moving; the checkpoint
+  keeps you honest when the coach isn't standing there.
+- **"How will I know when I'm doing it wrong?"** Every new
+  move has a characteristic miss. Knowing the failure mode
+  in advance lets you catch yourself drifting, instead of
+  grooving the error for three weeks until the next
+  lesson.
+
+---
+
+## Before you leave
+
+The clarity you feel walking off the range fades
+startlingly fast. Pin it down before you go.
+
+- **"What exactly do I practice, and how much?"** A change
+  without a dose is a wish. Get the specific drill and a
+  number — reps, minutes, or sessions — so "practice this"
+  becomes something you can schedule. Then spread it
+  across days rather than cramming it into one marathon;
+  practice spaced over time sticks far better than the
+  same reps in a single grind.
+- **"What do I ignore until next time?"** Permission to
+  work on one thing is the most underrated gift a coach
+  can give. Ask what to leave alone — including the new
+  tip you'll inevitably trip over online this week. Mixing
+  sources mid-change is how you end up with no swing at
+  all.
+- **"What should get worse first?"** A real swing change
+  usually dips before it climbs. Ask how rough the middle
+  gets and how long it lasts, so you don't abandon a good
+  change the first time it costs you a few shots.
+- **"When should we check this?"** Set the next checkpoint
+  before you leave — a date, or a milestone like "once I
+  can hit it 7 of 10." That's what turns a one-off tip
+  into a plan.
+
+> **If you ask one question, ask this:** "If I could only
+> practice one thing this week, what would it be?" It
+> forces your coach to prioritize out loud and hands you
+> the single highest-leverage rep to take home — the
+> antidote to leaving with a list of six things and doing
+> none of them well.
+
+---
+
+## Questions that waste the hour
+
+A few questions feel productive and aren't. Skip them.
+
+- **"What does [tour player] do here?"** Their body,
+  speed, and tens of thousands of reps aren't yours. The
+  right model is the checkpoint your coach set for *you*,
+  not a swing built for someone else.
+- **"Should I buy this club or gadget?"** A purchase or a
+  fitting is a different appointment. Don't spend your
+  most expensive coaching minutes on gear questions.
+- **"Is my swing fixed now?"** One lesson rarely fixes
+  anything — skill comes from reps and feedback loops, not
+  a single revelation on a Tuesday. Judge the coach over a
+  block of lessons, not the first hour.
+
+---
+
+## The thread under all of it
+
+A lesson isn't something done to you — it's something you
+steer. Ask what the change is *for*, how to verify it
+alone, what to ignore, and when to check back, and you
+walk out with a plan instead of a feeling. That's the
+whole difference between a tip you've forgotten by
+Saturday and a change that's still with you next season.
+
+---
+
+## Sources
+
+- **Focus on the ball, not the body part** —
+  [Wulf, International Review of Sport & Exercise Psychology (2013) · attentional focus, a 15-year review](https://gwulf.faculty.unlv.edu/wp-content/uploads/2018/11/Wulf_AF_review_2013.pdf)
+  and a golf-specific test in
+  [Journal of Motor Learning & Development (2013) · external focus, X-factor and carry distance](https://journals.humankinetics.com/view/journals/jmld/1/1/article-p2.xml)
+  — focusing on the movement's effect (the ball) beats
+  focusing on the body part making it.
+- **Space the practice you're given** —
+  [Shea et al., Human Movement Science (2000) · spacing practice across days](https://www.sciencedirect.com/science/article/abs/pii/S016794570000021X)
+  — the same reps spread over several days produce far
+  better retention than the same total packed into one
+  session.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/questions-for-coach.md*

--- a/docs/learn/self-diagnosis.md
+++ b/docs/learn/self-diagnosis.md
@@ -1,0 +1,273 @@
+---
+title: "Self-Diagnosis: Finding Your Weaknesses"
+section: On the Course
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Self-Diagnosis: Finding Your Weaknesses
+
+## You know something is off
+
+Most golfers can feel that a part of their game is leaking
+shots. Far fewer can say what is actually happening — and
+that gap is the difference between fixing a problem and
+flailing at it. "I'm playing bad" is not a diagnosis. "I
+lose most of my strokes on approach, my miss is a push to
+the right with the mid-irons, and it gets worse when I
+bear down" is a diagnosis. A diagnosis points at a fix.
+
+This guide hands you the vocabulary and the framework to
+read your own game. You don't need a coach behind you and
+you don't need a launch monitor. You need to watch where
+your ball actually goes, round after round, and be honest
+and specific about the pattern. The work here is noticing
+— not judging.
+
+---
+
+## Start where the strokes leak
+
+Golf hands you four bills to pay every round: the tee
+shot, the approach, the short game, and the putter. Before
+you diagnose a swing, find out which bill is bleeding you.
+Spending an afternoon fixing your driver when you
+three-putt six times a round is solving a problem you
+don't have.
+
+If you track strokes gained, this is already answered for
+you — whichever category is most negative is where to look
+first. If you don't track anything, you can still eyeball
+it over three or four rounds:
+
+- **Off the tee** — how often does a tee shot cost you a
+  penalty stroke or a chip-out sideways?
+- **Approach** — how often do you miss the green, and when
+  you miss, is it by a little or by a lot?
+- **Short game** — when you miss a green, how often do you
+  get up and down in two?
+- **Putting** — how many putts a round, and how many of
+  those are three-putts?
+
+Whichever answer makes you wince is your starting point.
+Diagnose that area first and ignore the rest for now. You
+can only rebuild one wall at a time.
+
+---
+
+## Four questions for any miss
+
+Once you know the area, the same four questions crack open
+almost any ball-flight problem. Ask them in order. Each
+answer narrows the field.
+
+- **01 · What is your miss?**
+  - Direction — face & path (push · pull · slice · hook)
+  - Contact — low point (fat · thin · toe · heel)
+- **02 · Same shape every time?**
+  - Consistent — a fixable pattern
+  - Random — check fundamentals
+- **03 · Only under pressure?**
+  - Yes — tempo, not technique
+  - No — keep reading the pattern
+- **04 · One club, or all of them?**
+  - One club — that club's setup
+  - All clubs — something systemic
+
+### 1. What is your typical miss?
+
+Name it precisely. Direction misses — *push, pull, slice,
+hook* — are mostly a story about your clubface and your
+swing path at impact. Contact misses — *fat, thin, toe,
+heel* — are mostly a story about where the bottom of your
+swing arc lives. A "bad shot" is useless information. "A
+pull that starts left and stays left" tells you the face
+was closed to your target. Specificity is the whole game
+here.
+
+### 2. Is it consistent or random?
+
+This is the most important question and the most
+encouraging one. A **consistent** miss — the same shape
+almost every time — is a pattern, and a pattern can be
+aimed around or adjusted out. That is good news. A
+**random** miss — left, then right, then fat, with no
+rhyme — usually points further back, at contact and
+fundamentals: grip, posture, alignment, or balance
+changing from swing to swing. Consistency is a sign you
+are closer to fixed than you feel.
+
+### 3. Does it get worse under pressure?
+
+If a miss only shows up on the first tee, over water, or
+when you are trying to protect a good score, the cause is
+often tension and tempo, not technique. Pressure speeds
+people up and tightens the hands. A swing that works on
+the range and falls apart on the card is rarely a
+mechanical problem — it is a rhythm-and-grip-pressure
+problem wearing a mechanical costume.
+
+### 4. All clubs, or specific ones?
+
+A miss that shows up with **every club** is systemic —
+something in your setup or motion that travels with you:
+grip, posture, alignment, ball position. A miss isolated
+to **one club** is usually about that club specifically —
+the driver's length and low loft exaggerate whatever your
+hands do, a particular wedge you don't trust, a long iron
+most amateurs simply shouldn't be carrying.
+
+---
+
+## Off the tee
+
+The expensive tee misses are the ones that find penalty
+areas: the big slice and the snap hook. Run the four
+questions. A consistent curve in one direction is a
+face-to-path relationship you can work on or simply aim
+for in the meantime. A two-way miss — slice one hole, hook
+the next — is harder to live with and usually traces to
+alignment and tempo rather than one fixable flaw.
+
+> *"Consistent slice with the driver, but straight with
+> the irons"*
+>
+> **What it reads as:** The face is open to a path that's
+> swinging across the ball, left of target — and the
+> driver's length and low loft magnify the side-spin the
+> irons hide. Because the irons are fine, this is rarely a
+> whole-swing rebuild.
+>
+> **Where to focus:** Check alignment first (slicers often
+> aim further left to compensate, which steepens the
+> across-the-ball path and feeds the slice), then check
+> grip strength. A grip rotated too far toward the target
+> leaves the face open at speed.
+
+---
+
+## Approach
+
+Approach misses come in two flavors: *direction*
+(push/pull, or a curve) and *contact* (fat/thin).
+Direction misses behave like the tee — read the curve and
+the start line. Contact misses are about your low point:
+fat means the arc bottoms out behind the ball, thin means
+you caught it on the way up or pulled out of the shot.
+
+> *"Fat shots with the irons, especially under pressure"*
+>
+> **What it reads as:** Catching it heavy means the low
+> point of your swing fell behind the ball. Under pressure
+> this is commonly weight hanging on the back foot or the
+> hips thrusting toward the ball through impact (early
+> extension) — both move the bottom of the arc backward.
+>
+> **Where to focus:** An impact-bag drill teaches the
+> hands and body where solid contact lives; a slow,
+> balance-focused drill — hold your finish for three
+> seconds on every range ball — retrains weight moving
+> forward. Confirm with a coach if it persists, because
+> fat contact has more than one cause.
+
+---
+
+## Short game
+
+Around the green, the two killers are the chunk and the
+skull — and they are often the same fault from opposite
+directions: a low point that wanders because the hands try
+to lift the ball into the air instead of letting the loft
+do it. The fix lives in setup and a quieter, descending
+strike, not in a different club.
+
+Distance control is the other half. If your chips finish
+reliably short or reliably long, that is a consistent,
+fixable pattern — adjust your default and re-calibrate. If
+they scatter with no pattern, the contact is the problem,
+not the green-reading or the touch.
+
+---
+
+## Putting
+
+Putting misses are easy to mislabel. Most golfers blame
+their read when the real culprit is speed. Read errors and
+pace errors look different on the green: a read error
+leaves you a tester on the same side most of the time; a
+pace error leaves you long and short, and it is what turns
+a routine two-putt into a three.
+
+> *"Three-putts from inside 20 feet"*
+>
+> **What it reads as:** From that range you almost never
+> misread the line badly enough to three-putt — the cause
+> is pace. The first putt finishes too far past or too far
+> short, leaving a knee-knocker you then miss.
+>
+> **Where to focus:** Train speed, not line. Hit putts
+> with your eyes closed and guess where each finished
+> before you look; you'll sharpen the feel for distance
+> fast. Lag drills to a tee or a coin — not a hole — keep
+> your focus on the speed instead of the make.
+
+---
+
+## Consistent is fixable; random is fundamentals
+
+If you take one thing from this guide, take the second
+question. A consistent miss is a friend — it is
+repeatable, which means it is understandable, which means
+it is fixable, and in the meantime it is aimable. A random
+miss is telling you to go back to the boring basics: grip,
+posture, alignment, ball position, balance. Nobody wants
+the answer to be "check your setup," but it usually is.
+
+---
+
+## When to bring this to a coach
+
+Self-diagnosis tells you *what* is happening and points
+you at the likely *why*. It does not replace a trained eye
+and a camera for the things you cannot see in your own
+swing. Bring a coach a diagnosis, not a vague complaint —
+"consistent push with the mid-irons, worse under pressure,
+fine with the wedges" gets you a productive lesson far
+faster than "I'm hitting it bad." You will have done half
+their work for them, and you will know whether the fix
+they give you actually addresses the pattern you walked in
+with.
+
+---
+
+## Sources
+
+- **Ball flight — start line, curve, and why the driver
+  curves more** —
+  [TrackMan · Face to Path](https://www.trackman.com/blog/golf/face-to-path)
+  and [Club Path](https://www.trackman.com/blog/golf/club-path)
+  — the clubface sets roughly 85% of the start line; the
+  face-to-path gap sets the curve. The driver's lower loft
+  means a smaller
+  [spin loft](https://www.trackman.com/blog/golf/spin-loft),
+  so the spin axis tilts more easily — which is why it
+  curves more than the irons.
+- **Low point and fat contact** —
+  [Titleist Performance Institute · Early Extension](https://www.mytpi.com/articles/swing/why-early-extension-causes-a-reduction-of-power-in-the-golf-swing);
+  [Golf.com on GolfTEC swing data](https://golf.com/instruction/biggest-swing-mistake-amateurs-make/).
+- **Putting — pace over read from range** — Mark Broadie,
+  *Every Shot Counts* (2014);
+  [PGA · lag-putting expectations](https://www.pga.info/discover/latest/news/why-setting-realistic-expectations-lag-putting-key-shooting-lower-scores/).
+- **Pressure — why a range swing breaks on the card** —
+  [Peak Performance Sport Psychology (Dr. Patrick Cohn)](https://www.peaksports.com/sports-psychology-blog/choking-under-pressure-in-golf/)
+  and
+  [Trine University · choking in sport](https://www.trine.edu/academics/centers/center-for-sports-studies/blog/2022/choking_in_sports.aspx)
+  — under pressure the automatic motion is disrupted, the
+  hands tighten and tempo goes; the reset is feel and
+  rhythm, not mechanics.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/self-diagnosis.md*

--- a/docs/learn/strokes-gained.md
+++ b/docs/learn/strokes-gained.md
@@ -1,0 +1,105 @@
+---
+title: How Strokes Gained Works
+section: Understanding the Game
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# How Strokes Gained Works
+
+*Strokes gained* measures every shot against an
+expectation. From every lie and distance there's an
+expected outcome — what a player at your level typically
+does from there. Beat it and you gained strokes; come up
+short, you lost some. Sum the deltas across a round and
+you get a precise read on where your strokes are
+actually coming from — or going.
+
+Score alone tells you the result. Strokes gained tells
+you *why*. A 78 might be built on a great short game
+bailing out wayward irons, or it might be the iron play
+carrying a leaky putter. The overall score is identical;
+the work to fix it is not.
+
+---
+
+## The four categories
+
+Every shot fits in exactly one bucket:
+
+- **Off the tee** — Tee shots on par 4s and par 5s.
+  Your driver swing, essentially.
+- **Approach** — Shots from more than 30 yards out
+  (measured to the edge of the green) that aren't par-4
+  or par-5 tee shots — a par-3 tee shot counts as
+  approach.
+- **Around the green** — Shots from within 30 yards of
+  the green's edge that are not on the putting surface —
+  chips, pitches, bunker shots.
+- **Putting** — Every shot taken from the green.
+
+---
+
+## A worked example
+
+You hit a 7-iron from *155 yards* in the fairway and end
+up *22 feet* from the hole on the green.
+
+| Quantity | Value | Note |
+|---|---|---|
+| Expected from 155 yd | 3.67 | Strokes a 10-handicap typically takes to hole out from there. |
+| Expected from 22 ft | 2.02 | What it usually takes to hole out from that distance — about a two-putt. |
+| Strokes gained | **+0.65** | 3.67 − 2.02 − 1 (the shot you just hit). |
+
+Well above baseline — for a 10-handicap, finding the
+green at all from 155 beats the expectation. Chunk the
+same swing 40 yards instead, leaving *115 in the
+fairway*, and the sign flips: 3.67 − 3.39 − 1 = *−0.72*
+— nearly three-quarters of a stroke lost on one swing.
+Three of those in a round and you have handed back more
+than two strokes before a putt even drops.
+
+---
+
+## Reading the sign
+
+Positive numbers mean you played better than the bracket
+baseline at your handicap. Negative means you lost
+strokes to that baseline. *+0.3 SG-Putting* means your
+putting gave you about a third of a stroke per round vs
+a typical player at your level. *−1.4 SG-Approach* means
+your irons are leaking 1.4 strokes a round.
+
+Green numbers are gained strokes; red is where they
+leak. If a category sits at zero you are the average for
+your bracket — fine, not a leak.
+
+---
+
+## What counts where
+
+| Category | What counts | Example |
+|---|---|---|
+| Off the tee | Tee shots on par 4s and par 5s. | Driver from the tee on a 410-yd hole. |
+| Approach | Anything more than 30 yd from the green's edge that isn't a par-4 or par-5 tee shot. | 155 yd 7-iron from the fairway. Tee shot on a par-3. |
+| Around the green | Inside 30 yd of the green's edge, not on the putting surface. | Chip from the fringe; 20 yd flop from rough. |
+| Putting | Every shot played from the green. | 22-ft lag; 4-ft come-backer. |
+
+---
+
+## Sources
+
+- **Strokes-gained framework and baselines** — Mark
+  Broadie's "Every Shot Counts" (2014) and the PGA
+  Tour's ShotLink-derived strokes-gained statistics
+  define the framework. The worked example uses OGA's
+  10-handicap bracket baselines, which adapt Broadie's
+  scratch tables with published amateur shot data — so
+  the expectations are for a player at your level, not
+  a tour pro.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/strokes-gained.md*

--- a/docs/learn/swing-variations.md
+++ b/docs/learn/swing-variations.md
@@ -1,0 +1,357 @@
+---
+title: Swing Variations for Different Body Types
+section: Improving Your Game
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Swing Variations for Different Body Types
+
+Almost all golf instruction quietly assumes one student: a
+flexible, able-bodied, average-height, right-handed player
+with a full, painless turn. If that's not you — and for
+most golfers it isn't — a tip built for that body can be
+useless or worse. The evidence for this is sitting in the
+Hall of Fame, where some of the best players who ever lived
+swung in ways a textbook would red-pen. There is no single
+correct golf swing. There is, however, an *easier* swing
+for your body — one that's more repeatable and less likely
+to hurt you — and a well-trained coach is the fastest way
+to find it.
+
+---
+
+## Before you take advice from anyone
+
+Generic tips are optimized for the average golfer. Before
+you take one from a video or an article, run it through a
+few honest questions:
+
+**Run this before you copy a tip**
+
+- Am I as flexible as this instructor assumes?
+- Do I have an injury or limitation that affects how far I
+  can rotate?
+- Is this person built like me — similar height, age,
+  mobility?
+- Is this tip aimed at my actual miss, or is it generic?
+- Is it written for my handedness?
+- What is it quietly assuming about my swing that may not
+  be true of mine?
+
+None of this means ignore instruction. It means apply it
+critically — a tip that transformed someone built nothing
+like you is a hypothesis for your swing, not a
+prescription.
+
+---
+
+## The proof: great swings that broke the rules
+
+If there were one correct swing, the best players in the
+world would all own it. They emphatically don't. A short,
+non-exhaustive list of "incorrect" swings that won at the
+highest level:
+
+| Player | The swing | The record |
+|---|---|---|
+| Jim Furyk | A double-loop swing no coach would teach from scratch. | Won the 2003 U.S. Open; shot 58, the lowest round in PGA Tour history. |
+| Lee Trevino | Open stance, a deliberate fade, self-taught — told for years to change it. | Six major championships. Hall of Fame. |
+| Nancy Lopez | High hands and a slow, looping takeaway no textbook would draw. | 48 LPGA Tour wins and a Hall of Fame career. |
+| Moe Norman | A single-plane swing dismissed for decades as eccentric. | Sam Snead and others called him the greatest ball-striker who ever lived. |
+| John Daly | "Grip it and rip it" — a backswing well past parallel. | Two major championships: the 1991 PGA and the 1995 Open. |
+| Gary Player | Smaller stature; a swing he kept reshaping as he aged. | Nine majors, and competitive into his 70s. |
+
+The pattern isn't that technique doesn't matter — it
+matters enormously. It's that each of these players found a
+motion that was repeatable for *their* body and then owned
+it, instead of grinding toward a position someone else's
+body was built for.
+
+---
+
+## Every striking sport finds the same thing
+
+Golf isn't special here. Sports science has spent decades
+studying how athletes swing implements and throw objects —
+baseball pitches and swings, the tennis serve, the javelin
+and hammer, cricket, hockey — and two findings keep
+surfacing that map straight onto the golf swing.
+
+The first: there is no single optimal movement. The
+motor-control pioneer Nikolai Bernstein described skilled
+action as *"repetition without repetition"* — even an
+expert never repeats a motion exactly, and,
+counterintuitively, experts vary *more* than beginners,
+because many different movement solutions reach the same
+result. Studies of elite throwers land in the same place,
+calling for individualized technical profiling rather than
+one template for everyone.
+
+The second: what good technique shares isn't a position,
+it's a sequence. Across pitching, the tennis serve, the
+javelin and the rest, power comes from a kinetic chain that
+fires from the ground up — legs and trunk first, then out
+to the fast, distal end: the hand, the racquet head, the
+clubface. The shape of the motion varies from athlete to
+athlete; the order doesn't. It's why a shorter,
+well-sequenced backswing so often beats a long one that
+loses its timing — the same thing a pitching coach drills.
+
+Together they're just "swing your swing" in lab form: build
+a motion your body can sequence and repeat, rather than
+chasing a specific position borrowed from a body unlike
+yours. The Hall of Fame and the biomechanics literature
+agree.
+
+---
+
+## Your body shapes your swing
+
+Height, build, mobility, and handedness all change what a
+sound setup and swing look like for you. These are
+tendencies, not rules — but they're a better starting point
+than a one-size template.
+
+| Body | Tendency |
+|---|---|
+| Taller (6′2″+) | Tend to stand more upright, with a flatter natural plane. Usually need longer clubs and more upright lie angles — off-the-rack clubs are built to a standard, not to you. |
+| Shorter | Stand closer to the ball with a more upright shaft angle; an upright plane is natural and correct here. Shorter clubs and flatter lie angles often fit better. |
+| Limited flexibility / older | A restricted turn changes everything. A shorter backswing with good sequencing beats a long one that collapses; force the "modern" power move and you risk injury. Gary Player's swing evolved with his body for a reason. |
+| Heavier build | A restricted hip turn is common, and compensating with more arm swing is adaptive, not wrong. Grip size and shaft flex fitting matter more, not less; standing a touch further from the ball can help. |
+| Left-handed | Most instruction is written for righties — mirror the cues. Left-handed equipment is more limited, so custom fitting matters even more. |
+
+Notice how much of this is about equipment as well as
+motion. A swing and the clubs that swing it are one system;
+fitting one to your body without the other leaves
+performance on the table.
+
+---
+
+## Schools of thought
+
+"Swing plane" — roughly, how upright or flat the club
+travels — is where much of the genuine expert disagreement
+lives. These are perspectives with serious adherents, not a
+ranking. Most of the debate runs along a line from steep
+and upright to flat and rotary, with single-plane methods
+at one end.
+
+- **The modern tour swing.** Big separation between the
+  shoulders and hips at the top — what Jim McLean
+  popularized in 1992 as the *X-Factor* — plus heavy use of
+  the ground for speed. It's what most online instruction
+  assumes, and it produces enormous power. It also asks for
+  real flexibility, and its importance is genuinely
+  disputed: a number of teachers argue that chasing maximum
+  X-Factor adds lower-back stress for modest gain.
+  Powerful, but not free, and not for every body.
+- **The classic flatter plane (Hogan).** Ben Hogan's *Five
+  Lessons* and its famous "pane of glass" image describe a
+  flatter, on-plane move that's still hugely influential.
+  Tellingly, even Hogan's plane isn't universal: as
+  instructors have long noted, shorter players tend to work
+  above that pane and taller players below it — proof that
+  the most famous swing model in print still has to bend to
+  the body using it.
+- **The single-plane swing (Moe Norman / Graves).** Club,
+  arms, and body set on essentially one plane at address
+  and impact, stripping out moving parts. Moe Norman — whom
+  Sam Snead and others called the greatest ball-striker who
+  ever lived — built it intuitively; Todd Graves, taught
+  directly by Norman, now teaches it through the Graves
+  Golf Academy. Fewer moving parts and low spinal stress
+  make it worth a look for players who fight conventional
+  complexity or have back limitations.
+- **Stack and Tilt.** Created by instructors Mike Bennett
+  and Andy Plummer, it keeps the weight forward over the
+  lead side throughout the swing to kill lateral sway.
+  Controversial, but with real tour adherents over the
+  years (Aaron Baddeley and Mike Weir among them), and
+  potentially friendlier to limited hip mobility.
+- **Rotary, body-driven methods.** A family of approaches
+  that lead with body rotation over hand and arm
+  manipulation, on the argument that fewer timing-dependent
+  parts make the swing more repeatable and easier on the
+  body.
+
+Other respected methods aren't really about plane at all —
+they're about making the motion simpler, more repeatable,
+or kinder to the body, which is the same goal reached
+through a different door.
+
+- **Peak Performance (Don Trahan).** A short, vertical,
+  limited-turn backswing — "a little turn, a lot of lift" —
+  that Trahan built with orthopedic input to be easy on the
+  back and friendly to players who've lost flexibility,
+  while arguing it gives up little or no clubhead speed.
+- **The A Swing (David Leadbetter).** An "alternative" that
+  rebuilds the backswing to be simpler and more repeatable,
+  so the downswing becomes mostly a reaction — aimed
+  squarely at golfers who can't groove the conventional
+  move.
+- **Swing the clubhead (Manuel de la Torre).** A feel-first
+  school in the Ernest Jones tradition: focus on swinging
+  the club itself rather than choreographing body
+  positions, trusting the body to follow a correct clubhead
+  motion. De la Torre was the PGA's first National Teacher
+  of the Year, in 1986.
+
+The honest takeaway is not "pick the right one." It's that
+a method which transforms one golfer can fight another's
+body outright — so the question is never "which swing is
+correct," but "which of these fits the body I actually
+have."
+
+---
+
+## Physical conditions and adaptations
+
+> **This is general information, not medical advice.** If
+> you have any of the conditions below, get cleared by a
+> medical professional and work with a TPI-certified
+> (Titleist Performance Institute) instructor *before*
+> changing your swing or starting intensive practice. The
+> notes here are starting points for that conversation, not
+> prescriptions.
+
+- **Scoliosis.** Spinal curvature can make a high-torque
+  rotational swing a poor fit; a flatter, more arms-based
+  or single-plane motion may put less stress on the spine.
+  This is exactly the case for a physical screening before
+  any intensive change.
+- **Hip replacement or hip limitations.** Weight shift and
+  hip clearance are affected. Methods that reduce lateral
+  movement (such as single-plane or weight-forward styles)
+  and a wider, more stable stance can lower the demand on
+  the hip.
+- **Shoulder injury or limited shoulder mobility.**
+  Backswing length and follow-through are the first things
+  to give. A shorter, more controlled backswing that
+  prioritizes solid contact usually beats forcing a full
+  turn you don't have.
+- **Back injury or fused vertebrae.** When rotation is
+  restricted or gone, arms-dominant, minimal-rotation
+  swings are the adaptation, and Moe Norman's low-stress
+  single-plane motion is worth studying. Medical clearance
+  first, always.
+- **One-arm and adaptive golfers.** Competitive one-arm and
+  adaptive players exist and thrive. The mechanics are
+  genuinely different, not a tweak of the standard swing,
+  and specialized adaptive instruction exists to teach
+  them.
+
+---
+
+## How a good coach finds your swing
+
+This is where a well-trained teacher earns their fee. The
+Titleist Performance Institute (TPI) has done the most
+rigorous work on what it calls the *body-swing connection*
+— mapping specific physical limitations to the swing
+characteristics they tend to produce. A TPI screening
+identifies what your body can and can't do *before* you try
+to change anything, which is often more valuable than any
+single swing tip.
+
+That's the practical core of "swing your swing." A good
+coach assesses your body first and prescribes to it; a good
+fitter measures your impact and ball flight rather than
+textbook numbers; and the right equipment is built to fit
+the swing your body actually makes. As the companion guides
+on lessons and on the questions to ask your coach put it —
+the teacher worth hiring is the one who looks at you before
+they look at a model.
+
+---
+
+## The bottom line
+
+"Swing your swing" isn't lazy advice. It's the most
+sophisticated advice in golf. There is no one correct swing
+— the Hall of Fame settles that — but there is a swing
+that's easier, more repeatable, and safer for your
+particular body. Find your constraints honestly, build a
+motion that works within them, fit your equipment to that
+motion, and work with a coach who starts from your body and
+not a textbook. That, not copying a position built for
+someone else, is the actual path to better golf.
+
+---
+
+## Sources
+
+- **The body-swing connection** —
+  [Titleist Performance Institute · About Certification](https://www.mytpi.com/certification/about)
+  and
+  [TPI · X-Factor essentials](https://mytpi.com/articles/fitness/x-factor_essentials_what_it_is_and_how_to_train_it)
+  — screening the body first, and mapping physical limits
+  to swing characteristics.
+- **What other striking and throwing sports show** —
+  [Bernstein's "repetition without repetition" (motor-control review)](https://pmc.ncbi.nlm.nih.gov/articles/PMC7438768/)
+  — skilled movement is variable, with many solutions to
+  one task;
+  [the kinetic chain in overhand pitching](https://pmc.ncbi.nlm.nih.gov/articles/PMC3445080/)
+  and
+  [fifty years of performance-related sports biomechanics](https://www.sciencedirect.com/science/article/pii/S002192902300235X)
+  — power runs proximal-to-distal across throwing and
+  striking sports, and elite technique calls for individual
+  profiling, not one template.
+- **The modern swing and the X-Factor — and the dispute** —
+  [Golf Digest · Jim McLean on the X-Factor](https://www.golfdigest.com/story/jim-mcleans-new-x-factor)
+  (popularized 1992) and a critical view in
+  [a review of the X-Factor evidence](https://www.perfectgolfswingreview.net/xfactor.htm)
+  — power gains are real but contested, and high separation
+  can add lower-back stress.
+- **The modern swing and lower-back load** —
+  [Journal of Neurosurgery: Spine (2019) · lumbar degeneration in modern-era golfers](https://thejns.org/spine/view/journals/j-neurosurg-spine/31/6/article-p914.xml)
+  links the repetitive modern swing to early disc wear,
+  while a
+  [2024 systematic review (Journal of Sports Sciences)](https://www.tandfonline.com/doi/full/10.1080/02640414.2024.2319443)
+  cautions that the biomechanics-to-back-pain evidence is
+  still limited and conflicting — a real concern, not
+  settled science.
+- **The classic flatter plane (Hogan)** —
+  [MyGolfSpy · Ben Hogan's swing](https://mygolfspy.com/news-opinion/ben-hogans-swing/)
+  — the "pane of glass" plane, and why it doesn't fit every
+  height.
+- **The single-plane swing (Moe Norman / Graves)** —
+  [Graves Golf · About Moe Norman](https://gravesgolf.com/about-moe-norman/)
+  and
+  [Todd Graves · Moe Norman](https://moenorman.org/) — the
+  single-plane method, and the ball-striking reputation
+  behind it.
+- **Stack and Tilt** —
+  [Bennett & Plummer (Stack and Tilt)](https://en.wikipedia.org/wiki/Mike_Bennett_and_Andy_Plummer)
+  — weight-forward method and its tour adherents.
+- **Simpler and body-friendly methods** —
+  [Don Trahan · Peak Performance Golf Swing](https://www.swingsurgeon.com/learn-the-swing)
+  (vertical, limited-turn, body-friendly),
+  [David Leadbetter · the A Swing](https://www.golfdigest.com/story/david-leadbetter-a-swing-starter-kit)
+  (a simpler, repeatable backswing), and
+  [Manuel de la Torre](https://www.wisconsin.golf/19th_hole/gary_d_amato/manuel-de-la-torres-former-students-committed-to-keeping-alive-his-simple-concepts-of-the/article_58cb7714-9baa-11ea-b99c-c79f89a574d7.html)
+  (Ernest Jones's "swing the clubhead," 1986 PGA Teacher of
+  the Year).
+- **Fitting clubs to your body** —
+  [Plugged In Golf · lie-angle testing](https://pluggedingolf.com/much-lie-angle-matter-golf-myths-unplugged/)
+  (a correct lie tightens left-right dispersion) and
+  [PING's custom-fitting guide](https://www.pga.info/discover/latest/news/pings-ultimate-guide-better-custom-fitting/)
+  — most golfers don't fit the standard off-the-rack build.
+- **Great "incorrect" swings** —
+  [Jim Furyk](https://en.wikipedia.org/wiki/Jim_Furyk)
+  (2003 U.S. Open;
+  [the 58](https://en.wikipedia.org/wiki/Jim_Furyk's_round_of_58)),
+  [Lee Trevino](https://en.wikipedia.org/wiki/Lee_Trevino)
+  (six majors, self-taught fade),
+  [Nancy Lopez](https://en.wikipedia.org/wiki/Nancy_Lopez)
+  (48 LPGA wins),
+  [John Daly](https://en.wikipedia.org/wiki/John_Daly_(golfer))
+  (two majors), and
+  [Gary Player](https://en.wikipedia.org/wiki/Gary_Player)
+  (nine majors, competitive into his 70s).
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/swing-variations.md*

--- a/docs/learn/training-aids.md
+++ b/docs/learn/training-aids.md
@@ -1,0 +1,290 @@
+---
+title: Training Aids Explained
+section: Your Equipment
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Training Aids Explained
+
+## Feeling productive isn't the same as getting better
+
+The training-aid aisle sells a feeling: that buying the
+device is the same as building the skill. Most of it
+isn't. A few aids genuinely teach — they show you
+something you can't see on your own and let you fix it.
+The rest just make practice feel like work without
+changing what your ball does on Saturday.
+
+This isn't a list of brands to buy. It's the categories
+— what problem each kind of aid solves, how it works,
+who actually needs it, and when in your development it
+earns a place in the bag. Before any of that, one test
+sorts the coaches from the crutches.
+
+**The test for any aid**
+
+- **"Does it show me something I can't see myself?"** —
+  If you can already feel it, you don't need a device to
+  tell you.
+- **"Can I trust the feedback on every rep?"** — A gate
+  that lies or a number that bounces around trains
+  nothing.
+- **"Does the skill survive when I put it down?"** — An
+  aid you can't wean off is a crutch, not a coach.
+
+---
+
+## The seven kinds, and what each one trains
+
+Six aids you can rehearse with, then the one that
+measures — the launch monitor — which gets its own
+section because the numbers need explaining.
+
+*[The app version illustrates several of these
+categories with small line-art diagrams.]*
+
+### Alignment aids
+
+**Trains** — Where you're actually aimed
+
+Standing beside the ball, your eyes lie. Most golfers
+aim well off the target without feeling it, then build a
+compensation into the swing to pull the ball back —
+baking in a fault to fix a setup error. Sticks on the
+ground make the invisible error visible: one along your
+toes, one on the ball-to-target line, body parallel-left
+like railroad tracks while the clubface points at the
+target.
+
+Everyone, from the first lesson on. Alignment is the
+cheapest fundamental in the game and the one most
+quietly broken — even four degrees off misses a 150-yard
+target by more than ten yards with a perfect swing.
+
+**Look for** — Two sticks, or two clubs from your bag. A
+laser adds precision you don't need yet.
+
+### Putting aids
+
+**Trains** — A square face and a repeating stroke
+
+At putting distance the face angle decides almost
+everything about where the ball starts — a couple of
+degrees open and you've missed — and you can't watch
+your own eyes or face at address. A mirror shows eye
+position and shoulder line; gates (two tees just wider
+than the ball) force a square strike on an on-line
+start, or the ball clips a tee; an arc trainer guides
+the stroke shape.
+
+Anyone who three-putts or misses the short ones, which
+is nearly everyone — putting is roughly 40% of the
+strokes in a round, and the cheapest skill to train at
+home.
+
+**Look for** — A mirror plus two tees covers it. Save
+the arc trainer for when you're chasing a specific
+stroke shape.
+
+### Impact aids
+
+**Trains** — What actually happens at the ball
+
+Impact lasts under half a thousandth of a second — you
+cannot feel where on the face you caught it, yet strike
+location quietly drives both distance and curve.
+Dry-erase or foot spray on the face leaves a mark
+showing exactly where contact was: toe, heel, high, low.
+An impact bag trains a hands-forward, flat-lead-wrist
+delivery with no ball to chase.
+
+The player who strikes it "fine sometimes" and loses
+distance for no obvious reason. Off-center contact is
+usually the answer, and you can't fix a pattern you
+can't see.
+
+**Look for** — A can of spray costs a couple of dollars
+and is the highest-feedback aid on this page.
+
+### Swing plane aids
+
+**Trains** — The path the club travels
+
+Swing plane is the tilted circle the club swings around
+your body. Get steep or over the top of it and you fight
+strike and start direction all day. It's hard to feel
+and easy to misjudge alone. A plane board or an angled
+rod gives the club something to stay under or trace, so
+an over-the-top move turns from a mystery into something
+obvious.
+
+A player with one stubborn miss — a pull or a slice —
+once contact is already repeatable. Not for a brand-new
+swing still hunting for the center of the face; there's
+nothing stable yet to shape.
+
+**Look for** — Simplicity. An alignment stick angled
+into the ground does most of what an expensive plane
+board does.
+
+### Tempo aids
+
+**Trains** — The rhythm that holds the swing together
+
+Tempo is the first thing to leave under pressure — a
+rushed transition wrecks an otherwise sound swing. Tour
+players hold a remarkably steady ratio, the backswing
+taking roughly three times as long as the downswing,
+while amateurs often drift to four-to-one or worse and
+snatch the club from the top. A metronome or a tones app
+trains that three-to-one feel; a weighted club
+exaggerates the load so you stop rushing.
+
+The player whose range swing deserts them on the first
+tee. Tempo is a finishing skill, not a beginner one —
+there has to be a swing before there's a rhythm to
+smooth.
+
+**Look for** — A free metronome app does the job. Don't
+swing a weighted club full-speed cold.
+
+### Chipping & pitching aids
+
+**Trains** — Landing spot and clean contact near the
+green
+
+Short game is feel, and feel needs reps with feedback —
+but most backyard chipping is aimless and trains
+nothing. A landing target — a towel, a hoop, a small net
+— gives the one thing that actually matters in a chip,
+where it lands, a clear bullseye, so you're rehearsing a
+number instead of just making contact. Impact tape
+catches the thin and fat patterns that wreck short
+shots.
+
+Anyone leaking strokes inside 40 yards, which
+strokes-gained data says is most amateurs.
+
+**Look for** — A towel on the ground is a landing
+target. You don't need a branded net.
+
+---
+
+## Launch monitors — the numbers, and which ones are yours
+
+A launch monitor is the one aid that measures rather
+than guides. Point it at your swing and it reports ball
+speed, club speed, launch angle, spin, carry, total
+distance, and smash factor — and on better units, club
+path and face angle. The trap is drowning in numbers
+that aren't yours to worry about yet. Here is which is
+which.
+
+| Number | Who it's for |
+|---|---|
+| Carry distance | Everyone. Your real number, not the one good swing — build your gapping from it. |
+| Smash factor | Everyone. Ball speed over club speed: how flush you caught it. Separates a club problem from a strike problem. |
+| Dispersion | Everyone. How tight your pattern is. Reward this over the occasional long bomb. |
+| Ball speed | Everyone. The most reliable number on a budget unit, and the engine behind distance. |
+| Spin rate | Better players and fittings. Dials in flight once contact repeats — and the least accurate reading on cheap units. |
+| Path & face angle | Coaches and better players. Face angle alone sets about 75–85% of your start line (most with the driver) — worth knowing, hard to change without help. |
+
+### Free vs paid
+
+Phone apps and sub-$500 units give reliable ball speed,
+club speed, and carry with no subscription — and ball
+speed is the most stable reading even on cheap hardware.
+Spin and launch get less precise as the price drops; the
+$15,000-and-up commercial units (TrackMan, Foresight)
+earn their cost in spin accuracy and indoor club data,
+which is why fitters and tour players use them. For an
+amateur, a budget unit that nails carry and smash factor
+measures everything you'd actually act on.
+
+### What to do with the data
+
+Build a real yardage chart — most golfers overstate
+every club by a full club, and the monitor settles it
+honestly. Watch your dispersion, not your one longest
+carry. Use smash factor to tell a club problem from a
+strike problem before you spend money on either. And
+leave alone the numbers you can't change yet: chasing
+spin optimization before your contact repeats is
+measuring mishits with a very expensive ruler.
+
+---
+
+## What most golfers actually need
+
+Set against the thesis, the honest shortlist is short
+and cheap. The aids worth owning give you feedback you
+can't get on your own; the rest mostly sell the feeling
+of practice.
+
+### Worth owning
+
+- **Two alignment sticks** — or two clubs. Aim, ball
+  position, and a rough swing plane, all from one cheap
+  pair.
+- **A mirror** — putting setup and a square face, the
+  cheapest strokes to find at home.
+- **Impact spray or tape** — the unvarnished truth about
+  where you strike it.
+- **A landing towel** — turns aimless chipping into reps
+  at a real target.
+- **A free metronome app** — tempo, for nothing.
+
+### Skip, or wait
+
+- Anything promising speed or distance from swinging it
+  through the air alone.
+- Single-purpose gadgets that just duplicate a
+  three-dollar stick.
+- A premium launch monitor before your carry and contact
+  repeat — you'll only be measuring mishits.
+- Aids that work in the yard but never make it to the
+  course, where the skill has to show up.
+
+The pattern holds across all of it: a real training aid
+shows you something you can't see, then gets out of the
+way. If the skill vanishes the moment you set the gadget
+down, it was a feeling — not a habit you built.
+
+---
+
+## Sources
+
+- **Why alignment is foundational** —
+  [PGA of America · 4 alignment mistakes](https://www.pga.com/story/4-alignment-mistakes-killing-your-golf-game-and-how-to-fix-them)
+  and
+  [Golf.com · why your aim is poor](https://golf.com/instruction/why-aim-alignment-poor-how-fix/)
+  — most golfers aim off the target without feeling it,
+  and small errors miss by yards over distance.
+- **Face angle sets the start line** —
+  [TrackMan · what is face angle](https://www.trackman.com/blog/golf/what-is-face-angle)
+  and
+  [6 numbers every amateur should know](https://www.trackman.com/blog/golf/6-trackman-numbers-all-amateur-golfers-should-know)
+  — the clubface controls roughly 75–85% of where the
+  ball starts (most with the driver), which is why
+  putting and impact aids train a square strike.
+- **Tempo — the three-to-one ratio** —
+  [Tour Tempo](https://tourtempo.com/pages/tour-tempo-app)
+  on the 3:1 backswing-to-downswing finding, and
+  [PGA of America · rhythm and tempo](https://www.pga.com/story/find-a-rhythm-and-tempo-that-fits-your-game)
+  — tour players hold a steady ratio; amateurs often
+  rush the transition.
+- **Launch monitors — which numbers, and what they
+  cost** —
+  [TrackMan · the ultimate guide to the data](https://www.trackman.com/blog/golf/the-ultimate-guide-to-understanding-trackman)
+  and
+  [MyGolfSpy · $500 to $5,000 tested](https://mygolfspy.com/buyers-guide/we-tested-12-launch-monitors-ranging-from-500-to-5000-whats-the-real-difference/)
+  — ball speed and carry are reliable on budget units;
+  spin and launch precision are what the expensive ones
+  buy.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/training-aids.md*

--- a/docs/learn/understanding-your-swing.md
+++ b/docs/learn/understanding-your-swing.md
@@ -1,0 +1,136 @@
+---
+title: Understanding Your Own Swing
+section: Improving Your Game
+status: published
+last_reviewed: 2026-05
+contributors: []
+---
+
+# Understanding Your Own Swing
+
+You don't need a coach behind you or a launch monitor in
+front of you to know what your swing just did. Every shot
+leaves evidence — the line the ball starts on, the way it
+curves, the divot in front of it, the mark on the face —
+and that evidence is a readout of what the club was doing
+at impact. Learn to read it and you can diagnose your own
+swing on any range in the world. The companion
+*self-diagnosis* guide helps you find *which* part of your
+game is leaking strokes; this one is about reading *what*
+your swing is actually doing once you're there.
+
+---
+
+## Start line and curve: the two-number readout
+
+Modern launch-monitor data overturned what most of us were
+taught. Two things at impact write the whole shot:
+
+**What writes the shot**
+
+| Factor | What it writes |
+|---|---|
+| Face angle | Where the ball starts. At impact the face sets roughly three-quarters of the start line with an iron — closer to 85% with the driver. |
+| Face vs. path | How the ball curves. The gap between where the face points and where the club is travelling tilts the spin: open to the path curves away, closed to it draws back. |
+
+So read every ball as two separate facts. **Where it
+starts** is mostly your face. **How it curves** is the gap
+between face and path. A shot that starts left and slices
+back right, for instance, means the face was pointed left
+of the target but still open relative to an
+even-more-leftward path — the classic out-to-in pull-slice
+(directions throughout are for a right-handed golfer —
+mirror them if you play left-handed). The ball just told
+you both numbers; you only had to listen.
+
+*[The app version includes a diagram of a ball flight: it
+starts where the face points, then bends by the gap between
+face and path. Two facts, read off one shot.]*
+
+---
+
+## The divot tells you the rest
+
+With an iron, the turf is a second instrument. On solid
+contact the divot begins *after* the ball, not under it —
+proof you struck the ball first and the low point of your
+arc was ahead of it. Beyond that, the divot's shape and
+direction fill in the path your ball flight implied:
+
+- **Direction.** A divot pointing left of target is the
+  fingerprint of an out-to-in (over-the-top) path; one
+  pointing right signals in-to-out. It should roughly agree
+  with the curve you read off the ball.
+- **Depth and evenness.** A deep, gouged divot says your
+  low point is too far forward or your attack too steep; no
+  divot at all usually means you're bottoming out behind
+  the ball. A divot deeper on the toe or heel side points
+  at how the club is delivered, not just where it lands.
+- **Where it starts.** A divot that begins well behind the
+  ball is the turf-side version of fat contact — the arc
+  bottomed out early.
+
+---
+
+## The strike fills in the blanks
+
+Where on the face you make contact is the cheapest data in
+golf to collect: a dusting of foot spray, face tape, or
+even the wear pattern on a dirty clubface shows it. Toward
+the toe or heel explains distance you can't account for and
+a surprising amount of curve; high or low on the face
+explains a shot that flew or ballooned for no obvious
+reason. A scattered strike pattern, like a scattered ball
+flight, points back at the fundamentals — setup, posture,
+balance — rather than any one swing move.
+
+---
+
+## Three reads, one cause
+
+The skill isn't any single read — it's that the ball, the
+divot, and the strike almost always converge on the same
+story. A pull that curves right, a divot aimed left, and a
+strike toward the heel are three witnesses to one out-to-in
+delivery, not three separate problems. Find where they
+agree and you've found the cause worth working on. And as
+the self-diagnosis guide stresses: chase the *pattern*, not
+the one ugly shot. A miss that repeats is a swing trait you
+can read and fix; a miss that's different every time is a
+fundamentals problem hiding upstream.
+
+---
+
+## When the read runs out
+
+Reading your swing and *changing* it are different skills.
+You can often diagnose the cause — an open face, a steep
+path — long before you can reliably fix it, and that's
+exactly the moment a good coach earns their fee. Walk in
+able to say "I start it left and it slices, my divots point
+left" and you've handed them the diagnosis and bought
+yourself a far more useful hour. The companion guides on
+lessons and on the questions to ask your coach pick up from
+there. Until then: the ball doesn't lie. Learn its language
+and you're never completely in the dark about your own
+swing.
+
+---
+
+## Sources
+
+- **The modern ball-flight laws** —
+  [TrackMan · data parameter definitions (face angle, club path)](https://support.trackmangolf.com/hc/en-us/articles/5089892383515-Practice-Trackman-Data-Parameter-Definitions)
+  and
+  [a plain-English explainer of the new ball-flight laws](https://theleftrough.com/new-ball-flight-laws/)
+  — the face sets the start line; the face-to-path gap sets
+  the curve.
+- **Reading path from the ball and the divot** —
+  [GolfWRX · using the ball-flight laws to read your own tendencies](https://www.golfwrx.com/251459/use-the-new-ball-flight-laws-to-understand-your-tendencies/)
+  — translating start line, curve, and divot direction back
+  into face and path.
+
+---
+
+*Last reviewed: May 2026*
+*To contribute: open a PR editing docs/learn/understanding-your-swing.md*


### PR DESCRIPTION
Lifts the full Learn catalog into `docs/learn/` so every published article has a markdown mirror.

- **15 new mirrors** generated from the current web article TSX (source of truth, post-audit-fix wave #771–#776): strokes-gained, benchmarks, guide-to-fittings, training-aids, building-your-bag, practice-modes, measurable-goals, understanding-your-swing, swing-variations, operation-36, practice-vs-scoring-round, self-diagnosis, lessons-and-coaching, fittings-with-coaches, questions-for-coach.
- **Conventions** match the existing mirrors exactly: frontmatter (title/section/status/last_reviewed/contributors), `##` sections, structured components rendered as markdown tables/lists, `## Sources` bold-label bullets porting every in-app citation, review footer. Figures omitted except three one-line italic notes where a figure carries content prose doesn't.
- **Glossary mirror normalized**: draft/content_warning scaffolding removed (status → published), a Sources methodology note ported from the app, and the historical-club-equivalencies TODO cleared (verified during the audit).
- Docs-only change — no app code touched.

Related: #768 (mirror drift — establishes full coverage going forward).