### PR TITLE
feature(crawl): reverse-geocode course city from coordinates (OSM Nominatim)

### DIFF
--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -41,6 +41,7 @@ import { countCourses, fetchAllCrawlState } from './crawl/db-writer'
 import { crawlOsm } from './crawl/osm-fetcher'
 import { crawlOsmHoles } from './crawl/holes-fetcher'
 import { crawlEnrich, crawlOpenGolfApi } from './crawl/enricher'
+import { crawlGeocode } from './crawl/geocoder'
 import type { Args, Source } from './crawl/types'
 
 function parseArgs(argv: string[]): Args {
@@ -54,7 +55,7 @@ function parseArgs(argv: string[]): Args {
     const a = argv[i]
     const next = argv[i + 1]
     if (a === '--source' && next) {
-      const allowed = ['opengolfapi', 'osm', 'osm-first', 'enrich', 'osm-holes'] as const
+      const allowed = ['opengolfapi', 'osm', 'osm-first', 'enrich', 'osm-holes', 'geocode'] as const
       if (!allowed.includes(next as Source)) {
         throw new Error(`--source must be one of ${allowed.join(', ')} (got: ${next})`)
       }
@@ -122,6 +123,7 @@ async function main(): Promise<void> {
         '  tsx scripts/crawl-courses.ts --source osm-holes [--states TX,OK] [--force] [--limit N]\n' +
         '  tsx scripts/crawl-courses.ts --source enrich [--states TX,OK] [--force]\n' +
         '  tsx scripts/crawl-courses.ts --source opengolfapi [--states TX,OK] [--force]\n' +
+        '  tsx scripts/crawl-courses.ts --source geocode [--limit N]\n' +
         '  tsx scripts/crawl-courses.ts --status',
     )
     process.exit(1)
@@ -131,6 +133,14 @@ async function main(): Promise<void> {
     const states = args.states ?? [...ALL_STATES]
     console.log(`OpenGolfAPI crawl: ${states.length} state(s)${args.force ? ' (force)' : ''}`)
     await crawlOpenGolfApi(states, args.force, args.limit)
+    return
+  }
+
+  // Geocode operates on the whole courses table (any coord course with a null
+  // city), so it needs no state bbox.
+  if (args.source === 'geocode') {
+    console.log(`Geocode crawl${args.limit != null ? ` (limit ${args.limit})` : ''}`)
+    await crawlGeocode(args.limit)
     return
   }
 

--- a/scripts/crawl/db-writer.ts
+++ b/scripts/crawl/db-writer.ts
@@ -126,6 +126,51 @@ export async function fetchCourseGeoForState(state: string): Promise<CourseGeo[]
   return all
 }
 
+// Courses that have a centroid but no city. The geocode pass reverse-geocodes
+// each one's coordinates (OSM Nominatim) to fill the city. Optional cap so a
+// rate-limited run stays bounded.
+export async function fetchCitylessCourses(
+  limit: number | null,
+): Promise<{ id: string; name: string; lat: number; lng: number }[]> {
+  const PAGE_SIZE = 500
+  const out: { id: string; name: string; lat: number; lng: number }[] = []
+  let from = 0
+  while (true) {
+    const to = limit != null ? Math.min(from + PAGE_SIZE, limit) - 1 : from + PAGE_SIZE - 1
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id, name, lat, lng')
+      .is('city', null)
+      .not('lat', 'is', null)
+      .not('lng', 'is', null)
+      .range(from, to)
+    if (error) {
+      throw new Error(
+        `cityless fetch failed (range=${from}-${to}): ${error.message ?? JSON.stringify(error)}`,
+      )
+    }
+    const rows = (data ?? []) as { id: string; name: string; lat: number | null; lng: number | null }[]
+    for (const r of rows) {
+      if (r.lat != null && r.lng != null) out.push({ id: r.id, name: r.name, lat: r.lat, lng: r.lng })
+    }
+    if (rows.length < PAGE_SIZE) break
+    if (limit != null && out.length >= limit) break
+    from += PAGE_SIZE
+  }
+  return limit != null ? out.slice(0, limit) : out
+}
+
+// Fill a course's city (and optionally rewrite its "Golf Course" fallback
+// name). Used by the geocode pass only.
+export async function updateCourseCity(id: string, city: string, name?: string): Promise<void> {
+  const patch: { city: string; name?: string } = { city }
+  if (name) patch.name = name
+  const { error } = await supabase.from('courses').update(patch).eq('id', id)
+  if (error) {
+    throw new Error(`city update failed (course=${id}): ${error.message ?? JSON.stringify(error)}`)
+  }
+}
+
 // Course ids that already have at least one hole carrying coordinates. The
 // osm-holes pass skips these so it never clobbers hand-curated or previously
 // imported geometry (idempotent + safe to re-run). Chunked like the tee lookup.

--- a/scripts/crawl/geocoder.ts
+++ b/scripts/crawl/geocoder.ts
@@ -1,0 +1,82 @@
+// OSM Nominatim reverse geocoding — derive a course's city from its centroid.
+// Most OSM golf_course ways carry no addr:city, so osm-fetcher can only give
+// them a bare "Golf Course" fallback name. This pass reverse-geocodes those
+// coordinates to a real city so courses become locatable without hand-editing.
+import { sleep } from './util'
+import { fetchCitylessCourses, updateCourseCity } from './db-writer'
+
+const NOMINATIM_REVERSE = 'https://nominatim.openstreetmap.org/reverse'
+// Nominatim usage policy: absolute max 1 req/sec, identifying User-Agent required.
+const NOMINATIM_DELAY_MS = 1100
+const USER_AGENT = 'oga-course-crawler/0.1 (https://github.com/cner-smith/opengolfapp)'
+
+// Reverse-geocode a coordinate to its city name. Returns null when Nominatim
+// has no populated place for the point (or on repeated failure). Prefers the
+// most specific place field; county is intentionally skipped as too coarse for
+// a useful course label.
+export async function reverseGeocodeCity(lat: number, lng: number): Promise<string | null> {
+  // No zoom override: zoom=10 collapses to county-level and drops the city.
+  const url = `${NOMINATIM_REVERSE}?format=jsonv2&lat=${lat}&lon=${lng}&addressdetails=1`
+  let attempts = 0
+  const MAX_ATTEMPTS = 2
+  while (true) {
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+      })
+      if (res.status === 429) {
+        console.warn('[geocode] rate limited — waiting 30s')
+        await sleep(30000)
+        continue
+      }
+      if (!res.ok) {
+        attempts++
+        if (attempts < MAX_ATTEMPTS) {
+          console.warn(`[geocode] HTTP ${res.status} — retrying in 5s`)
+          await sleep(5000)
+          continue
+        }
+        return null
+      }
+      const data = (await res.json()) as { address?: Record<string, string> }
+      const a = data.address ?? {}
+      return a.city || a.town || a.village || a.hamlet || a.municipality || null
+    } catch (err) {
+      attempts++
+      if (attempts < MAX_ATTEMPTS) {
+        console.warn(`[geocode] ${(err as Error).message} — retrying in 5s`)
+        await sleep(5000)
+        continue
+      }
+      return null
+    }
+  }
+}
+
+// Backfill city for every course that has coordinates but no city. Rewrites the
+// bare "Golf Course" fallback name to "Golf Course (City)" so nameless courses
+// gain a location label; leaves real names untouched. --limit caps a run
+// (Nominatim is ~1 req/sec, so a full national backfill takes hours).
+export async function crawlGeocode(limit: number | null): Promise<void> {
+  const courses = await fetchCitylessCourses(limit)
+  console.log(`Geocode: ${courses.length} course(s) with coords but no city`)
+  let filled = 0
+  let missed = 0
+  for (let i = 0; i < courses.length; i++) {
+    const c = courses[i]
+    if (!c) continue
+    const city = await reverseGeocodeCity(c.lat, c.lng)
+    if (city) {
+      const name = c.name.startsWith('Golf Course') ? `Golf Course (${city})` : undefined
+      await updateCourseCity(c.id, city, name)
+      filled++
+    } else {
+      missed++
+    }
+    if ((i + 1) % 25 === 0 || i === courses.length - 1) {
+      console.log(`[geocode] ${i + 1}/${courses.length} — filled ${filled}, no-match ${missed}`)
+    }
+    await sleep(NOMINATIM_DELAY_MS)
+  }
+  console.log(`\nGeocode complete: ${filled} cities filled, ${missed} without a match`)
+}

--- a/scripts/crawl/types.ts
+++ b/scripts/crawl/types.ts
@@ -93,7 +93,7 @@ export interface OsmCourseLite {
 
 export type CrawlStatus = 'pending' | 'in_progress' | 'done' | 'error'
 
-export type Source = 'opengolfapi' | 'osm' | 'osm-first' | 'enrich' | 'osm-holes'
+export type Source = 'opengolfapi' | 'osm' | 'osm-first' | 'enrich' | 'osm-holes' | 'geocode'
 
 /** A hole with optional per-hole geometry, written by the osm-holes pass. */
 export interface OgaHoleGeo {


### PR DESCRIPTION
## Why

Most OSM `golf_course` ways carry no `addr:city`, so the discovery pass can only give nameless courses a bare `Golf Course` fallback name (see #793). This adds a way to relate any coordinate-bearing course to a location automatically, so we don't hand-edit cities/names.

## What

New `--source geocode` pass + `reverseGeocodeCity(lat, lng)` (`scripts/crawl/geocoder.ts`):
- For every course with a centroid but **no city**, reverse-geocode via **OSM Nominatim** and fill `courses.city`.
- Bare `Golf Course` fallback names → `Golf Course (City)`. **Real names are left untouched** (guards manually-corrected rows like the hand-inserted `FireLake Golf Course`).
- Nominatim policy respected: 1 req/sec + identifying User-Agent, 429 backoff, one retry. `--limit N` caps a run.
- Table-wide (not per-state), so it needs no bbox.

```
tsx scripts/crawl-courses.ts --source geocode [--limit N]
```

## Validation (dry run, no DB writes)

Real `reverseGeocodeCity`:
- `35.3726675, -96.9697245` (FireLake) → **Shawnee** ✓
- `36.5674, -121.9487` (Pebble Beach) → **Del Monte Forest** ✓ (correct CDP)

Found during testing: `zoom=10` collapses Nominatim to county-level and drops the city — the query uses default zoom.

Typecheck clean (`tsc --noEmit` on the changed scripts).

## Notes
- Pairs with #793 (keep nameless courses): after that backfill creates `Golf Course` rows, this pass gives them real city labels.
- Only fills `city` (already-known 2-letter `state` is untouched — Nominatim returns full state names).