### PR TITLE
chore(web): hide Planner from nav until redesign

### DIFF
--- a/apps/web/src/components/layout/Sidebar.tsx
+++ b/apps/web/src/components/layout/Sidebar.tsx
@@ -16,7 +16,10 @@ const links: NavLinkDef[] = [
   { to: '/stats', label: 'Strokes Gained', section: 'menu' },
   { to: '/patterns', label: 'Shot Patterns', section: 'menu' },
   { to: '/practice', label: 'Practice', section: 'menu' },
-  { to: '/plan', label: 'Planner', section: 'menu' },
+  // Planner hidden from nav until the redesign lands (on-map HUD + notes,
+  // to match live-round). The /plan route still exists for dev/preview.
+  // Re-enable this line when #385 is polished.
+  // { to: '/plan', label: 'Planner', section: 'menu' },
   { to: '/learn', label: 'Learn', section: 'resources' },
   { to: '/settings/bag', label: 'My Bag', section: 'resources' },
   { to: '/settings', label: 'Settings', section: 'resources' },


### PR DESCRIPTION
The course planner (#385) is a rough first cut and would ship to oga.golf with the dev→main release (#784) as-is. Comments out the sidebar nav entry so it isn't exposed to users yet; the `/plan` route is untouched for continued development/preview.

Re-enable the one nav line when the planner redesign lands (on-map HUD to match live-round — dispersion toggle, tee-arc/approach-circle mode, styled club picker, prominent SG readout, and a notes box).

Web-only, typecheck green.