### PR TITLE
feature(crawl): course completion pass — containment holes + confident dedup

### DIFF
--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -43,6 +43,7 @@ import { crawlOsmHoles } from './crawl/holes-fetcher'
 import { crawlEnrich, crawlOpenGolfApi } from './crawl/enricher'
 import { crawlComplete } from './crawl/completer'
 import { crawlGeocode } from './crawl/geocoder'
+import { crawlReconcile } from './crawl/reconciler'
 import type { Args, Source } from './crawl/types'
 
 function parseArgs(argv: string[]): Args {
@@ -53,6 +54,7 @@ function parseArgs(argv: string[]): Args {
   let limit: number | null = null
   let maxCourses: number | null = null
   let dryRun = false
+  let apply = false
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     const next = argv[i + 1]
@@ -65,6 +67,7 @@ function parseArgs(argv: string[]): Args {
         'osm-holes',
         'geocode',
         'complete',
+        'reconcile',
       ] as const
       if (!allowed.includes(next as Source)) {
         throw new Error(`--source must be one of ${allowed.join(', ')} (got: ${next})`)
@@ -81,6 +84,8 @@ function parseArgs(argv: string[]): Args {
       force = true
     } else if (a === '--dry-run') {
       dryRun = true
+    } else if (a === '--apply') {
+      apply = true
     } else if (a === '--status') {
       status = true
     } else if (a === '--limit' && next) {
@@ -95,7 +100,7 @@ function parseArgs(argv: string[]): Args {
       i++
     }
   }
-  return { source, states, force, status, limit, maxCourses, dryRun }
+  return { source, states, force, status, limit, maxCourses, dryRun, apply }
 }
 
 async function showStatus(): Promise<void> {
@@ -137,6 +142,7 @@ async function main(): Promise<void> {
         '  tsx scripts/crawl-courses.ts --source enrich [--states TX,OK] [--force]\n' +
         '  tsx scripts/crawl-courses.ts --source opengolfapi [--states TX,OK] [--force]\n' +
         '  tsx scripts/crawl-courses.ts --source geocode [--limit N]\n' +
+        '  tsx scripts/crawl-courses.ts --source reconcile [--states RI] [--apply]\n' +
         '  tsx scripts/crawl-courses.ts --status',
     )
     process.exit(1)
@@ -154,6 +160,16 @@ async function main(): Promise<void> {
   if (args.source === 'geocode') {
     console.log(`Geocode crawl${args.limit != null ? ` (limit ${args.limit})` : ''}`)
     await crawlGeocode(args.limit)
+    return
+  }
+
+  // Reconcile queries the courses table by state string (no bbox needed).
+  if (args.source === 'reconcile') {
+    const states = args.states ?? Object.keys(STATE_BBOX)
+    console.log(
+      `Reconcile (exact-dup): ${states.length} state(s)${args.apply ? ' [APPLY]' : ' [dry-run]'}`,
+    )
+    await crawlReconcile(states, args.apply)
     return
   }
 

--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -41,6 +41,7 @@ import { countCourses, fetchAllCrawlState } from './crawl/db-writer'
 import { crawlOsm } from './crawl/osm-fetcher'
 import { crawlOsmHoles } from './crawl/holes-fetcher'
 import { crawlEnrich, crawlOpenGolfApi } from './crawl/enricher'
+import { crawlComplete } from './crawl/completer'
 import { crawlGeocode } from './crawl/geocoder'
 import type { Args, Source } from './crawl/types'
 
@@ -51,11 +52,20 @@ function parseArgs(argv: string[]): Args {
   let status = false
   let limit: number | null = null
   let maxCourses: number | null = null
+  let dryRun = false
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i]
     const next = argv[i + 1]
     if (a === '--source' && next) {
-      const allowed = ['opengolfapi', 'osm', 'osm-first', 'enrich', 'osm-holes', 'geocode'] as const
+      const allowed = [
+        'opengolfapi',
+        'osm',
+        'osm-first',
+        'enrich',
+        'osm-holes',
+        'geocode',
+        'complete',
+      ] as const
       if (!allowed.includes(next as Source)) {
         throw new Error(`--source must be one of ${allowed.join(', ')} (got: ${next})`)
       }
@@ -69,6 +79,8 @@ function parseArgs(argv: string[]): Args {
       i++
     } else if (a === '--force') {
       force = true
+    } else if (a === '--dry-run') {
+      dryRun = true
     } else if (a === '--status') {
       status = true
     } else if (a === '--limit' && next) {
@@ -83,7 +95,7 @@ function parseArgs(argv: string[]): Args {
       i++
     }
   }
-  return { source, states, force, status, limit, maxCourses }
+  return { source, states, force, status, limit, maxCourses, dryRun }
 }
 
 async function showStatus(): Promise<void> {
@@ -121,6 +133,7 @@ async function main(): Promise<void> {
         '  tsx scripts/crawl-courses.ts --source osm-first [--states TX,OK] [--force] [--limit N]\n' +
         '  tsx scripts/crawl-courses.ts --source osm [--states TX,OK] [--force]\n' +
         '  tsx scripts/crawl-courses.ts --source osm-holes [--states TX,OK] [--force] [--limit N]\n' +
+        '  tsx scripts/crawl-courses.ts --source complete [--states TX,OK] [--force] [--dry-run]\n' +
         '  tsx scripts/crawl-courses.ts --source enrich [--states TX,OK] [--force]\n' +
         '  tsx scripts/crawl-courses.ts --source opengolfapi [--states TX,OK] [--force]\n' +
         '  tsx scripts/crawl-courses.ts --source geocode [--limit N]\n' +
@@ -152,7 +165,12 @@ async function main(): Promise<void> {
     throw new Error(`OSM bbox not configured for: ${unsupported.join(', ')}. Add to STATE_BBOX.`)
   }
 
-  if (args.source === 'osm') {
+  if (args.source === 'complete') {
+    console.log(
+      `Completion pass: ${states.length} state(s)${args.force ? ' (force)' : ''}${args.dryRun ? ' [dry-run]' : ''}`,
+    )
+    await crawlComplete(states, args.force, args.limit, args.dryRun)
+  } else if (args.source === 'osm') {
     console.log(`OSM crawl: ${states.length} state(s)${args.force ? ' (force)' : ''}`)
     await crawlOsm(states, args.force, args.limit)
   } else if (args.source === 'osm-holes') {

--- a/scripts/crawl-courses.ts
+++ b/scripts/crawl-courses.ts
@@ -41,6 +41,7 @@ import { countCourses, fetchAllCrawlState } from './crawl/db-writer'
 import { crawlOsm } from './crawl/osm-fetcher'
 import { crawlOsmHoles } from './crawl/holes-fetcher'
 import { crawlEnrich, crawlOpenGolfApi } from './crawl/enricher'
+import { crawlGeocode } from './crawl/geocoder'
 import type { Args, Source } from './crawl/types'
 
 function parseArgs(argv: string[]): Args {
@@ -54,7 +55,7 @@ function parseArgs(argv: string[]): Args {
     const a = argv[i]
     const next = argv[i + 1]
     if (a === '--source' && next) {
-      const allowed = ['opengolfapi', 'osm', 'osm-first', 'enrich', 'osm-holes'] as const
+      const allowed = ['opengolfapi', 'osm', 'osm-first', 'enrich', 'osm-holes', 'geocode'] as const
       if (!allowed.includes(next as Source)) {
         throw new Error(`--source must be one of ${allowed.join(', ')} (got: ${next})`)
       }
@@ -122,6 +123,7 @@ async function main(): Promise<void> {
         '  tsx scripts/crawl-courses.ts --source osm-holes [--states TX,OK] [--force] [--limit N]\n' +
         '  tsx scripts/crawl-courses.ts --source enrich [--states TX,OK] [--force]\n' +
         '  tsx scripts/crawl-courses.ts --source opengolfapi [--states TX,OK] [--force]\n' +
+        '  tsx scripts/crawl-courses.ts --source geocode [--limit N]\n' +
         '  tsx scripts/crawl-courses.ts --status',
     )
     process.exit(1)
@@ -131,6 +133,14 @@ async function main(): Promise<void> {
     const states = args.states ?? [...ALL_STATES]
     console.log(`OpenGolfAPI crawl: ${states.length} state(s)${args.force ? ' (force)' : ''}`)
     await crawlOpenGolfApi(states, args.force, args.limit)
+    return
+  }
+
+  // Geocode operates on the whole courses table (any coord course with a null
+  // city), so it needs no state bbox.
+  if (args.source === 'geocode') {
+    console.log(`Geocode crawl${args.limit != null ? ` (limit ${args.limit})` : ''}`)
+    await crawlGeocode(args.limit)
     return
   }
 

--- a/scripts/crawl/completer.ts
+++ b/scripts/crawl/completer.ts
@@ -13,6 +13,7 @@ import {
   OVERPASS_ENDPOINTS,
   STATE_BBOX,
   haversineMeters,
+  isFallbackName,
   pointInPolygon,
   sleep,
 } from './util'
@@ -514,13 +515,11 @@ export async function crawlComplete(
       // of a single named course sitting inside a NAMELESS polygon (usually the
       // real course; flagged so a wrong adoption can be caught) → fallback.
       const existingReal =
-        existingCourse && !existingCourse.name.startsWith('Golf Course')
-          ? existingCourse.name
-          : undefined
+        existingCourse && !isFallbackName(existingCourse.name) ? existingCourse.name : undefined
       let derived = poly.name ?? existingReal
       let adopted: string | undefined
       if (!derived) {
-        const named = inside.filter((c) => !c.name.startsWith('Golf Course'))
+        const named = inside.filter((c) => !isFallbackName(c.name))
         if (named.length === 1) {
           derived = named[0].name
           adopted = named[0].name

--- a/scripts/crawl/completer.ts
+++ b/scripts/crawl/completer.ts
@@ -18,6 +18,7 @@ import {
 } from './util'
 import { buildOrientedHole, parseHoleFeatures, type HoleWay, type Pt } from './holes-fetcher'
 import {
+  courseHasUserData,
   fetchCoursesForState,
   fetchCoursesWithHoleGeometry,
   mergeAndDeletePhantom,
@@ -550,6 +551,12 @@ export async function crawlComplete(
         totalHoles += holes.length
       }
       for (const c of [...siblings, ...toMerge]) {
+        // Never fold a course a user has played — deleting its holes would
+        // orphan their scorecards (and the FK aborts the whole run). Flag it.
+        if (await courseHasUserData(c.id)) {
+          flagged.push(`${state}: NOT merged "${c.name}" into "${name}" — has user data (manual)`)
+          continue
+        }
         await mergeAndDeletePhantom(c.id, courseId)
         totalMerged++
       }

--- a/scripts/crawl/completer.ts
+++ b/scripts/crawl/completer.ts
@@ -1,0 +1,306 @@
+// Course completion pass — a per-polygon "derive what's missing" checklist.
+//
+// For each OSM golf_course polygon in a state: ensure a course row exists,
+// derive its name/city when absent, assign the holes that fall INSIDE the
+// polygon (exact containment, not nearest-centroid — which bleeds holes between
+// adjacent courses), and fold any phantom course whose centroid sits inside the
+// same polygon (e.g. an OpenGolfAPI ghost) into the real one.
+//
+// --dry-run reports every change without writing. Idempotent: hole geometry is
+// (re)written only when a course lacks it or --force is set.
+import {
+  OSM_DELAY_MS,
+  OVERPASS_ENDPOINTS,
+  STATE_BBOX,
+  haversineMeters,
+  pointInPolygon,
+  sleep,
+} from './util'
+import { buildOrientedHole, parseHoleFeatures, type HoleWay, type Pt } from './holes-fetcher'
+import {
+  fetchCoursesForState,
+  fetchCoursesWithHoleGeometry,
+  mergeAndDeletePhantom,
+  upsertCourse,
+  upsertHoleGeometry,
+} from './db-writer'
+import type { OgaHoleGeo, OverpassGeomElement, OverpassGeomResponse } from './types'
+
+const USER_AGENT = 'oga-course-crawler/0.1 (https://github.com/cner-smith/opengolfapp)'
+
+interface CoursePolygon {
+  osmId: number
+  name?: string
+  city?: string
+  ring: Pt[]
+  centroid: Pt
+}
+
+function ringCentroid(ring: Pt[]): Pt {
+  let lat = 0
+  let lng = 0
+  for (const p of ring) {
+    lat += p.lat
+    lng += p.lng
+  }
+  return { lat: lat / ring.length, lng: lng / ring.length }
+}
+
+// Reduce a course name to its distinguishing tokens (drop generic golf words +
+// punctuation) so "Tulsa C.C." and "Tulsa Country Club" compare equal.
+const NAME_STOPWORDS = new Set([
+  'golf',
+  'course',
+  'club',
+  'country',
+  'the',
+  'at',
+  'and',
+  'of',
+  'cc',
+])
+function nameTokens(name: string): Set<string> {
+  return new Set(
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9 ]/g, ' ')
+      .split(/\s+/)
+      .filter((t) => t && !NAME_STOPWORDS.has(t)),
+  )
+}
+
+// Jaccard overlap of distinguishing tokens ≥ 0.5. Only a confident match
+// auto-merges a duplicate; anything else is flagged for human review. Empty
+// token sets (e.g. a bare "Golf Course" fallback) never match → always flagged.
+function namesMatch(a: string, b: string): boolean {
+  const ta = nameTokens(a)
+  const tb = nameTokens(b)
+  if (ta.size === 0 || tb.size === 0) return false
+  let inter = 0
+  for (const t of ta) if (tb.has(t)) inter++
+  return inter / (ta.size + tb.size - inter) >= 0.5
+}
+
+// Way polygons only. Relation (multipolygon) golf courses carry member
+// geometry, not a single ring — v1 counts + skips them (they still get holes
+// via the nearest-centroid osm-holes pass); handle if they prove common.
+function parsePolygons(elements: OverpassGeomElement[]): {
+  polygons: CoursePolygon[]
+  relationsSkipped: number
+} {
+  const polygons: CoursePolygon[] = []
+  let relationsSkipped = 0
+  for (const el of elements) {
+    const tags = el.tags ?? {}
+    if (tags['leisure'] !== 'golf_course') continue
+    if (el.type === 'relation') {
+      relationsSkipped++
+      continue
+    }
+    if (el.type !== 'way' || !el.geometry || el.geometry.length < 3) continue
+    const ring = el.geometry.map((g) => ({ lat: g.lat, lng: g.lon }))
+    polygons.push({
+      osmId: el.id,
+      name: tags['name'],
+      city: (tags['addr:city'] ?? '').trim() || undefined,
+      ring,
+      centroid: ringCentroid(ring),
+    })
+  }
+  return { polygons, relationsSkipped }
+}
+
+// One Overpass query per state for course polygons + hole/green/tee geometry,
+// with the same endpoint-cycle + backoff sweep the other OSM passes use.
+// ponytail: 3rd copy of this endpoint loop (osm-fetcher, holes-fetcher, here) —
+// extract a shared overpassPost(query) into util if a 4th caller appears.
+async function fetchStateGeom(state: string): Promise<OverpassGeomElement[]> {
+  const bbox = STATE_BBOX[state]
+  if (!bbox) throw new Error(`OSM bbox not configured for state "${state}".`)
+  const [s, w, n, e] = bbox
+  const q = `
+[out:json][timeout:180];
+(
+  way["leisure"="golf_course"](${s},${w},${n},${e});
+  relation["leisure"="golf_course"](${s},${w},${n},${e});
+  way["golf"="hole"](${s},${w},${n},${e});
+  way["golf"="green"](${s},${w},${n},${e});
+  node["golf"="tee"](${s},${w},${n},${e});
+  way["golf"="tee"](${s},${w},${n},${e});
+);
+out geom tags;`.trim()
+
+  const BACKOFFS_MS = [5_000, 15_000, 45_000]
+  let lastErr: Error | null = null
+  for (let attempt = 0; attempt <= BACKOFFS_MS.length; attempt++) {
+    for (const endpoint of OVERPASS_ENDPOINTS) {
+      try {
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'User-Agent': USER_AGENT,
+          },
+          body: 'data=' + encodeURIComponent(q),
+        })
+        if (!res.ok) {
+          lastErr = new Error(`${endpoint} ${res.status}`)
+          continue
+        }
+        const data = (await res.json()) as OverpassGeomResponse
+        return data.elements
+      } catch (err) {
+        lastErr = err as Error
+      }
+      await sleep(500)
+    }
+    const backoff = BACKOFFS_MS[attempt]
+    if (backoff == null) break
+    console.warn(
+      `[complete:${state}] Overpass failed (last: ${lastErr?.message ?? 'unknown'}) — retry in ${backoff / 1000}s`,
+    )
+    await sleep(backoff)
+  }
+  throw lastErr ?? new Error('Overpass query failed')
+}
+
+export async function crawlComplete(
+  states: string[],
+  force: boolean,
+  limit: number | null,
+  dryRun: boolean,
+): Promise<void> {
+  let totalCourses = 0
+  let totalHoles = 0
+  let totalMerged = 0
+  const flagged: string[] = []
+  for (const state of states) {
+    console.log(`[complete:${state}] querying Overpass (polygons + holes)…`)
+    const elements = await fetchStateGeom(state)
+    const { polygons, relationsSkipped } = parsePolygons(elements)
+    const features = parseHoleFeatures(elements)
+    const existing = await fetchCoursesForState(state)
+    const byExt = new Map(
+      existing.filter((c) => c.externalId).map((c) => [c.externalId as string, c]),
+    )
+    const withGeom = await fetchCoursesWithHoleGeometry(
+      existing.map((c) => c.id),
+      `complete:${state}`,
+    )
+    console.log(
+      `[complete:${state}] ${polygons.length} way polygons, ${features.holeWays.length} holes, ${existing.length} existing courses` +
+        (relationsSkipped ? ` (${relationsSkipped} relation courses skipped)` : ''),
+    )
+
+    // Assign each hole to EXACTLY ONE polygon — the containing polygon whose
+    // centroid is nearest — so a multi-course club (each course its own polygon)
+    // splits cleanly and overlapping rings never double-count a hole. Holes with
+    // ref outside 1..18 were already dropped by parseHoleFeatures (a 27-hole
+    // course mapped as one polygon keeps 1..18; our model is one 18-hole course
+    // per row).
+    const holesByPoly = new Map<number, HoleWay[]>()
+    for (const hw of features.holeWays) {
+      let bestIdx = -1
+      let bestD = Infinity
+      for (let i = 0; i < polygons.length; i++) {
+        if (!pointInPolygon(hw.centroid, polygons[i].ring)) continue
+        const d = haversineMeters(
+          hw.centroid.lat,
+          hw.centroid.lng,
+          polygons[i].centroid.lat,
+          polygons[i].centroid.lng,
+        )
+        if (d < bestD) {
+          bestD = d
+          bestIdx = i
+        }
+      }
+      if (bestIdx < 0) continue
+      const arr = holesByPoly.get(bestIdx) ?? []
+      arr.push(hw)
+      holesByPoly.set(bestIdx, arr)
+    }
+
+    const targets = limit != null ? polygons.slice(0, limit) : polygons
+    for (let pi = 0; pi < targets.length; pi++) {
+      const poly = targets[pi]
+      const extId = `osm_way_${poly.osmId}`
+      const existingCourse = byExt.get(extId)
+
+      // This polygon's holes (deduped by ref, keeping the first).
+      const seen = new Set<number>()
+      const holes: OgaHoleGeo[] = []
+      for (const hw of holesByPoly.get(pi) ?? []) {
+        if (seen.has(hw.ref)) continue
+        seen.add(hw.ref)
+        holes.push(buildOrientedHole(hw, features))
+      }
+      holes.sort((a, b) => a.number - b.number)
+
+      // City: OSM addr tag or an existing value only — no reverse-geocoding here.
+      // Nominatim's 1-req/sec limit makes inline geocoding a bottleneck at scale;
+      // the dedicated `--source geocode` pass fills any remaining cities (and
+      // rewrites bare "Golf Course" fallbacks to "Golf Course (City)") afterward.
+      const city = poly.city ?? existingCourse?.city ?? undefined
+      // Name: OSM name wins; else keep an existing real (non-fallback) name; else fallback.
+      const existingReal =
+        existingCourse && !existingCourse.name.startsWith('Golf Course')
+          ? existingCourse.name
+          : undefined
+      const name = poly.name ?? existingReal ?? `Golf Course${city ? ` (${city})` : ''}`
+
+      // Duplicates: non-OSM course centroids inside this polygon. Auto-merge ONLY
+      // a confident name match; flag the rest for review (a coord-error course
+      // from elsewhere can land inside an unrelated polygon — never auto-delete it).
+      const inside = existing.filter(
+        (c) =>
+          c.externalId !== extId &&
+          !(c.externalId ?? '').startsWith('osm_') &&
+          pointInPolygon({ lat: c.lat, lng: c.lng }, poly.ring),
+      )
+      const toMerge = inside.filter((c) => namesMatch(c.name, name))
+      const toFlag = inside.filter((c) => !namesMatch(c.name, name))
+      for (const c of toFlag) flagged.push(`${state}: "${name}" (${extId}) ⊃ "${c.name}"`)
+
+      const hasGeom = existingCourse ? withGeom.has(existingCourse.id) : false
+      const willWriteHoles = holes.length > 0 && (force || !hasGeom)
+
+      if (dryRun) {
+        const bits = [`${holes.length} holes${willWriteHoles ? '' : ' (skip: has geom)'}`]
+        if (toMerge.length) bits.push(`auto-merge: ${toMerge.map((p) => p.name).join(', ')}`)
+        if (toFlag.length) bits.push(`FLAG: ${toFlag.map((p) => p.name).join(', ')}`)
+        console.log(`[dry] ${extId} "${name}"${city ? ` — ${city}` : ''}: ${bits.join('; ')}`)
+        totalCourses++
+        if (willWriteHoles) totalHoles += holes.length
+        totalMerged += toMerge.length
+        continue
+      }
+
+      const { id: courseId } = await upsertCourse({
+        externalId: extId,
+        name,
+        city: city ?? null,
+        state,
+        lat: poly.centroid.lat,
+        lng: poly.centroid.lng,
+      })
+      totalCourses++
+      if (willWriteHoles) {
+        await upsertHoleGeometry(courseId, holes)
+        totalHoles += holes.length
+      }
+      for (const p of toMerge) {
+        await mergeAndDeletePhantom(p.id, courseId)
+        totalMerged++
+      }
+    }
+    await sleep(OSM_DELAY_MS)
+  }
+  console.log(
+    `\ncomplete${dryRun ? ' (DRY-RUN)' : ''}: ${totalCourses} courses, ${totalHoles} holes, ${totalMerged} auto-merged, ${flagged.length} flagged for review`,
+  )
+  if (flagged.length) {
+    console.log('\nFLAGGED duplicates (name mismatch — reviewed, NOT auto-merged):')
+    for (const f of flagged) console.log('  - ' + f)
+  }
+}

--- a/scripts/crawl/completer.ts
+++ b/scripts/crawl/completer.ts
@@ -23,27 +23,96 @@ import {
   mergeAndDeletePhantom,
   upsertCourse,
   upsertHoleGeometry,
+  type CourseFull,
 } from './db-writer'
 import type { OgaHoleGeo, OverpassGeomElement, OverpassGeomResponse } from './types'
 
 const USER_AGENT = 'oga-course-crawler/0.1 (https://github.com/cner-smith/opengolfapp)'
 
 interface CoursePolygon {
+  osmType: 'way' | 'relation'
   osmId: number
   name?: string
   city?: string
-  ring: Pt[]
+  rings: Pt[][] // a way = one ring; a relation multipolygon = its outer ring(s)
   centroid: Pt
 }
 
-function ringCentroid(ring: Pt[]): Pt {
+function polyCentroid(rings: Pt[][]): Pt {
   let lat = 0
   let lng = 0
-  for (const p of ring) {
-    lat += p.lat
-    lng += p.lng
+  let n = 0
+  for (const ring of rings)
+    for (const p of ring) {
+      lat += p.lat
+      lng += p.lng
+      n++
+    }
+  return { lat: lat / n, lng: lng / n }
+}
+
+function inAnyRing(pt: Pt, rings: Pt[][]): boolean {
+  return rings.some((r) => pointInPolygon(pt, r))
+}
+
+// A real golf course spans hundreds of metres end to end; a single tee/green
+// (sometimes mis-tagged leisure=golf_course in OSM, e.g. "#8 White Tee") is
+// ~20-60m. Polygons whose bbox diagonal is below this are dropped as mistags.
+const MIN_COURSE_DIAGONAL_M = 150
+function bboxDiagonalM(rings: Pt[][]): number {
+  let minLat = Infinity
+  let maxLat = -Infinity
+  let minLng = Infinity
+  let maxLng = -Infinity
+  for (const r of rings)
+    for (const p of r) {
+      if (p.lat < minLat) minLat = p.lat
+      if (p.lat > maxLat) maxLat = p.lat
+      if (p.lng < minLng) minLng = p.lng
+      if (p.lng > maxLng) maxLng = p.lng
+    }
+  return haversineMeters(minLat, minLng, maxLat, maxLng)
+}
+
+function ptsClose(a: Pt, b: Pt): boolean {
+  return Math.abs(a.lat - b.lat) < 1e-7 && Math.abs(a.lng - b.lng) < 1e-7
+}
+
+// Stitch relation outer member ways (often split into segments) into closed
+// rings, greedily matching endpoints. Good enough for OSM golf-course
+// multipolygons; unclosable/degenerate segments are dropped.
+function assembleRings(segments: Pt[][]): Pt[][] {
+  const segs = segments.filter((s) => s.length >= 2).map((s) => [...s])
+  const used = new Array(segs.length).fill(false)
+  const rings: Pt[][] = []
+  for (let i = 0; i < segs.length; i++) {
+    if (used[i]) continue
+    used[i] = true
+    const ring = [...segs[i]]
+    let extended = true
+    while (extended && !ptsClose(ring[0], ring[ring.length - 1])) {
+      extended = false
+      for (let j = 0; j < segs.length; j++) {
+        if (used[j]) continue
+        const s = segs[j]
+        const last = ring[ring.length - 1]
+        if (ptsClose(s[0], last)) {
+          ring.push(...s.slice(1))
+          used[j] = true
+          extended = true
+          break
+        }
+        if (ptsClose(s[s.length - 1], last)) {
+          ring.push(...s.slice(0, -1).reverse())
+          used[j] = true
+          extended = true
+          break
+        }
+      }
+    }
+    if (ring.length >= 3) rings.push(ring)
   }
-  return { lat: lat / ring.length, lng: lng / ring.length }
+  return rings
 }
 
 // Reduce a course name to its distinguishing tokens (drop generic golf words +
@@ -69,45 +138,118 @@ function nameTokens(name: string): Set<string> {
   )
 }
 
-// Jaccard overlap of distinguishing tokens ≥ 0.5. Only a confident match
-// auto-merges a duplicate; anything else is flagged for human review. Empty
-// token sets (e.g. a bare "Golf Course" fallback) never match → always flagged.
-function namesMatch(a: string, b: string): boolean {
-  const ta = nameTokens(a)
-  const tb = nameTokens(b)
+// Jaccard overlap of two token sets ≥ 0.5. Empty sets never match. Used for
+// DEDUP (fuzzy: "Tulsa CC" ≈ "Tulsa Country Club").
+function jaccard(ta: Set<string>, tb: Set<string>): boolean {
   if (ta.size === 0 || tb.size === 0) return false
   let inter = 0
   for (const t of ta) if (tb.has(t)) inter++
   return inter / (ta.size + tb.size - inter) >= 0.5
 }
 
-// Way polygons only. Relation (multipolygon) golf courses carry member
-// geometry, not a single ring — v1 counts + skips them (they still get holes
-// via the nearest-centroid osm-holes pass); handle if they prove common.
+// Exact token-set equality. Used for GROUPING fragments of one course, which
+// share an identical name (Centennial Valley ×7). Fuzzy match would wrongly
+// cluster different courses at a resort ("Desert Mountain Outlaw" vs "Cochise").
+function sameTokenSet(a: Set<string>, b: Set<string>): boolean {
+  if (a.size === 0 || a.size !== b.size) return false
+  for (const t of a) if (!b.has(t)) return false
+  return true
+}
+
+// Only a confident name match auto-merges a duplicate; anything else is flagged
+// for human review. A bare "Golf Course" fallback tokenizes to empty → never
+// matches → always flagged.
+function namesMatch(a: string, b: string): boolean {
+  return jaccard(nameTokens(a), nameTokens(b))
+}
+
+// A hole belongs to a polygon if its centroid OR either endpoint (tee/green) is
+// inside. Testing the centroid alone drops dogleg holes whose average point
+// falls off the corridor of a concave boundary (e.g. Ken McDonald #16) — the
+// endpoints sit on the course, so this recovers them.
+function holeInPolygon(hw: HoleWay, rings: Pt[][]): boolean {
+  return inAnyRing(hw.centroid, rings) || inAnyRing(hw.first, rings) || inAnyRing(hw.last, rings)
+}
+
+// OSM sometimes maps one course as several adjacent same-named golf_course ways
+// (e.g. Centennial Valley = 7 consecutive ways, 18 holes scattered across them).
+// Union-find groups such polygons by close name match + proximity so they become
+// ONE course. Nameless polygons tokenize to empty → never cluster, so distinct
+// courses are never wrongly folded. Returns the group root index per polygon.
+const GROUP_RADIUS_M = 3000
+function groupPolygons(polygons: CoursePolygon[]): number[] {
+  const tokens = polygons.map((p) => (p.name ? nameTokens(p.name) : new Set<string>()))
+  const parent = polygons.map((_, i) => i)
+  const find = (x: number): number => {
+    while (parent[x] !== x) {
+      parent[x] = parent[parent[x]]
+      x = parent[x]
+    }
+    return x
+  }
+  // ponytail: O(n²) over a state's polygons (~1.5k worst case = a few seconds in
+  // a multi-hour run). Bucket by first token if it ever matters.
+  for (let i = 0; i < polygons.length; i++) {
+    if (tokens[i].size === 0) continue
+    for (let j = i + 1; j < polygons.length; j++) {
+      if (!sameTokenSet(tokens[i], tokens[j])) continue
+      const d = haversineMeters(
+        polygons[i].centroid.lat,
+        polygons[i].centroid.lng,
+        polygons[j].centroid.lat,
+        polygons[j].centroid.lng,
+      )
+      if (d <= GROUP_RADIUS_M) parent[find(i)] = find(j)
+    }
+  }
+  return polygons.map((_, i) => find(i))
+}
+
+// Parse golf_course polygons: a way = one ring; a relation multipolygon =
+// its outer ring(s), stitched from member ways. Mis-tagged single features
+// (tiny bbox) and relations with no usable outer geometry are counted + dropped.
 function parsePolygons(elements: OverpassGeomElement[]): {
   polygons: CoursePolygon[]
   relationsSkipped: number
+  junkSkipped: number
 } {
   const polygons: CoursePolygon[] = []
   let relationsSkipped = 0
+  let junkSkipped = 0
   for (const el of elements) {
     const tags = el.tags ?? {}
     if (tags['leisure'] !== 'golf_course') continue
-    if (el.type === 'relation') {
-      relationsSkipped++
+    let rings: Pt[][] = []
+    if (el.type === 'way' && el.geometry && el.geometry.length >= 3) {
+      rings = [el.geometry.map((g) => ({ lat: g.lat, lng: g.lon }))]
+    } else if (el.type === 'relation') {
+      // Multipolygon: stitch the outer member ways into the boundary ring(s).
+      const outers = (el.members ?? [])
+        .filter(
+          (m) => m.type === 'way' && m.role === 'outer' && m.geometry && m.geometry.length >= 2,
+        )
+        .map((m) => m.geometry!.map((g) => ({ lat: g.lat, lng: g.lon })))
+      rings = assembleRings(outers)
+    }
+    if (rings.length === 0) {
+      if (el.type === 'relation') relationsSkipped++
       continue
     }
-    if (el.type !== 'way' || !el.geometry || el.geometry.length < 3) continue
-    const ring = el.geometry.map((g) => ({ lat: g.lat, lng: g.lon }))
+    // Drop mis-tagged single features (a tee/green tagged golf_course).
+    if (bboxDiagonalM(rings) < MIN_COURSE_DIAGONAL_M) {
+      junkSkipped++
+      continue
+    }
     polygons.push({
+      osmType: el.type === 'relation' ? 'relation' : 'way',
       osmId: el.id,
       name: tags['name'],
       city: (tags['addr:city'] ?? '').trim() || undefined,
-      ring,
-      centroid: ringCentroid(ring),
+      rings,
+      centroid: polyCentroid(rings),
     })
   }
-  return { polygons, relationsSkipped }
+  return { polygons, relationsSkipped, junkSkipped }
 }
 
 // One Overpass query per state for course polygons + hole/green/tee geometry,
@@ -128,7 +270,7 @@ async function fetchStateGeom(state: string): Promise<OverpassGeomElement[]> {
   node["golf"="tee"](${s},${w},${n},${e});
   way["golf"="tee"](${s},${w},${n},${e});
 );
-out geom tags;`.trim()
+out geom;`.trim()
 
   const BACKOFFS_MS = [5_000, 15_000, 45_000]
   let lastErr: Error | null = null
@@ -174,10 +316,11 @@ export async function crawlComplete(
   let totalHoles = 0
   let totalMerged = 0
   const flagged: string[] = []
+  const oddCount: string[] = []
   for (const state of states) {
     console.log(`[complete:${state}] querying Overpass (polygons + holes)…`)
     const elements = await fetchStateGeom(state)
-    const { polygons, relationsSkipped } = parsePolygons(elements)
+    const { polygons, relationsSkipped, junkSkipped } = parsePolygons(elements)
     const features = parseHoleFeatures(elements)
     const existing = await fetchCoursesForState(state)
     const byExt = new Map(
@@ -187,23 +330,23 @@ export async function crawlComplete(
       existing.map((c) => c.id),
       `complete:${state}`,
     )
+    const skips: string[] = []
+    if (relationsSkipped) skips.push(`${relationsSkipped} relations unparseable`)
+    if (junkSkipped) skips.push(`${junkSkipped} mistags dropped`)
     console.log(
-      `[complete:${state}] ${polygons.length} way polygons, ${features.holeWays.length} holes, ${existing.length} existing courses` +
-        (relationsSkipped ? ` (${relationsSkipped} relation courses skipped)` : ''),
+      `[complete:${state}] ${polygons.length} polygons, ${features.holeWays.length} holes, ` +
+        `${existing.length} existing courses${skips.length ? ` (${skips.join(', ')})` : ''}`,
     )
 
-    // Assign each hole to EXACTLY ONE polygon — the containing polygon whose
-    // centroid is nearest — so a multi-course club (each course its own polygon)
-    // splits cleanly and overlapping rings never double-count a hole. Holes with
-    // ref outside 1..18 were already dropped by parseHoleFeatures (a 27-hole
-    // course mapped as one polygon keeps 1..18; our model is one 18-hole course
-    // per row).
+    // Assign each hole to the polygon that contains it (centroid or endpoint,
+    // via holeInPolygon), nearest-centroid tiebreak when it sits inside more than
+    // one. Holes with ref outside 1..18 were already dropped by parseHoleFeatures.
     const holesByPoly = new Map<number, HoleWay[]>()
     for (const hw of features.holeWays) {
       let bestIdx = -1
       let bestD = Infinity
       for (let i = 0; i < polygons.length; i++) {
-        if (!pointInPolygon(hw.centroid, polygons[i].ring)) continue
+        if (!holeInPolygon(hw, polygons[i].rings)) continue
         const d = haversineMeters(
           hw.centroid.lat,
           hw.centroid.lng,
@@ -221,19 +364,68 @@ export async function crawlComplete(
       holesByPoly.set(bestIdx, arr)
     }
 
-    const targets = limit != null ? polygons.slice(0, limit) : polygons
-    for (let pi = 0; pi < targets.length; pi++) {
-      const poly = targets[pi]
-      const extId = `osm_way_${poly.osmId}`
+    // Group polygons that are one course mapped as several same-named ways, so
+    // each group becomes a single course row with all its holes.
+    const groupRoot = groupPolygons(polygons)
+    const groups = new Map<number, number[]>()
+    for (let i = 0; i < polygons.length; i++) {
+      const arr = groups.get(groupRoot[i]) ?? []
+      arr.push(i)
+      groups.set(groupRoot[i], arr)
+    }
+
+    // Split a same-name group apart if its polygons have OVERLAPPING hole refs —
+    // that's a multi-loop facility (e.g. three nines all numbered 1-9), not one
+    // fragmented course. True fragments have disjoint refs (Centennial Valley =
+    // 1-18 spread across ways) and stay consolidated so no holes are lost.
+    // Split only on SUBSTANTIAL ref overlap: a real second loop duplicates a
+    // whole nine (~9 refs), whereas a fragmented course with a stray OSM
+    // duplicate ref overlaps by 1-2 and should stay consolidated (dedup drops
+    // the stray). overlap = holes that would be lost to dedup if we merged.
+    const MULTILOOP_OVERLAP = 4
+    const units: number[][] = []
+    for (const idxs of groups.values()) {
+      if (idxs.length > 1) {
+        const refs = new Set<number>()
+        let total = 0
+        for (const i of idxs)
+          for (const hw of holesByPoly.get(i) ?? []) {
+            total++
+            refs.add(hw.ref)
+          }
+        if (total - refs.size >= MULTILOOP_OVERLAP) {
+          for (const i of idxs) units.push([i])
+          flagged.push(
+            `${state}: multi-loop "${polygons[idxs[0]].name ?? '?'}" kept as ${idxs.length} separate courses`,
+          )
+          continue
+        }
+      }
+      units.push(idxs)
+    }
+    const unitList = limit != null ? units.slice(0, limit) : units
+    for (const idxs of unitList) {
+      // Canonical polygon = the one with the most holes (tiebreak: lowest osmId),
+      // so identity is stable across runs.
+      let canon = idxs[0]
+      for (const i of idxs) {
+        const ni = holesByPoly.get(i)?.length ?? 0
+        const nc = holesByPoly.get(canon)?.length ?? 0
+        if (ni > nc || (ni === nc && polygons[i].osmId < polygons[canon].osmId)) canon = i
+      }
+      const poly = polygons[canon]
+      const extId = `osm_${poly.osmType}_${poly.osmId}`
       const existingCourse = byExt.get(extId)
 
-      // This polygon's holes (deduped by ref, keeping the first).
+      // Union holes from every polygon in the group (dedup by ref).
       const seen = new Set<number>()
       const holes: OgaHoleGeo[] = []
-      for (const hw of holesByPoly.get(pi) ?? []) {
-        if (seen.has(hw.ref)) continue
-        seen.add(hw.ref)
-        holes.push(buildOrientedHole(hw, features))
+      for (const i of idxs) {
+        for (const hw of holesByPoly.get(i) ?? []) {
+          if (seen.has(hw.ref)) continue
+          seen.add(hw.ref)
+          holes.push(buildOrientedHole(hw, features))
+        }
       }
       holes.sort((a, b) => a.number - b.number)
 
@@ -242,37 +434,72 @@ export async function crawlComplete(
       // the dedicated `--source geocode` pass fills any remaining cities (and
       // rewrites bare "Golf Course" fallbacks to "Golf Course (City)") afterward.
       const city = poly.city ?? existingCourse?.city ?? undefined
-      // Name: OSM name wins; else keep an existing real (non-fallback) name; else fallback.
+
+      // Sibling OSM rows (the group's other polygons) fold into the canonical.
+      const siblings = idxs
+        .filter((i) => i !== canon)
+        .map((i) => byExt.get(`osm_${polygons[i].osmType}_${polygons[i].osmId}`))
+        .filter((c): c is CourseFull => !!c)
+
+      // Non-OSM courses whose centroid sits inside any polygon of the group.
+      const inside = existing.filter(
+        (c) =>
+          !(c.externalId ?? '').startsWith('osm_') &&
+          idxs.some((i) => inAnyRing({ lat: c.lat, lng: c.lng }, polygons[i].rings)),
+      )
+
+      // Name: OSM name → an existing real (non-fallback) name → adopt the name
+      // of a single named course sitting inside a NAMELESS polygon (usually the
+      // real course; flagged so a wrong adoption can be caught) → fallback.
       const existingReal =
         existingCourse && !existingCourse.name.startsWith('Golf Course')
           ? existingCourse.name
           : undefined
-      const name = poly.name ?? existingReal ?? `Golf Course${city ? ` (${city})` : ''}`
+      let derived = poly.name ?? existingReal
+      let adopted: string | undefined
+      if (!derived) {
+        const named = inside.filter((c) => !c.name.startsWith('Golf Course'))
+        if (named.length === 1) {
+          derived = named[0].name
+          adopted = named[0].name
+        }
+      }
+      const name = derived ?? `Golf Course${city ? ` (${city})` : ''}`
 
-      // Duplicates: non-OSM course centroids inside this polygon. Auto-merge ONLY
-      // a confident name match; flag the rest for review (a coord-error course
-      // from elsewhere can land inside an unrelated polygon — never auto-delete it).
-      const inside = existing.filter(
-        (c) =>
-          c.externalId !== extId &&
-          !(c.externalId ?? '').startsWith('osm_') &&
-          pointInPolygon({ lat: c.lat, lng: c.lng }, poly.ring),
-      )
+      // Auto-merge a duplicate on a confident name match; flag the rest (never
+      // auto-delete a mismatch — a coord-error course can land inside an
+      // unrelated polygon).
       const toMerge = inside.filter((c) => namesMatch(c.name, name))
       const toFlag = inside.filter((c) => !namesMatch(c.name, name))
       for (const c of toFlag) flagged.push(`${state}: "${name}" (${extId}) ⊃ "${c.name}"`)
+      if (adopted)
+        flagged.push(`${state}: adopted name "${adopted}" for nameless ${extId} — verify`)
+
+      // Real courses are 9 / 18 (/27/36, but we cap at 18). Anything 1-17 except
+      // 9 means dropped or still-fragmented holes — surface it loudly.
+      const suspicious = holes.length > 0 && holes.length !== 9 && holes.length < 18
+      if (suspicious) oddCount.push(`${state}: "${name}" — ${holes.length} holes (${extId})`)
+      const foldCount = siblings.length + toMerge.length
 
       const hasGeom = existingCourse ? withGeom.has(existingCourse.id) : false
       const willWriteHoles = holes.length > 0 && (force || !hasGeom)
 
+      const changes: string[] = []
+      if (willWriteHoles || (dryRun && holes.length > 0)) {
+        changes.push(
+          `${holes.length} holes${!willWriteHoles && !dryRun ? ' (skip: has geom)' : ''}`,
+        )
+      }
+      if (idxs.length > 1) changes.push(`consolidated ${idxs.length} polygons`)
+      if (toMerge.length) changes.push(`merged ${toMerge.map((p) => p.name).join(' + ')}`)
+      if (toFlag.length) changes.push(`FLAG ${toFlag.length}`)
+      if (suspicious) changes.push('⚠ odd hole count')
+
       if (dryRun) {
-        const bits = [`${holes.length} holes${willWriteHoles ? '' : ' (skip: has geom)'}`]
-        if (toMerge.length) bits.push(`auto-merge: ${toMerge.map((p) => p.name).join(', ')}`)
-        if (toFlag.length) bits.push(`FLAG: ${toFlag.map((p) => p.name).join(', ')}`)
-        console.log(`[dry] ${extId} "${name}"${city ? ` — ${city}` : ''}: ${bits.join('; ')}`)
+        console.log(`[dry] ${extId} "${name}"${city ? ` — ${city}` : ''}: ${changes.join('; ')}`)
         totalCourses++
         if (willWriteHoles) totalHoles += holes.length
-        totalMerged += toMerge.length
+        totalMerged += foldCount
         continue
       }
 
@@ -289,25 +516,24 @@ export async function crawlComplete(
         await upsertHoleGeometry(courseId, holes)
         totalHoles += holes.length
       }
-      for (const p of toMerge) {
-        await mergeAndDeletePhantom(p.id, courseId)
+      for (const c of [...siblings, ...toMerge]) {
+        await mergeAndDeletePhantom(c.id, courseId)
         totalMerged++
       }
-      // Live progress: one line per course that actually changed, so a run is
-      // watchable instead of silent-until-the-state-summary.
-      const did: string[] = []
-      if (willWriteHoles) did.push(`${holes.length} holes`)
-      if (toMerge.length) did.push(`merged ${toMerge.map((p) => p.name).join(' + ')}`)
-      if (toFlag.length) did.push(`flagged ${toFlag.length}`)
-      if (did.length) console.log(`[complete:${state}] ✓ ${name} — ${did.join(', ')}`)
+      // Live progress: one line per course that actually changed.
+      if (changes.length) console.log(`[complete:${state}] ✓ ${name} — ${changes.join('; ')}`)
     }
     await sleep(OSM_DELAY_MS)
   }
   console.log(
-    `\ncomplete${dryRun ? ' (DRY-RUN)' : ''}: ${totalCourses} courses, ${totalHoles} holes, ${totalMerged} auto-merged, ${flagged.length} flagged for review`,
+    `\ncomplete${dryRun ? ' (DRY-RUN)' : ''}: ${totalCourses} courses, ${totalHoles} holes, ${totalMerged} folded, ${flagged.length} flagged, ${oddCount.length} odd hole counts`,
   )
+  if (oddCount.length) {
+    console.log('\n⚠ ODD HOLE COUNTS (not 9 or 18 — dropped holes or OSM gaps, review):')
+    for (const o of oddCount) console.log('  - ' + o)
+  }
   if (flagged.length) {
-    console.log('\nFLAGGED duplicates (name mismatch — reviewed, NOT auto-merged):')
+    console.log('\nFLAGGED duplicates (name mismatch — NOT auto-merged, review):')
     for (const f of flagged) console.log('  - ' + f)
   }
 }

--- a/scripts/crawl/completer.ts
+++ b/scripts/crawl/completer.ts
@@ -205,9 +205,26 @@ function groupPolygons(polygons: CoursePolygon[]): number[] {
   return polygons.map((_, i) => find(i))
 }
 
+// Names that are golf SUB-FEATURES mis-tagged as a whole course (a fairway,
+// green, tee, or numbered hole) — dropped so they don't become junk rows. A
+// long fairway passes the size guard, so this catches it by name.
+function isFeatureName(name: string): boolean {
+  const t = name.trim().toLowerCase()
+  if (/^#|^hole\s*\d/.test(t)) return true
+  if (
+    /^(fairway|green|tee|rough|bunker|driving range|putting green|practice green|cart path)s?$/.test(
+      t,
+    )
+  )
+    return true
+  if (/\b(green|tee)\s*#?\s*\d/.test(t)) return true
+  return false
+}
+
 // Parse golf_course polygons: a way = one ring; a relation multipolygon =
 // its outer ring(s), stitched from member ways. Mis-tagged single features
-// (tiny bbox) and relations with no usable outer geometry are counted + dropped.
+// (tiny bbox or a feature name) and relations with no usable outer geometry are
+// counted + dropped; sub-area polygons nested inside a larger course are too.
 function parsePolygons(elements: OverpassGeomElement[]): {
   polygons: CoursePolygon[]
   relationsSkipped: number
@@ -235,8 +252,9 @@ function parsePolygons(elements: OverpassGeomElement[]): {
       if (el.type === 'relation') relationsSkipped++
       continue
     }
-    // Drop mis-tagged single features (a tee/green tagged golf_course).
-    if (bboxDiagonalM(rings) < MIN_COURSE_DIAGONAL_M) {
+    // Drop mis-tagged single features: tiny bbox (a tee/green) or a feature name.
+    const nm = tags['name']
+    if (bboxDiagonalM(rings) < MIN_COURSE_DIAGONAL_M || (nm && isFeatureName(nm))) {
       junkSkipped++
       continue
     }
@@ -249,7 +267,22 @@ function parsePolygons(elements: OverpassGeomElement[]): {
       centroid: polyCentroid(rings),
     })
   }
-  return { polygons, relationsSkipped, junkSkipped }
+  // Drop polygons nested inside a LARGER golf_course polygon — they're sub-areas
+  // (a course drawn as boundary + inner regions), whose holes belong to the
+  // enclosing course, not to a separate row. Without this the small inner
+  // polygons steal holes via the nearest-centroid tiebreak and become junk rows.
+  // ponytail: O(n²), but the size prefilter (only larger polygons can enclose)
+  // prunes hard; fine for a per-state batch.
+  const diag = polygons.map((p) => bboxDiagonalM(p.rings))
+  const kept = polygons.filter((p, i) => {
+    for (let j = 0; j < polygons.length; j++) {
+      if (i === j || diag[j] <= diag[i]) continue
+      if (inAnyRing(p.centroid, polygons[j].rings)) return false
+    }
+    return true
+  })
+  junkSkipped += polygons.length - kept.length
+  return { polygons: kept, relationsSkipped, junkSkipped }
 }
 
 // One Overpass query per state for course polygons + hole/green/tee geometry,

--- a/scripts/crawl/completer.ts
+++ b/scripts/crawl/completer.ts
@@ -27,6 +27,23 @@ import {
   type CourseFull,
 } from './db-writer'
 import type { OgaHoleGeo, OverpassGeomElement, OverpassGeomResponse } from './types'
+import { writeFileSync } from 'node:fs'
+
+// Structured flag record for the reconciliation pass. Written to disk per-state
+// so a mid-run crash (the WI/Deertrak FK abort lost the whole national flag set)
+// never strands the flags in memory. Reconcile consumes this JSON directly —
+// no log→regex step. Override the path with FLAGS_OUT.
+interface FlagRecord {
+  kind: 'dup' | 'adopt' | 'odd' | 'multiloop' | 'userdata'
+  state: string
+  extId?: string
+  name?: string // canonical polygon/course name
+  other?: string // the duplicate / adopted / user-data course name
+  otherId?: string // duplicate course DB id (dup only — the row to act on)
+  holes?: number
+  lat?: number
+  lng?: number
+}
 
 const USER_AGENT = 'oga-course-crawler/0.1 (https://github.com/cner-smith/opengolfapp)'
 
@@ -351,6 +368,9 @@ export async function crawlComplete(
   let totalMerged = 0
   const flagged: string[] = []
   const oddCount: string[] = []
+  const flagRecords: FlagRecord[] = []
+  const flagsPath = process.env.FLAGS_OUT ?? '/tmp/reconcile-flags.json'
+  const flushFlags = () => writeFileSync(flagsPath, JSON.stringify(flagRecords, null, 2))
   for (const state of states) {
     console.log(`[complete:${state}] querying Overpass (polygons + holes)…`)
     const elements = await fetchStateGeom(state)
@@ -429,6 +449,14 @@ export async function crawlComplete(
           }
         if (total - refs.size >= MULTILOOP_OVERLAP) {
           for (const i of idxs) units.push([i])
+          flagRecords.push({
+            kind: 'multiloop',
+            state,
+            name: polygons[idxs[0]].name ?? undefined,
+            holes: idxs.length,
+            lat: polygons[idxs[0]].centroid.lat,
+            lng: polygons[idxs[0]].centroid.lng,
+          })
           flagged.push(
             `${state}: multi-loop "${polygons[idxs[0]].name ?? '?'}" kept as ${idxs.length} separate courses`,
           )
@@ -505,14 +533,47 @@ export async function crawlComplete(
       // unrelated polygon).
       const toMerge = inside.filter((c) => namesMatch(c.name, name))
       const toFlag = inside.filter((c) => !namesMatch(c.name, name))
-      for (const c of toFlag) flagged.push(`${state}: "${name}" (${extId}) ⊃ "${c.name}"`)
-      if (adopted)
+      for (const c of toFlag) {
+        flagRecords.push({
+          kind: 'dup',
+          state,
+          extId,
+          name,
+          other: c.name,
+          otherId: c.id,
+          lat: poly.centroid.lat,
+          lng: poly.centroid.lng,
+        })
+        flagged.push(`${state}: "${name}" (${extId}) ⊃ "${c.name}"`)
+      }
+      if (adopted) {
+        flagRecords.push({
+          kind: 'adopt',
+          state,
+          extId,
+          name,
+          other: adopted,
+          lat: poly.centroid.lat,
+          lng: poly.centroid.lng,
+        })
         flagged.push(`${state}: adopted name "${adopted}" for nameless ${extId} — verify`)
+      }
 
       // Real courses are 9 / 18 (/27/36, but we cap at 18). Anything 1-17 except
       // 9 means dropped or still-fragmented holes — surface it loudly.
       const suspicious = holes.length > 0 && holes.length !== 9 && holes.length < 18
-      if (suspicious) oddCount.push(`${state}: "${name}" — ${holes.length} holes (${extId})`)
+      if (suspicious) {
+        flagRecords.push({
+          kind: 'odd',
+          state,
+          extId,
+          name,
+          holes: holes.length,
+          lat: poly.centroid.lat,
+          lng: poly.centroid.lng,
+        })
+        oddCount.push(`${state}: "${name}" — ${holes.length} holes (${extId})`)
+      }
       const foldCount = siblings.length + toMerge.length
 
       const hasGeom = existingCourse ? withGeom.has(existingCourse.id) : false
@@ -554,6 +615,7 @@ export async function crawlComplete(
         // Never fold a course a user has played — deleting its holes would
         // orphan their scorecards (and the FK aborts the whole run). Flag it.
         if (await courseHasUserData(c.id)) {
+          flagRecords.push({ kind: 'userdata', state, extId, name, other: c.name, otherId: c.id })
           flagged.push(`${state}: NOT merged "${c.name}" into "${name}" — has user data (manual)`)
           continue
         }
@@ -563,8 +625,11 @@ export async function crawlComplete(
       // Live progress: one line per course that actually changed.
       if (changes.length) console.log(`[complete:${state}] ✓ ${name} — ${changes.join('; ')}`)
     }
+    flushFlags() // crash-safe: persist after every state
     await sleep(OSM_DELAY_MS)
   }
+  flushFlags()
+  console.log(`\n${flagRecords.length} flag records → ${flagsPath}`)
   console.log(
     `\ncomplete${dryRun ? ' (DRY-RUN)' : ''}: ${totalCourses} courses, ${totalHoles} holes, ${totalMerged} folded, ${flagged.length} flagged, ${oddCount.length} odd hole counts`,
   )

--- a/scripts/crawl/completer.ts
+++ b/scripts/crawl/completer.ts
@@ -293,6 +293,13 @@ export async function crawlComplete(
         await mergeAndDeletePhantom(p.id, courseId)
         totalMerged++
       }
+      // Live progress: one line per course that actually changed, so a run is
+      // watchable instead of silent-until-the-state-summary.
+      const did: string[] = []
+      if (willWriteHoles) did.push(`${holes.length} holes`)
+      if (toMerge.length) did.push(`merged ${toMerge.map((p) => p.name).join(' + ')}`)
+      if (toFlag.length) did.push(`flagged ${toFlag.length}`)
+      if (did.length) console.log(`[complete:${state}] ✓ ${name} — ${did.join(', ')}`)
     }
     await sleep(OSM_DELAY_MS)
   }

--- a/scripts/crawl/db-writer.ts
+++ b/scripts/crawl/db-writer.ts
@@ -149,9 +149,15 @@ export async function fetchCitylessCourses(
         `cityless fetch failed (range=${from}-${to}): ${error.message ?? JSON.stringify(error)}`,
       )
     }
-    const rows = (data ?? []) as { id: string; name: string; lat: number | null; lng: number | null }[]
+    const rows = (data ?? []) as {
+      id: string
+      name: string
+      lat: number | null
+      lng: number | null
+    }[]
     for (const r of rows) {
-      if (r.lat != null && r.lng != null) out.push({ id: r.id, name: r.name, lat: r.lat, lng: r.lng })
+      if (r.lat != null && r.lng != null)
+        out.push({ id: r.id, name: r.name, lat: r.lat, lng: r.lng })
     }
     if (rows.length < PAGE_SIZE) break
     if (limit != null && out.length >= limit) break
@@ -169,6 +175,105 @@ export async function updateCourseCity(id: string, city: string, name?: string):
   if (error) {
     throw new Error(`city update failed (course=${id}): ${error.message ?? JSON.stringify(error)}`)
   }
+}
+
+export interface CourseFull {
+  id: string
+  externalId: string | null
+  name: string
+  city: string | null
+  lat: number
+  lng: number
+}
+
+// All coord-bearing courses in a state with the fields the completion pass
+// needs to reconcile them against OSM polygons (identity, name, city, centroid).
+export async function fetchCoursesForState(state: string): Promise<CourseFull[]> {
+  const PAGE_SIZE = 500
+  const all: CourseFull[] = []
+  let from = 0
+  while (true) {
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id, external_id, name, city, lat, lng')
+      .eq('state', state)
+      .not('lat', 'is', null)
+      .not('lng', 'is', null)
+      .range(from, from + PAGE_SIZE - 1)
+    if (error) {
+      throw new Error(
+        `courses fetch failed (state=${state}): ${error.message ?? JSON.stringify(error)}`,
+      )
+    }
+    const rows = (data ?? []) as {
+      id: string
+      external_id: string | null
+      name: string
+      city: string | null
+      lat: number | null
+      lng: number | null
+    }[]
+    for (const r of rows) {
+      if (r.lat != null && r.lng != null) {
+        all.push({
+          id: r.id,
+          externalId: r.external_id,
+          name: r.name,
+          city: r.city,
+          lat: r.lat,
+          lng: r.lng,
+        })
+      }
+    }
+    if (rows.length < PAGE_SIZE) break
+    from += PAGE_SIZE
+  }
+  return all
+}
+
+// Fold a duplicate course (a non-OSM centroid inside a real OSM polygon,
+// confirmed by a name match) into the real course. Order matters so a failure
+// can never lose data: (1) move user rounds, (2) MOVE tee ratings — real
+// enrichment, never deleted; the real course came from a bare OSM polygon and
+// normally has no tees, so an onConflict(course_id,tee_color) collision is rare
+// and surfaced if it hits — (3) delete the duplicate's holes (the real course
+// now carries exact containment geometry), then the duplicate row.
+export async function mergeAndDeletePhantom(phantomId: string, realId: string): Promise<void> {
+  const rounds = await supabase
+    .from('rounds')
+    .update({ course_id: realId })
+    .eq('course_id', phantomId)
+  if (rounds.error) {
+    throw new Error(`merge: move rounds ${phantomId}->${realId} failed: ${rounds.error.message}`)
+  }
+  // A tee_color the real course already carries can't be moved (unique
+  // course_id,tee_color) — drop the duplicate's copy (real course wins), then
+  // move the rest.
+  const realTees = await supabase.from('course_tees').select('tee_color').eq('course_id', realId)
+  if (realTees.error)
+    throw new Error(`merge: read real tees ${realId} failed: ${realTees.error.message}`)
+  const haveColors = (realTees.data ?? []).map((r) => r.tee_color as string)
+  if (haveColors.length) {
+    const dropDup = await supabase
+      .from('course_tees')
+      .delete()
+      .eq('course_id', phantomId)
+      .in('tee_color', haveColors)
+    if (dropDup.error)
+      throw new Error(`merge: drop dup tees ${phantomId} failed: ${dropDup.error.message}`)
+  }
+  const tees = await supabase
+    .from('course_tees')
+    .update({ course_id: realId })
+    .eq('course_id', phantomId)
+  if (tees.error)
+    throw new Error(`merge: move tees ${phantomId}->${realId} failed: ${tees.error.message}`)
+  const holes = await supabase.from('holes').delete().eq('course_id', phantomId)
+  if (holes.error)
+    throw new Error(`merge: delete dup holes ${phantomId} failed: ${holes.error.message}`)
+  const course = await supabase.from('courses').delete().eq('id', phantomId)
+  if (course.error)
+    throw new Error(`merge: delete dup course ${phantomId} failed: ${course.error.message}`)
 }
 
 // Course ids that already have at least one hole carrying coordinates. The

--- a/scripts/crawl/db-writer.ts
+++ b/scripts/crawl/db-writer.ts
@@ -261,6 +261,11 @@ export async function courseHasUserData(courseId: string): Promise<boolean> {
 // and surfaced if it hits — (3) delete the duplicate's holes (the real course
 // now carries exact containment geometry), then the duplicate row.
 export async function mergeAndDeletePhantom(phantomId: string, realId: string): Promise<void> {
+  if (await courseHasUserData(phantomId)) {
+    throw new Error(
+      `refusing to merge ${phantomId}: it has user data (rounds/hole_scores); flag for manual handling`,
+    )
+  }
   const rounds = await supabase
     .from('rounds')
     .update({ course_id: realId })

--- a/scripts/crawl/db-writer.ts
+++ b/scripts/crawl/db-writer.ts
@@ -231,6 +231,28 @@ export async function fetchCoursesForState(state: string): Promise<CourseFull[]>
   return all
 }
 
+// True if a course has any user activity — a logged round, or a hole score on
+// one of its holes (the exact FK that aborts a merge's hole delete). A course a
+// user has played is never auto-merged; it's flagged for manual handling.
+export async function courseHasUserData(courseId: string): Promise<boolean> {
+  const r = await supabase
+    .from('rounds')
+    .select('id', { count: 'exact', head: true })
+    .eq('course_id', courseId)
+  if (r.error) throw new Error(`rounds check failed (${courseId}): ${r.error.message}`)
+  if ((r.count ?? 0) > 0) return true
+  const h = await supabase.from('holes').select('id').eq('course_id', courseId)
+  if (h.error) throw new Error(`holes fetch failed (${courseId}): ${h.error.message}`)
+  const holeIds = (h.data ?? []).map((x) => x.id as string)
+  if (holeIds.length === 0) return false
+  const hs = await supabase
+    .from('hole_scores')
+    .select('id', { count: 'exact', head: true })
+    .in('hole_id', holeIds)
+  if (hs.error) throw new Error(`hole_scores check failed (${courseId}): ${hs.error.message}`)
+  return (hs.count ?? 0) > 0
+}
+
 // Fold a duplicate course (a non-OSM centroid inside a real OSM polygon,
 // confirmed by a name match) into the real course. Order matters so a failure
 // can never lose data: (1) move user rounds, (2) MOVE tee ratings — real

--- a/scripts/crawl/db-writer.ts
+++ b/scripts/crawl/db-writer.ts
@@ -126,6 +126,51 @@ export async function fetchCourseGeoForState(state: string): Promise<CourseGeo[]
   return all
 }
 
+// Courses that have a centroid but no city. The geocode pass reverse-geocodes
+// each one's coordinates (OSM Nominatim) to fill the city. Optional cap so a
+// rate-limited run stays bounded.
+export async function fetchCitylessCourses(
+  limit: number | null,
+): Promise<{ id: string; name: string; lat: number; lng: number }[]> {
+  const PAGE_SIZE = 500
+  const out: { id: string; name: string; lat: number; lng: number }[] = []
+  let from = 0
+  while (true) {
+    const to = limit != null ? Math.min(from + PAGE_SIZE, limit) - 1 : from + PAGE_SIZE - 1
+    const { data, error } = await supabase
+      .from('courses')
+      .select('id, name, lat, lng')
+      .is('city', null)
+      .not('lat', 'is', null)
+      .not('lng', 'is', null)
+      .range(from, to)
+    if (error) {
+      throw new Error(
+        `cityless fetch failed (range=${from}-${to}): ${error.message ?? JSON.stringify(error)}`,
+      )
+    }
+    const rows = (data ?? []) as { id: string; name: string; lat: number | null; lng: number | null }[]
+    for (const r of rows) {
+      if (r.lat != null && r.lng != null) out.push({ id: r.id, name: r.name, lat: r.lat, lng: r.lng })
+    }
+    if (rows.length < PAGE_SIZE) break
+    if (limit != null && out.length >= limit) break
+    from += PAGE_SIZE
+  }
+  return limit != null ? out.slice(0, limit) : out
+}
+
+// Fill a course's city (and optionally rewrite its "Golf Course" fallback
+// name). Used by the geocode pass only.
+export async function updateCourseCity(id: string, city: string, name?: string): Promise<void> {
+  const patch: { city: string; name?: string } = { city }
+  if (name) patch.name = name
+  const { error } = await supabase.from('courses').update(patch).eq('id', id)
+  if (error) {
+    throw new Error(`city update failed (course=${id}): ${error.message ?? JSON.stringify(error)}`)
+  }
+}
+
 // Course ids that already have at least one hole carrying coordinates. The
 // osm-holes pass skips these so it never clobbers hand-curated or previously
 // imported geometry (idempotent + safe to re-run). Chunked like the tee lookup.

--- a/scripts/crawl/geocoder.ts
+++ b/scripts/crawl/geocoder.ts
@@ -2,7 +2,7 @@
 // Most OSM golf_course ways carry no addr:city, so osm-fetcher can only give
 // them a bare "Golf Course" fallback name. This pass reverse-geocodes those
 // coordinates to a real city so courses become locatable without hand-editing.
-import { sleep } from './util'
+import { isFallbackName, sleep } from './util'
 import { fetchCitylessCourses, updateCourseCity } from './db-writer'
 
 const NOMINATIM_REVERSE = 'https://nominatim.openstreetmap.org/reverse'
@@ -19,13 +19,20 @@ export async function reverseGeocodeCity(lat: number, lng: number): Promise<stri
   const url = `${NOMINATIM_REVERSE}?format=jsonv2&lat=${lat}&lon=${lng}&addressdetails=1`
   let attempts = 0
   const MAX_ATTEMPTS = 2
+  let rateLimitHits = 0
+  const MAX_RATE_LIMIT = 6
   while (true) {
     try {
       const res = await fetch(url, {
         headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
       })
       if (res.status === 429) {
-        console.warn('[geocode] rate limited — waiting 30s')
+        rateLimitHits++
+        if (rateLimitHits > MAX_RATE_LIMIT) {
+          console.warn('[geocode] rate limited too many times — giving up on this course')
+          return null
+        }
+        console.warn(`[geocode] rate limited — waiting 30s (${rateLimitHits}/${MAX_RATE_LIMIT})`)
         await sleep(30000)
         continue
       }
@@ -67,7 +74,7 @@ export async function crawlGeocode(limit: number | null): Promise<void> {
     if (!c) continue
     const city = await reverseGeocodeCity(c.lat, c.lng)
     if (city) {
-      const name = c.name.startsWith('Golf Course') ? `Golf Course (${city})` : undefined
+      const name = isFallbackName(c.name) ? `Golf Course (${city})` : undefined
       await updateCourseCity(c.id, city, name)
       filled++
     } else {

--- a/scripts/crawl/geocoder.ts
+++ b/scripts/crawl/geocoder.ts
@@ -1,0 +1,82 @@
+// OSM Nominatim reverse geocoding — derive a course's city from its centroid.
+// Most OSM golf_course ways carry no addr:city, so osm-fetcher can only give
+// them a bare "Golf Course" fallback name. This pass reverse-geocodes those
+// coordinates to a real city so courses become locatable without hand-editing.
+import { sleep } from './util'
+import { fetchCitylessCourses, updateCourseCity } from './db-writer'
+
+const NOMINATIM_REVERSE = 'https://nominatim.openstreetmap.org/reverse'
+// Nominatim usage policy: absolute max 1 req/sec, identifying User-Agent required.
+const NOMINATIM_DELAY_MS = 1100
+const USER_AGENT = 'oga-course-crawler/0.1 (https://github.com/cner-smith/opengolfapp)'
+
+// Reverse-geocode a coordinate to its city name. Returns null when Nominatim
+// has no populated place for the point (or on repeated failure). Prefers the
+// most specific place field; county is intentionally skipped as too coarse for
+// a useful course label.
+export async function reverseGeocodeCity(lat: number, lng: number): Promise<string | null> {
+  // No zoom override: zoom=10 collapses to county-level and drops the city.
+  const url = `${NOMINATIM_REVERSE}?format=jsonv2&lat=${lat}&lon=${lng}&addressdetails=1`
+  let attempts = 0
+  const MAX_ATTEMPTS = 2
+  while (true) {
+    try {
+      const res = await fetch(url, {
+        headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+      })
+      if (res.status === 429) {
+        console.warn('[geocode] rate limited — waiting 30s')
+        await sleep(30000)
+        continue
+      }
+      if (!res.ok) {
+        attempts++
+        if (attempts < MAX_ATTEMPTS) {
+          console.warn(`[geocode] HTTP ${res.status} — retrying in 5s`)
+          await sleep(5000)
+          continue
+        }
+        return null
+      }
+      const data = (await res.json()) as { address?: Record<string, string> }
+      const a = data.address ?? {}
+      return a.city || a.town || a.village || a.hamlet || a.municipality || null
+    } catch (err) {
+      attempts++
+      if (attempts < MAX_ATTEMPTS) {
+        console.warn(`[geocode] ${(err as Error).message} — retrying in 5s`)
+        await sleep(5000)
+        continue
+      }
+      return null
+    }
+  }
+}
+
+// Backfill city for every course that has coordinates but no city. Rewrites the
+// bare "Golf Course" fallback name to "Golf Course (City)" so nameless courses
+// gain a location label; leaves real names untouched. --limit caps a run
+// (Nominatim is ~1 req/sec, so a full national backfill takes hours).
+export async function crawlGeocode(limit: number | null): Promise<void> {
+  const courses = await fetchCitylessCourses(limit)
+  console.log(`Geocode: ${courses.length} course(s) with coords but no city`)
+  let filled = 0
+  let missed = 0
+  for (let i = 0; i < courses.length; i++) {
+    const c = courses[i]
+    if (!c) continue
+    const city = await reverseGeocodeCity(c.lat, c.lng)
+    if (city) {
+      const name = c.name.startsWith('Golf Course') ? `Golf Course (${city})` : undefined
+      await updateCourseCity(c.id, city, name)
+      filled++
+    } else {
+      missed++
+    }
+    if ((i + 1) % 25 === 0 || i === courses.length - 1) {
+      console.log(`[geocode] ${i + 1}/${courses.length} — filled ${filled}, no-match ${missed}`)
+    }
+    await sleep(NOMINATIM_DELAY_MS)
+  }
+  console.log(`\nGeocode complete: ${filled} cities filled, ${missed} without a match`)
+}

--- a/scripts/crawl/holes-fetcher.ts
+++ b/scripts/crawl/holes-fetcher.ts
@@ -21,18 +21,18 @@ import {
 } from './db-writer'
 import type { CourseGeo, OgaHoleGeo, OverpassGeomElement, OverpassGeomResponse } from './types'
 
-interface Pt {
+export interface Pt {
   lat: number
   lng: number
 }
-interface HoleWay {
+export interface HoleWay {
   ref: number
   par: number | null
   first: Pt
   last: Pt
   centroid: Pt
 }
-interface HoleFeatures {
+export interface HoleFeatures {
   holeWays: HoleWay[]
   greens: Pt[]
   tees: Pt[]
@@ -64,7 +64,7 @@ function nearest(pt: Pt, arr: Pt[]): { d: number; pt: Pt | null } {
   return { d: best, pt: bestPt }
 }
 
-function parseHoleFeatures(elements: OverpassGeomElement[]): HoleFeatures {
+export function parseHoleFeatures(elements: OverpassGeomElement[]): HoleFeatures {
   const holeWays: HoleWay[] = []
   const greens: Pt[] = []
   const tees: Pt[] = []
@@ -174,36 +174,39 @@ function buildHolesForCourses(courses: CourseGeo[], f: HoleFeatures): Map<string
 
   const out = new Map<string, OgaHoleGeo[]>()
   for (const [courseId, refs] of byCourse) {
-    const holes: OgaHoleGeo[] = []
-    for (const { hw } of refs.values()) {
-      // Orient: whichever endpoint is nearer a green is the green/pin end.
-      const gFirst = nearest(hw.first, f.greens).d
-      const gLast = nearest(hw.last, f.greens).d
-      const greenEnd = gLast <= gFirst ? hw.last : hw.first
-      const teeEnd = gLast <= gFirst ? hw.first : hw.last
-      // Snap to an explicit tee/green feature when one sits right on the end.
-      const ng = nearest(greenEnd, f.greens)
-      const nt = nearest(teeEnd, f.tees)
-      const pin = ng.pt && ng.d < SNAP_M ? ng.pt : greenEnd
-      const tee = nt.pt && nt.d < SNAP_M ? nt.pt : teeEnd
-      const yards = Math.round(haversineMeters(tee.lat, tee.lng, pin.lat, pin.lng) * 1.09361)
-      // holes.par CHECK is 3..6 — clamp the occasional out-of-range OSM par
-      // (pitch-and-putt 2s, mistagged 7s) rather than failing the whole batch.
-      const par = Math.min(6, Math.max(3, hw.par ?? 4))
-      holes.push({
-        number: hw.ref,
-        par,
-        yards: yards > 0 ? yards : undefined,
-        teeLat: +tee.lat.toFixed(6),
-        teeLng: +tee.lng.toFixed(6),
-        pinLat: +pin.lat.toFixed(6),
-        pinLng: +pin.lng.toFixed(6),
-      })
-    }
+    const holes = [...refs.values()].map(({ hw }) => buildOrientedHole(hw, f))
     holes.sort((a, b) => a.number - b.number)
     if (holes.length > 0) out.set(courseId, holes)
   }
   return out
+}
+
+// Build one numbered hole with oriented tee/pin geometry from a hole way:
+// whichever endpoint is nearer a green is the pin end; snap to an explicit
+// golf=tee/green feature when one sits on the endpoint. Shared by the
+// nearest-centroid osm-holes pass and the containment-based completion pass.
+export function buildOrientedHole(hw: HoleWay, f: HoleFeatures): OgaHoleGeo {
+  const gFirst = nearest(hw.first, f.greens).d
+  const gLast = nearest(hw.last, f.greens).d
+  const greenEnd = gLast <= gFirst ? hw.last : hw.first
+  const teeEnd = gLast <= gFirst ? hw.first : hw.last
+  const ng = nearest(greenEnd, f.greens)
+  const nt = nearest(teeEnd, f.tees)
+  const pin = ng.pt && ng.d < SNAP_M ? ng.pt : greenEnd
+  const tee = nt.pt && nt.d < SNAP_M ? nt.pt : teeEnd
+  const yards = Math.round(haversineMeters(tee.lat, tee.lng, pin.lat, pin.lng) * 1.09361)
+  // holes.par CHECK is 3..6 — clamp the occasional out-of-range OSM par
+  // (pitch-and-putt 2s, mistagged 7s) rather than failing the whole batch.
+  const par = Math.min(6, Math.max(3, hw.par ?? 4))
+  return {
+    number: hw.ref,
+    par,
+    yards: yards > 0 ? yards : undefined,
+    teeLat: +tee.lat.toFixed(6),
+    teeLng: +tee.lng.toFixed(6),
+    pinLat: +pin.lat.toFixed(6),
+    pinLng: +pin.lng.toFixed(6),
+  }
 }
 
 export async function crawlOsmHoles(

--- a/scripts/crawl/reconciler.ts
+++ b/scripts/crawl/reconciler.ts
@@ -18,11 +18,10 @@ import {
   mergeAndDeletePhantom,
   type CourseFull,
 } from './db-writer'
-import { haversineMeters } from './util'
+import { haversineMeters, isFallbackName } from './util'
 
 const norm = (s: string | null) => (s ?? '').trim().toLowerCase()
 const isOsm = (c: CourseFull) => (c.externalId ?? '').startsWith('osm_')
-const isFallback = (name: string) => name.startsWith('Golf Course')
 
 // A matched-name ghost this far from its OSM twin isn't the same course — it's a
 // name+city collision (two "Springfield" cities) or a bad OpenGolfAPI coordinate.
@@ -40,7 +39,7 @@ export async function crawlReconcile(states: string[], apply: boolean): Promise<
     const courses = await fetchCoursesForState(state)
     const groups = new Map<string, CourseFull[]>()
     for (const c of courses) {
-      if (isFallback(c.name)) continue
+      if (isFallbackName(c.name)) continue
       const key = `${norm(c.name)}|${norm(c.city)}`
       const g = groups.get(key)
       if (g) g.push(c)

--- a/scripts/crawl/reconciler.ts
+++ b/scripts/crawl/reconciler.ts
@@ -1,0 +1,97 @@
+// Reconciliation pass — resolve the duplicates the completion pass leaves behind.
+//
+// Job 1 (exact-name dedup): the same course crawled twice — once as an OSM
+// polygon (carries hole geometry), once as a non-OSM listing (OpenGolfAPI
+// ghost, no geometry). They share an exact name + city but the ghost sits far
+// enough from the polygon that geometric containment missed it. We fold the
+// ghost into the OSM row, moving its rounds/tees across, exactly like the
+// completion pass's own dedup — only matched by name instead of containment.
+//
+// Fallback-named rows ("Golf Course (City)") are NEVER grouped: several distinct
+// unnamed courses can share a city, so name+city is not identity for them.
+//
+// Ambiguous groups (no single OSM survivor, or two real OSM courses same name)
+// are flagged, never auto-merged. Dry by default; --apply performs the merge.
+import {
+  courseHasUserData,
+  fetchCoursesForState,
+  mergeAndDeletePhantom,
+  type CourseFull,
+} from './db-writer'
+import { haversineMeters } from './util'
+
+const norm = (s: string | null) => (s ?? '').trim().toLowerCase()
+const isOsm = (c: CourseFull) => (c.externalId ?? '').startsWith('osm_')
+const isFallback = (name: string) => name.startsWith('Golf Course')
+
+// A matched-name ghost this far from its OSM twin isn't the same course — it's a
+// name+city collision (two "Springfield" cities) or a bad OpenGolfAPI coordinate.
+// 96% of real pairs sit <1km apart; there's a clean gap at 5km. Beyond it we
+// flag, never merge — an unmergeable dup is cheap, a wrongly-deleted course isn't.
+const MAX_MERGE_METERS = 5000
+
+export async function crawlReconcile(states: string[], apply: boolean): Promise<void> {
+  let candidates = 0
+  let merged = 0
+  let skippedUser = 0
+  let flaggedGroups = 0
+
+  for (const state of states) {
+    const courses = await fetchCoursesForState(state)
+    const groups = new Map<string, CourseFull[]>()
+    for (const c of courses) {
+      if (isFallback(c.name)) continue
+      const key = `${norm(c.name)}|${norm(c.city)}`
+      const g = groups.get(key)
+      if (g) g.push(c)
+      else groups.set(key, [c])
+    }
+
+    for (const grp of groups.values()) {
+      if (grp.length < 2) continue
+      const osm = grp.filter(isOsm)
+      const nonOsm = grp.filter((c) => !isOsm(c))
+      // Need exactly one geometried survivor to fold the rest into.
+      if (osm.length !== 1 || nonOsm.length === 0) {
+        flaggedGroups++
+        console.log(
+          `[reconcile:${state}] FLAG ambiguous "${grp[0].name}" — ${osm.length} osm / ${nonOsm.length} non-osm (manual)`,
+        )
+        continue
+      }
+      const survivor = osm[0]
+      for (const phantom of nonOsm) {
+        // Distance guard: same name+city but far away = collision or bad coord.
+        const dist = haversineMeters(phantom.lat, phantom.lng, survivor.lat, survivor.lng)
+        if (dist >= MAX_MERGE_METERS) {
+          flaggedGroups++
+          console.log(
+            `[reconcile:${state}] FLAG far "${phantom.name}" (${phantom.id}) — ${(dist / 1000).toFixed(0)}km from twin (manual)`,
+          )
+          continue
+        }
+        // Never fold a course a user has played — deleting its holes would
+        // orphan scorecards and FK-abort the run (the WI/Deertrak crash).
+        if (await courseHasUserData(phantom.id)) {
+          skippedUser++
+          console.log(`[reconcile:${state}] SKIP "${phantom.name}" (${phantom.id}) — has user data`)
+          continue
+        }
+        candidates++
+        console.log(
+          `[reconcile:${state}] ${apply ? 'MERGE' : '[dry] would merge'} "${phantom.name}" (${phantom.id}) → osm ${survivor.externalId} (${survivor.id})`,
+        )
+        if (apply) {
+          await mergeAndDeletePhantom(phantom.id, survivor.id)
+          merged++
+        }
+      }
+    }
+  }
+
+  console.log(
+    `\nreconcile exact-dup${apply ? '' : ' (DRY-RUN)'}: ` +
+      `${apply ? `${merged} merged` : `${candidates} merge candidates`}, ` +
+      `${skippedUser} skipped (user data), ${flaggedGroups} ambiguous groups flagged`,
+  )
+}

--- a/scripts/crawl/types.ts
+++ b/scripts/crawl/types.ts
@@ -93,7 +93,14 @@ export interface OsmCourseLite {
 
 export type CrawlStatus = 'pending' | 'in_progress' | 'done' | 'error'
 
-export type Source = 'opengolfapi' | 'osm' | 'osm-first' | 'enrich' | 'osm-holes' | 'geocode'
+export type Source =
+  | 'opengolfapi'
+  | 'osm'
+  | 'osm-first'
+  | 'enrich'
+  | 'osm-holes'
+  | 'geocode'
+  | 'complete'
 
 /** A hole with optional per-hole geometry, written by the osm-holes pass. */
 export interface OgaHoleGeo {
@@ -115,7 +122,7 @@ export interface CourseGeo {
 
 /** Overpass element from an `out geom` query (ways carry a node list). */
 export interface OverpassGeomElement {
-  type: 'way' | 'node'
+  type: 'way' | 'node' | 'relation'
   id: number
   lat?: number
   lon?: number
@@ -133,6 +140,7 @@ export interface Args {
   status: boolean
   limit: number | null // optional cap on courses per state (for testing)
   maxCourses: number | null // global cap on API-processed courses this run (enrich rate-limit budget)
+  dryRun: boolean // completion pass: report changes without writing
 }
 
 export interface CrawlStateRow {

--- a/scripts/crawl/types.ts
+++ b/scripts/crawl/types.ts
@@ -127,6 +127,8 @@ export interface OverpassGeomElement {
   lat?: number
   lon?: number
   geometry?: { lat: number; lon: number }[]
+  // Present on relations from `out geom`: member ways carry role + geometry.
+  members?: { type: string; ref: number; role?: string; geometry?: { lat: number; lon: number }[] }[]
   tags?: Record<string, string>
 }
 export interface OverpassGeomResponse {

--- a/scripts/crawl/types.ts
+++ b/scripts/crawl/types.ts
@@ -101,6 +101,7 @@ export type Source =
   | 'osm-holes'
   | 'geocode'
   | 'complete'
+  | 'reconcile'
 
 /** A hole with optional per-hole geometry, written by the osm-holes pass. */
 export interface OgaHoleGeo {
@@ -143,6 +144,7 @@ export interface Args {
   limit: number | null // optional cap on courses per state (for testing)
   maxCourses: number | null // global cap on API-processed courses this run (enrich rate-limit budget)
   dryRun: boolean // completion pass: report changes without writing
+  apply: boolean // reconcile pass: actually merge/delete (default is dry)
 }
 
 export interface CrawlStateRow {

--- a/scripts/crawl/types.ts
+++ b/scripts/crawl/types.ts
@@ -93,7 +93,7 @@ export interface OsmCourseLite {
 
 export type CrawlStatus = 'pending' | 'in_progress' | 'done' | 'error'
 
-export type Source = 'opengolfapi' | 'osm' | 'osm-first' | 'enrich' | 'osm-holes'
+export type Source = 'opengolfapi' | 'osm' | 'osm-first' | 'enrich' | 'osm-holes' | 'geocode'
 
 /** A hole with optional per-hole geometry, written by the osm-holes pass. */
 export interface OgaHoleGeo {

--- a/scripts/crawl/util.ts
+++ b/scripts/crawl/util.ts
@@ -141,6 +141,31 @@ export function asNumber(v: unknown): number | undefined {
   return undefined
 }
 
+// Ray-casting point-in-polygon test. ring is the polygon's ordered vertices
+// ({lat,lng}); returns true if the point lies inside. Used by the completion
+// pass to assign each OSM hole to the course polygon that actually contains it
+// (exact), instead of the nearest centroid (a guess that bleeds holes between
+// adjacent courses).
+export function pointInPolygon(
+  pt: { lat: number; lng: number },
+  ring: { lat: number; lng: number }[],
+): boolean {
+  let inside = false
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const yi = ring[i].lat
+    const xi = ring[i].lng
+    const yj = ring[j].lat
+    const xj = ring[j].lng
+    // Casts a ray in +lat at x=pt.lng; the xi>lng!==xj>lng test excludes
+    // vertical edges (and guards the divide), so horizontal edges must NOT be
+    // skipped — they're resolved by the formula. Matches the validated variant.
+    if (xi > pt.lng !== xj > pt.lng && pt.lat < ((yj - yi) * (pt.lng - xi)) / (xj - xi) + yi) {
+      inside = !inside
+    }
+  }
+  return inside
+}
+
 // Great-circle distance in metres. Used by the osm-holes pass to assign each
 // OSM hole way to its nearest course centroid and to snap tee/green endpoints.
 export function haversineMeters(aLat: number, aLng: number, bLat: number, bLng: number): number {

--- a/scripts/crawl/util.ts
+++ b/scripts/crawl/util.ts
@@ -119,6 +119,12 @@ export const STATE_BBOX: Record<string, [number, number, number, number]> = {
 
 export const MATCH_THRESHOLD = 0.7
 
+// The crawler's fallback names are exactly "Golf Course" or "Golf Course (City)".
+// Anchor the match so real names beginning with "Golf Course" (e.g. "Golf Course
+// at the Bluffs") are NOT treated as fallbacks.
+export const isFallbackName = (name: string): boolean =>
+  name === 'Golf Course' || /^Golf Course \(.+\)$/.test(name)
+
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }


### PR DESCRIPTION
**Stacked on #794** (uses no code from it directly anymore, but shares crawler files — base on #794 to keep the diff clean; retarget to `dev` if #794 merges first).

## What

New `--source complete` pass — a per-OSM-polygon "derive what's missing" checklist:

| step | how |
|---|---|
| **holes** | **polygon containment** (point-in-polygon), each hole assigned to exactly one polygon |
| **par/yards/tee/pin** | from the contained `golf=hole` ways (reuses `buildOrientedHole`) |
| **dedup** | non-OSM centroid inside a polygon → auto-merge **only on close name match** (Jaccard of significant tokens); tees + rounds **moved**, dup holes/row deleted |
| **flag** | every non-matching in-polygon duplicate → printed for human review, **never auto-deleted** |

`--dry-run` reports without writing. Idempotent + resumable. **Zero Nominatim calls** — city-filling stays in `--source geocode` so this scales across all states.

## Why containment

Nearest-centroid (the old `osm-holes` assignment) is a guess that bleeds holes between adjacent courses. Concretely: an OpenGolfAPI phantom 172 m from FireLake stole 5 of its 18 holes. Containment is exact — a hole inside the boundary belongs to that course.

## Why name-gated dedup

Pure containment over-merges. The OK dry-run caught both failure modes:
- **Elks** — same course as FireLake but a totally different name → correctly **flagged**, not blind-merged.
- **Pawhuska → Ponca City** — a real course with wrong OpenGolfAPI coords lands inside an unrelated polygon → correctly **flagged**, not deleted.

So: auto-fix what's exact (holes), surface what's judgment (dedup).

## Validation (OK, prod)

- **FireLake: 13 → 18 holes** with real pars (3/4/5), phantom Elks flagged.
- 186 polygons, **45 confident merges** (tees preserved), **10 flagged** for review.
- Hardened mid-run: a real `course_tees(course_id,tee_color)` unique collision surfaced → merge now drops the duplicate's colliding tee color (real course wins) before moving the rest.

## Run

```
tsx scripts/crawl-courses.ts --source complete [--states OK] [--force] [--dry-run]
```

National flow: `--source complete --force` (all states, fast) → `--source geocode` (cities, rate-limited). Review the accumulated flag list once.

## Notes / follow-ups
- Relation (multipolygon) golf courses are counted + skipped in v1 (26 in OK); they still get holes via the nearest-centroid `osm-holes` pass. Handle if common.
- A 27/36-hole course mapped as ONE polygon keeps holes 1–18 (DB CHECK); multi-course clubs mapped as separate polygons are handled correctly (a containment strength).