### PR TITLE
feature(web): 'how'd it go?' hole summary — tickers, detail chips, on-demand putt aimer (#791)

### DIFF
--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -12,7 +12,7 @@ import {
   formatClubLabel,
   haversineYards,
   horizontalBreakFromAim,
-  isPuttShot,
+  isPuttEntry,
   type BreakDirectionHorizontal,
   type BreakDirectionVertical,
   type Club,
@@ -190,7 +190,7 @@ export function HoleReviewSheet({
       })
     setRows(merged)
     setScore(merged.length)
-    setPutts(merged.filter((r) => isPuttShot(r.lieType)).length)
+    setPutts(merged.filter((r) => isPuttEntry(r.lieType, r.club)).length)
     setPenalties(0)
   }, [open, holeNumber, par, pinLat, pinLng])
 
@@ -520,7 +520,7 @@ function ShotRow({
   // Putt-ness is the green lie only (set when a putt is placed). Raw
   // distance must NOT classify: a chip/bunker inside 30 yd is not a putt,
   // and unmapped rows read distanceToPin 0 (#660).
-  const isPutt = isPuttShot(row.lieType)
+  const isPutt = isPuttEntry(row.lieType, row.club)
   const { toDisplay, toDisplayFt } = useUnits()
   const { bag } = useUserBag()
   // Source the club options from the user's bag, falling back to
@@ -615,6 +615,12 @@ function ShotRow({
       {isPutt ? (
         <>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            <FieldChip
+              label={clubLabel}
+              filled
+              active={open === 'club'}
+              onClick={() => toggle('club')}
+            />
             <button
               type="button"
               onClick={() =>
@@ -657,6 +663,17 @@ function ShotRow({
             />
             <FieldChip label="Read ▸" filled={hasRead} onClick={onOpenAimer} />
           </div>
+          {open === 'club' && (
+            <ChipExpand
+              label="Club"
+              options={clubOptions}
+              value={row.club}
+              onSelect={(v) => {
+                onChange({ ...row, club: v as Club })
+                setOpen(null)
+              }}
+            />
+          )}
           {open === 'break' && <BreakExpand row={row} onChange={onChange} />}
           {open === 'speed' && (
             <ChipExpand

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -38,7 +38,7 @@ interface HoleReviewSheetProps {
   saving: boolean
   /** "Edit on map" — close the sheet and let the user drag markers. */
   onEditOnMap: () => void
-  onSave: (rows: ReviewedShotRow[]) => void | Promise<void>
+  onSave: (rows: ReviewedShotRow[], penalties: number) => void | Promise<void>
 }
 
 const PUTT_DISTANCE_OPTIONS: { value: PuttDistanceResult; label: string }[] = [
@@ -67,6 +67,10 @@ export function HoleReviewSheet({
   onSave,
 }: HoleReviewSheetProps) {
   const [rows, setRows] = useState<ReviewedShotRow[]>([])
+  // Penalty strokes are the one hole-level number not derivable from placed
+  // shots (a penalty isn't a marker), so it's an editable ticker. Score and
+  // putts stay derived from the shots you placed. #791
+  const [penalties, setPenalties] = useState(0)
 
   // Read the latest placedPoints inside the effect via ref so the effect
   // doesn't re-fire (and clobber user edits) just because the parent
@@ -90,6 +94,7 @@ export function HoleReviewSheet({
     }
     if (hydratedHoleRef.current === holeNumber) return
     hydratedHoleRef.current = holeNumber
+    setPenalties(0)
     // When pin coords are unavailable (course has no OSM hole layout and
     // the user hasn't manually placed a pin), build rows directly from
     // placed points: end of shot N is the next placed point, last shot
@@ -237,6 +242,7 @@ export function HoleReviewSheet({
         <div style={{ display: 'flex', gap: 10 }}>
           <SummaryStat label="Score" value={shotCount} vsPar={vsPar} />
           <SummaryStat label="Putts" value={puttCount} />
+          <PenaltyTicker value={penalties} onChange={setPenalties} />
         </div>
       </div>
 
@@ -338,7 +344,7 @@ export function HoleReviewSheet({
         </button>
         <button
           type="button"
-          onClick={() => onSave(rows)}
+          onClick={() => onSave(rows, penalties)}
           disabled={saving || rows.length === 0}
           className="bg-caddie-accent text-caddie-accent-ink disabled:opacity-40"
           style={{
@@ -413,6 +419,73 @@ function SummaryStat({
           {vsParText}
         </span>
       )}
+    </div>
+  )
+}
+
+function PenaltyTicker({
+  value,
+  onChange,
+}: {
+  value: number
+  onChange: (n: number) => void
+}) {
+  const btn = (label: string, delta: number, disabled: boolean) => (
+    <button
+      type="button"
+      aria-label={delta < 0 ? 'Fewer penalties' : 'More penalties'}
+      onClick={() => onChange(Math.max(0, value + delta))}
+      disabled={disabled}
+      className="text-caddie-ink-dim disabled:opacity-30"
+      style={{
+        width: 26,
+        height: 26,
+        borderRadius: '50%',
+        border: '1px solid #9F9580',
+        background: 'transparent',
+        fontSize: 16,
+        lineHeight: 1,
+        cursor: disabled ? 'default' : 'pointer',
+      }}
+    >
+      {label}
+    </button>
+  )
+  return (
+    <div
+      style={{
+        flex: 1,
+        background: '#F2EEE5',
+        border: '1px solid #D9D2BF',
+        borderRadius: 6,
+        padding: '8px 10px 9px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <span
+          className="font-serif tabular text-caddie-ink"
+          style={{
+            fontSize: 26,
+            fontWeight: 500,
+            lineHeight: 1,
+            color: value > 0 ? '#A66A1F' : '#1C211C',
+          }}
+        >
+          {value}
+        </span>
+        <span className="kicker" style={{ color: '#8A8B7E', marginTop: 2 }}>
+          Penalties
+        </span>
+      </div>
+      <div
+        style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}
+      >
+        {btn('−', -1, value === 0)}
+        {btn('+', 1, false)}
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -164,6 +164,15 @@ export function HoleReviewSheet({
 
   if (!open) return null
 
+  // Summary values, derived from the shots placed on the map — same rule
+  // saveReviewedHole persists (score = shot count, putts = green-lie shots).
+  // Shown prominently so the sheet reads as "how'd it go?" first, detail
+  // second. (Editable score/putts + penalties are a deliberate follow-up:
+  // they need a save-path/schema decision made alongside the mobile build.)
+  const shotCount = rows.length
+  const puttCount = rows.filter((r) => isPuttShot(r.lieType)).length
+  const vsPar = shotCount > 0 ? shotCount - par : null
+
   return (
     <div
       role="dialog"
@@ -205,23 +214,27 @@ export function HoleReviewSheet({
       </div>
       <div
         style={{
-          display: 'flex',
-          alignItems: 'baseline',
-          justifyContent: 'space-between',
           padding: '0 22px 14px',
           borderBottom: '1px solid #D9D2BF',
         }}
       >
-        <div>
-          <div className="kicker" style={{ marginBottom: 4 }}>
-            Hole {holeNumber} review
-          </div>
-          <div
-            className="font-serif text-caddie-ink"
-            style={{ fontSize: 22, fontWeight: 500, fontStyle: 'italic' }}
-          >
-            {rows.length} shot{rows.length === 1 ? '' : 's'} · par {par}
-          </div>
+        <div className="kicker" style={{ marginBottom: 4 }}>
+          Hole {holeNumber} · Par {par}
+        </div>
+        <div
+          className="font-serif text-caddie-ink"
+          style={{
+            fontSize: 24,
+            fontWeight: 500,
+            fontStyle: 'italic',
+            marginBottom: 14,
+          }}
+        >
+          Nice — how'd it go?
+        </div>
+        <div style={{ display: 'flex', gap: 10 }}>
+          <SummaryStat label="Score" value={shotCount} vsPar={vsPar} />
+          <SummaryStat label="Putts" value={puttCount} />
         </div>
       </div>
 
@@ -241,7 +254,14 @@ export function HoleReviewSheet({
             No placed shots. Drop pins on the map and try again.
           </div>
         ) : (
-          rows.map((row, idx) => (
+          <>
+          <div
+            className="kicker"
+            style={{ paddingTop: 10, paddingBottom: 2, color: '#8A8B7E' }}
+          >
+            Your shots · optional
+          </div>
+          {rows.map((row, idx) => (
             <ShotRow
               key={row.shotNumber}
               row={row}
@@ -282,7 +302,8 @@ export function HoleReviewSheet({
                 })
               }
             />
-          ))
+          ))}
+          </>
         )}
       </div>
 
@@ -326,7 +347,7 @@ export function HoleReviewSheet({
             letterSpacing: '0.02em',
           }}
         >
-          {saving ? 'Saving…' : 'Save hole'}{' '}
+          {saving ? 'Saving…' : 'Save & next hole'}{' '}
           {!saving && (
             <span className="font-serif" style={{ fontStyle: 'italic' }}>
               →
@@ -334,6 +355,62 @@ export function HoleReviewSheet({
           )}
         </button>
       </div>
+    </div>
+  )
+}
+
+function SummaryStat({
+  label,
+  value,
+  vsPar,
+}: {
+  label: string
+  value: number
+  vsPar?: number | null
+}) {
+  const vsParText =
+    vsPar == null ? null : vsPar === 0 ? 'E' : vsPar > 0 ? `+${vsPar}` : `${vsPar}`
+  // Muted brick over par, forest under, ink at even — never a bright red.
+  const vsParColor =
+    vsPar == null || vsPar === 0 ? '#5C6356' : vsPar > 0 ? '#A33A2A' : '#1F3D2C'
+  return (
+    <div
+      style={{
+        flex: 1,
+        background: '#F2EEE5',
+        border: '1px solid #D9D2BF',
+        borderRadius: 6,
+        padding: '10px 12px 11px',
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 8,
+      }}
+    >
+      <span
+        className="font-serif tabular text-caddie-ink"
+        style={{ fontSize: 28, fontWeight: 500, lineHeight: 1 }}
+      >
+        {value}
+      </span>
+      <span
+        className="kicker"
+        style={{ color: '#8A8B7E' }}
+      >
+        {label}
+      </span>
+      {vsParText && (
+        <span
+          className="font-serif"
+          style={{
+            marginLeft: 'auto',
+            fontSize: 14,
+            fontStyle: 'italic',
+            color: vsParColor,
+          }}
+        >
+          {vsParText}
+        </span>
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -181,8 +181,8 @@ export function HoleReviewSheet({
         position: 'absolute',
         left: 0,
         right: 0,
+        top: 0,
         bottom: 0,
-        maxHeight: 'min(60vh, 60%)',
         background: '#FBF8F1',
         borderTop: '1px solid #9F9580',
         borderTopLeftRadius: 12,
@@ -191,7 +191,9 @@ export function HoleReviewSheet({
         flexDirection: 'column',
         transform: slidIn ? 'translateY(0)' : 'translateY(100%)',
         transition: 'transform 220ms ease-out',
-        zIndex: 5,
+        // Fill the whole map area and sit above the map HUD (EXP / rail /
+        // PATTERN / aim overlays) so nothing bleeds over the summary. #791
+        zIndex: 40,
       }}
     >
       <div

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -2,16 +2,30 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   DEFAULT_BAG,
   LIE_TYPES,
+  LIE_TYPE_LABELS,
+  LIE_SLOPES_FORWARD,
+  LIE_SLOPES_SIDE,
+  SHOT_RESULTS,
+  SHOT_RESULT_LABELS,
   buildInitialRows,
+  combinedBreakDirection,
   formatClubLabel,
   haversineYards,
+  horizontalBreakFromAim,
   isPuttShot,
+  type BreakDirectionHorizontal,
+  type BreakDirectionVertical,
   type Club,
+  type GreenSpeed,
   type LieType,
+  type LieSlopeForward,
+  type LieSlopeSide,
   type PuttDirectionResult,
   type PuttDistanceResult,
   type ReviewedShotRow,
+  type ShotResult,
 } from '@oga/core'
+import { GreenDiagram } from './GreenDiagram'
 import type { PlacedPoint } from './RoundMap'
 import type { WebPuttData } from './WebPuttingSheet'
 import { useUnits } from '../../hooks/useUnits'
@@ -38,7 +52,10 @@ interface HoleReviewSheetProps {
   saving: boolean
   /** "Edit on map" — close the sheet and let the user drag markers. */
   onEditOnMap: () => void
-  onSave: (rows: ReviewedShotRow[], penalties: number) => void | Promise<void>
+  onSave: (
+    rows: ReviewedShotRow[],
+    summary: { score: number; putts: number; penalties: number },
+  ) => void | Promise<void>
 }
 
 const PUTT_DISTANCE_OPTIONS: { value: PuttDistanceResult; label: string }[] = [
@@ -54,6 +71,24 @@ const PUTT_DIRECTION_OPTIONS: {
   { value: 'right', label: 'Missed right' },
 ]
 
+// Putt read vocab — mirrors WebPuttingSheet so the summary and the old
+// sheet stay in sync. Break line = the horizontal read, slope = up/down.
+const BREAK_LINE_OPTIONS: { value: BreakDirectionHorizontal; label: string }[] = [
+  { value: 'left_to_right', label: 'L → R' },
+  { value: 'right_to_left', label: 'R → L' },
+  { value: 'straight', label: 'Straight' },
+]
+const BREAK_SLOPE_OPTIONS: { value: BreakDirectionVertical; label: string }[] = [
+  { value: 'uphill', label: 'Uphill' },
+  { value: 'flat', label: 'Level' },
+  { value: 'downhill', label: 'Downhill' },
+]
+const SPEED_OPTIONS: { value: GreenSpeed; label: string }[] = [
+  { value: 'slow', label: 'Slow' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'fast', label: 'Fast' },
+]
+
 export function HoleReviewSheet({
   open,
   holeNumber,
@@ -67,10 +102,16 @@ export function HoleReviewSheet({
   onSave,
 }: HoleReviewSheetProps) {
   const [rows, setRows] = useState<ReviewedShotRow[]>([])
-  // Penalty strokes are the one hole-level number not derivable from placed
-  // shots (a penalty isn't a marker), so it's an editable ticker. Score and
-  // putts stay derived from the shots you placed. #791
+  // Score / putts / penalties are editable tickers on the summary. Score and
+  // putts pre-fill from the shots you placed (shot count, green-lie shots);
+  // penalties is the one number no marker implies. All three become the
+  // authoritative hole_scores values on save. #791
+  const [score, setScore] = useState(0)
+  const [putts, setPutts] = useState(0)
   const [penalties, setPenalties] = useState(0)
+  // Which putt row (by shotNumber) has the on-demand aimer open, if any.
+  // The read tool is a full-sheet overlay — never auto-opens. #791
+  const [aimingShot, setAimingShot] = useState<number | null>(null)
 
   // Read the latest placedPoints inside the effect via ref so the effect
   // doesn't re-fire (and clobber user edits) just because the parent
@@ -94,7 +135,6 @@ export function HoleReviewSheet({
     }
     if (hydratedHoleRef.current === holeNumber) return
     hydratedHoleRef.current = holeNumber
-    setPenalties(0)
     // When pin coords are unavailable (course has no OSM hole layout and
     // the user hasn't manually placed a pin), build rows directly from
     // placed points: end of shot N is the next placed point, last shot
@@ -120,20 +160,19 @@ export function HoleReviewSheet({
               isLastShot: isLast,
             }
           })
-    const putts = placedPuttsRef.current ?? []
+    const puttData = placedPuttsRef.current ?? []
     // Merge any inline-collected putt data into the inferred rows so the
     // player doesn't have to re-enter what they just answered in the
     // putting sheet. Distance in feet maps to distanceYards / 3 so the
     // sheet's edit display stays consistent.
-    setRows(
-      baseRows.map((row, idx) => {
-        const inline = putts[idx]
+    const merged = baseRows.map((row, idx) => {
+        const inline = puttData[idx]
         if (!inline) return row
         // A placed putt is on the green by definition — pin lieType so putt
         // classification keys off real intent (lie/club), not raw distance.
         return {
           ...row,
-          lieType: 'green',
+          lieType: 'green' as const,
           puttMade: inline.puttMade,
           puttDistanceResult: inline.puttDistanceResult,
           puttDirectionResult: inline.puttDirectionResult,
@@ -148,8 +187,11 @@ export function HoleReviewSheet({
               ? inline.puttDistanceFt / 3
               : row.distanceYards,
         }
-      }),
-    )
+      })
+    setRows(merged)
+    setScore(merged.length)
+    setPutts(merged.filter((r) => isPuttShot(r.lieType)).length)
+    setPenalties(0)
   }, [open, holeNumber, par, pinLat, pinLng])
 
   // Slide-in: mount at translateY(100%), flip to 0 next frame so CSS
@@ -169,14 +211,7 @@ export function HoleReviewSheet({
 
   if (!open) return null
 
-  // Summary values, derived from the shots placed on the map — same rule
-  // saveReviewedHole persists (score = shot count, putts = green-lie shots).
-  // Shown prominently so the sheet reads as "how'd it go?" first, detail
-  // second. (Editable score/putts + penalties are a deliberate follow-up:
-  // they need a save-path/schema decision made alongside the mobile build.)
-  const shotCount = rows.length
-  const puttCount = rows.filter((r) => isPuttShot(r.lieType)).length
-  const vsPar = shotCount > 0 ? shotCount - par : null
+  const vsPar = score > 0 ? score - par : null
 
   return (
     <div
@@ -240,9 +275,9 @@ export function HoleReviewSheet({
           Nice — how'd it go?
         </div>
         <div style={{ display: 'flex', gap: 10 }}>
-          <SummaryStat label="Score" value={shotCount} vsPar={vsPar} />
-          <SummaryStat label="Putts" value={puttCount} />
-          <PenaltyTicker value={penalties} onChange={setPenalties} />
+          <Ticker label="Score" value={score} onChange={setScore} vsPar={vsPar} />
+          <Ticker label="Putts" value={putts} onChange={setPutts} />
+          <Ticker label="Penalties" value={penalties} onChange={setPenalties} amber />
         </div>
       </div>
 
@@ -273,6 +308,7 @@ export function HoleReviewSheet({
             <ShotRow
               key={row.shotNumber}
               row={row}
+              onOpenAimer={() => setAimingShot(row.shotNumber)}
               onChange={(next) =>
                 setRows((prev) => {
                   const copy = prev.slice()
@@ -344,7 +380,7 @@ export function HoleReviewSheet({
         </button>
         <button
           type="button"
-          onClick={() => onSave(rows, penalties)}
+          onClick={() => onSave(rows, { score, putts, penalties })}
           disabled={saving || rows.length === 0}
           className="bg-caddie-accent text-caddie-accent-ink disabled:opacity-40"
           style={{
@@ -363,129 +399,107 @@ export function HoleReviewSheet({
           )}
         </button>
       </div>
+
+      {aimingShot != null &&
+        (() => {
+          const idx = rows.findIndex((r) => r.shotNumber === aimingShot)
+          if (idx < 0) return null
+          return (
+            <AimerOverlay
+              row={rows[idx]!}
+              onChange={(next) =>
+                setRows((prev) => {
+                  const copy = prev.slice()
+                  copy[idx] = next
+                  return copy
+                })
+              }
+              onClose={() => setAimingShot(null)}
+            />
+          )
+        })()}
     </div>
   )
 }
 
-function SummaryStat({
+function Ticker({
   label,
   value,
+  onChange,
   vsPar,
+  amber,
 }: {
   label: string
   value: number
+  onChange: (n: number) => void
   vsPar?: number | null
+  amber?: boolean
 }) {
   const vsParText =
     vsPar == null ? null : vsPar === 0 ? 'E' : vsPar > 0 ? `+${vsPar}` : `${vsPar}`
   // Muted brick over par, forest under, ink at even — never a bright red.
   const vsParColor =
-    vsPar == null || vsPar === 0 ? '#5C6356' : vsPar > 0 ? '#A33A2A' : '#1F3D2C'
-  return (
-    <div
-      style={{
-        flex: 1,
-        background: '#F2EEE5',
-        border: '1px solid #D9D2BF',
-        borderRadius: 6,
-        padding: '10px 12px 11px',
-        display: 'flex',
-        alignItems: 'baseline',
-        gap: 8,
-      }}
-    >
-      <span
-        className="font-serif tabular text-caddie-ink"
-        style={{ fontSize: 28, fontWeight: 500, lineHeight: 1 }}
-      >
-        {value}
-      </span>
-      <span
-        className="kicker"
-        style={{ color: '#8A8B7E' }}
-      >
-        {label}
-      </span>
-      {vsParText && (
-        <span
-          className="font-serif"
-          style={{
-            marginLeft: 'auto',
-            fontSize: 14,
-            fontStyle: 'italic',
-            color: vsParColor,
-          }}
-        >
-          {vsParText}
-        </span>
-      )}
-    </div>
-  )
-}
-
-function PenaltyTicker({
-  value,
-  onChange,
-}: {
-  value: number
-  onChange: (n: number) => void
-}) {
-  const btn = (label: string, delta: number, disabled: boolean) => (
+    vsPar == null || vsPar === 0 ? '#8A8B7E' : vsPar > 0 ? '#A33A2A' : '#1F3D2C'
+  const step = (delta: number, disabled: boolean) => (
     <button
       type="button"
-      aria-label={delta < 0 ? 'Fewer penalties' : 'More penalties'}
+      aria-label={`${delta < 0 ? 'Fewer' : 'More'} ${label.toLowerCase()}`}
       onClick={() => onChange(Math.max(0, value + delta))}
       disabled={disabled}
-      className="text-caddie-ink-dim disabled:opacity-30"
+      className="text-caddie-ink-dim disabled:opacity-25"
       style={{
-        width: 26,
-        height: 26,
+        width: 24,
+        height: 24,
+        flexShrink: 0,
         borderRadius: '50%',
         border: '1px solid #9F9580',
         background: 'transparent',
-        fontSize: 16,
+        fontSize: 15,
         lineHeight: 1,
         cursor: disabled ? 'default' : 'pointer',
       }}
     >
-      {label}
+      {delta < 0 ? '−' : '+'}
     </button>
   )
   return (
     <div
       style={{
         flex: 1,
+        minWidth: 0,
         background: '#F2EEE5',
         border: '1px solid #D9D2BF',
         borderRadius: 6,
-        padding: '8px 10px 9px',
+        padding: '9px 8px 8px',
         display: 'flex',
+        flexDirection: 'column',
         alignItems: 'center',
-        gap: 8,
+        gap: 5,
       }}
     >
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        {step(-1, value === 0)}
         <span
-          className="font-serif tabular text-caddie-ink"
+          className="font-serif tabular"
           style={{
             fontSize: 26,
             fontWeight: 500,
             lineHeight: 1,
-            color: value > 0 ? '#A66A1F' : '#1C211C',
+            minWidth: 20,
+            textAlign: 'center',
+            color: amber && value > 0 ? '#A66A1F' : '#1C211C',
           }}
         >
           {value}
         </span>
-        <span className="kicker" style={{ color: '#8A8B7E', marginTop: 2 }}>
-          Penalties
-        </span>
+        {step(1, false)}
       </div>
-      <div
-        style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}
-      >
-        {btn('−', -1, value === 0)}
-        {btn('+', 1, false)}
-      </div>
+      <span className="kicker" style={{ color: '#8A8B7E' }}>
+        {label}
+        {vsParText && (
+          <span style={{ color: vsParColor }}> · {vsParText}</span>
+        )}
+      </span>
     </div>
   )
 }
@@ -493,9 +507,12 @@ function PenaltyTicker({
 function ShotRow({
   row,
   onChange,
+  onOpenAimer,
 }: {
   row: ReviewedShotRow
   onChange: (next: ReviewedShotRow) => void
+  /** Open the full-sheet green aimer for this putt row. */
+  onOpenAimer: () => void
 }) {
   // Mirror mobile's PUTTING_RADIUS_YARDS — any shot starting within 30 yd
   // of the pin gets the putt entry surface (made/short/long, miss left/
@@ -532,122 +549,562 @@ function ShotRow({
     }
     return base
   }, [bag, row.club])
+  // Which field's options are unfolded inline (Version A). One at a time.
+  const [open, setOpen] = useState<
+    'club' | 'lie' | 'slope' | 'result' | 'break' | 'speed' | null
+  >(null)
+  const toggle = (
+    f: 'club' | 'lie' | 'slope' | 'result' | 'break' | 'speed',
+  ) => setOpen((o) => (o === f ? null : f))
+  // Chip labels are Sentence case across lie/slope/result; formatClubLabel
+  // returns lowercase golf shorthand ("driver", "8i", "pw"), so capitalize
+  // the club chip to match. Digit-led codes ("8i", "3w") are unchanged.
+  const rawClubLabel =
+    clubOptions.find((c) => c.value === row.club)?.label ?? String(row.club)
+  const clubLabel = rawClubLabel.charAt(0).toUpperCase() + rawClubLabel.slice(1)
+  const slopeSet = row.lieSlopeForward != null || row.lieSlopeSide != null
+  const slopeText = [
+    row.lieSlopeForward && slopeLabel(row.lieSlopeForward),
+    row.lieSlopeSide && slopeLabel(row.lieSlopeSide),
+  ]
+    .filter(Boolean)
+    .join(' · ')
+  // Putt read summary for the collapsed chips.
+  const breakSet =
+    row.breakDirectionHorizontal != null || row.breakDirectionVertical != null
+  const breakText = [
+    BREAK_LINE_OPTIONS.find((o) => o.value === row.breakDirectionHorizontal)
+      ?.label,
+    BREAK_SLOPE_OPTIONS.find((o) => o.value === row.breakDirectionVertical)
+      ?.label,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+  const speedLabel =
+    SPEED_OPTIONS.find((o) => o.value === row.greenSpeed)?.label ?? null
+  const hasRead = row.aimOffsetInches != null && row.aimOffsetInches !== 0
+  return (
+    <div style={{ padding: '13px 0', borderBottom: '1px solid #D9D2BF' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 12,
+          marginBottom: 9,
+        }}
+      >
+        <span className="kicker" style={{ color: '#8A8B7E' }}>
+          Shot {row.shotNumber}
+        </span>
+        <span
+          className="font-serif tabular text-caddie-ink"
+          style={{ fontSize: 20, fontStyle: 'italic' }}
+        >
+          {isPutt
+            ? `${toDisplayFt(row.distanceYards * 3)} putt`
+            : toDisplay(row.distanceYards)}
+        </span>
+        <span
+          className="text-caddie-ink-mute"
+          style={{ fontSize: 12, marginLeft: 'auto' }}
+        >
+          {toDisplay(row.distanceToPin)} to pin
+        </span>
+      </div>
+
+      {isPutt ? (
+        <>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            <button
+              type="button"
+              onClick={() =>
+                onChange({
+                  ...row,
+                  puttMade: !row.puttMade,
+                  puttDistanceResult: !row.puttMade
+                    ? undefined
+                    : row.puttDistanceResult,
+                  puttDirectionResult: !row.puttMade
+                    ? undefined
+                    : row.puttDirectionResult,
+                })
+              }
+              aria-pressed={!!row.puttMade}
+              style={{
+                background: row.puttMade ? '#1F3D2C' : '#FBF8F1',
+                color: row.puttMade ? '#F2EEE5' : '#1F3D2C',
+                border: '1px solid #1F3D2C',
+                borderRadius: 16,
+                padding: '5px 14px',
+                fontSize: 12,
+                fontWeight: 600,
+                cursor: 'pointer',
+              }}
+            >
+              {row.puttMade ? 'Made it ✓' : 'Made it'}
+            </button>
+            <FieldChip
+              label={breakSet ? breakText : '+ break'}
+              filled={breakSet}
+              active={open === 'break'}
+              onClick={() => toggle('break')}
+            />
+            <FieldChip
+              label={speedLabel ?? '+ speed'}
+              filled={!!speedLabel}
+              active={open === 'speed'}
+              onClick={() => toggle('speed')}
+            />
+            <FieldChip label="Read ▸" filled={hasRead} onClick={onOpenAimer} />
+          </div>
+          {open === 'break' && <BreakExpand row={row} onChange={onChange} />}
+          {open === 'speed' && (
+            <ChipExpand
+              label="Speed"
+              options={SPEED_OPTIONS}
+              value={row.greenSpeed}
+              onSelect={(v) => {
+                onChange({
+                  ...row,
+                  greenSpeed: row.greenSpeed === v ? undefined : v,
+                })
+                setOpen(null)
+              }}
+            />
+          )}
+          {!row.puttMade && (
+            <div style={{ marginTop: 10 }}>
+              <PuttMissAxes row={row} onChange={onChange} />
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+            <FieldChip
+              label={clubLabel}
+              filled
+              active={open === 'club'}
+              onClick={() => toggle('club')}
+            />
+            <FieldChip
+              label={LIE_TYPE_LABELS[row.lieType]}
+              filled
+              active={open === 'lie'}
+              onClick={() => toggle('lie')}
+            />
+            <FieldChip
+              label={slopeSet ? slopeText : '+ slope'}
+              filled={slopeSet}
+              active={open === 'slope'}
+              onClick={() => toggle('slope')}
+            />
+            <FieldChip
+              label={
+                row.shotResult
+                  ? SHOT_RESULT_LABELS[row.shotResult]
+                  : '+ result'
+              }
+              filled={!!row.shotResult}
+              active={open === 'result'}
+              onClick={() => toggle('result')}
+            />
+          </div>
+          {open === 'club' && (
+            <ChipExpand
+              label="Club"
+              options={clubOptions}
+              value={row.club}
+              onSelect={(v) => {
+                onChange({ ...row, club: v as Club })
+                setOpen(null)
+              }}
+            />
+          )}
+          {open === 'lie' && (
+            <ChipExpand
+              label="Lie"
+              options={LIE_TYPES.map((l) => ({
+                value: l,
+                label: LIE_TYPE_LABELS[l],
+              }))}
+              value={row.lieType}
+              onSelect={(v) => {
+                onChange({ ...row, lieType: v as LieType })
+                setOpen(null)
+              }}
+            />
+          )}
+          {open === 'slope' && <SlopeExpand row={row} onChange={onChange} />}
+          {open === 'result' && (
+            <ChipExpand
+              label="Result"
+              options={SHOT_RESULTS.map((r) => ({
+                value: r,
+                label: SHOT_RESULT_LABELS[r],
+              }))}
+              value={row.shotResult}
+              onSelect={(v) => {
+                onChange({
+                  ...row,
+                  shotResult:
+                    row.shotResult === v ? undefined : (v as ShotResult),
+                })
+                setOpen(null)
+              }}
+            />
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+// 'ball_above' → 'Ball above', 'uphill' → 'Uphill'.
+function slopeLabel(v: string): string {
+  const s = v.replace(/_/g, ' ')
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+// A field entry on a shot row: filled (forest), blank ("+ field", dashed), or
+// active (unfolded — light forest). Tapping unfolds/collapses its options.
+function FieldChip({
+  label,
+  filled,
+  active,
+  onClick,
+}: {
+  label: string
+  filled?: boolean
+  active?: boolean
+  onClick: () => void
+}) {
+  const bg = active ? '#E6EDE6' : filled ? '#1F3D2C' : 'transparent'
+  const color = active ? '#1F3D2C' : filled ? '#F2EEE5' : '#8A8B7E'
+  const border = active || filled ? '#1F3D2C' : '#9F9580'
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-expanded={active}
+      style={{
+        fontFamily: 'inherit',
+        fontSize: 12,
+        padding: '5px 11px',
+        borderRadius: 16,
+        cursor: 'pointer',
+        border: `1px ${filled || active ? 'solid' : 'dashed'} ${border}`,
+        background: bg,
+        color,
+      }}
+    >
+      {label}
+      {active ? ' ▾' : ''}
+    </button>
+  )
+}
+
+function OptChip({
+  label,
+  on,
+  onClick,
+}: {
+  label: string
+  on: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={on}
+      style={{
+        fontFamily: 'inherit',
+        fontSize: 11,
+        padding: '4px 10px',
+        borderRadius: 14,
+        cursor: 'pointer',
+        border: `1px solid ${on ? '#1F3D2C' : '#D9D2BF'}`,
+        background: on ? '#1F3D2C' : '#F2EEE5',
+        color: on ? '#F2EEE5' : '#1C211C',
+      }}
+    >
+      {label}
+    </button>
+  )
+}
+
+// Inline unfolded options for a single-select field (club / lie / result).
+function ChipExpand<V extends string>({
+  label,
+  options,
+  value,
+  onSelect,
+}: {
+  label: string
+  options: { value: V; label: string }[]
+  value: V | undefined
+  onSelect: (v: V) => void
+}) {
   return (
     <div
       style={{
+        marginTop: 9,
+        background: '#EBE5D6',
+        borderRadius: 8,
+        padding: '9px 10px',
+      }}
+    >
+      <div className="kicker" style={{ color: '#8A8B7E', marginBottom: 7 }}>
+        {label}
+      </div>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {options.map((o) => (
+          <OptChip
+            key={o.value}
+            label={o.label}
+            on={o.value === value}
+            onClick={() => onSelect(o.value)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// The two-axis slope grid (uphill/level/downhill × ball above/below), unfolded
+// inline. Each axis toggles independently; either can stay unset.
+function SlopeExpand({
+  row,
+  onChange,
+}: {
+  row: ReviewedShotRow
+  onChange: (next: ReviewedShotRow) => void
+}) {
+  return (
+    <div
+      style={{
+        marginTop: 9,
+        background: '#EBE5D6',
+        borderRadius: 8,
+        padding: '9px 10px',
         display: 'flex',
         flexDirection: 'column',
-        gap: 10,
-        padding: '14px 0',
-        borderBottom: '1px solid #D9D2BF',
+        gap: 9,
+      }}
+    >
+      <div>
+        <div className="kicker" style={{ color: '#8A8B7E', marginBottom: 6 }}>
+          Uphill / downhill
+        </div>
+        <div style={{ display: 'flex', gap: 6 }}>
+          {LIE_SLOPES_FORWARD.map((f) => (
+            <OptChip
+              key={f}
+              label={slopeLabel(f)}
+              on={row.lieSlopeForward === f}
+              onClick={() =>
+                onChange({
+                  ...row,
+                  lieSlopeForward:
+                    row.lieSlopeForward === f
+                      ? undefined
+                      : (f as LieSlopeForward),
+                })
+              }
+            />
+          ))}
+        </div>
+      </div>
+      <div>
+        <div className="kicker" style={{ color: '#8A8B7E', marginBottom: 6 }}>
+          Ball above / below
+        </div>
+        <div style={{ display: 'flex', gap: 6 }}>
+          {LIE_SLOPES_SIDE.map((s) => (
+            <OptChip
+              key={s}
+              label={slopeLabel(s)}
+              on={row.lieSlopeSide === s}
+              onClick={() =>
+                onChange({
+                  ...row,
+                  lieSlopeSide:
+                    row.lieSlopeSide === s ? undefined : (s as LieSlopeSide),
+                })
+              }
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// The putt break read, unfolded inline: line (L→R / R→L / straight) + slope
+// (uphill / level / downhill). Each axis toggles independently.
+function BreakExpand({
+  row,
+  onChange,
+}: {
+  row: ReviewedShotRow
+  onChange: (next: ReviewedShotRow) => void
+}) {
+  return (
+    <div
+      style={{
+        marginTop: 9,
+        background: '#EBE5D6',
+        borderRadius: 8,
+        padding: '9px 10px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 9,
+      }}
+    >
+      <div>
+        <div className="kicker" style={{ color: '#8A8B7E', marginBottom: 6 }}>
+          Break — which way
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {BREAK_LINE_OPTIONS.map((o) => (
+            <OptChip
+              key={o.value}
+              label={o.label}
+              on={row.breakDirectionHorizontal === o.value}
+              onClick={() =>
+                onChange({
+                  ...row,
+                  breakDirectionHorizontal:
+                    row.breakDirectionHorizontal === o.value
+                      ? undefined
+                      : o.value,
+                })
+              }
+            />
+          ))}
+        </div>
+      </div>
+      <div>
+        <div className="kicker" style={{ color: '#8A8B7E', marginBottom: 6 }}>
+          Slope
+        </div>
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {BREAK_SLOPE_OPTIONS.map((o) => (
+            <OptChip
+              key={o.value}
+              label={o.label}
+              on={row.breakDirectionVertical === o.value}
+              onClick={() =>
+                onChange({
+                  ...row,
+                  breakDirectionVertical:
+                    row.breakDirectionVertical === o.value
+                      ? undefined
+                      : o.value,
+                })
+              }
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// The on-demand read tool: a full-sheet overlay hosting the draggable green
+// aimer. Setting the aim also derives the horizontal break line (aim off the
+// pin = the read), mirroring the old putting sheet. #791
+function AimerOverlay({
+  row,
+  onChange,
+  onClose,
+}: {
+  row: ReviewedShotRow
+  onChange: (next: ReviewedShotRow) => void
+  onClose: () => void
+}) {
+  const distanceFt = row.distanceYards * 3
+  const breakDirection =
+    combinedBreakDirection({
+      vertical: row.breakDirectionVertical ?? null,
+      horizontal: row.breakDirectionHorizontal ?? null,
+    }) ?? 'straight'
+  return (
+    <div
+      role="dialog"
+      aria-label={`Read the green, shot ${row.shotNumber}`}
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: '#FBF8F1',
+        zIndex: 50,
+        display: 'flex',
+        flexDirection: 'column',
       }}
     >
       <div
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 14,
-          flexWrap: 'wrap',
+          padding: '16px 22px 12px',
+          borderBottom: '1px solid #D9D2BF',
         }}
       >
-      <div
-        className="kicker"
-        style={{ minWidth: 56 }}
-      >
-        Shot {row.shotNumber}
+        <div className="kicker" style={{ marginBottom: 4, color: '#8A8B7E' }}>
+          Shot {row.shotNumber} · read the green
+        </div>
+        <div
+          className="font-serif text-caddie-ink"
+          style={{ fontSize: 22, fontWeight: 500, fontStyle: 'italic' }}
+        >
+          Aim &amp; break
+        </div>
       </div>
       <div
-        className="font-serif tabular text-caddie-ink"
         style={{
-          fontSize: 22,
-          fontWeight: 500,
-          fontStyle: 'italic',
-          minWidth: 100,
+          flex: 1,
+          minHeight: 0,
+          overflowY: 'auto',
+          padding: '18px 22px',
         }}
       >
-        {isPutt
-          ? `${toDisplayFt(row.distanceYards * 3)} putt`
-          : toDisplay(row.distanceYards)}
-      </div>
-      <select
-        value={row.club}
-        onChange={(e) => onChange({ ...row, club: e.target.value as Club })}
-        className="bg-caddie-bg text-caddie-ink"
-        style={{
-          border: '1px solid #D9D2BF',
-          borderRadius: 2,
-          padding: '8px 10px',
-          fontSize: 13,
-          minWidth: 110,
-        }}
-      >
-        {clubOptions.map((c) => (
-          <option key={c.value} value={c.value}>
-            {c.label}
-          </option>
-        ))}
-      </select>
-      <select
-        value={row.lieType}
-        onChange={(e) =>
-          onChange({ ...row, lieType: e.target.value as LieType })
-        }
-        className="bg-caddie-bg text-caddie-ink"
-        style={{
-          border: '1px solid #D9D2BF',
-          borderRadius: 2,
-          padding: '8px 10px',
-          fontSize: 13,
-          minWidth: 110,
-        }}
-      >
-        {LIE_TYPES.map((l) => (
-          <option key={l} value={l}>
-            {l}
-          </option>
-        ))}
-      </select>
-      {isPutt && (
-        <button
-          type="button"
-          onClick={() =>
+        <GreenDiagram
+          distanceFt={distanceFt}
+          aimOffsetInches={row.aimOffsetInches ?? 0}
+          breakDirection={breakDirection}
+          onAimChange={(n) =>
             onChange({
               ...row,
-              puttMade: !row.puttMade,
-              // Toggling made → on clears both miss axes.
-              puttDistanceResult: !row.puttMade
-                ? undefined
-                : row.puttDistanceResult,
-              puttDirectionResult: !row.puttMade
-                ? undefined
-                : row.puttDirectionResult,
+              aimOffsetInches: n,
+              breakDirectionHorizontal:
+                horizontalBreakFromAim(n) ?? row.breakDirectionHorizontal,
             })
           }
-          aria-pressed={!!row.puttMade}
+        />
+      </div>
+      <div
+        style={{
+          padding: '14px 22px 18px',
+          borderTop: '1px solid #D9D2BF',
+        }}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          className="bg-caddie-accent text-caddie-accent-ink"
           style={{
-            background: row.puttMade ? '#1F3D2C' : '#FBF8F1',
-            color: row.puttMade ? '#F2EEE5' : '#1F3D2C',
-            border: '1px solid #1F3D2C',
+            width: '100%',
             borderRadius: 2,
-            padding: '6px 12px',
-            fontSize: 12,
+            padding: '12px 18px',
+            fontSize: 14,
             fontWeight: 600,
             letterSpacing: '0.02em',
-            cursor: 'pointer',
           }}
         >
-          {row.puttMade ? 'Made it ✓' : 'Made it'}
+          Save read
         </button>
-      )}
-      <span
-        className="text-caddie-ink-mute"
-        style={{ fontSize: 12, marginLeft: 'auto' }}
-      >
-        {toDisplay(row.distanceToPin)} to pin
-      </span>
-      {isPutt && !row.puttMade && (
-        <PuttMissAxes row={row} onChange={onChange} />
-      )}
       </div>
     </div>
   )

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -35,10 +35,6 @@ export function RoundDetailPage() {
   const { user } = useAuth()
 
   const [confirmDelete, setConfirmDelete] = useState(false)
-  // "On the green?" confirmation. Holds the placed point while the
-  // dialog is open. Cleared on either response — Yes pushes with the
-  // putting sheet, No pushes without it.
-  const [onGreenPrompt, setOnGreenPrompt] = useState<PlacedPoint | null>(null)
   // "Set an aim point?" prompt — opens after every non-putt PUSH_POINT
   // so the player decides explicitly whether this shot has aim data.
   // Replaces the easy-to-miss "Set aim" button on the strip as the
@@ -165,7 +161,6 @@ export function RoundDetailPage() {
     setConfirmDelete,
     setCompleteError,
     setSharing,
-    setOnGreenPrompt,
     setAimPromptOpen,
   })
   const {
@@ -283,32 +278,6 @@ export function RoundDetailPage() {
         onCancel={() => setConfirmDelete(false)}
       />
 
-      <ConfirmDialog
-        open={onGreenPrompt != null}
-        title="On the green?"
-        message="Within 30 yd of the pin — were you putting, or chipping/in a bunker?"
-        confirmLabel="Yes, I'm putting"
-        cancelLabel="No"
-        onConfirm={() => {
-          if (onGreenPrompt) {
-            dispatchHoleView({
-              type: 'PUSH_POINT',
-              point: onGreenPrompt,
-              openPuttSheet: true,
-            })
-          }
-          setOnGreenPrompt(null)
-        }}
-        onCancel={() => {
-          if (onGreenPrompt) {
-            // Not putting (chip / bunker / fringe) — push as a normal shot
-            // through the shared path so live entry auto-spawns the aim and
-            // past-round entry gets the explicit aim prompt.
-            placeHandlers.onConfirmNonPutt(onGreenPrompt)
-          }
-          setOnGreenPrompt(null)
-        }}
-      />
 
       <ConfirmDialog
         open={aimPromptOpen}

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -105,7 +105,7 @@ export interface UseRoundActionsResult {
   applyShotDragUndo: () => Promise<void>
   saveReviewedHole: (
     rows: ReviewedShotRow[],
-    penalties?: number,
+    summary?: { score: number; putts: number; penalties: number },
   ) => Promise<void>
   handleDelete: () => Promise<void>
   handleComplete: () => Promise<void>
@@ -573,7 +573,10 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
   }, [shareCardRef, sharing, shareTone, round.data, setSharing, setCompleteError])
 
   const saveReviewedHole = useCallback(
-    async (rows: ReviewedShotRow[], penalties = 0) => {
+    async (
+      rows: ReviewedShotRow[],
+      summary?: { score: number; putts: number; penalties: number },
+    ) => {
       if (!user || !activeHole || !round.data) return
       setSavingHole(true)
       dispatchHoleView({ type: 'SAVE_ERROR', message: null })
@@ -615,9 +618,9 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
           id: existing?.id,
           round_id: round.data.id,
           hole_id: realHoleId,
-          score: rows.length,
-          putts: puttCount,
-          penalties,
+          score: summary?.score ?? rows.length,
+          putts: summary?.putts ?? puttCount,
+          penalties: summary?.penalties ?? 0,
           fairway_hit: existing?.fairway_hit ?? inferred.fairway,
           gir: existing?.gir ?? inferred.gir,
           // Persist a manually placed pin. On unmapped courses no hole_scores
@@ -663,7 +666,9 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
             distance_to_target: isPuttRow ? null : Math.round(row.distanceToPin),
             club: row.club,
             lie_type: row.lieType,
-            shot_result: null,
+            lie_slope_forward: isPuttRow ? null : row.lieSlopeForward ?? null,
+            lie_slope_side: isPuttRow ? null : row.lieSlopeSide ?? null,
+            shot_result: isPuttRow ? null : row.shotResult ?? null,
             penalty: false,
             ob: false,
             // Putt-specific fields. distanceYards on a putt row is the

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -103,7 +103,10 @@ export interface UseRoundActionsResult {
   handleMoveExistingShot: (shotId: string, point: PlacedPoint) => Promise<void>
   handleMoveExistingShotAim: (shotId: string, point: PlacedPoint) => Promise<void>
   applyShotDragUndo: () => Promise<void>
-  saveReviewedHole: (rows: ReviewedShotRow[]) => Promise<void>
+  saveReviewedHole: (
+    rows: ReviewedShotRow[],
+    penalties?: number,
+  ) => Promise<void>
   handleDelete: () => Promise<void>
   handleComplete: () => Promise<void>
   handleShare: () => Promise<void>
@@ -570,7 +573,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
   }, [shareCardRef, sharing, shareTone, round.data, setSharing, setCompleteError])
 
   const saveReviewedHole = useCallback(
-    async (rows: ReviewedShotRow[]) => {
+    async (rows: ReviewedShotRow[], penalties = 0) => {
       if (!user || !activeHole || !round.data) return
       setSavingHole(true)
       dispatchHoleView({ type: 'SAVE_ERROR', message: null })
@@ -614,6 +617,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
           hole_id: realHoleId,
           score: rows.length,
           putts: puttCount,
+          penalties,
           fairway_hit: existing?.fairway_hit ?? inferred.fairway,
           gir: existing?.gir ?? inferred.gir,
           // Persist a manually placed pin. On unmapped courses no hole_scores

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -10,7 +10,7 @@ import {
   DEFAULT_HANDICAP,
   haversineYards,
   inferHoleStats,
-  isPuttShot,
+  isPuttEntry,
   NEAR_GREEN_YARDS,
 } from '@oga/core'
 import type { PlacedPoint } from '../../../components/round/RoundMap'
@@ -589,7 +589,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         // Match HoleReviewSheet's isPutt — putt-ness is the green lie (set
         // when a putt is placed), never club or raw distance (a near-green
         // chip isn't a putt; unmapped rows read 0).
-        const puttCount = rows.filter((r) => isPuttShot(r.lieType)).length
+        const puttCount = rows.filter((r) => isPuttEntry(r.lieType, r.club)).length
         // Materialize the synthetic hole if needed before upserting the
         // hole_score (FK to holes.id). The RPC inserts only (course_id,
         // number, par, stroke_index) — per-round tee/pin overrides
@@ -647,7 +647,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         if (delErr) throw delErr
 
         for (const row of rows) {
-          const isPuttRow = isPuttShot(row.lieType)
+          const isPuttRow = isPuttEntry(row.lieType, row.club)
           // Persist the aim only if the player actually set/dragged it — an
           // untouched auto-spawn suggestion is dropped so it can't enter the
           // dispersion dataset (aim must be explicit to count).

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -11,7 +11,6 @@ import {
   haversineYards,
   inferHoleStats,
   isPuttEntry,
-  NEAR_GREEN_YARDS,
 } from '@oga/core'
 import type { PlacedPoint } from '../../../components/round/RoundMap'
 import type { ReviewedShotRow } from '../../../components/round/HoleReviewSheet'
@@ -75,7 +74,6 @@ interface UseRoundActionsInput {
   setConfirmDelete: (b: boolean) => void
   setCompleteError: (s: string | null) => void
   setSharing: (b: boolean) => void
-  setOnGreenPrompt: (p: PlacedPoint | null) => void
   setAimPromptOpen: (b: boolean) => void
 }
 
@@ -84,9 +82,6 @@ export interface UseRoundActionsResult {
   persistRoundPin: (point: PlacedPoint) => Promise<void>
   placeHandlers: {
     onPlace: (p: PlacedPoint) => void
-    /** Push a confirmed non-putt shot (used by the on-green "No" branch)
-     *  through the same auto-spawn / aim-prompt path as a fresh tap. */
-    onConfirmNonPutt: (p: PlacedPoint) => void
     onMovePoint: (idx: number, p: PlacedPoint) => void
     onMovePin: (p: PlacedPoint) => void
     onMoveTee: (p: PlacedPoint) => void
@@ -138,7 +133,6 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
     setConfirmDelete,
     setCompleteError,
     setSharing,
-    setOnGreenPrompt,
     setAimPromptOpen,
   } = input
   const navigate = useNavigate()
@@ -230,12 +224,13 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
     [activeHoleScore, roundId, dispatchHoleView],
   )
 
-  // Push a confirmed non-putt shot, then either auto-spawn its aim (live
-  // entry) or prompt the player to set it (past-round review). The aim
-  // seeds on the straight start→pin line so the aim path + carry/remaining
-  // render immediately. SET_AIM targets the slot PUSH_POINT just appended
+  // Push a placed shot, then either auto-spawn its aim (live entry) or
+  // prompt the player to set it (past-round review). The aim seeds on the
+  // straight start→pin line so the aim path + carry/remaining render
+  // immediately. SET_AIM targets the slot PUSH_POINT just appended
   // (`placedAims.length` before the push), so it always lands on the new
-  // shot. Shared by onPlace and the on-green "No" branch.
+  // shot. Every placement flows through here now — a near-green shot is no
+  // longer special-cased; its putt-ness is decided at the end-of-hole review.
   const pushShotWithAim = useCallback(
     (p: PlacedPoint) => {
       dispatchHoleView({ type: 'PUSH_POINT', point: p, openPuttSheet: false })
@@ -259,26 +254,13 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
   )
 
   const placeHandlers = {
-    onPlace: useCallback(
-      (p: PlacedPoint) => {
-        // Within ~30 yd of the pin, ask before opening the putting
-        // sheet — the prior auto-switch was wrong on chips, bunkers,
-        // and fringe lies, and forced the player to back out and re-
-        // place to log a non-putt. The point goes into a holding cell
-        // until the prompt resolves.
-        const nearGreen =
-          effectivePin != null &&
-          haversineYards(p.lat, p.lng, effectivePin.lat, effectivePin.lng) <=
-            NEAR_GREEN_YARDS
-        if (nearGreen) {
-          setOnGreenPrompt(p)
-          return
-        }
-        pushShotWithAim(p)
-      },
-      [effectivePin, setOnGreenPrompt, pushShotWithAim],
-    ),
-    onConfirmNonPutt: pushShotWithAim,
+    // Placing a shot just records its location. Putt-vs-not — and all shot
+    // detail — is decided at the end-of-hole review, where the summary infers
+    // a putt from the ball's position (green lie) and the club chip overrides
+    // it. The old on-green "are you putting?" prompt + inline WebPuttingSheet
+    // were redundant with that surface and were dropped for lock-step with
+    // mobile (#791).
+    onPlace: pushShotWithAim,
     onMovePoint: useCallback(
       (idx: number, p: PlacedPoint) =>
         dispatchHoleView({ type: 'MOVE_POINT', index: idx, point: p }),

--- a/packages/core/src/__tests__/round.test.ts
+++ b/packages/core/src/__tests__/round.test.ts
@@ -3,6 +3,7 @@ import {
   buildInitialRows,
   inferHoleCount,
   isPuttShot,
+  isPuttEntry,
   legacySlopeToAxes,
   playedRowsForDifferential,
   summarizePuttParts,
@@ -133,6 +134,24 @@ describe('isPuttShot', () => {
   it('null/undefined lie is NOT a putt', () => {
     expect(isPuttShot(null)).toBe(false)
     expect(isPuttShot(undefined)).toBe(false)
+  })
+})
+
+describe('isPuttEntry', () => {
+  it('green lie with the putter is a putt', () => {
+    expect(isPuttEntry('green', 'putter')).toBe(true)
+  })
+  it('green lie with a wedge is NOT a putt (on-green chip)', () => {
+    expect(isPuttEntry('green', 'lw')).toBe(false)
+    expect(isPuttEntry('green', '9i')).toBe(false)
+  })
+  it('putter off the green (Texas wedge) is NOT a putt', () => {
+    expect(isPuttEntry('fringe', 'putter')).toBe(false)
+    expect(isPuttEntry('fairway', 'putter')).toBe(false)
+  })
+  it('null lie or club is NOT a putt', () => {
+    expect(isPuttEntry(null, 'putter')).toBe(false)
+    expect(isPuttEntry('green', null)).toBe(false)
   })
 })
 

--- a/packages/core/src/__tests__/sg.test.ts
+++ b/packages/core/src/__tests__/sg.test.ts
@@ -234,6 +234,7 @@ describe('computeRoundSG (sg.ts) — DB row → result adapter', () => {
       score: overrides.score ?? 4,
       par: overrides.par ?? null,
       putts: overrides.putts ?? null,
+      penalties: overrides.penalties ?? 0,
       fairway_hit: overrides.fairway_hit ?? null,
       gir: overrides.gir ?? null,
       pin_lat: overrides.pin_lat ?? null,

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -65,6 +65,12 @@ export interface ReviewedShotRow {
   greenSpeed?: GreenSpeed
   /** Free-text note on the putt. Stored as notes. */
   notes?: string
+  /** Shot outcome — solid / push_right / thin / … Stored as shot_result. */
+  shotResult?: ShotResult
+  /** Lie slope, uphill axis (uphill/level/downhill). Stored as lie_slope_forward. */
+  lieSlopeForward?: LieSlopeForward
+  /** Lie slope, side axis (ball_above/ball_below). Stored as lie_slope_side. */
+  lieSlopeSide?: LieSlopeSide
 }
 
 // Infer how many holes a course actually has from the hole NUMBERS we

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -120,6 +120,18 @@ export function isPuttShot(lieType: string | null | undefined): boolean {
   return lieType === 'green'
 }
 
+// Entry-surface classification for the end-of-hole review: show the PUTT UI
+// only when the player putted (green lie AND the putter). This deliberately
+// differs from isPuttShot (lie-only): the rare "on the green but chipped/bladed
+// a wedge" shot keeps a normal club + result. Its inverse, a Texas wedge off
+// the green (putter, non-green lie), also stays a normal shot. #691/#732.
+export function isPuttEntry(
+  lieType: string | null | undefined,
+  club: string | null | undefined,
+): boolean {
+  return lieType === 'green' && club === 'putter'
+}
+
 // Structural subset of a snake_case shots row that the shot-summary
 // formatters read — web and mobile pass their own DB Row types.
 export interface ShotSummaryFields {

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -251,6 +251,7 @@ export type Database = {
           par: number | null
           pin_lat: number | null
           pin_lng: number | null
+          penalties: number
           putts: number | null
           round_id: string
           score: number
@@ -267,6 +268,7 @@ export type Database = {
           par?: number | null
           pin_lat?: number | null
           pin_lng?: number | null
+          penalties?: number
           putts?: number | null
           round_id: string
           score: number
@@ -283,6 +285,7 @@ export type Database = {
           par?: number | null
           pin_lat?: number | null
           pin_lng?: number | null
+          penalties?: number
           putts?: number | null
           round_id?: string
           score?: number

--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -41,6 +41,8 @@ import { countCourses, fetchAllCrawlState } from './crawl/db-writer'
 import { crawlOsm } from './crawl/osm-fetcher'
 import { crawlOsmHoles } from './crawl/holes-fetcher'
 import { crawlEnrich, crawlOpenGolfApi } from './crawl/enricher'
+import { crawlComplete } from './crawl/completer'
+import { crawlGeocode } from './crawl/geocoder'
 import type { Args, Source } from './crawl/types'
 
 function parseArgs(argv: string[]): Args {
@@ -50,11 +52,20 @@ function parseArgs(argv: string[]): Args {
   let status = false
   let limit: number | null = null
   let maxCourses: number | null = null
+  let dryRun = false
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     const next = argv[i + 1]
     if (a === '--source' && next) {
-      const allowed = ['opengolfapi', 'osm', 'osm-first', 'enrich', 'osm-holes'] as const
+      const allowed = [
+        'opengolfapi',
+        'osm',
+        'osm-first',
+        'enrich',
+        'osm-holes',
+        'geocode',
+        'complete',
+      ] as const
       if (!allowed.includes(next as Source)) {
         throw new Error(`--source must be one of ${allowed.join(', ')} (got: ${next})`)
       }
@@ -68,6 +79,8 @@ function parseArgs(argv: string[]): Args {
       i++
     } else if (a === '--force') {
       force = true
+    } else if (a === '--dry-run') {
+      dryRun = true
     } else if (a === '--status') {
       status = true
     } else if (a === '--limit' && next) {
@@ -82,7 +95,7 @@ function parseArgs(argv: string[]): Args {
       i++
     }
   }
-  return { source, states, force, status, limit, maxCourses }
+  return { source, states, force, status, limit, maxCourses, dryRun }
 }
 
 async function showStatus(): Promise<void> {
@@ -120,8 +133,10 @@ async function main(): Promise<void> {
         '  tsx scripts/crawl-courses.ts --source osm-first [--states TX,OK] [--force] [--limit N]\n' +
         '  tsx scripts/crawl-courses.ts --source osm [--states TX,OK] [--force]\n' +
         '  tsx scripts/crawl-courses.ts --source osm-holes [--states TX,OK] [--force] [--limit N]\n' +
+        '  tsx scripts/crawl-courses.ts --source complete [--states TX,OK] [--force] [--dry-run]\n' +
         '  tsx scripts/crawl-courses.ts --source enrich [--states TX,OK] [--force]\n' +
         '  tsx scripts/crawl-courses.ts --source opengolfapi [--states TX,OK] [--force]\n' +
+        '  tsx scripts/crawl-courses.ts --source geocode [--limit N]\n' +
         '  tsx scripts/crawl-courses.ts --status',
     )
     process.exit(1)
@@ -134,6 +149,14 @@ async function main(): Promise<void> {
     return
   }
 
+  // Geocode operates on the whole courses table (any coord course with a null
+  // city), so it needs no state bbox.
+  if (args.source === 'geocode') {
+    console.log(`Geocode crawl${args.limit != null ? ` (limit ${args.limit})` : ''}`)
+    await crawlGeocode(args.limit)
+    return
+  }
+
   // The remaining sources all rely on the OSM bbox table.
   const configured = Object.keys(STATE_BBOX)
   const states = args.states ?? configured
@@ -142,7 +165,12 @@ async function main(): Promise<void> {
     throw new Error(`OSM bbox not configured for: ${unsupported.join(', ')}. Add to STATE_BBOX.`)
   }
 
-  if (args.source === 'osm') {
+  if (args.source === 'complete') {
+    console.log(
+      `Completion pass: ${states.length} state(s)${args.force ? ' (force)' : ''}${args.dryRun ? ' [dry-run]' : ''}`,
+    )
+    await crawlComplete(states, args.force, args.limit, args.dryRun)
+  } else if (args.source === 'osm') {
     console.log(`OSM crawl: ${states.length} state(s)${args.force ? ' (force)' : ''}`)
     await crawlOsm(states, args.force, args.limit)
   } else if (args.source === 'osm-holes') {

--- a/scripts/crawl/completer.ts
+++ b/scripts/crawl/completer.ts
@@ -1,0 +1,313 @@
+// Course completion pass — a per-polygon "derive what's missing" checklist.
+//
+// For each OSM golf_course polygon in a state: ensure a course row exists,
+// derive its name/city when absent, assign the holes that fall INSIDE the
+// polygon (exact containment, not nearest-centroid — which bleeds holes between
+// adjacent courses), and fold any phantom course whose centroid sits inside the
+// same polygon (e.g. an OpenGolfAPI ghost) into the real one.
+//
+// --dry-run reports every change without writing. Idempotent: hole geometry is
+// (re)written only when a course lacks it or --force is set.
+import {
+  OSM_DELAY_MS,
+  OVERPASS_ENDPOINTS,
+  STATE_BBOX,
+  haversineMeters,
+  pointInPolygon,
+  sleep,
+} from './util'
+import { buildOrientedHole, parseHoleFeatures, type HoleWay, type Pt } from './holes-fetcher'
+import {
+  fetchCoursesForState,
+  fetchCoursesWithHoleGeometry,
+  mergeAndDeletePhantom,
+  upsertCourse,
+  upsertHoleGeometry,
+} from './db-writer'
+import type { OgaHoleGeo, OverpassGeomElement, OverpassGeomResponse } from './types'
+
+const USER_AGENT = 'oga-course-crawler/0.1 (https://github.com/cner-smith/opengolfapp)'
+
+interface CoursePolygon {
+  osmId: number
+  name?: string
+  city?: string
+  ring: Pt[]
+  centroid: Pt
+}
+
+function ringCentroid(ring: Pt[]): Pt {
+  let lat = 0
+  let lng = 0
+  for (const p of ring) {
+    lat += p.lat
+    lng += p.lng
+  }
+  return { lat: lat / ring.length, lng: lng / ring.length }
+}
+
+// Reduce a course name to its distinguishing tokens (drop generic golf words +
+// punctuation) so "Tulsa C.C." and "Tulsa Country Club" compare equal.
+const NAME_STOPWORDS = new Set([
+  'golf',
+  'course',
+  'club',
+  'country',
+  'the',
+  'at',
+  'and',
+  'of',
+  'cc',
+])
+function nameTokens(name: string): Set<string> {
+  return new Set(
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9 ]/g, ' ')
+      .split(/\s+/)
+      .filter((t) => t && !NAME_STOPWORDS.has(t)),
+  )
+}
+
+// Jaccard overlap of distinguishing tokens ≥ 0.5. Only a confident match
+// auto-merges a duplicate; anything else is flagged for human review. Empty
+// token sets (e.g. a bare "Golf Course" fallback) never match → always flagged.
+function namesMatch(a: string, b: string): boolean {
+  const ta = nameTokens(a)
+  const tb = nameTokens(b)
+  if (ta.size === 0 || tb.size === 0) return false
+  let inter = 0
+  for (const t of ta) if (tb.has(t)) inter++
+  return inter / (ta.size + tb.size - inter) >= 0.5
+}
+
+// Way polygons only. Relation (multipolygon) golf courses carry member
+// geometry, not a single ring — v1 counts + skips them (they still get holes
+// via the nearest-centroid osm-holes pass); handle if they prove common.
+function parsePolygons(elements: OverpassGeomElement[]): {
+  polygons: CoursePolygon[]
+  relationsSkipped: number
+} {
+  const polygons: CoursePolygon[] = []
+  let relationsSkipped = 0
+  for (const el of elements) {
+    const tags = el.tags ?? {}
+    if (tags['leisure'] !== 'golf_course') continue
+    if (el.type === 'relation') {
+      relationsSkipped++
+      continue
+    }
+    if (el.type !== 'way' || !el.geometry || el.geometry.length < 3) continue
+    const ring = el.geometry.map((g) => ({ lat: g.lat, lng: g.lon }))
+    polygons.push({
+      osmId: el.id,
+      name: tags['name'],
+      city: (tags['addr:city'] ?? '').trim() || undefined,
+      ring,
+      centroid: ringCentroid(ring),
+    })
+  }
+  return { polygons, relationsSkipped }
+}
+
+// One Overpass query per state for course polygons + hole/green/tee geometry,
+// with the same endpoint-cycle + backoff sweep the other OSM passes use.
+// ponytail: 3rd copy of this endpoint loop (osm-fetcher, holes-fetcher, here) —
+// extract a shared overpassPost(query) into util if a 4th caller appears.
+async function fetchStateGeom(state: string): Promise<OverpassGeomElement[]> {
+  const bbox = STATE_BBOX[state]
+  if (!bbox) throw new Error(`OSM bbox not configured for state "${state}".`)
+  const [s, w, n, e] = bbox
+  const q = `
+[out:json][timeout:180];
+(
+  way["leisure"="golf_course"](${s},${w},${n},${e});
+  relation["leisure"="golf_course"](${s},${w},${n},${e});
+  way["golf"="hole"](${s},${w},${n},${e});
+  way["golf"="green"](${s},${w},${n},${e});
+  node["golf"="tee"](${s},${w},${n},${e});
+  way["golf"="tee"](${s},${w},${n},${e});
+);
+out geom tags;`.trim()
+
+  const BACKOFFS_MS = [5_000, 15_000, 45_000]
+  let lastErr: Error | null = null
+  for (let attempt = 0; attempt <= BACKOFFS_MS.length; attempt++) {
+    for (const endpoint of OVERPASS_ENDPOINTS) {
+      try {
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': USER_AGENT,
+          },
+          body: 'data=' + encodeURIComponent(q),
+        })
+        if (!res.ok) {
+          lastErr = new Error(`${endpoint} ${res.status}`)
+          continue
+        }
+        const data = (await res.json()) as OverpassGeomResponse
+        return data.elements
+      } catch (err) {
+        lastErr = err as Error
+      }
+      await sleep(500)
+    }
+    const backoff = BACKOFFS_MS[attempt]
+    if (backoff == null) break
+    console.warn(
+      `[complete:${state}] Overpass failed (last: ${lastErr?.message ?? 'unknown'}) — retry in ${backoff / 1000}s`,
+    )
+    await sleep(backoff)
+  }
+  throw lastErr ?? new Error('Overpass query failed')
+}
+
+export async function crawlComplete(
+  states: string[],
+  force: boolean,
+  limit: number | null,
+  dryRun: boolean,
+): Promise<void> {
+  let totalCourses = 0
+  let totalHoles = 0
+  let totalMerged = 0
+  const flagged: string[] = []
+  for (const state of states) {
+    console.log(`[complete:${state}] querying Overpass (polygons + holes)…`)
+    const elements = await fetchStateGeom(state)
+    const { polygons, relationsSkipped } = parsePolygons(elements)
+    const features = parseHoleFeatures(elements)
+    const existing = await fetchCoursesForState(state)
+    const byExt = new Map(
+      existing.filter((c) => c.externalId).map((c) => [c.externalId as string, c]),
+    )
+    const withGeom = await fetchCoursesWithHoleGeometry(
+      existing.map((c) => c.id),
+      `complete:${state}`,
+    )
+    console.log(
+      `[complete:${state}] ${polygons.length} way polygons, ${features.holeWays.length} holes, ${existing.length} existing courses` +
+        (relationsSkipped ? ` (${relationsSkipped} relation courses skipped)` : ''),
+    )
+
+    // Assign each hole to EXACTLY ONE polygon — the containing polygon whose
+    // centroid is nearest — so a multi-course club (each course its own polygon)
+    // splits cleanly and overlapping rings never double-count a hole. Holes with
+    // ref outside 1..18 were already dropped by parseHoleFeatures (a 27-hole
+    // course mapped as one polygon keeps 1..18; our model is one 18-hole course
+    // per row).
+    const holesByPoly = new Map<number, HoleWay[]>()
+    for (const hw of features.holeWays) {
+      let bestIdx = -1
+      let bestD = Infinity
+      for (let i = 0; i < polygons.length; i++) {
+        if (!pointInPolygon(hw.centroid, polygons[i].ring)) continue
+        const d = haversineMeters(
+          hw.centroid.lat,
+          hw.centroid.lng,
+          polygons[i].centroid.lat,
+          polygons[i].centroid.lng,
+        )
+        if (d < bestD) {
+          bestD = d
+          bestIdx = i
+        }
+      }
+      if (bestIdx < 0) continue
+      const arr = holesByPoly.get(bestIdx) ?? []
+      arr.push(hw)
+      holesByPoly.set(bestIdx, arr)
+    }
+
+    const targets = limit != null ? polygons.slice(0, limit) : polygons
+    for (let pi = 0; pi < targets.length; pi++) {
+      const poly = targets[pi]
+      const extId = `osm_way_${poly.osmId}`
+      const existingCourse = byExt.get(extId)
+
+      // This polygon's holes (deduped by ref, keeping the first).
+      const seen = new Set<number>()
+      const holes: OgaHoleGeo[] = []
+      for (const hw of holesByPoly.get(pi) ?? []) {
+        if (seen.has(hw.ref)) continue
+        seen.add(hw.ref)
+        holes.push(buildOrientedHole(hw, features))
+      }
+      holes.sort((a, b) => a.number - b.number)
+
+      // City: OSM addr tag or an existing value only — no reverse-geocoding here.
+      // Nominatim's 1-req/sec limit makes inline geocoding a bottleneck at scale;
+      // the dedicated `--source geocode` pass fills any remaining cities (and
+      // rewrites bare "Golf Course" fallbacks to "Golf Course (City)") afterward.
+      const city = poly.city ?? existingCourse?.city ?? undefined
+      // Name: OSM name wins; else keep an existing real (non-fallback) name; else fallback.
+      const existingReal =
+        existingCourse && !existingCourse.name.startsWith('Golf Course')
+          ? existingCourse.name
+          : undefined
+      const name = poly.name ?? existingReal ?? `Golf Course${city ? ` (${city})` : ''}`
+
+      // Duplicates: non-OSM course centroids inside this polygon. Auto-merge ONLY
+      // a confident name match; flag the rest for review (a coord-error course
+      // from elsewhere can land inside an unrelated polygon — never auto-delete it).
+      const inside = existing.filter(
+        (c) =>
+          c.externalId !== extId &&
+          !(c.externalId ?? '').startsWith('osm_') &&
+          pointInPolygon({ lat: c.lat, lng: c.lng }, poly.ring),
+      )
+      const toMerge = inside.filter((c) => namesMatch(c.name, name))
+      const toFlag = inside.filter((c) => !namesMatch(c.name, name))
+      for (const c of toFlag) flagged.push(`${state}: "${name}" (${extId}) ⊃ "${c.name}"`)
+
+      const hasGeom = existingCourse ? withGeom.has(existingCourse.id) : false
+      const willWriteHoles = holes.length > 0 && (force || !hasGeom)
+
+      if (dryRun) {
+        const bits = [`${holes.length} holes${willWriteHoles ? '' : ' (skip: has geom)'}`]
+        if (toMerge.length) bits.push(`auto-merge: ${toMerge.map((p) => p.name).join(', ')}`)
+        if (toFlag.length) bits.push(`FLAG: ${toFlag.map((p) => p.name).join(', ')}`)
+        console.log(`[dry] ${extId} "${name}"${city ? ` — ${city}` : ''}: ${bits.join('; ')}`)
+        totalCourses++
+        if (willWriteHoles) totalHoles += holes.length
+        totalMerged += toMerge.length
+        continue
+      }
+
+      const { id: courseId } = await upsertCourse({
+        externalId: extId,
+        name,
+        city: city ?? null,
+        state,
+        lat: poly.centroid.lat,
+        lng: poly.centroid.lng,
+      })
+      totalCourses++
+      if (willWriteHoles) {
+        await upsertHoleGeometry(courseId, holes)
+        totalHoles += holes.length
+      }
+      for (const p of toMerge) {
+        await mergeAndDeletePhantom(p.id, courseId)
+        totalMerged++
+      }
+      // Live progress: one line per course that actually changed, so a run is
+      // watchable instead of silent-until-the-state-summary.
+      const did: string[] = []
+      if (willWriteHoles) did.push(`${holes.length} holes`)
+      if (toMerge.length) did.push(`merged ${toMerge.map((p) => p.name).join(' + ')}`)
+      if (toFlag.length) did.push(`flagged ${toFlag.length}`)
+      if (did.length) console.log(`[complete:${state}] ✓ ${name} — ${did.join(', ')}`)
+    }
+    await sleep(OSM_DELAY_MS)
+  }
+  console.log(
+    `\ncomplete${dryRun ? ' (DRY-RUN)' : ''}: ${totalCourses} courses, ${totalHoles} holes, ${totalMerged} auto-merged, ${flagged.length} flagged for review`,
+  )
+  if (flagged.length) {
+    console.log('\nFLAGGED duplicates (name mismatch — reviewed, NOT auto-merged):')
+    for (const f of flagged) console.log('  - ' + f)
+  }
+}

--- a/scripts/crawl/db-writer.ts
+++ b/scripts/crawl/db-writer.ts
@@ -126,6 +126,156 @@ export async function fetchCourseGeoForState(state: string): Promise<CourseGeo[]
   return all
 }
 
+// Courses that have a centroid but no city. The geocode pass reverse-geocodes
+// each one's coordinates (OSM Nominatim) to fill the city. Optional cap so a
+// rate-limited run stays bounded.
+export async function fetchCitylessCourses(
+  limit: number | null,
+): Promise<{ id: string; name: string; lat: number; lng: number }[]> {
+  const PAGE_SIZE = 500
+  const out: { id: string; name: string; lat: number; lng: number }[] = []
+  let from = 0
+  while (true) {
+    const to = limit != null ? Math.min(from + PAGE_SIZE, limit) - 1 : from + PAGE_SIZE - 1
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id, name, lat, lng')
+      .is('city', null)
+      .not('lat', 'is', null)
+      .not('lng', 'is', null)
+      .range(from, to)
+    if (error) {
+      throw new Error(
+        `cityless fetch failed (range=${from}-${to}): ${error.message ?? JSON.stringify(error)}`,
+      )
+    }
+    const rows = (data ?? []) as {
+      id: string
+      name: string
+      lat: number | null
+      lng: number | null
+    }[]
+    for (const r of rows) {
+      if (r.lat != null && r.lng != null)
+        out.push({ id: r.id, name: r.name, lat: r.lat, lng: r.lng })
+    }
+    if (rows.length < PAGE_SIZE) break
+    if (limit != null && out.length >= limit) break
+    from += PAGE_SIZE
+  }
+  return limit != null ? out.slice(0, limit) : out
+}
+
+// Fill a course's city (and optionally rewrite its "Golf Course" fallback
+// name). Used by the geocode pass only.
+export async function updateCourseCity(id: string, city: string, name?: string): Promise<void> {
+  const patch: { city: string; name?: string } = { city }
+  if (name) patch.name = name
+  const { error } = await supabase.from('courses').update(patch).eq('id', id)
+  if (error) {
+    throw new Error(`city update failed (course=${id}): ${error.message ?? JSON.stringify(error)}`)
+  }
+}
+
+export interface CourseFull {
+  id: string
+  externalId: string | null
+  name: string
+  city: string | null
+  lat: number
+  lng: number
+}
+
+// All coord-bearing courses in a state with the fields the completion pass
+// needs to reconcile them against OSM polygons (identity, name, city, centroid).
+export async function fetchCoursesForState(state: string): Promise<CourseFull[]> {
+  const PAGE_SIZE = 500
+  const all: CourseFull[] = []
+  let from = 0
+  while (true) {
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id, external_id, name, city, lat, lng')
+      .eq('state', state)
+      .not('lat', 'is', null)
+      .not('lng', 'is', null)
+      .range(from, from + PAGE_SIZE - 1)
+    if (error) {
+      throw new Error(
+        `courses fetch failed (state=${state}): ${error.message ?? JSON.stringify(error)}`,
+      )
+    }
+    const rows = (data ?? []) as {
+      id: string
+      external_id: string | null
+      name: string
+      city: string | null
+      lat: number | null
+      lng: number | null
+    }[]
+    for (const r of rows) {
+      if (r.lat != null && r.lng != null) {
+        all.push({
+          id: r.id,
+          externalId: r.external_id,
+          name: r.name,
+          city: r.city,
+          lat: r.lat,
+          lng: r.lng,
+        })
+      }
+    }
+    if (rows.length < PAGE_SIZE) break
+    from += PAGE_SIZE
+  }
+  return all
+}
+
+// Fold a duplicate course (a non-OSM centroid inside a real OSM polygon,
+// confirmed by a name match) into the real course. Order matters so a failure
+// can never lose data: (1) move user rounds, (2) MOVE tee ratings — real
+// enrichment, never deleted; the real course came from a bare OSM polygon and
+// normally has no tees, so an onConflict(course_id,tee_color) collision is rare
+// and surfaced if it hits — (3) delete the duplicate's holes (the real course
+// now carries exact containment geometry), then the duplicate row.
+export async function mergeAndDeletePhantom(phantomId: string, realId: string): Promise<void> {
+  const rounds = await supabase
+    .from('rounds')
+    .update({ course_id: realId })
+    .eq('course_id', phantomId)
+  if (rounds.error) {
+    throw new Error(`merge: move rounds ${phantomId}->${realId} failed: ${rounds.error.message}`)
+  }
+  // A tee_color the real course already carries can't be moved (unique
+  // course_id,tee_color) — drop the duplicate's copy (real course wins), then
+  // move the rest.
+  const realTees = await supabase.from('course_tees').select('tee_color').eq('course_id', realId)
+  if (realTees.error)
+    throw new Error(`merge: read real tees ${realId} failed: ${realTees.error.message}`)
+  const haveColors = (realTees.data ?? []).map((r) => r.tee_color as string)
+  if (haveColors.length) {
+    const dropDup = await supabase
+      .from('course_tees')
+      .delete()
+      .eq('course_id', phantomId)
+      .in('tee_color', haveColors)
+    if (dropDup.error)
+      throw new Error(`merge: drop dup tees ${phantomId} failed: ${dropDup.error.message}`)
+  }
+  const tees = await supabase
+    .from('course_tees')
+    .update({ course_id: realId })
+    .eq('course_id', phantomId)
+  if (tees.error)
+    throw new Error(`merge: move tees ${phantomId}->${realId} failed: ${tees.error.message}`)
+  const holes = await supabase.from('holes').delete().eq('course_id', phantomId)
+  if (holes.error)
+    throw new Error(`merge: delete dup holes ${phantomId} failed: ${holes.error.message}`)
+  const course = await supabase.from('courses').delete().eq('id', phantomId)
+  if (course.error)
+    throw new Error(`merge: delete dup course ${phantomId} failed: ${course.error.message}`)
+}
+
 // Course ids that already have at least one hole carrying coordinates. The
 // osm-holes pass skips these so it never clobbers hand-curated or previously
 // imported geometry (idempotent + safe to re-run). Chunked like the tee lookup.

--- a/scripts/crawl/geocoder.ts
+++ b/scripts/crawl/geocoder.ts
@@ -1,0 +1,82 @@
+// OSM Nominatim reverse geocoding — derive a course's city from its centroid.
+// Most OSM golf_course ways carry no addr:city, so osm-fetcher can only give
+// them a bare "Golf Course" fallback name. This pass reverse-geocodes those
+// coordinates to a real city so courses become locatable without hand-editing.
+import { sleep } from './util'
+import { fetchCitylessCourses, updateCourseCity } from './db-writer'
+
+const NOMINATIM_REVERSE = 'https://nominatim.openstreetmap.org/reverse'
+// Nominatim usage policy: absolute max 1 req/sec, identifying User-Agent required.
+const NOMINATIM_DELAY_MS = 1100
+const USER_AGENT = 'oga-course-crawler/0.1 (https://github.com/cner-smith/opengolfapp)'
+
+// Reverse-geocode a coordinate to its city name. Returns null when Nominatim
+// has no populated place for the point (or on repeated failure). Prefers the
+// most specific place field; county is intentionally skipped as too coarse for
+// a useful course label.
+export async function reverseGeocodeCity(lat: number, lng: number): Promise<string | null> {
+  // No zoom override: zoom=10 collapses to county-level and drops the city.
+  const url = `${NOMINATIM_REVERSE}?format=jsonv2&lat=${lat}&lon=${lng}&addressdetails=1`
+  let attempts = 0
+  const MAX_ATTEMPTS = 2
+  while (true) {
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+      })
+      if (res.status === 429) {
+        console.warn('[geocode] rate limited — waiting 30s')
+        await sleep(30000)
+        continue
+      }
+      if (!res.ok) {
+        attempts++
+        if (attempts < MAX_ATTEMPTS) {
+          console.warn(`[geocode] HTTP ${res.status} — retrying in 5s`)
+          await sleep(5000)
+          continue
+        }
+        return null
+      }
+      const data = (await res.json()) as { address?: Record<string, string> }
+      const a = data.address ?? {}
+      return a.city || a.town || a.village || a.hamlet || a.municipality || null
+    } catch (err) {
+      attempts++
+      if (attempts < MAX_ATTEMPTS) {
+        console.warn(`[geocode] ${(err as Error).message} — retrying in 5s`)
+        await sleep(5000)
+        continue
+      }
+      return null
+    }
+  }
+}
+
+// Backfill city for every course that has coordinates but no city. Rewrites the
+// bare "Golf Course" fallback name to "Golf Course (City)" so nameless courses
+// gain a location label; leaves real names untouched. --limit caps a run
+// (Nominatim is ~1 req/sec, so a full national backfill takes hours).
+export async function crawlGeocode(limit: number | null): Promise<void> {
+  const courses = await fetchCitylessCourses(limit)
+  console.log(`Geocode: ${courses.length} course(s) with coords but no city`)
+  let filled = 0
+  let missed = 0
+  for (let i = 0; i < courses.length; i++) {
+    const c = courses[i]
+    if (!c) continue
+    const city = await reverseGeocodeCity(c.lat, c.lng)
+    if (city) {
+      const name = c.name.startsWith('Golf Course') ? `Golf Course (${city})` : undefined
+      await updateCourseCity(c.id, city, name)
+      filled++
+    } else {
+      missed++
+    }
+    if ((i + 1) % 25 === 0 || i === courses.length - 1) {
+      console.log(`[geocode] ${i + 1}/${courses.length} — filled ${filled}, no-match ${missed}`)
+    }
+    await sleep(NOMINATIM_DELAY_MS)
+  }
+  console.log(`\nGeocode complete: ${filled} cities filled, ${missed} without a match`)
+}

--- a/scripts/crawl/holes-fetcher.ts
+++ b/scripts/crawl/holes-fetcher.ts
@@ -21,18 +21,18 @@ import {
 } from './db-writer'
 import type { CourseGeo, OgaHoleGeo, OverpassGeomElement, OverpassGeomResponse } from './types'
 
-interface Pt {
+export interface Pt {
   lat: number
   lng: number
 }
-interface HoleWay {
+export interface HoleWay {
   ref: number
   par: number | null
   first: Pt
   last: Pt
   centroid: Pt
 }
-interface HoleFeatures {
+export interface HoleFeatures {
   holeWays: HoleWay[]
   greens: Pt[]
   tees: Pt[]
@@ -64,7 +64,7 @@ function nearest(pt: Pt, arr: Pt[]): { d: number; pt: Pt | null } {
   return { d: best, pt: bestPt }
 }
 
-function parseHoleFeatures(elements: OverpassGeomElement[]): HoleFeatures {
+export function parseHoleFeatures(elements: OverpassGeomElement[]): HoleFeatures {
   const holeWays: HoleWay[] = []
   const greens: Pt[] = []
   const tees: Pt[] = []
@@ -174,36 +174,39 @@ function buildHolesForCourses(courses: CourseGeo[], f: HoleFeatures): Map<string
 
   const out = new Map<string, OgaHoleGeo[]>()
   for (const [courseId, refs] of byCourse) {
-    const holes: OgaHoleGeo[] = []
-    for (const { hw } of refs.values()) {
-      // Orient: whichever endpoint is nearer a green is the green/pin end.
-      const gFirst = nearest(hw.first, f.greens).d
-      const gLast = nearest(hw.last, f.greens).d
-      const greenEnd = gLast <= gFirst ? hw.last : hw.first
-      const teeEnd = gLast <= gFirst ? hw.first : hw.last
-      // Snap to an explicit tee/green feature when one sits right on the end.
-      const ng = nearest(greenEnd, f.greens)
-      const nt = nearest(teeEnd, f.tees)
-      const pin = ng.pt && ng.d < SNAP_M ? ng.pt : greenEnd
-      const tee = nt.pt && nt.d < SNAP_M ? nt.pt : teeEnd
-      const yards = Math.round(haversineMeters(tee.lat, tee.lng, pin.lat, pin.lng) * 1.09361)
-      // holes.par CHECK is 3..6 — clamp the occasional out-of-range OSM par
-      // (pitch-and-putt 2s, mistagged 7s) rather than failing the whole batch.
-      const par = Math.min(6, Math.max(3, hw.par ?? 4))
-      holes.push({
-        number: hw.ref,
-        par,
-        yards: yards > 0 ? yards : undefined,
-        teeLat: +tee.lat.toFixed(6),
-        teeLng: +tee.lng.toFixed(6),
-        pinLat: +pin.lat.toFixed(6),
-        pinLng: +pin.lng.toFixed(6),
-      })
-    }
+    const holes = [...refs.values()].map(({ hw }) => buildOrientedHole(hw, f))
     holes.sort((a, b) => a.number - b.number)
     if (holes.length > 0) out.set(courseId, holes)
   }
   return out
+}
+
+// Build one numbered hole with oriented tee/pin geometry from a hole way:
+// whichever endpoint is nearer a green is the pin end; snap to an explicit
+// golf=tee/green feature when one sits on the endpoint. Shared by the
+// nearest-centroid osm-holes pass and the containment-based completion pass.
+export function buildOrientedHole(hw: HoleWay, f: HoleFeatures): OgaHoleGeo {
+  const gFirst = nearest(hw.first, f.greens).d
+  const gLast = nearest(hw.last, f.greens).d
+  const greenEnd = gLast <= gFirst ? hw.last : hw.first
+  const teeEnd = gLast <= gFirst ? hw.first : hw.last
+  const ng = nearest(greenEnd, f.greens)
+  const nt = nearest(teeEnd, f.tees)
+  const pin = ng.pt && ng.d < SNAP_M ? ng.pt : greenEnd
+  const tee = nt.pt && nt.d < SNAP_M ? nt.pt : teeEnd
+  const yards = Math.round(haversineMeters(tee.lat, tee.lng, pin.lat, pin.lng) * 1.09361)
+  // holes.par CHECK is 3..6 — clamp the occasional out-of-range OSM par
+  // (pitch-and-putt 2s, mistagged 7s) rather than failing the whole batch.
+  const par = Math.min(6, Math.max(3, hw.par ?? 4))
+  return {
+    number: hw.ref,
+    par,
+    yards: yards > 0 ? yards : undefined,
+    teeLat: +tee.lat.toFixed(6),
+    teeLng: +tee.lng.toFixed(6),
+    pinLat: +pin.lat.toFixed(6),
+    pinLng: +pin.lng.toFixed(6),
+  }
 }
 
 export async function crawlOsmHoles(

--- a/scripts/crawl/types.ts
+++ b/scripts/crawl/types.ts
@@ -93,7 +93,14 @@ export interface OsmCourseLite {
 
 export type CrawlStatus = 'pending' | 'in_progress' | 'done' | 'error'
 
-export type Source = 'opengolfapi' | 'osm' | 'osm-first' | 'enrich' | 'osm-holes'
+export type Source =
+  | 'opengolfapi'
+  | 'osm'
+  | 'osm-first'
+  | 'enrich'
+  | 'osm-holes'
+  | 'geocode'
+  | 'complete'
 
 /** A hole with optional per-hole geometry, written by the osm-holes pass. */
 export interface OgaHoleGeo {
@@ -115,7 +122,7 @@ export interface CourseGeo {
 
 /** Overpass element from an `out geom` query (ways carry a node list). */
 export interface OverpassGeomElement {
-  type: 'way' | 'node'
+  type: 'way' | 'node' | 'relation'
   id: number
   lat?: number
   lon?: number
@@ -133,6 +140,7 @@ export interface Args {
   status: boolean
   limit: number | null // optional cap on courses per state (for testing)
   maxCourses: number | null // global cap on API-processed courses this run (enrich rate-limit budget)
+  dryRun: boolean // completion pass: report changes without writing
 }
 
 export interface CrawlStateRow {

--- a/scripts/crawl/util.ts
+++ b/scripts/crawl/util.ts
@@ -141,6 +141,31 @@ export function asNumber(v: unknown): number | undefined {
   return undefined
 }
 
+// Ray-casting point-in-polygon test. ring is the polygon's ordered vertices
+// ({lat,lng}); returns true if the point lies inside. Used by the completion
+// pass to assign each OSM hole to the course polygon that actually contains it
+// (exact), instead of the nearest centroid (a guess that bleeds holes between
+// adjacent courses).
+export function pointInPolygon(
+  pt: { lat: number; lng: number },
+  ring: { lat: number; lng: number }[],
+): boolean {
+  let inside = false
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const yi = ring[i].lat
+    const xi = ring[i].lng
+    const yj = ring[j].lat
+    const xj = ring[j].lng
+    // Casts a ray in +lat at x=pt.lng; the xi>lng!==xj>lng test excludes
+    // vertical edges (and guards the divide), so horizontal edges must NOT be
+    // skipped — they're resolved by the formula. Matches the validated variant.
+    if (xi > pt.lng !== xj > pt.lng && pt.lat < ((yj - yi) * (pt.lng - xi)) / (xj - xi) + yi) {
+      inside = !inside
+    }
+  }
+  return inside
+}
+
 // Great-circle distance in metres. Used by the osm-holes pass to assign each
 // OSM hole way to its nearest course centroid and to snap tee/green endpoints.
 export function haversineMeters(aLat: number, aLng: number, bLat: number, bLng: number): number {

--- a/supabase/migrations/0041_hole_scores_penalties.sql
+++ b/supabase/migrations/0041_hole_scores_penalties.sql
@@ -1,0 +1,6 @@
+-- Per-hole penalty-stroke count, entered in the end-of-hole summary
+-- ("how'd it go?" — score / putts / penalties tickers). Additive and
+-- defaulted to 0, so existing rows, the scorecard, and all SG/score math
+-- are unaffected until a user actually records a penalty.
+alter table public.hole_scores
+  add column if not exists penalties integer not null default 0;


### PR DESCRIPTION
Refines the web `HoleReviewSheet` into the end-of-hole **"how'd it go?"** summary (epic #791), so the web deferred-metadata model becomes the shared target the mobile port follows.

## What's here
- **Summary strip** — three uniform editable tickers (Score · vs-par / Putts / Penalties), all with ± steppers. Penalties is a new hole-level field.
- **Full-height sheet** — fills the map area above the HUD (z-index 40); no overlays bleed through.
- **Shot detail chips (Version A, inline-expand)** — each shot row has club / lie / slope (two-axis) / result chips. Blank chips read `+ field` (dashed); tapping unfolds the options in place. Club chip capitalized to match the Sentence-case lie/slope/result labels.
- **Putt rows** — Made it + short/long · miss-side axes, plus **break** (line + slope) and **green-speed** chips, and a **Read ▸** chip that brings up the full-sheet `GreenDiagram` aimer on demand. Replaces the auto-popping putting sheet.

## Data
- Migration `0041` adds `hole_scores.penalties integer not null default 0` (already applied to dev + prod; idempotent `add column if not exists`, so the release `db push` is a no-op).
- `ReviewedShotRow` gains `shotResult` / `lieSlopeForward` / `lieSlopeSide`; `saveReviewedHole` persists them. Break/speed/aim columns were already wired.

## Verification
- `pnpm typecheck` clean; `pnpm --filter @oga/core test` green (592).
- Every state rendered locally and screenshotted before shipping (summary, chip expand, putt break/speed, Read aimer).

Mobile port to match is the next step, in lock-step.