### PR TITLE
fix(core): proximity stat falls back to following putt distance (#575)

### DIFF
--- a/packages/core/src/__tests__/stats.test.ts
+++ b/packages/core/src/__tests__/stats.test.ts
@@ -618,3 +618,65 @@ describe('ballStrikingStats — girPct', () => {
     expect(ballStrikingStats([r]).girPct).toBeNull()
   })
 })
+
+describe('ballStrikingStats — proximityAvg (#575)', () => {
+  const PIN_LAT = 35.4676
+  const PIN_LNG = -97.5164
+
+  it('falls back to the following putt distance when no pin coordinate exists', () => {
+    // Synthetic-hole course: no pin on the hole or hole_score, and the
+    // approach has no end coords — but it was followed by a 15 ft putt, so
+    // proximity = 15 ft / 3 = 5 yd.
+    const r = makeRound({
+      hole_scores: [
+        makeHoleScore({
+          holes: makeHole({ par: 4, pin_lat: null, pin_lng: null }),
+          shots: [
+            makeShot({ shot_number: 1, lie_type: 'tee', distance_to_target: 400 }),
+            makeShot({ shot_number: 2, lie_type: 'fairway', distance_to_target: 150 }),
+            makeShot({ shot_number: 3, lie_type: 'green', putt_distance_ft: 15 }),
+          ],
+        }),
+      ],
+    })
+    expect(ballStrikingStats([r]).proximityAvg).toBeCloseTo(5, 5)
+  })
+
+  it('still prefers pin geometry when a pin coordinate is present', () => {
+    const r = makeRound({
+      hole_scores: [
+        makeHoleScore({
+          holes: makeHole({ par: 4, pin_lat: PIN_LAT, pin_lng: PIN_LNG }),
+          shots: [
+            makeShot({ shot_number: 1, lie_type: 'tee', distance_to_target: 400 }),
+            makeShot({
+              shot_number: 2,
+              lie_type: 'fairway',
+              distance_to_target: 150,
+              end_lat: PIN_LAT,
+              end_lng: PIN_LNG,
+            }),
+            // A putt exists but pin-based proximity (0 yd, coincident) wins.
+            makeShot({ shot_number: 3, lie_type: 'green', putt_distance_ft: 30 }),
+          ],
+        }),
+      ],
+    })
+    expect(ballStrikingStats([r]).proximityAvg).toBeCloseTo(0, 5)
+  })
+
+  it('is null when there is neither a pin nor a following putt', () => {
+    const r = makeRound({
+      hole_scores: [
+        makeHoleScore({
+          holes: makeHole({ par: 4, pin_lat: null, pin_lng: null }),
+          shots: [
+            makeShot({ shot_number: 1, lie_type: 'tee', distance_to_target: 400 }),
+            makeShot({ shot_number: 2, lie_type: 'fairway', distance_to_target: 150 }),
+          ],
+        }),
+      ],
+    })
+    expect(ballStrikingStats([r]).proximityAvg).toBeNull()
+  })
+})

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -5,6 +5,7 @@ import {
 } from './sg-calculator'
 import { NEAR_GREEN_YARDS } from './constants'
 import type { LieSlopeForward, LieSlopeSide, LieType, ShotCategory, ShotResult } from './constants'
+import { isPuttShot } from './round'
 import { METERS_TO_YARDS, YARDS_TO_METERS, haversineYards, toRadians } from './units'
 import { RESULT_QUALITY } from './types'
 import type { DistanceUnit } from './types'
@@ -528,11 +529,23 @@ export function ballStrikingStats(rounds: DetailedRound[]): BallStrikingStats {
         if (
           category === 'approach' &&
           s.distance_to_target != null &&
-          s.distance_to_target > NEAR_GREEN_YARDS &&
-          s.end_lat != null &&
-          s.end_lng != null
+          s.distance_to_target > NEAR_GREEN_YARDS
         ) {
-          const prox = getProximityYards(s.end_lat, s.end_lng, hs, hole)
+          // Prefer pin geometry (needs end coords + a pin coordinate).
+          let prox: number | null =
+            s.end_lat != null && s.end_lng != null
+              ? getProximityYards(s.end_lat, s.end_lng, hs, hole)
+              : null
+          // Fallback when there's no pin — typical on synthetic-hole courses
+          // where per-round pins are optional. If the approach was followed
+          // by a putt, that putt's length from the hole IS how close the
+          // approach finished. putt_distance_ft → yards (3 ft = 1 yd). #575
+          if (prox == null) {
+            const next = shots[i + 1]
+            if (next && isPuttShot(next.lie_type) && next.putt_distance_ft != null) {
+              prox = next.putt_distance_ft / 3
+            }
+          }
           if (prox != null && prox < 100) {
             proximities.push(prox)
             roundsWithProximity.add(r.id)


### PR DESCRIPTION
**Ball-striking PROXIMITY showed a bare em-dash** for most users. It required a pin coordinate (`hole_scores`/`holes` `pin_lat/lng`), which is null on the majority of prod courses — only OSM-mapped courses have `holes` rows, and per-round pin placement is optional. The other three ball-striking stats don't need a pin, so they populated while proximity alone went dark.

**Fix:** `ballStrikingStats` now falls back — when an approach has no pin-based proximity but was followed by a putt, that putt's distance from the hole *is* how close the approach finished (`putt_distance_ft / 3` → yards). Pin geometry still wins when a pin exists. Also covers approaches logged without end coords (scorecard-only rounds with putt data).

+3 core tests (fallback fires, pin-geometry precedence, null when neither). All 592 core tests green, workspace typecheck green.

Closes #575