### PR TITLE
fix(web): infer hole count for unmapped 9-hole courses (#727)

### DIFF
--- a/apps/web/src/pages/rounds/hooks/useRoundData.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundData.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import type { Database } from '@oga/supabase'
-import { getShotMarkerCategory, type LieType } from '@oga/core'
+import { getShotMarkerCategory, inferHoleCount, type LieType } from '@oga/core'
 import type {
   ExistingShot,
   HoleGeo,
@@ -91,15 +91,23 @@ export function useRoundData({
   // if fewer rows than the course expects, fill the gap.
   //
   // Expected count comes from `course_tees.par` when present (≤36 = 9,
-  // else 18); falls back to 18 when no tees row exists. 9-hole real
-  // courses with no course_tees row would over-pad — that combination
-  // is rare enough to leave for a follow-up.
+  // else 18). With no tees row, infer from the round's own hole_scores
+  // hole numbers — the authoritative per-round set — instead of assuming
+  // 18, so a 9-hole unmapped course doesn't get a phantom back nine
+  // (#727). inferHoleCount returns 18 for an empty set AND for any hole
+  // number > 9, so this can never strand holes 10–18 on an 18-hole round;
+  // it only trims to 9 when every scored hole is ≤ 9.
   const expectedHoleCount = useMemo(() => {
     const tees = teesQuery.data ?? []
     const totalPar = tees[0]?.par
-    if (totalPar != null && totalPar <= 36) return 9
-    return 18
-  }, [teesQuery.data])
+    if (totalPar != null) return totalPar <= 36 ? 9 : 18
+    const scores =
+      (round.data as { hole_scores?: HSWithJoin[] })?.hole_scores ?? []
+    const nums = scores
+      .map((hs) => hs.holes?.number)
+      .filter((n): n is number => n != null)
+    return inferHoleCount(nums)
+  }, [teesQuery.data, round.data])
 
   const holes = useMemo<HoleRow[]>(() => {
     const fetched = holesQuery.data ?? []


### PR DESCRIPTION
`useRoundData`'s `expectedHoleCount` fell back to a hardcoded 18 whenever a course had no `course_tees` row — so a 9-hole unmapped course got a phantom back nine (holes 10–18 synthesized). The old comment even flagged it as a known follow-up.

Now, when there's no tees par, it infers the count from the round's own `hole_scores` hole numbers (the authoritative per-round set) via core `inferHoleCount`. That helper returns 18 for an empty set **and** for any hole number > 9, so an 18-hole round can never be trimmed — it only returns 9 when every scored hole is ≤ 9. The length-based synthetic-hole detection (which CLAUDE.md warns against regressing) is untouched — only the count derivation changed.

Verified against current code in the bug-status audit. Web-only, typecheck green.

Closes #727