### PR TITLE
fix(mobile): web-dashboard CTA on Android profile + stats rider polish

### DIFF
--- a/apps/mobile/app/(app)/profile.tsx
+++ b/apps/mobile/app/(app)/profile.tsx
@@ -477,6 +477,43 @@ export default function ProfileTab() {
             </>
           ) : (
             <>
+              <Text style={{ ...KICKER, marginBottom: 10 }}>OGA on the web</Text>
+              <Text
+                style={[TYPE.body, {
+                  color: '#1C211C',
+                  fontSize: 14,
+                  lineHeight: 20,
+                  marginBottom: 14,
+                }]}
+              >
+                Your rounds sync to a free web dashboard. Sign in at oga.golf
+                with the same account for bigger stats, strokes gained, and
+                shot-pattern charts.
+              </Text>
+              <Pressable
+                accessibilityRole="link"
+                accessibilityLabel="Open the OGA website"
+                onPress={() => Linking.openURL('https://oga.golf')}
+                style={{
+                  borderWidth: 1,
+                  borderColor: '#1F3D2C',
+                  paddingVertical: 12,
+                  alignItems: 'center',
+                  borderRadius: 2,
+                }}
+              >
+                <Text
+                  style={[TYPE.bodyBold, {
+                    color: '#1F3D2C',
+                    fontSize: 13,
+                    fontWeight: '600',
+                    letterSpacing: 0.3,
+                  }]}
+                >
+                  Website · oga.golf ↗
+                </Text>
+              </Pressable>
+              <View style={{ height: 1, backgroundColor: '#D9D2BF', marginVertical: 18 }} />
               <Text style={{ ...KICKER, marginBottom: 10 }}>Support OGA</Text>
               <Text
                 style={[TYPE.body, {

--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -184,7 +184,7 @@ export default function Stats() {
         eyebrow="Performance"
         title="Strokes Gained"
         right={
-          <View style={{ alignItems: 'flex-end', gap: 7 }}>
+          <View style={{ alignItems: 'flex-end', gap: 10 }}>
             <Pressable
               accessibilityRole="link"
               accessibilityLabel="Open the full dashboard on the web at oga.golf"
@@ -192,12 +192,14 @@ export default function Stats() {
               hitSlop={8}
             >
               <Text
+                numberOfLines={1}
                 style={[TYPE.body, {
                   color: 'rgba(242,238,229,0.4)',
                   fontSize: 11,
+                  lineHeight: 16,
                 }]}
               >
-                oga.golf ↗
+                Full dashboard → oga.golf ↗
               </Text>
             </Pressable>
             <View


### PR DESCRIPTION
Follow-up to the #743 web-companion pointers, from on-device QA (Android/S23).

**Profile (Android):** the web CTA was gated `Platform.OS === 'ios'` — on Android the card showed only the Ko-fi / GitHub Sponsors donation links, so Android users never saw a pointer to the web dashboard. Now the Android branch shows an 'OGA on the web' block (full-dashboard copy + oga.golf link) **above** the donation links, which are **kept** (divider between). iOS unchanged (still web-only, per App Review 3.1.1).

**Stats rider:** was the bare, barely-visible 'oga.golf ↗'. Now 'Full dashboard → oga.golf ↗' (lead-in), with `lineHeight: 16` + `gap: 10` so the 'g' descenders no longer clip behind the L5/L10/L20 toggle, and `numberOfLines={1}` so it can't wrap into the buttons on a narrow screen.

Mobile typecheck green. Pure-JS → OTA-eligible.