### PR TITLE
fix(crawl): keep nameless OSM golf courses instead of dropping them

### DIFF
--- a/scripts/crawl/osm-fetcher.ts
+++ b/scripts/crawl/osm-fetcher.ts
@@ -1,16 +1,7 @@
 // OSM Overpass — state-level course discovery (centroid only).
-import {
-  OSM_DELAY_MS,
-  OVERPASS_ENDPOINTS,
-  STATE_BBOX,
-  sleep,
-} from './util'
+import { OSM_DELAY_MS, OVERPASS_ENDPOINTS, STATE_BBOX, sleep } from './util'
 import type { OsmCourseLite, OverpassResponse } from './types'
-import {
-  getCrawlState,
-  setCrawlState,
-  upsertCourse,
-} from './db-writer'
+import { getCrawlState, setCrawlState, upsertCourse } from './db-writer'
 
 export async function fetchOsmCoursesInState(state: string): Promise<OsmCourseLite[]> {
   const bbox = STATE_BBOX[state]
@@ -56,8 +47,6 @@ out center tags;
         const out: OsmCourseLite[] = []
         for (const el of data.elements) {
           const tags = el.tags ?? {}
-          const name = tags['name']
-          if (!name) continue
           let lat: number | undefined
           let lng: number | undefined
           if (el.type === 'node') {
@@ -71,6 +60,11 @@ out center tags;
           }
           if (lat == null || lng == null) continue
           const city = (tags['addr:city'] ?? '').trim() || undefined
+          // ~20% of golf_course ways in OSM carry no name tag (a mapper drew
+          // the outline but never named it). They're real courses — keep them
+          // with a location fallback instead of dropping. Upsert-on-external_id
+          // patches the real name in if OSM gets one on a later crawl.
+          const name = tags['name'] || `Golf Course${city ? ` (${city})` : ''}`
           out.push({
             osmType: el.type,
             osmId: el.id,
@@ -109,9 +103,7 @@ export async function crawlOsm(
     const crawlId = `osm:state:${state}`
     const prev = await getCrawlState(crawlId)
     if (prev?.status === 'done' && !force) {
-      console.log(
-        `[osm:${state}] skip — already done (${prev.items_processed} courses)`,
-      )
+      console.log(`[osm:${state}] skip — already done (${prev.items_processed} courses)`)
       continue
     }
     await setCrawlState(crawlId, { status: 'in_progress', errorMessage: null })
@@ -157,9 +149,7 @@ export async function crawlOsm(
         itemsProcessed: stateCount,
         errorMessage: null,
       })
-      console.log(
-        `[osm:${state}] done — ${stateCount} processed, ${stateErrors} errors`,
-      )
+      console.log(`[osm:${state}] done — ${stateCount} processed, ${stateErrors} errors`)
     } catch (err) {
       console.error(`[osm:${state}] fatal: ${(err as Error).message}`)
       await setCrawlState(crawlId, {


### PR DESCRIPTION
## Problem

The OSM course-discovery pass (`scripts/crawl/osm-fetcher.ts`) dropped every `leisure=golf_course` way that had no `name` tag via `if (!name) continue`. But **~20% of golf-course ways in OSM are nameless** — a mapper drew the outline (often with full hole/green geometry) but never typed a name. Those are real courses.

Concrete miss: **FireLake Golf Course** (Shawnee, OK — Citizen Potawatomi Nation, 18 holes) is fully mapped in OSM as nameless way `676111573`, so it never entered the `courses` table. Its 16 mapped holes also had no course centroid to attach to in the `osm-holes` pass. Double miss, same root cause.

## Fix

Keep nameless courses with a location fallback name:

```js
const name = tags['name'] || `Golf Course${city ? ` (${city})` : ''}`
```

Upsert-on-`external_id` means a later crawl patches the real name in if OSM ever gets one. App course-selection is GPS-proximity based, so a located-but-generically-named course is far more useful than a missing one.

## Validation (Oklahoma, dry run — no writes)

Ran the real `fetchOsmCoursesInState('OK')`:
- **212 courses captured**, **41 previously dropped** as nameless.
- FireLake way `676111573` now captured.

## Notes / follow-ups
- **Backfill still required** to populate prod — re-run `--source osm --force` (states skip when already `done`), then `--source osm-holes --force` to attach orphaned holes.
- **Name-clobber caveat:** `upsertCourse` overwrites `name` unconditionally, so a backfill would rename any manually-corrected row back to the fallback. FireLake was hand-inserted with its real name + `external_id=osm_way_676111573`; guard the update (don't overwrite a real name with a fallback) before running the national backfill.
- Nameless courses won't get OpenGolfAPI enrichment (tee ratings) since that pass is name-search based; they still get course + hole geometry.