### PR TITLE
fix(mobile): shot-pattern slope filter falls back to legacy lie_slope

### DIFF
--- a/apps/mobile/app/(app)/patterns.tsx
+++ b/apps/mobile/app/(app)/patterns.tsx
@@ -15,6 +15,7 @@ import {
   dispersionVerdict,
   filterDispersionByLie,
   getAimCorrection,
+  legacySlopeToAxes,
   type Club,
   type DispersionPoint,
   type DispersionStats,
@@ -67,6 +68,12 @@ interface ShotRowMin {
 }
 
 function rowToShot(r: ShotRowMin): Shot {
+  // Most stored shots predate the two-axis slope columns and only carry the
+  // legacy single-select `lie_slope`. Fall back to it so the slope filter
+  // matches whichever axis those shots recorded — otherwise every selection
+  // filters to zero. (A legacy shot only ever recorded one axis, so it can
+  // never match a forward AND a side selection at once — that's unrecoverable.)
+  const legacy = legacySlopeToAxes(r.lie_slope ?? null)
   return {
     id: r.id,
     holeScoreId: r.hole_score_id,
@@ -82,8 +89,8 @@ function rowToShot(r: ShotRowMin): Shot {
     club: (r.club as Shot['club']) ?? undefined,
     lieType: r.lie_type ?? undefined,
     lieSlope: r.lie_slope ?? undefined,
-    lieSlopeForward: r.lie_slope_forward ?? undefined,
-    lieSlopeSide: r.lie_slope_side ?? undefined,
+    lieSlopeForward: r.lie_slope_forward ?? legacy.forward,
+    lieSlopeSide: r.lie_slope_side ?? legacy.side,
     shotResult: (r.shot_result as Shot['shotResult']) ?? undefined,
     penalty: r.penalty,
     ob: r.ob,


### PR DESCRIPTION
**Bug (user-reported, on-device):** On the Shot Patterns page, selecting any lie-slope chip shows "no data".

**Root cause:** The two-axis slope filter from #746 reads only `lie_slope_forward` / `lie_slope_side`. In prod, **530 of 531 shots** have those columns null — their slope lives in the legacy single-select `lie_slope` column (which stored *either* a forward *or* a side value, never both). So every selection filtered to zero.

**Fix:** `rowToShot` now derives the axes from `lie_slope` via core's `legacySlopeToAxes()` when the new columns are null — the same pattern core's own shot mapper (`round.ts:294`) already uses. Two lines + one import.

**Verified:** the shot-save path (`useShotActions.ts:157`, `PastHoleShotsSheet.tsx:462`) already writes both axis columns, so new logs are unaffected; only legacy reads needed the fallback. Mobile typecheck green.

**Known limitation (in a code comment):** a legacy shot recorded only one axis, so old shots can't match a forward *and* a side selection at once — unrecoverable from the old single-select data. New two-axis shots match both.

Closes #746 follow-up.