### PR TITLE
feature(web): hole review sheet → 'how'd it go?' summary (#791 step 2, web)

### DIFF
--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -38,7 +38,7 @@ interface HoleReviewSheetProps {
   saving: boolean
   /** "Edit on map" — close the sheet and let the user drag markers. */
   onEditOnMap: () => void
-  onSave: (rows: ReviewedShotRow[]) => void | Promise<void>
+  onSave: (rows: ReviewedShotRow[], penalties: number) => void | Promise<void>
 }
 
 const PUTT_DISTANCE_OPTIONS: { value: PuttDistanceResult; label: string }[] = [
@@ -67,6 +67,10 @@ export function HoleReviewSheet({
   onSave,
 }: HoleReviewSheetProps) {
   const [rows, setRows] = useState<ReviewedShotRow[]>([])
+  // Penalty strokes are the one hole-level number not derivable from placed
+  // shots (a penalty isn't a marker), so it's an editable ticker. Score and
+  // putts stay derived from the shots you placed. #791
+  const [penalties, setPenalties] = useState(0)
 
   // Read the latest placedPoints inside the effect via ref so the effect
   // doesn't re-fire (and clobber user edits) just because the parent
@@ -90,6 +94,7 @@ export function HoleReviewSheet({
     }
     if (hydratedHoleRef.current === holeNumber) return
     hydratedHoleRef.current = holeNumber
+    setPenalties(0)
     // When pin coords are unavailable (course has no OSM hole layout and
     // the user hasn't manually placed a pin), build rows directly from
     // placed points: end of shot N is the next placed point, last shot
@@ -237,6 +242,7 @@ export function HoleReviewSheet({
         <div style={{ display: 'flex', gap: 10 }}>
           <SummaryStat label="Score" value={shotCount} vsPar={vsPar} />
           <SummaryStat label="Putts" value={puttCount} />
+          <PenaltyTicker value={penalties} onChange={setPenalties} />
         </div>
       </div>
 
@@ -338,7 +344,7 @@ export function HoleReviewSheet({
         </button>
         <button
           type="button"
-          onClick={() => onSave(rows)}
+          onClick={() => onSave(rows, penalties)}
           disabled={saving || rows.length === 0}
           className="bg-caddie-accent text-caddie-accent-ink disabled:opacity-40"
           style={{
@@ -413,6 +419,73 @@ function SummaryStat({
           {vsParText}
         </span>
       )}
+    </div>
+  )
+}
+
+function PenaltyTicker({
+  value,
+  onChange,
+}: {
+  value: number
+  onChange: (n: number) => void
+}) {
+  const btn = (label: string, delta: number, disabled: boolean) => (
+    <button
+      type="button"
+      aria-label={delta < 0 ? 'Fewer penalties' : 'More penalties'}
+      onClick={() => onChange(Math.max(0, value + delta))}
+      disabled={disabled}
+      className="text-caddie-ink-dim disabled:opacity-30"
+      style={{
+        width: 26,
+        height: 26,
+        borderRadius: '50%',
+        border: '1px solid #9F9580',
+        background: 'transparent',
+        fontSize: 16,
+        lineHeight: 1,
+        cursor: disabled ? 'default' : 'pointer',
+      }}
+    >
+      {label}
+    </button>
+  )
+  return (
+    <div
+      style={{
+        flex: 1,
+        background: '#F2EEE5',
+        border: '1px solid #D9D2BF',
+        borderRadius: 6,
+        padding: '8px 10px 9px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <span
+          className="font-serif tabular text-caddie-ink"
+          style={{
+            fontSize: 26,
+            fontWeight: 500,
+            lineHeight: 1,
+            color: value > 0 ? '#A66A1F' : '#1C211C',
+          }}
+        >
+          {value}
+        </span>
+        <span className="kicker" style={{ color: '#8A8B7E', marginTop: 2 }}>
+          Penalties
+        </span>
+      </div>
+      <div
+        style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}
+      >
+        {btn('−', -1, value === 0)}
+        {btn('+', 1, false)}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -164,6 +164,15 @@ export function HoleReviewSheet({
 
   if (!open) return null
 
+  // Summary values, derived from the shots placed on the map — same rule
+  // saveReviewedHole persists (score = shot count, putts = green-lie shots).
+  // Shown prominently so the sheet reads as "how'd it go?" first, detail
+  // second. (Editable score/putts + penalties are a deliberate follow-up:
+  // they need a save-path/schema decision made alongside the mobile build.)
+  const shotCount = rows.length
+  const puttCount = rows.filter((r) => isPuttShot(r.lieType)).length
+  const vsPar = shotCount > 0 ? shotCount - par : null
+
   return (
     <div
       role="dialog"
@@ -205,23 +214,27 @@ export function HoleReviewSheet({
       </div>
       <div
         style={{
-          display: 'flex',
-          alignItems: 'baseline',
-          justifyContent: 'space-between',
           padding: '0 22px 14px',
           borderBottom: '1px solid #D9D2BF',
         }}
       >
-        <div>
-          <div className="kicker" style={{ marginBottom: 4 }}>
-            Hole {holeNumber} review
-          </div>
-          <div
-            className="font-serif text-caddie-ink"
-            style={{ fontSize: 22, fontWeight: 500, fontStyle: 'italic' }}
-          >
-            {rows.length} shot{rows.length === 1 ? '' : 's'} · par {par}
-          </div>
+        <div className="kicker" style={{ marginBottom: 4 }}>
+          Hole {holeNumber} · Par {par}
+        </div>
+        <div
+          className="font-serif text-caddie-ink"
+          style={{
+            fontSize: 24,
+            fontWeight: 500,
+            fontStyle: 'italic',
+            marginBottom: 14,
+          }}
+        >
+          Nice — how'd it go?
+        </div>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <SummaryStat label="Score" value={shotCount} vsPar={vsPar} />
+          <SummaryStat label="Putts" value={puttCount} />
         </div>
       </div>
 
@@ -241,7 +254,14 @@ export function HoleReviewSheet({
             No placed shots. Drop pins on the map and try again.
           </div>
         ) : (
-          rows.map((row, idx) => (
+          <>
+          <div
+            className="kicker"
+            style={{ paddingTop: 10, paddingBottom: 2, color: '#8A8B7E' }}
+          >
+            Your shots · optional
+          </div>
+          {rows.map((row, idx) => (
             <ShotRow
               key={row.shotNumber}
               row={row}
@@ -282,7 +302,8 @@ export function HoleReviewSheet({
                 })
               }
             />
-          ))
+          ))}
+          </>
         )}
       </div>
 
@@ -326,7 +347,7 @@ export function HoleReviewSheet({
             letterSpacing: '0.02em',
           }}
         >
-          {saving ? 'Saving…' : 'Save hole'}{' '}
+          {saving ? 'Saving…' : 'Save & next hole'}{' '}
           {!saving && (
             <span className="font-serif" style={{ fontStyle: 'italic' }}>
               →
@@ -334,6 +355,62 @@ export function HoleReviewSheet({
           )}
         </button>
       </div>
+    </div>
+  )
+}
+
+function SummaryStat({
+  label,
+  value,
+  vsPar,
+}: {
+  label: string
+  value: number
+  vsPar?: number | null
+}) {
+  const vsParText =
+    vsPar == null ? null : vsPar === 0 ? 'E' : vsPar > 0 ? `+${vsPar}` : `${vsPar}`
+  // Muted brick over par, forest under, ink at even — never a bright red.
+  const vsParColor =
+    vsPar == null || vsPar === 0 ? '#5C6356' : vsPar > 0 ? '#A33A2A' : '#1F3D2C'
+  return (
+    <div
+      style={{
+        flex: 1,
+        background: '#F2EEE5',
+        border: '1px solid #D9D2BF',
+        borderRadius: 6,
+        padding: '10px 12px 11px',
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 8,
+      }}
+    >
+      <span
+        className="font-serif tabular text-caddie-ink"
+        style={{ fontSize: 28, fontWeight: 500, lineHeight: 1 }}
+      >
+        {value}
+      </span>
+      <span
+        className="kicker"
+        style={{ color: '#8A8B7E' }}
+      >
+        {label}
+      </span>
+      {vsParText && (
+        <span
+          className="font-serif"
+          style={{
+            marginLeft: 'auto',
+            fontSize: 14,
+            fontStyle: 'italic',
+            color: vsParColor,
+          }}
+        >
+          {vsParText}
+        </span>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -181,8 +181,8 @@ export function HoleReviewSheet({
         position: 'absolute',
         left: 0,
         right: 0,
+        top: 0,
         bottom: 0,
-        maxHeight: 'min(60vh, 60%)',
         background: '#FBF8F1',
         borderTop: '1px solid #9F9580',
         borderTopLeftRadius: 12,
@@ -191,7 +191,9 @@ export function HoleReviewSheet({
         flexDirection: 'column',
         transform: slidIn ? 'translateY(0)' : 'translateY(100%)',
         transition: 'transform 220ms ease-out',
-        zIndex: 5,
+        // Fill the whole map area and sit above the map HUD (EXP / rail /
+        // PATTERN / aim overlays) so nothing bleeds over the summary. #791
+        zIndex: 40,
       }}
     >
       <div

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -103,7 +103,10 @@ export interface UseRoundActionsResult {
   handleMoveExistingShot: (shotId: string, point: PlacedPoint) => Promise<void>
   handleMoveExistingShotAim: (shotId: string, point: PlacedPoint) => Promise<void>
   applyShotDragUndo: () => Promise<void>
-  saveReviewedHole: (rows: ReviewedShotRow[]) => Promise<void>
+  saveReviewedHole: (
+    rows: ReviewedShotRow[],
+    penalties?: number,
+  ) => Promise<void>
   handleDelete: () => Promise<void>
   handleComplete: () => Promise<void>
   handleShare: () => Promise<void>
@@ -570,7 +573,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
   }, [shareCardRef, sharing, shareTone, round.data, setSharing, setCompleteError])
 
   const saveReviewedHole = useCallback(
-    async (rows: ReviewedShotRow[]) => {
+    async (rows: ReviewedShotRow[], penalties = 0) => {
       if (!user || !activeHole || !round.data) return
       setSavingHole(true)
       dispatchHoleView({ type: 'SAVE_ERROR', message: null })
@@ -614,6 +617,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
           hole_id: realHoleId,
           score: rows.length,
           putts: puttCount,
+          penalties,
           fairway_hit: existing?.fairway_hit ?? inferred.fairway,
           gir: existing?.gir ?? inferred.gir,
           // Persist a manually placed pin. On unmapped courses no hole_scores

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -251,6 +251,7 @@ export type Database = {
           par: number | null
           pin_lat: number | null
           pin_lng: number | null
+          penalties: number
           putts: number | null
           round_id: string
           score: number
@@ -267,6 +268,7 @@ export type Database = {
           par?: number | null
           pin_lat?: number | null
           pin_lng?: number | null
+          penalties?: number
           putts?: number | null
           round_id: string
           score: number
@@ -283,6 +285,7 @@ export type Database = {
           par?: number | null
           pin_lat?: number | null
           pin_lng?: number | null
+          penalties?: number
           putts?: number | null
           round_id?: string
           score?: number

--- a/supabase/migrations/0041_hole_scores_penalties.sql
+++ b/supabase/migrations/0041_hole_scores_penalties.sql
@@ -1,0 +1,6 @@
+-- Per-hole penalty-stroke count, entered in the end-of-hole summary
+-- ("how'd it go?" — score / putts / penalties tickers). Additive and
+-- defaulted to 0, so existing rows, the scorecard, and all SG/score math
+-- are unaffected until a user actually records a penalty.
+alter table public.hole_scores
+  add column if not exists penalties integer not null default 0;


### PR DESCRIPTION
First step of the live-round redesign epic (#791), web side. The trace found web already defers metadata to this end-of-hole review sheet (mobile is the outlier), so web leads: refine the sheet into the 'how'd it go?' summary that both platforms will share.

**Changes (presentation only — one component):**
- Warm header **'Nice — how'd it go?'** + 'Hole N · Par X' kicker.
- Prominent **Score + Putts** summary stats up top (derived from placed shots — score = shot count, putts = green-lie shots), with a vs-par delta chip (muted brick over par, forest under, ink at even).
- Per-shot detail reframed under a quiet **'Your shots · optional'** subhead — same editing rows, now clearly the secondary layer.
- CTA 'Save hole' → **'Save & next hole'**.

**No persistence/schema change.** `saveReviewedHole` still derives score/putts identically. Typecheck + web build green.

**Deferred (flagged in a code comment, on purpose):**
- **Editable** score/putts steppers — needs threading overrides through `saveReviewedHole`; do it alongside the mobile build so the model matches.
- **Penalties** — no hole-level column exists (only per-shot `shots.penalty`); adding it is a schema/modeling decision (small migration or per-shot derivation), not something to slip into a UI refactor.

Please eyeball the Vercel preview — the sheet opens from 'Done with hole' in a live round map view.

Part of #791.