### PR TITLE
fix(learn): drop misleading swing-plane figure + correct retention curve

### DIFF
--- a/apps/mobile/components/learn/articles/PracticeModes.tsx
+++ b/apps/mobile/components/learn/articles/PracticeModes.tsx
@@ -289,7 +289,7 @@ function RetentionDiagram() {
       <Line x1={24} y1={14} x2={24} y2={86} stroke={C.mute} strokeWidth={1.5} />
       <Line x1={106} y1={18} x2={106} y2={86} stroke={C.line} strokeWidth={1} strokeDasharray="3 3" />
       {/* blocked: high in practice, drops later */}
-      <Polyline points="30,44 106,30 182,68" fill="none" stroke={C.mute} strokeWidth={2} />
+      <Polyline points="30,44 106,30 182,52" fill="none" stroke={C.mute} strokeWidth={2} />
       {/* random: low in practice, best later (accent) */}
       <Polyline points="30,74 106,60 182,30" fill="none" stroke={C.accent} strokeWidth={2} />
       <SvgText x={54} y={100} fontSize={7} fontFamily={FONT.mono} letterSpacing={1} fill={C.mute}>

--- a/apps/mobile/components/learn/articles/SwingVariations.tsx
+++ b/apps/mobile/components/learn/articles/SwingVariations.tsx
@@ -1,12 +1,10 @@
 import { Text, View } from 'react-native'
-import Svg, { Circle, Line, Text as SvgText } from 'react-native-svg'
 import {
   ArticleHeader,
   ArticleFooter,
   BulletList,
   Callout,
   Em,
-  Figure,
   H3,
   Hr,
   Link,
@@ -136,7 +134,6 @@ export function SwingVariationsArticle() {
         from steep and upright to flat and rotary, with single-plane methods at
         one end.
       </P>
-      <PlaneSpectrum />
       <BulletList
         items={[
           <Text key="a">
@@ -613,37 +610,5 @@ function BodyTypeTable() {
         </View>
       ))}
     </View>
-  )
-}
-
-// Editorial line-art: the shaft plane from upright to flat, with single-plane
-// shown as arms-and-shaft aligned. Same viewBox + coordinate data as the web
-// inline svg after its re-draw (all three lines are believable plane angles
-// fanning up from the ball — upright ~63°, flat ~45°, single plane ~33°),
-// re-authored in react-native-svg. Single plane in accent.
-function PlaneSpectrum() {
-  return (
-    <Figure caption='Roughly how the club travels — steep and upright through flat and rotary to a single plane. None is "correct"; each fits a different body.'>
-      <Svg width="100%" height={120} viewBox="0 0 240 120">
-        {/* ground + ball, shared origin at lower right */}
-        <Line x1={20} y1={100} x2={220} y2={100} stroke={C.mute} strokeWidth={1.5} />
-        <Circle cx={190} cy={100} r={3} fill={C.ink} />
-        {/* upright (steep) plane ~63° */}
-        <Line x1={190} y1={100} x2={147} y2={16} stroke={C.mute} strokeWidth={2} />
-        {/* flat (Hogan) plane ~45° */}
-        <Line x1={190} y1={100} x2={108} y2={18} stroke={C.mute} strokeWidth={2} />
-        {/* single plane (accent), flattest ~33° */}
-        <Line x1={190} y1={100} x2={72} y2={24} stroke={C.accent} strokeWidth={2.5} />
-        <SvgText x={150} y={13} fontSize={7} fontFamily={FONT.mono} letterSpacing={0.5} fill={C.mute}>
-          UPRIGHT
-        </SvgText>
-        <SvgText x={86} y={13} fontSize={7} fontFamily={FONT.mono} letterSpacing={0.5} fill={C.mute}>
-          FLAT
-        </SvgText>
-        <SvgText x={14} y={22} fontSize={7} fontFamily={FONT.mono} letterSpacing={0.5} fill={C.accent}>
-          SINGLE PLANE
-        </SvgText>
-      </Svg>
-    </Figure>
   )
 }

--- a/apps/web/src/pages/learn/articles/PracticeModesArticle.tsx
+++ b/apps/web/src/pages/learn/articles/PracticeModesArticle.tsx
@@ -330,7 +330,7 @@ function RetentionDiagram() {
           <line x1="24" y1="14" x2="24" y2="86" stroke="#9F9580" strokeWidth="1.5" />
           <line x1="106" y1="18" x2="106" y2="86" stroke="#D9D2BF" strokeWidth="1" strokeDasharray="3 3" />
           {/* blocked: high in practice, drops later */}
-          <polyline points="30,44 106,30 182,68" fill="none" stroke="#9F9580" strokeWidth="2" />
+          <polyline points="30,44 106,30 182,52" fill="none" stroke="#9F9580" strokeWidth="2" />
           {/* random: low in practice, best later (accent) */}
           <polyline points="30,74 106,60 182,30" fill="none" stroke="#1F3D2C" strokeWidth="2" />
           <text x="54" y="100" fontSize="7" fontFamily="monospace" letterSpacing="1" fill="#8A8B7E">

--- a/apps/web/src/pages/learn/articles/SwingVariationsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/SwingVariationsArticle.tsx
@@ -138,7 +138,6 @@ export function SwingVariationsArticle() {
         from steep and upright to flat and rotary, with single-plane methods at
         one end.
       </P>
-      <PlaneSpectrum />
       <ul style={UL_STYLE}>
         <li>
           <strong>The modern tour swing.</strong> Big separation between the
@@ -541,50 +540,6 @@ function BodyTypeTable() {
 
 // Editorial line-art: the shaft plane from upright to flat, with single-plane
 // shown as arms-and-shaft aligned. Hairline strokes; the single plane in accent.
-function PlaneSpectrum() {
-  return (
-    <div style={{ maxWidth: 420, marginBottom: 18 }}>
-      <div
-        style={{
-          background: '#EBE5D6',
-          border: '1px solid #D9D2BF',
-          borderRadius: 2,
-          padding: '14px 12px 8px',
-        }}
-      >
-        <svg width="100%" viewBox="0 0 240 120" aria-hidden="true" style={{ display: 'block' }}>
-          {/* ground + ball, shared origin at lower right */}
-          <line x1="20" y1="100" x2="220" y2="100" stroke="#9F9580" strokeWidth="1.5" />
-          <circle cx="190" cy="100" r="3" fill="#1C211C" />
-          {/* All three are believable swing-plane angles fanning up from the
-              ball — upright steepest (~63°), flat shallower (~45°), single
-              plane the flattest (~33°). The old single-plane line sat ~13°,
-              almost flat on the ground, which read as broken. */}
-          {/* upright (steep) plane ~63° */}
-          <line x1="190" y1="100" x2="147" y2="16" stroke="#9F9580" strokeWidth="2" />
-          {/* flat (Hogan) plane ~45° */}
-          <line x1="190" y1="100" x2="108" y2="18" stroke="#9F9580" strokeWidth="2" />
-          {/* single plane (accent), flattest ~33° */}
-          <line x1="190" y1="100" x2="72" y2="24" stroke="#1F3D2C" strokeWidth="2.5" />
-          <text x="150" y="13" fontSize="7" fontFamily="monospace" letterSpacing="0.5" fill="#8A8B7E">
-            UPRIGHT
-          </text>
-          <text x="86" y="13" fontSize="7" fontFamily="monospace" letterSpacing="0.5" fill="#8A8B7E">
-            FLAT
-          </text>
-          <text x="14" y="22" fontSize="7" fontFamily="monospace" letterSpacing="0.5" fill="#1F3D2C">
-            SINGLE PLANE
-          </text>
-        </svg>
-      </div>
-      <div className="text-caddie-ink-mute" style={{ fontSize: 12, lineHeight: 1.5, marginTop: 6 }}>
-        Roughly how the club travels — steep and upright through flat and rotary to
-        a single plane. None is "correct"; each fits a different body.
-      </div>
-    </div>
-  )
-}
-
 function Sources() {
   return (
     <section style={{ borderTop: '1px solid #D9D2BF', paddingTop: 18, marginTop: 22 }}>


### PR DESCRIPTION
Second, thorough pass over every Learn figure (13 total, all computed from coordinates). **11 verified correct and kept** — only these two needed action:

**1. Remove the SwingVariations `PlaneSpectrum` diagram (web + mobile).** It tried to place "single plane" on an upright↔flat *steepness* axis, but one-plane-vs-two-plane is an independent build distinction — a category error no arrangement of three fanned lines can fix. It also mislabeled which end Moe Norman's single-plane method sits at. The prose already explains the spectrum in words; the figure only subtracted clarity. Orphaned `react-native-svg` imports removed with it.

**2. Correct the `RetentionDiagram` blocked-practice curve (web + mobile).** It ended at y=68 — below its own practice-start of y=44 — depicting blocked practice as making you *worse than baseline*. The contextual-interference finding is that blocked *retention* is lower than random's, not net-negative. Endpoint moved 68 → 52: still clearly below random's y=30 (random wins retention), no longer collapsing below baseline.

Docs mirrors unaffected (decorative figures weren't mirrored). Both typechecks green. The other 11 figures (ball-flight, alignment, putting-gate, impact-face, swing-plane/over-the-top, tempo 3:1, gap-ladder, wedge-loft, difficulty-band, schedule) verified correct by coordinate computation.