### PR TITLE
docs(learn): bump last-reviewed date to July 2026

### DIFF
--- a/apps/mobile/components/learn/articles/BuildingYourBag.tsx
+++ b/apps/mobile/components/learn/articles/BuildingYourBag.tsx
@@ -191,7 +191,7 @@ export function BuildingYourBagArticle() {
         ]}
       />
 
-      <ArticleFooter>Last reviewed May 2026</ArticleFooter>
+      <ArticleFooter>Last reviewed July 2026</ArticleFooter>
     </View>
   )
 }

--- a/apps/mobile/components/learn/articles/CourseManagement.tsx
+++ b/apps/mobile/components/learn/articles/CourseManagement.tsx
@@ -500,7 +500,7 @@ export function CourseManagementArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/FittingsWithCoaches.tsx
+++ b/apps/mobile/components/learn/articles/FittingsWithCoaches.tsx
@@ -211,7 +211,7 @@ export function FittingsWithCoachesArticle() {
         ]}
       />
 
-      <ArticleFooter>Last reviewed May 2026</ArticleFooter>
+      <ArticleFooter>Last reviewed July 2026</ArticleFooter>
     </View>
   )
 }

--- a/apps/mobile/components/learn/articles/Glossary.tsx
+++ b/apps/mobile/components/learn/articles/Glossary.tsx
@@ -37,7 +37,7 @@ export function GlossaryArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/GuideToFittings.tsx
+++ b/apps/mobile/components/learn/articles/GuideToFittings.tsx
@@ -335,7 +335,7 @@ export function GuideToFittingsArticle() {
         ]}
       />
 
-      <ArticleFooter>Last reviewed May 2026</ArticleFooter>
+      <ArticleFooter>Last reviewed July 2026</ArticleFooter>
     </View>
   )
 }

--- a/apps/mobile/components/learn/articles/HowToPractice.tsx
+++ b/apps/mobile/components/learn/articles/HowToPractice.tsx
@@ -366,7 +366,7 @@ export function HowToPracticeArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/LessonsAndCoaching.tsx
+++ b/apps/mobile/components/learn/articles/LessonsAndCoaching.tsx
@@ -295,7 +295,7 @@ export function LessonsAndCoachingArticle() {
         ]}
       />
 
-      <ArticleFooter>Last reviewed May 2026</ArticleFooter>
+      <ArticleFooter>Last reviewed July 2026</ArticleFooter>
     </View>
   )
 }

--- a/apps/mobile/components/learn/articles/MeasurableGoals.tsx
+++ b/apps/mobile/components/learn/articles/MeasurableGoals.tsx
@@ -133,7 +133,7 @@ export function MeasurableGoalsArticle() {
         ]}
       />
 
-      <ArticleFooter>Last reviewed May 2026</ArticleFooter>
+      <ArticleFooter>Last reviewed July 2026</ArticleFooter>
     </View>
   )
 }

--- a/apps/mobile/components/learn/articles/MentalGame.tsx
+++ b/apps/mobile/components/learn/articles/MentalGame.tsx
@@ -371,7 +371,7 @@ export function MentalGameArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/Operation36.tsx
+++ b/apps/mobile/components/learn/articles/Operation36.tsx
@@ -298,7 +298,7 @@ export function Operation36Article() {
         ]}
       />
 
-      <ArticleFooter>Last reviewed May 2026</ArticleFooter>
+      <ArticleFooter>Last reviewed July 2026</ArticleFooter>
     </View>
   )
 }

--- a/apps/mobile/components/learn/articles/PracticeModes.tsx
+++ b/apps/mobile/components/learn/articles/PracticeModes.tsx
@@ -232,7 +232,7 @@ export function PracticeModesArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/PracticeVsScoringRound.tsx
+++ b/apps/mobile/components/learn/articles/PracticeVsScoringRound.tsx
@@ -340,7 +340,7 @@ export function PracticeVsScoringRoundArticle() {
         ]}
       />
 
-      <ArticleFooter>Last reviewed May 2026</ArticleFooter>
+      <ArticleFooter>Last reviewed July 2026</ArticleFooter>
     </View>
   )
 }

--- a/apps/mobile/components/learn/articles/QuestionsForCoach.tsx
+++ b/apps/mobile/components/learn/articles/QuestionsForCoach.tsx
@@ -195,7 +195,7 @@ export function QuestionsForCoachArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/SelfDiagnosis.tsx
+++ b/apps/mobile/components/learn/articles/SelfDiagnosis.tsx
@@ -295,7 +295,7 @@ export function SelfDiagnosisArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/SkillGames.tsx
+++ b/apps/mobile/components/learn/articles/SkillGames.tsx
@@ -323,7 +323,7 @@ export function SkillGamesArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/SwingVariations.tsx
+++ b/apps/mobile/components/learn/articles/SwingVariations.tsx
@@ -470,7 +470,7 @@ export function SwingVariationsArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/TrainingAids.tsx
+++ b/apps/mobile/components/learn/articles/TrainingAids.tsx
@@ -376,7 +376,7 @@ export function TrainingAidsArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/mobile/components/learn/articles/UnderstandingYourSwing.tsx
+++ b/apps/mobile/components/learn/articles/UnderstandingYourSwing.tsx
@@ -177,7 +177,7 @@ export function UnderstandingYourSwingArticle() {
       />
 
       <ArticleFooter>
-        Last reviewed May 2026
+        Last reviewed July 2026
       </ArticleFooter>
     </View>
   )

--- a/apps/web/src/pages/learn/articles/BuildingYourBagArticle.tsx
+++ b/apps/web/src/pages/learn/articles/BuildingYourBagArticle.tsx
@@ -468,7 +468,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/CourseManagementArticle.tsx
+++ b/apps/web/src/pages/learn/articles/CourseManagementArticle.tsx
@@ -689,7 +689,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/FittingsWithCoachesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/FittingsWithCoachesArticle.tsx
@@ -397,7 +397,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/GlossaryArticle.tsx
+++ b/apps/web/src/pages/learn/articles/GlossaryArticle.tsx
@@ -681,7 +681,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/GuideToFittingsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/GuideToFittingsArticle.tsx
@@ -537,7 +537,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/HowToPracticeArticle.tsx
+++ b/apps/web/src/pages/learn/articles/HowToPracticeArticle.tsx
@@ -624,7 +624,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/LessonsAndCoachingArticle.tsx
+++ b/apps/web/src/pages/learn/articles/LessonsAndCoachingArticle.tsx
@@ -492,7 +492,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/MeasurableGoalsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/MeasurableGoalsArticle.tsx
@@ -381,7 +381,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/MentalGameArticle.tsx
+++ b/apps/web/src/pages/learn/articles/MentalGameArticle.tsx
@@ -644,7 +644,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/Operation36Article.tsx
+++ b/apps/web/src/pages/learn/articles/Operation36Article.tsx
@@ -512,7 +512,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/PracticeModesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/PracticeModesArticle.tsx
@@ -496,7 +496,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/PracticeVsScoringRoundArticle.tsx
+++ b/apps/web/src/pages/learn/articles/PracticeVsScoringRoundArticle.tsx
@@ -507,7 +507,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/QuestionsForCoachArticle.tsx
+++ b/apps/web/src/pages/learn/articles/QuestionsForCoachArticle.tsx
@@ -343,7 +343,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/SelfDiagnosisArticle.tsx
+++ b/apps/web/src/pages/learn/articles/SelfDiagnosisArticle.tsx
@@ -585,7 +585,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/SkillGamesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/SkillGamesArticle.tsx
@@ -572,7 +572,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/SwingVariationsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/SwingVariationsArticle.tsx
@@ -764,7 +764,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/TrainingAidsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/TrainingAidsArticle.tsx
@@ -735,7 +735,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/apps/web/src/pages/learn/articles/UnderstandingYourSwingArticle.tsx
+++ b/apps/web/src/pages/learn/articles/UnderstandingYourSwingArticle.tsx
@@ -336,7 +336,7 @@ function Footer() {
         lineHeight: 1.6,
       }}
     >
-      Last reviewed May 2026
+      Last reviewed July 2026
     </div>
   )
 }

--- a/docs/learn/benchmarks.md
+++ b/docs/learn/benchmarks.md
@@ -2,7 +2,7 @@
 title: Reading Your Stats
 section: Understanding the Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -78,5 +78,5 @@ Per round, versus a scratch baseline.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/benchmarks.md*

--- a/docs/learn/building-your-bag.md
+++ b/docs/learn/building-your-bag.md
@@ -2,7 +2,7 @@
 title: Building Your Bag
 section: Your Equipment
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -159,5 +159,5 @@ instead of habit shoots lower without buying a thing.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/building-your-bag.md*

--- a/docs/learn/course-management.md
+++ b/docs/learn/course-management.md
@@ -2,7 +2,7 @@
 title: Course Management
 section: On the Course
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -222,5 +222,5 @@ The Way of the Playa is not a swing philosophy. It's a mindset. And it's availab
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/course-management.md*

--- a/docs/learn/fittings-with-coaches.md
+++ b/docs/learn/fittings-with-coaches.md
@@ -2,7 +2,7 @@
 title: Fittings and Your Coach
 section: Working with Coaches
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -160,5 +160,5 @@ the same plan as your lessons.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/fittings-with-coaches.md*

--- a/docs/learn/glossary.md
+++ b/docs/learn/glossary.md
@@ -2,7 +2,7 @@
 title: Glossary of Golf Terms
 section: Understanding the Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -583,5 +583,5 @@ one of its most important.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/glossary.md*

--- a/docs/learn/guide-to-fittings.md
+++ b/docs/learn/guide-to-fittings.md
@@ -2,7 +2,7 @@
 title: Guide to Golf Fittings
 section: Your Equipment
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -334,5 +334,5 @@ stroke-saver on this page.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/guide-to-fittings.md*

--- a/docs/learn/how-to-practice.md
+++ b/docs/learn/how-to-practice.md
@@ -2,7 +2,7 @@
 title: How to Practice
 section: Improving Your Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -265,5 +265,5 @@ commit to it fully.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/how-to-practice.md*

--- a/docs/learn/lessons-and-coaching.md
+++ b/docs/learn/lessons-and-coaching.md
@@ -2,7 +2,7 @@
 title: Guide to Lessons and Coaching
 section: Working with Coaches
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -256,5 +256,5 @@ is to actually get better.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/lessons-and-coaching.md*

--- a/docs/learn/measurable-goals.md
+++ b/docs/learn/measurable-goals.md
@@ -2,7 +2,7 @@
 title: Creating Measurable Practice Goals
 section: Improving Your Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -127,5 +127,5 @@ goal you can't score isn't a goal. It's a hope.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/measurable-goals.md*

--- a/docs/learn/mental-game.md
+++ b/docs/learn/mental-game.md
@@ -2,7 +2,7 @@
 title: The Mental Game
 section: On the Course
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -423,5 +423,5 @@ absence of difficulty. The speed of return.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/mental-game.md*

--- a/docs/learn/operation-36.md
+++ b/docs/learn/operation-36.md
@@ -2,7 +2,7 @@
 title: The Operation 36 Philosophy
 section: Improving Your Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -254,5 +254,5 @@ bag, without signing up for anything.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/operation-36.md*

--- a/docs/learn/practice-modes.md
+++ b/docs/learn/practice-modes.md
@@ -2,7 +2,7 @@
 title: Block, Random, and Pressure Practice
 section: Improving Your Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -167,5 +167,5 @@ places.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/practice-modes.md*

--- a/docs/learn/practice-vs-scoring-round.md
+++ b/docs/learn/practice-vs-scoring-round.md
@@ -2,7 +2,7 @@
 title: Practice Round vs Scoring Round
 section: On the Course
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -257,5 +257,5 @@ both your scores and your practice get sharper for it.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/practice-vs-scoring-round.md*

--- a/docs/learn/questions-for-coach.md
+++ b/docs/learn/questions-for-coach.md
@@ -2,7 +2,7 @@
 title: Questions to Ask Your Coach
 section: Working with Coaches
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -138,5 +138,5 @@ Saturday and a change that's still with you next season.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/questions-for-coach.md*

--- a/docs/learn/self-diagnosis.md
+++ b/docs/learn/self-diagnosis.md
@@ -2,7 +2,7 @@
 title: "Self-Diagnosis: Finding Your Weaknesses"
 section: On the Course
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -269,5 +269,5 @@ with.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/self-diagnosis.md*

--- a/docs/learn/skill-games-pressure-games.md
+++ b/docs/learn/skill-games-pressure-games.md
@@ -2,7 +2,7 @@
 title: Skill Games and Pressure Games
 section: Improving Your Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -351,6 +351,6 @@ over months is genuinely motivating.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing
 docs/learn/skill-games-pressure-games.md*

--- a/docs/learn/strokes-gained.md
+++ b/docs/learn/strokes-gained.md
@@ -2,7 +2,7 @@
 title: How Strokes Gained Works
 section: Understanding the Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -101,5 +101,5 @@ your bracket — fine, not a leak.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/strokes-gained.md*

--- a/docs/learn/swing-variations.md
+++ b/docs/learn/swing-variations.md
@@ -2,7 +2,7 @@
 title: Swing Variations for Different Body Types
 section: Improving Your Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -353,5 +353,5 @@ someone else, is the actual path to better golf.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/swing-variations.md*

--- a/docs/learn/training-aids.md
+++ b/docs/learn/training-aids.md
@@ -2,7 +2,7 @@
 title: Training Aids Explained
 section: Your Equipment
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -286,5 +286,5 @@ down, it was a feeling — not a habit you built.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/training-aids.md*

--- a/docs/learn/understanding-your-swing.md
+++ b/docs/learn/understanding-your-swing.md
@@ -2,7 +2,7 @@
 title: Understanding Your Own Swing
 section: Improving Your Game
 status: published
-last_reviewed: 2026-05
+last_reviewed: 2026-07
 contributors: []
 ---
 
@@ -132,5 +132,5 @@ swing.
 
 ---
 
-*Last reviewed: May 2026*
+*Last reviewed: July 2026*
 *To contribute: open a PR editing docs/learn/understanding-your-swing.md*


### PR DESCRIPTION
Every Learn article footer still read "Last reviewed May 2026", but the July 2026 accuracy audit re-reviewed all 21 articles and corrected most of them (#771–#777). Bumps the review date to reflect reality.

- Web + mobile article footers (36 files): "Last reviewed May 2026" → "July 2026".
- Docs mirrors (20 files): body footer + `last_reviewed` frontmatter → 2026-07.
- No other copy touched — date string only.