### PR TITLE
fix(web): putt-entry data integrity (#663, #666)

### DIFF
--- a/apps/web/src/components/round/WebPuttingSheet.tsx
+++ b/apps/web/src/components/round/WebPuttingSheet.tsx
@@ -113,6 +113,12 @@ export function WebPuttingSheet({
   // is the right key — opening the sheet for shot 4 then shot 5 (without
   // closing in between) should restart the form from the new shot's
   // seed values, not retain shot 4's typed distance.
+  //
+  // `initialDistanceFt` is deliberately NOT a dependency: it recomputes
+  // live as the player drags the putt marker or pin while the sheet is
+  // open, and re-running this effect on every drag wipes in-progress
+  // typed input. Snapshotting it at open/shot-change is correct — the
+  // distance is only a seed, and the player is now typing the real one (#666).
   useEffect(() => {
     if (!open) return
     const seed = initial ?? null
@@ -134,7 +140,7 @@ export function WebPuttingSheet({
     // eslint can't see the dependency and would request a useCallback.
     // Keeping it inline keeps the seed logic in one place.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, shotNumber, initialDistanceFt, initial, unit])
+  }, [open, shotNumber, initial, unit])
 
   const parsedDist = Number(distanceText)
   const distanceFt = Number.isFinite(parsedDist)

--- a/apps/web/src/components/rounds/ShotEntryModal.tsx
+++ b/apps/web/src/components/rounds/ShotEntryModal.tsx
@@ -189,12 +189,12 @@ export function ShotEntryModal({
       lie_slope_side: isPuttSave ? null : draft.lieSlopeSide ?? null,
       shot_result: isPuttSave ? null : draft.shotResult ?? null,
       distance_to_target: isPuttSave ? null : draft.distanceToTarget ?? null,
-      putt_distance_ft: draft.puttDistanceFt ?? null,
+      putt_distance_ft: isPuttSave ? draft.puttDistanceFt ?? null : null,
       putt_result: legacyPuttResult,
       putt_distance_result: isPuttSave ? distanceResult : null,
       putt_direction_result: isPuttSave ? directionResult : null,
-      putt_slope_pct: draft.puttSlopePct ?? null,
-      green_speed: draft.greenSpeed ?? null,
+      putt_slope_pct: isPuttSave ? draft.puttSlopePct ?? null : null,
+      green_speed: isPuttSave ? draft.greenSpeed ?? null : null,
       break_direction: isPuttSave
         ? combinedBreakDirection({
             vertical: draft.breakDirectionVertical,


### PR DESCRIPTION
Two small, verified round-detail putting fixes.

**#663 — stale putt columns on putt→non-putt edit.** `ShotEntryModal` gated `putt_distance_result`/`putt_direction_result`/`putt_result` on `isPuttSave` but left `putt_distance_ft`, `putt_slope_pct`, and `green_speed` writing unconditionally — so editing a putt into a non-putt persisted stale putt data hydrated from the old row. Now all three are gated the same way.

**#666 — putting sheet wipes typed input.** The `WebPuttingSheet` re-seed effect depended on `initialDistanceFt`, which recomputes live as the player drags the putt marker/pin. Any drag while the sheet was open re-ran the effect and reset every field mid-entry. Dropped it from the deps — the distance is snapshotted at open/shot-change (it's only a seed; the player types the real value).

Both verified against current code in the bug-status audit. Web-only, typecheck green.

Closes #663
Closes #666