### PR TITLE
feature(mobile): end-of-hole review — location-now, details-at-EOH (#791)

### DIFF
--- a/apps/mobile/components/round/HoleReviewSheet.tsx
+++ b/apps/mobile/components/round/HoleReviewSheet.tsx
@@ -258,6 +258,13 @@ export function HoleReviewSheet({
           <PressableTouch
             accessibilityRole="button"
             accessibilityLabel="Edit shots on the map"
+            // Disabled while a save is in flight: onEditOnMap drops roundState
+            // to PLACE_BALL and closes the sheet, but an in-flight saveHoleSummary
+            // (async) still finishes and would then advanceAfterHole() out from
+            // under the player — mirror the Save button's guard so the two can't
+            // race.
+            accessibilityState={{ disabled: saving }}
+            disabled={saving}
             onPress={onEditOnMap}
             style={{
               borderWidth: 1,
@@ -265,6 +272,7 @@ export function HoleReviewSheet({
               borderRadius: 2,
               paddingVertical: 12,
               paddingHorizontal: 16,
+              opacity: saving ? 0.4 : 1,
             }}
           >
             <Text

--- a/apps/mobile/components/round/HoleReviewSheet.tsx
+++ b/apps/mobile/components/round/HoleReviewSheet.tsx
@@ -13,7 +13,7 @@ import {
   combinedBreakDirection,
   formatClubLabel,
   horizontalBreakFromAim,
-  isPuttShot,
+  isPuttEntry,
   type BreakDirectionHorizontal,
   type BreakDirectionVertical,
   type Club,
@@ -138,7 +138,7 @@ export function HoleReviewSheet({
     const next = initialRowsRef.current
     setRows(next)
     setScore(next.length)
-    setPutts(next.filter((r) => isPuttShot(r.lieType)).length)
+    setPutts(next.filter((r) => isPuttEntry(r.lieType, r.club)).length)
     setPenalties(0)
   }, [visible, holeNumber])
 
@@ -409,7 +409,7 @@ function ShotRow({
 }) {
   // Putt-ness is the green lie only (set when a putt is placed). Raw distance
   // must NOT classify — a chip/bunker inside 30 yd is not a putt (#660).
-  const isPutt = isPuttShot(row.lieType)
+  const isPutt = isPuttEntry(row.lieType, row.club)
   const { toDisplay, toDisplayFt } = useUnits()
   const { bag } = useUserBag()
   // Source the club options from the user's bag, falling back to DEFAULT_BAG
@@ -490,6 +490,12 @@ function ShotRow({
       {isPutt ? (
         <>
           <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+            <FieldChip
+              label={clubLabel}
+              filled
+              active={open === 'club'}
+              onPress={() => toggle('club')}
+            />
             <PressableTouch
               accessibilityRole="button"
               accessibilityLabel="Made the putt"
@@ -538,6 +544,17 @@ function ShotRow({
             />
             <FieldChip label="Read ▸" filled={hasRead} onPress={onOpenAimer} />
           </View>
+          {open === 'club' && (
+            <ChipExpand
+              label="Club"
+              options={clubOptions}
+              value={row.club}
+              onSelect={(v) => {
+                onChange({ ...row, club: v as Club })
+                setOpen(null)
+              }}
+            />
+          )}
           {open === 'break' && <BreakExpand row={row} onChange={onChange} />}
           {open === 'speed' && (
             <ChipExpand

--- a/apps/mobile/components/round/HoleReviewSheet.tsx
+++ b/apps/mobile/components/round/HoleReviewSheet.tsx
@@ -14,6 +14,7 @@ import {
   formatClubLabel,
   horizontalBreakFromAim,
   isPuttEntry,
+  isPuttShot,
   type BreakDirectionHorizontal,
   type BreakDirectionVertical,
   type Club,
@@ -138,7 +139,11 @@ export function HoleReviewSheet({
     const next = initialRowsRef.current
     setRows(next)
     setScore(next.length)
-    setPutts(next.filter((r) => isPuttEntry(r.lieType, r.club)).length)
+    // Putt TALLY counts any green-lie shot (isPuttShot), matching the SG
+    // putting engine + putt-count readers — a bladed wedge on the green still
+    // counts as a putt here even though its row shows normal-shot UI (the
+    // per-row isPutt gate below stays isPuttEntry). User-overridable ticker.
+    setPutts(next.filter((r) => isPuttShot(r.lieType)).length)
     setPenalties(0)
   }, [visible, holeNumber])
 

--- a/apps/mobile/components/round/HoleReviewSheet.tsx
+++ b/apps/mobile/components/round/HoleReviewSheet.tsx
@@ -1,0 +1,1061 @@
+import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
+import { ScrollView, Text, View, type TextStyle } from 'react-native'
+import { GestureHandlerRootView } from 'react-native-gesture-handler'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import {
+  DEFAULT_BAG,
+  LIE_TYPES,
+  LIE_TYPE_LABELS,
+  LIE_SLOPES_FORWARD,
+  LIE_SLOPES_SIDE,
+  SHOT_RESULTS,
+  SHOT_RESULT_LABELS,
+  combinedBreakDirection,
+  formatClubLabel,
+  horizontalBreakFromAim,
+  isPuttShot,
+  type BreakDirectionHorizontal,
+  type BreakDirectionVertical,
+  type Club,
+  type GreenSpeed,
+  type LieType,
+  type LieSlopeForward,
+  type LieSlopeSide,
+  type PuttDirectionResult,
+  type PuttDistanceResult,
+  type ReviewedShotRow,
+  type ShotResult,
+} from '@oga/core'
+import { GreenDiagram } from './GreenDiagram'
+import { PressableTouch } from '../ui/PressableTouch'
+import { useUnits } from '../../hooks/useUnits'
+import { useUserBag } from '../../hooks/useUserBag'
+import { TYPE } from '../../lib/typography'
+
+export interface HoleReviewSheetProps {
+  visible: boolean
+  holeNumber: number
+  par: number
+  /** Prebuilt by the caller via @oga/core buildInitialRows. The component
+   *  owns editing state, hydrating from these once per (hole, visible). */
+  initialRows: ReviewedShotRow[]
+  saving: boolean
+  onSave: (
+    rows: ReviewedShotRow[],
+    summary: { score: number; putts: number; penalties: number },
+  ) => void
+  /** Dismiss to let the user drag markers on the map. */
+  onEditOnMap: () => void
+}
+
+// Palette — mirrors the web review sheet hexes exactly. Static objects only;
+// NativeWind css-interop drops function styles on iOS (#303).
+const C = {
+  bg: '#FBF8F1',
+  surface: '#F2EEE5',
+  expand: '#EBE5D6',
+  line: '#D9D2BF',
+  border: '#9F9580',
+  mute: '#8A8B7E',
+  accent: '#1F3D2C',
+  accentInk: '#F2EEE5',
+  ink: '#1C211C',
+  amber: '#A66A1F',
+  brick: '#A33A2A',
+} as const
+
+const KICKER: TextStyle = {
+  color: C.mute,
+  fontSize: 10,
+  fontWeight: '500',
+  letterSpacing: 1.4,
+  textTransform: 'uppercase',
+}
+
+const PUTT_DISTANCE_OPTIONS: { value: PuttDistanceResult; label: string }[] = [
+  { value: 'short', label: 'Short' },
+  { value: 'long', label: 'Long' },
+]
+const PUTT_DIRECTION_OPTIONS: { value: PuttDirectionResult; label: string }[] = [
+  { value: 'left', label: 'Missed left' },
+  { value: 'right', label: 'Missed right' },
+]
+// Putt read vocab — mirrors PuttingSheet so the summary and the old sheet
+// stay in sync. Break line = the horizontal read, slope = up/down.
+const BREAK_LINE_OPTIONS: { value: BreakDirectionHorizontal; label: string }[] = [
+  { value: 'left_to_right', label: 'L → R' },
+  { value: 'right_to_left', label: 'R → L' },
+  { value: 'straight', label: 'Straight' },
+]
+const BREAK_SLOPE_OPTIONS: { value: BreakDirectionVertical; label: string }[] = [
+  { value: 'uphill', label: 'Uphill' },
+  { value: 'flat', label: 'Level' },
+  { value: 'downhill', label: 'Downhill' },
+]
+const SPEED_OPTIONS: { value: GreenSpeed; label: string }[] = [
+  { value: 'slow', label: 'Slow' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'fast', label: 'Fast' },
+]
+
+export function HoleReviewSheet({
+  visible,
+  holeNumber,
+  par,
+  initialRows,
+  saving,
+  onSave,
+  onEditOnMap,
+}: HoleReviewSheetProps): JSX.Element | null {
+  const insets = useSafeAreaInsets()
+  const [rows, setRows] = useState<ReviewedShotRow[]>([])
+  // Score / putts / penalties are editable tickers. Score and putts pre-fill
+  // from the placed shots (shot count, green-lie shots); penalties is the one
+  // number no marker implies. All three become the hole_scores values on save.
+  const [score, setScore] = useState(0)
+  const [putts, setPutts] = useState(0)
+  const [penalties, setPenalties] = useState(0)
+  // Which putt row (by shotNumber) has the on-demand aimer open, if any. The
+  // read tool is a full-screen overlay — never auto-opens.
+  const [aimingShot, setAimingShot] = useState<number | null>(null)
+
+  // Read the latest initialRows inside the effect via ref so the effect
+  // doesn't re-fire (and clobber user edits) just because the parent returned
+  // a new array reference.
+  const initialRowsRef = useRef(initialRows)
+  initialRowsRef.current = initialRows
+
+  // Hydrate rows once per (hole, visible). After hydration the user's edits
+  // are the source of truth — the sheet re-hydrates fresh on next open.
+  const hydratedHoleRef = useRef<number | null>(null)
+  useEffect(() => {
+    if (!visible) {
+      hydratedHoleRef.current = null
+      return
+    }
+    if (hydratedHoleRef.current === holeNumber) return
+    hydratedHoleRef.current = holeNumber
+    const next = initialRowsRef.current
+    setRows(next)
+    setScore(next.length)
+    setPutts(next.filter((r) => isPuttShot(r.lieType)).length)
+    setPenalties(0)
+  }, [visible, holeNumber])
+
+  if (!visible) return null
+
+  const vsPar = score > 0 ? score - par : null
+
+  const setRow = (idx: number, nextRow: ReviewedShotRow) =>
+    setRows((prev) => {
+      const copy = prev.slice()
+      copy[idx] = nextRow
+      return copy
+    })
+
+  return (
+    // RN <Modal> is intentionally NOT used — the web sheet is an absolute-fill
+    // overlay above the map HUD, and the caller mounts this inside the map's
+    // gesture root. Wrap in our own GestureHandlerRootView so the aimer
+    // overlay's GreenDiagram pan works (mirrors ShotLogger; #496).
+    <GestureHandlerRootView
+      style={{
+        position: 'absolute',
+        left: 0,
+        right: 0,
+        top: 0,
+        bottom: 0,
+        backgroundColor: C.bg,
+        borderTopWidth: 1,
+        borderColor: C.border,
+        borderTopLeftRadius: 12,
+        borderTopRightRadius: 12,
+        zIndex: 40,
+      }}
+    >
+      <View style={{ flex: 1, paddingTop: insets.top }}>
+        <View style={{ alignItems: 'center', paddingTop: 8, marginBottom: 12 }}>
+          <View
+            style={{ width: 32, height: 4, borderRadius: 2, backgroundColor: C.line }}
+          />
+        </View>
+
+        <View
+          style={{
+            paddingHorizontal: 22,
+            paddingBottom: 14,
+            borderBottomWidth: 1,
+            borderColor: C.line,
+          }}
+        >
+          <Text style={[TYPE.kicker, KICKER, { marginBottom: 4 }]}>
+            Hole {holeNumber} · Par {par}
+          </Text>
+          <Text
+            style={[
+              TYPE.serif,
+              { color: C.ink, fontSize: 24, marginBottom: 14 },
+            ]}
+          >
+            Nice — how'd it go?
+          </Text>
+          <View style={{ flexDirection: 'row', gap: 10 }}>
+            <Ticker label="Score" value={score} onChange={setScore} vsPar={vsPar} />
+            <Ticker label="Putts" value={putts} onChange={setPutts} />
+            <Ticker label="Penalties" value={penalties} onChange={setPenalties} amber />
+          </View>
+        </View>
+
+        <ScrollView
+          style={{ flex: 1 }}
+          contentContainerStyle={{ paddingHorizontal: 22, paddingTop: 4, paddingBottom: 14 }}
+        >
+          {rows.length === 0 ? (
+            <Text style={[TYPE.body, { color: C.mute, padding: 22, fontSize: 13 }]}>
+              No placed shots. Drop pins on the map and try again.
+            </Text>
+          ) : (
+            <>
+              <Text
+                style={[
+                  TYPE.kicker,
+                  KICKER,
+                  { color: C.mute, paddingTop: 10, paddingBottom: 2 },
+                ]}
+              >
+                Your shots · optional
+              </Text>
+              {rows.map((row, idx) => (
+                <ShotRow
+                  key={row.shotNumber}
+                  row={row}
+                  onOpenAimer={() => setAimingShot(row.shotNumber)}
+                  onChange={(nextRow) => setRow(idx, nextRow)}
+                />
+              ))}
+            </>
+          )}
+        </ScrollView>
+
+        <View
+          style={{
+            flexDirection: 'row',
+            gap: 10,
+            justifyContent: 'flex-end',
+            paddingHorizontal: 22,
+            paddingTop: 14,
+            paddingBottom: insets.bottom + 18,
+            borderTopWidth: 1,
+            borderColor: C.line,
+            backgroundColor: C.bg,
+          }}
+        >
+          <PressableTouch
+            accessibilityRole="button"
+            accessibilityLabel="Edit shots on the map"
+            onPress={onEditOnMap}
+            style={{
+              borderWidth: 1,
+              borderColor: C.accent,
+              borderRadius: 2,
+              paddingVertical: 12,
+              paddingHorizontal: 16,
+            }}
+          >
+            <Text
+              style={[
+                TYPE.bodyBold,
+                { color: C.accent, fontSize: 14, fontWeight: '600', letterSpacing: 0.3 },
+              ]}
+            >
+              Edit on map
+            </Text>
+          </PressableTouch>
+          <PressableTouch
+            accessibilityRole="button"
+            accessibilityLabel="Save hole and continue to next hole"
+            accessibilityState={{ disabled: saving || rows.length === 0 }}
+            disabled={saving || rows.length === 0}
+            onPress={() => onSave(rows, { score, putts, penalties })}
+            style={{
+              borderRadius: 2,
+              paddingVertical: 12,
+              paddingHorizontal: 18,
+              backgroundColor: C.accent,
+              opacity: saving || rows.length === 0 ? 0.4 : 1,
+            }}
+          >
+            <Text
+              style={[
+                TYPE.bodyBold,
+                { color: C.accentInk, fontSize: 14, fontWeight: '600', letterSpacing: 0.3 },
+              ]}
+            >
+              {saving ? 'Saving…' : 'Save & next hole →'}
+            </Text>
+          </PressableTouch>
+        </View>
+      </View>
+
+      {aimingShot != null &&
+        (() => {
+          const idx = rows.findIndex((r) => r.shotNumber === aimingShot)
+          if (idx < 0) return null
+          return (
+            <AimerOverlay
+              row={rows[idx]!}
+              onChange={(nextRow) => setRow(idx, nextRow)}
+              onClose={() => setAimingShot(null)}
+            />
+          )
+        })()}
+    </GestureHandlerRootView>
+  )
+}
+
+function Ticker({
+  label,
+  value,
+  onChange,
+  vsPar,
+  amber,
+}: {
+  label: string
+  value: number
+  onChange: (n: number) => void
+  vsPar?: number | null
+  amber?: boolean
+}) {
+  const vsParText =
+    vsPar == null ? null : vsPar === 0 ? 'E' : vsPar > 0 ? `+${vsPar}` : `${vsPar}`
+  // Muted brick over par, forest under, mute at even — never a bright red.
+  const vsParColor =
+    vsPar == null || vsPar === 0 ? C.mute : vsPar > 0 ? C.brick : C.accent
+  const Step = ({ delta, disabled }: { delta: number; disabled: boolean }) => (
+    <PressableTouch
+      accessibilityRole="button"
+      accessibilityLabel={`${delta < 0 ? 'Fewer' : 'More'} ${label.toLowerCase()}`}
+      accessibilityState={{ disabled }}
+      disabled={disabled}
+      onPress={() => onChange(Math.max(0, value + delta))}
+      style={{
+        width: 24,
+        height: 24,
+        borderRadius: 12,
+        borderWidth: 1,
+        borderColor: C.border,
+        alignItems: 'center',
+        justifyContent: 'center',
+        opacity: disabled ? 0.25 : 1,
+      }}
+    >
+      <Text style={{ color: C.mute, fontSize: 15, lineHeight: 17 }}>
+        {delta < 0 ? '−' : '+'}
+      </Text>
+    </PressableTouch>
+  )
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: C.surface,
+        borderWidth: 1,
+        borderColor: C.line,
+        borderRadius: 6,
+        paddingHorizontal: 8,
+        paddingTop: 9,
+        paddingBottom: 8,
+        alignItems: 'center',
+        gap: 5,
+      }}
+    >
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+        <Step delta={-1} disabled={value === 0} />
+        <Text
+          style={[
+            TYPE.serifUpright,
+            {
+              fontSize: 26,
+              lineHeight: 28,
+              minWidth: 20,
+              textAlign: 'center',
+              color: amber && value > 0 ? C.amber : C.ink,
+            },
+          ]}
+        >
+          {value}
+        </Text>
+        <Step delta={1} disabled={false} />
+      </View>
+      <Text style={[TYPE.kicker, KICKER, { color: C.mute }]}>
+        {label}
+        {vsParText != null && (
+          <Text style={{ color: vsParColor }}> · {vsParText}</Text>
+        )}
+      </Text>
+    </View>
+  )
+}
+
+function ShotRow({
+  row,
+  onChange,
+  onOpenAimer,
+}: {
+  row: ReviewedShotRow
+  onChange: (next: ReviewedShotRow) => void
+  /** Open the full-screen green aimer for this putt row. */
+  onOpenAimer: () => void
+}) {
+  // Putt-ness is the green lie only (set when a putt is placed). Raw distance
+  // must NOT classify — a chip/bunker inside 30 yd is not a putt (#660).
+  const isPutt = isPuttShot(row.lieType)
+  const { toDisplay, toDisplayFt } = useUnits()
+  const { bag } = useUserBag()
+  // Source the club options from the user's bag, falling back to DEFAULT_BAG
+  // when empty/loading. Splice in the row's current club when it isn't in the
+  // bag so the picker always shows what the player has. Labels route through
+  // formatClubLabel so a custom_wedge reads as its loft.
+  const clubOptions = useMemo<{ value: string; label: string }[]>(() => {
+    const source = bag.length > 0 ? bag : DEFAULT_BAG
+    const typeCounts = new Map<string, number>()
+    for (const c of source) {
+      typeCounts.set(c.club_type, (typeCounts.get(c.club_type) ?? 0) + 1)
+    }
+    const base = source.map((c) => ({
+      value: c.club_type,
+      label: formatClubLabel(c, {
+        hasDuplicateType: (typeCounts.get(c.club_type) ?? 0) > 1,
+      }),
+    }))
+    if (row.club && !base.some((o) => o.value === row.club)) {
+      return [{ value: row.club, label: String(row.club) }, ...base]
+    }
+    return base
+  }, [bag, row.club])
+  // Which field's options are unfolded inline (Version A). One at a time.
+  const [open, setOpen] = useState<
+    'club' | 'lie' | 'slope' | 'result' | 'break' | 'speed' | null
+  >(null)
+  const toggle = (f: NonNullable<typeof open>) =>
+    setOpen((o) => (o === f ? null : f))
+  // Chip labels are Sentence case across lie/slope/result; formatClubLabel
+  // returns lowercase shorthand ("driver", "8i", "pw"), so capitalize the club
+  // chip to match. Digit-led codes ("8i", "3w") are unchanged.
+  const rawClubLabel =
+    clubOptions.find((c) => c.value === row.club)?.label ?? String(row.club)
+  const clubLabel = rawClubLabel.charAt(0).toUpperCase() + rawClubLabel.slice(1)
+  const slopeSet = row.lieSlopeForward != null || row.lieSlopeSide != null
+  const slopeText = [
+    row.lieSlopeForward && slopeLabel(row.lieSlopeForward),
+    row.lieSlopeSide && slopeLabel(row.lieSlopeSide),
+  ]
+    .filter(Boolean)
+    .join(' · ')
+  const breakSet =
+    row.breakDirectionHorizontal != null || row.breakDirectionVertical != null
+  const breakText = [
+    BREAK_LINE_OPTIONS.find((o) => o.value === row.breakDirectionHorizontal)?.label,
+    BREAK_SLOPE_OPTIONS.find((o) => o.value === row.breakDirectionVertical)?.label,
+  ]
+    .filter(Boolean)
+    .join(' · ')
+  const speedText =
+    SPEED_OPTIONS.find((o) => o.value === row.greenSpeed)?.label ?? null
+  const hasRead = row.aimOffsetInches != null && row.aimOffsetInches !== 0
+
+  return (
+    <View style={{ paddingVertical: 13, borderBottomWidth: 1, borderColor: C.line }}>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'baseline',
+          gap: 12,
+          marginBottom: 9,
+        }}
+      >
+        <Text style={[TYPE.kicker, KICKER, { color: C.mute }]}>
+          Shot {row.shotNumber}
+        </Text>
+        <Text style={[TYPE.serif, { color: C.ink, fontSize: 20 }]}>
+          {isPutt
+            ? `${toDisplayFt(row.distanceYards * 3)} putt`
+            : toDisplay(row.distanceYards)}
+        </Text>
+        <Text style={[TYPE.body, { color: C.mute, fontSize: 12, marginLeft: 'auto' }]}>
+          {toDisplay(row.distanceToPin)} to pin
+        </Text>
+      </View>
+
+      {isPutt ? (
+        <>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+            <PressableTouch
+              accessibilityRole="button"
+              accessibilityLabel="Made the putt"
+              accessibilityState={{ selected: !!row.puttMade }}
+              onPress={() =>
+                onChange({
+                  ...row,
+                  puttMade: !row.puttMade,
+                  puttDistanceResult: !row.puttMade ? undefined : row.puttDistanceResult,
+                  puttDirectionResult: !row.puttMade ? undefined : row.puttDirectionResult,
+                })
+              }
+              style={{
+                backgroundColor: row.puttMade ? C.accent : C.bg,
+                borderWidth: 1,
+                borderColor: C.accent,
+                borderRadius: 16,
+                paddingVertical: 5,
+                paddingHorizontal: 14,
+              }}
+            >
+              <Text
+                style={[
+                  TYPE.bodyBold,
+                  {
+                    color: row.puttMade ? C.surface : C.accent,
+                    fontSize: 12,
+                    fontWeight: '600',
+                  },
+                ]}
+              >
+                {row.puttMade ? 'Made it ✓' : 'Made it'}
+              </Text>
+            </PressableTouch>
+            <FieldChip
+              label={breakSet ? breakText : '+ break'}
+              filled={breakSet}
+              active={open === 'break'}
+              onPress={() => toggle('break')}
+            />
+            <FieldChip
+              label={speedText ?? '+ speed'}
+              filled={!!speedText}
+              active={open === 'speed'}
+              onPress={() => toggle('speed')}
+            />
+            <FieldChip label="Read ▸" filled={hasRead} onPress={onOpenAimer} />
+          </View>
+          {open === 'break' && <BreakExpand row={row} onChange={onChange} />}
+          {open === 'speed' && (
+            <ChipExpand
+              label="Speed"
+              options={SPEED_OPTIONS}
+              value={row.greenSpeed}
+              onSelect={(v) => {
+                onChange({ ...row, greenSpeed: row.greenSpeed === v ? undefined : v })
+                setOpen(null)
+              }}
+            />
+          )}
+          {!row.puttMade && (
+            <View style={{ marginTop: 10 }}>
+              <PuttMissAxes row={row} onChange={onChange} />
+            </View>
+          )}
+        </>
+      ) : (
+        <>
+          <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+            <FieldChip
+              label={clubLabel}
+              filled
+              active={open === 'club'}
+              onPress={() => toggle('club')}
+            />
+            <FieldChip
+              label={LIE_TYPE_LABELS[row.lieType]}
+              filled
+              active={open === 'lie'}
+              onPress={() => toggle('lie')}
+            />
+            <FieldChip
+              label={slopeSet ? slopeText : '+ slope'}
+              filled={slopeSet}
+              active={open === 'slope'}
+              onPress={() => toggle('slope')}
+            />
+            <FieldChip
+              label={row.shotResult ? SHOT_RESULT_LABELS[row.shotResult] : '+ result'}
+              filled={!!row.shotResult}
+              active={open === 'result'}
+              onPress={() => toggle('result')}
+            />
+          </View>
+          {open === 'club' && (
+            <ChipExpand
+              label="Club"
+              options={clubOptions}
+              value={row.club}
+              onSelect={(v) => {
+                onChange({ ...row, club: v as Club })
+                setOpen(null)
+              }}
+            />
+          )}
+          {open === 'lie' && (
+            <ChipExpand
+              label="Lie"
+              options={LIE_TYPES.map((l) => ({ value: l, label: LIE_TYPE_LABELS[l] }))}
+              value={row.lieType}
+              onSelect={(v) => {
+                onChange({ ...row, lieType: v as LieType })
+                setOpen(null)
+              }}
+            />
+          )}
+          {open === 'slope' && <SlopeExpand row={row} onChange={onChange} />}
+          {open === 'result' && (
+            <ChipExpand
+              label="Result"
+              options={SHOT_RESULTS.map((r) => ({ value: r, label: SHOT_RESULT_LABELS[r] }))}
+              value={row.shotResult}
+              onSelect={(v) => {
+                onChange({
+                  ...row,
+                  shotResult: row.shotResult === v ? undefined : (v as ShotResult),
+                })
+                setOpen(null)
+              }}
+            />
+          )}
+        </>
+      )}
+    </View>
+  )
+}
+
+// 'ball_above' → 'Ball above', 'uphill' → 'Uphill'.
+function slopeLabel(v: string): string {
+  const s = v.replace(/_/g, ' ')
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+// A field entry on a shot row: filled (forest), blank ("+ field", dashed), or
+// active (unfolded — light forest). Tapping unfolds/collapses its options.
+function FieldChip({
+  label,
+  filled,
+  active,
+  onPress,
+}: {
+  label: string
+  filled?: boolean
+  active?: boolean
+  onPress: () => void
+}) {
+  const bg = active ? '#E6EDE6' : filled ? C.accent : 'transparent'
+  const color = active ? C.accent : filled ? C.surface : C.mute
+  const border = active || filled ? C.accent : C.border
+  return (
+    <PressableTouch
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      accessibilityState={{ expanded: active }}
+      onPress={onPress}
+      style={{
+        paddingVertical: 5,
+        paddingHorizontal: 11,
+        borderRadius: 16,
+        borderWidth: 1,
+        borderStyle: filled || active ? 'solid' : 'dashed',
+        borderColor: border,
+        backgroundColor: bg,
+      }}
+    >
+      <Text style={[TYPE.body, { color, fontSize: 12 }]}>
+        {label}
+        {active ? ' ▾' : ''}
+      </Text>
+    </PressableTouch>
+  )
+}
+
+function OptChip({
+  label,
+  on,
+  onPress,
+}: {
+  label: string
+  on: boolean
+  onPress: () => void
+}) {
+  return (
+    <PressableTouch
+      accessibilityRole="radio"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: on }}
+      onPress={onPress}
+      style={{
+        paddingVertical: 4,
+        paddingHorizontal: 10,
+        borderRadius: 14,
+        borderWidth: 1,
+        borderColor: on ? C.accent : C.line,
+        backgroundColor: on ? C.accent : C.surface,
+      }}
+    >
+      <Text style={[TYPE.body, { color: on ? C.surface : C.ink, fontSize: 11 }]}>
+        {label}
+      </Text>
+    </PressableTouch>
+  )
+}
+
+// Inline unfolded options for a single-select field (club / lie / result).
+function ChipExpand<V extends string>({
+  label,
+  options,
+  value,
+  onSelect,
+}: {
+  label: string
+  options: readonly { value: V; label: string }[]
+  value: V | undefined
+  onSelect: (v: V) => void
+}) {
+  return (
+    <View
+      style={{
+        marginTop: 9,
+        backgroundColor: C.expand,
+        borderRadius: 8,
+        paddingVertical: 9,
+        paddingHorizontal: 10,
+      }}
+    >
+      <Text style={[TYPE.kicker, KICKER, { color: C.mute, marginBottom: 7 }]}>
+        {label}
+      </Text>
+      <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+        {options.map((o) => (
+          <OptChip
+            key={o.value}
+            label={o.label}
+            on={o.value === value}
+            onPress={() => onSelect(o.value)}
+          />
+        ))}
+      </View>
+    </View>
+  )
+}
+
+// The two-axis slope grid (uphill/level/downhill × ball above/below), unfolded
+// inline. Each axis toggles independently; either can stay unset.
+function SlopeExpand({
+  row,
+  onChange,
+}: {
+  row: ReviewedShotRow
+  onChange: (next: ReviewedShotRow) => void
+}) {
+  return (
+    <View
+      style={{
+        marginTop: 9,
+        backgroundColor: C.expand,
+        borderRadius: 8,
+        paddingVertical: 9,
+        paddingHorizontal: 10,
+        gap: 9,
+      }}
+    >
+      <View>
+        <Text style={[TYPE.kicker, KICKER, { color: C.mute, marginBottom: 6 }]}>
+          Uphill / downhill
+        </Text>
+        <View style={{ flexDirection: 'row', gap: 6 }}>
+          {LIE_SLOPES_FORWARD.map((f) => (
+            <OptChip
+              key={f}
+              label={slopeLabel(f)}
+              on={row.lieSlopeForward === f}
+              onPress={() =>
+                onChange({
+                  ...row,
+                  lieSlopeForward:
+                    row.lieSlopeForward === f ? undefined : (f as LieSlopeForward),
+                })
+              }
+            />
+          ))}
+        </View>
+      </View>
+      <View>
+        <Text style={[TYPE.kicker, KICKER, { color: C.mute, marginBottom: 6 }]}>
+          Ball above / below
+        </Text>
+        <View style={{ flexDirection: 'row', gap: 6 }}>
+          {LIE_SLOPES_SIDE.map((s) => (
+            <OptChip
+              key={s}
+              label={slopeLabel(s)}
+              on={row.lieSlopeSide === s}
+              onPress={() =>
+                onChange({
+                  ...row,
+                  lieSlopeSide:
+                    row.lieSlopeSide === s ? undefined : (s as LieSlopeSide),
+                })
+              }
+            />
+          ))}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+// The putt break read, unfolded inline: line (L→R / R→L / straight) + slope
+// (uphill / level / downhill). Each axis toggles independently.
+function BreakExpand({
+  row,
+  onChange,
+}: {
+  row: ReviewedShotRow
+  onChange: (next: ReviewedShotRow) => void
+}) {
+  return (
+    <View
+      style={{
+        marginTop: 9,
+        backgroundColor: C.expand,
+        borderRadius: 8,
+        paddingVertical: 9,
+        paddingHorizontal: 10,
+        gap: 9,
+      }}
+    >
+      <View>
+        <Text style={[TYPE.kicker, KICKER, { color: C.mute, marginBottom: 6 }]}>
+          Break — which way
+        </Text>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+          {BREAK_LINE_OPTIONS.map((o) => (
+            <OptChip
+              key={o.value}
+              label={o.label}
+              on={row.breakDirectionHorizontal === o.value}
+              onPress={() =>
+                onChange({
+                  ...row,
+                  breakDirectionHorizontal:
+                    row.breakDirectionHorizontal === o.value ? undefined : o.value,
+                })
+              }
+            />
+          ))}
+        </View>
+      </View>
+      <View>
+        <Text style={[TYPE.kicker, KICKER, { color: C.mute, marginBottom: 6 }]}>
+          Slope
+        </Text>
+        <View style={{ flexDirection: 'row', flexWrap: 'wrap', gap: 6 }}>
+          {BREAK_SLOPE_OPTIONS.map((o) => (
+            <OptChip
+              key={o.value}
+              label={o.label}
+              on={row.breakDirectionVertical === o.value}
+              onPress={() =>
+                onChange({
+                  ...row,
+                  breakDirectionVertical:
+                    row.breakDirectionVertical === o.value ? undefined : o.value,
+                })
+              }
+            />
+          ))}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+// The on-demand read tool: a full-screen overlay hosting the draggable green
+// aimer. Setting the aim also derives the horizontal break line (aim off the
+// pin = the read), mirroring the putting sheet.
+function AimerOverlay({
+  row,
+  onChange,
+  onClose,
+}: {
+  row: ReviewedShotRow
+  onChange: (next: ReviewedShotRow) => void
+  onClose: () => void
+}) {
+  const insets = useSafeAreaInsets()
+  const distanceFt = row.distanceYards * 3
+  const breakDirection =
+    combinedBreakDirection({
+      vertical: row.breakDirectionVertical ?? null,
+      horizontal: row.breakDirectionHorizontal ?? null,
+    }) ?? 'straight'
+  return (
+    <View
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: C.bg,
+        zIndex: 50,
+        paddingTop: insets.top,
+      }}
+    >
+      <View
+        style={{
+          paddingHorizontal: 22,
+          paddingTop: 16,
+          paddingBottom: 12,
+          borderBottomWidth: 1,
+          borderColor: C.line,
+        }}
+      >
+        <Text style={[TYPE.kicker, KICKER, { color: C.mute, marginBottom: 4 }]}>
+          Shot {row.shotNumber} · read the green
+        </Text>
+        <Text style={[TYPE.serif, { color: C.ink, fontSize: 22 }]}>Aim & break</Text>
+      </View>
+      <ScrollView
+        style={{ flex: 1 }}
+        contentContainerStyle={{ paddingHorizontal: 22, paddingVertical: 18 }}
+      >
+        <GreenDiagram
+          distanceFt={distanceFt}
+          aimOffsetInches={row.aimOffsetInches ?? 0}
+          breakDirection={breakDirection}
+          onAimChange={(n) =>
+            onChange({
+              ...row,
+              aimOffsetInches: n,
+              breakDirectionHorizontal:
+                horizontalBreakFromAim(n) ?? row.breakDirectionHorizontal,
+            })
+          }
+        />
+      </ScrollView>
+      <View
+        style={{
+          paddingHorizontal: 22,
+          paddingTop: 14,
+          paddingBottom: insets.bottom + 18,
+          borderTopWidth: 1,
+          borderColor: C.line,
+        }}
+      >
+        <PressableTouch
+          accessibilityRole="button"
+          accessibilityLabel="Save read"
+          onPress={onClose}
+          style={{
+            backgroundColor: C.accent,
+            borderRadius: 2,
+            paddingVertical: 12,
+            paddingHorizontal: 18,
+            alignItems: 'center',
+          }}
+        >
+          <Text
+            style={[
+              TYPE.bodyBold,
+              { color: C.accentInk, fontSize: 14, fontWeight: '600', letterSpacing: 0.3 },
+            ]}
+          >
+            Save read
+          </Text>
+        </PressableTouch>
+      </View>
+    </View>
+  )
+}
+
+function PuttMissAxes({
+  row,
+  onChange,
+}: {
+  row: ReviewedShotRow
+  onChange: (next: ReviewedShotRow) => void
+}) {
+  return (
+    <View style={{ gap: 8, width: '100%' }}>
+      <AxisRow
+        label="Distance"
+        options={PUTT_DISTANCE_OPTIONS}
+        value={row.puttDistanceResult}
+        onSelect={(v) =>
+          onChange({
+            ...row,
+            puttDistanceResult: row.puttDistanceResult === v ? undefined : v,
+          })
+        }
+      />
+      <AxisRow
+        label="Direction"
+        options={PUTT_DIRECTION_OPTIONS}
+        value={row.puttDirectionResult}
+        onSelect={(v) =>
+          onChange({
+            ...row,
+            puttDirectionResult: row.puttDirectionResult === v ? undefined : v,
+          })
+        }
+      />
+    </View>
+  )
+}
+
+function AxisRow<V extends string>({
+  label,
+  options,
+  value,
+  onSelect,
+}: {
+  label: string
+  options: readonly { value: V; label: string }[]
+  value: V | undefined
+  onSelect: (v: V) => void
+}) {
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', flexWrap: 'wrap', gap: 6 }}>
+      <Text style={[TYPE.kicker, KICKER, { minWidth: 72, color: '#5C6356' }]}>
+        {label}
+      </Text>
+      {options.map((opt) => {
+        const active = value === opt.value
+        return (
+          <PressableTouch
+            key={opt.value}
+            accessibilityRole="radio"
+            accessibilityLabel={opt.label}
+            accessibilityState={{ selected: active }}
+            onPress={() => onSelect(opt.value)}
+            style={{
+              backgroundColor: active ? C.accent : C.expand,
+              borderRadius: 2,
+              paddingVertical: 6,
+              paddingHorizontal: 10,
+            }}
+          >
+            <Text
+              style={[
+                TYPE.body,
+                {
+                  color: active ? C.surface : C.ink,
+                  fontSize: 12,
+                  fontWeight: active ? '500' : '400',
+                },
+              ]}
+            >
+              {opt.label}
+            </Text>
+          </PressableTouch>
+        )
+      })}
+    </View>
+  )
+}

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -9,8 +9,14 @@ import { PressableTouch } from '../ui/PressableTouch'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useRouter } from 'expo-router'
 import { HoleMap, type LatLng } from './HoleMap'
+import { HoleReviewSheet } from './HoleReviewSheet'
 import type { ShotLoggerValue } from './ShotLogger'
-import { DEFAULT_HANDICAP, bearingDegrees, destinationYards } from '@oga/core'
+import {
+  DEFAULT_HANDICAP,
+  bearingDegrees,
+  buildInitialRows,
+  destinationYards,
+} from '@oga/core'
 import { getProfile } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
 import { distanceYards } from '../../lib/maps'
@@ -280,6 +286,28 @@ export default function LiveRoundSession({
     data.remoteShotCount + data.localShotCount > 0
       ? data.remoteShotCount + data.localShotCount
       : 0
+
+  // End-of-hole review rows. Built from the shots placed live (their start
+  // coords, in order) via the shared @oga/core inference — same call the web
+  // review sheet uses. Only computed while the summary is open. The pin
+  // anchors the last shot's end + every shot's distance-to-pin; with no pin
+  // (unmapped hole, none placed) the last placed point stands in so distances
+  // degrade to ~0 rather than exploding off [0,0].
+  const summaryRows = useMemo(() => {
+    if (finalState.roundState !== 'SUMMARY') return []
+    const pts = data.previousShots
+    if (pts.length === 0) return []
+    const pin = data.roundPin ?? data.storedPin ?? pts[pts.length - 1]!
+    const par = data.currentHoleScore?.par ?? data.currentHole?.par ?? 4
+    return buildInitialRows(pts, par, pin.lat, pin.lng)
+  }, [
+    finalState.roundState,
+    data.previousShots,
+    data.roundPin,
+    data.storedPin,
+    data.currentHoleScore?.par,
+    data.currentHole?.par,
+  ])
 
   const actions = useShotActions({
     id: roundId,
@@ -731,6 +759,20 @@ export default function LiveRoundSession({
         onGreenNo={actions.handleOnGreenNo}
         onAimPromptConfirm={actions.handleAimPromptConfirm}
         onAimPromptSkip={actions.handleAimPromptSkip}
+      />
+
+      {/* End-of-hole review — full-screen overlay (zIndex 40). Confirms each
+          shot's club / lie / result + putt read for the shots logged
+          location-only during play, then writes metadata + hole_scores and
+          advances (#791). */}
+      <HoleReviewSheet
+        visible={finalState.roundState === 'SUMMARY'}
+        holeNumber={holeNumber}
+        par={data.currentHoleScore?.par ?? data.currentHole.par}
+        initialRows={summaryRows}
+        saving={actions.saving}
+        onSave={actions.saveHoleSummary}
+        onEditOnMap={actions.editHoleOnMap}
       />
 
       {/* Round-options popover. Full-screen transparent backdrop catches the

--- a/apps/mobile/components/round/hole/types.ts
+++ b/apps/mobile/components/round/hole/types.ts
@@ -7,7 +7,16 @@
 // SHOT_DETAIL: ShotLogger sheet open; save returns to PLACE_BALL.
 // PUTTING: PuttingSheet open with green diagram; save returns to PLACE_BALL
 //   (player loops here for each successive putt).
-export type RoundState = 'PLACE_BALL' | 'SET_AIM' | 'SHOT_DETAIL' | 'PUTTING'
+// SUMMARY: end-of-hole review sheet (HoleReviewSheet) open — the player
+//   confirms/annotates every placed shot's club/lie/result + putt read, then
+//   save writes the metadata + hole_scores and advances. Shots are logged
+//   location-only during play; their details are captured here (#791).
+export type RoundState =
+  | 'PLACE_BALL'
+  | 'SET_AIM'
+  | 'SHOT_DETAIL'
+  | 'PUTTING'
+  | 'SUMMARY'
 
 // Mutually exclusive confirm dialog for the live-round screen. Only one
 // can be on screen at a time by construction — solves the "back button

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -742,7 +742,11 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
         })
         .eq('id', currentHoleScore.id)
       if (hsErr) {
-        // eslint-disable-next-line no-console
+        // Non-fatal: the shots (with their metadata) already re-queued and
+        // will sync; only the hole_scores tally write failed. Warn for
+        // diagnostics rather than alerting — completeRound self-repairs score
+        // from the shot count at round end.
+        // eslint-disable-next-line no-console -- diagnostic for a non-fatal tally-write failure
         console.warn('[hole/summary-score-update]', hsErr.message)
       }
 

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -2,7 +2,6 @@ import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { Alert } from 'react-native'
 import { useRouter } from 'expo-router'
 import type { User } from '@supabase/supabase-js'
-import { uuid } from 'expo-modules-core'
 import {
   combinedBreakDirection,
   combinedPuttResult,
@@ -585,10 +584,18 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       // Pair reviewed rows to the live shots by shot_number. Local queue
       // (pending + synced) is the primary source for id + live aim; the
       // remote table is the fallback for a shot whose local row was purged
-      // after a prior session's sync (restart mid-hole).
-      const localRows = await allShotsForHoleScore(currentHoleScore.id).catch(
-        () => [] as Awaited<ReturnType<typeof allShotsForHoleScore>>,
+      // after a prior session's sync (restart mid-hole). BOTH reads get a
+      // one-retry (mirrors useHoleData's SQLite/remote reads) — a transient
+      // failure that empties either map must not silently strand a shot on
+      // the abort path below.
+      let localRows = await allShotsForHoleScore(currentHoleScore.id).catch(
+        () => null,
       )
+      if (localRows === null) {
+        localRows = await allShotsForHoleScore(currentHoleScore.id).catch(
+          () => [] as Awaited<ReturnType<typeof allShotsForHoleScore>>,
+        )
+      }
       const localByNum = new Map<number, ShotPayload>()
       for (const r of localRows) {
         try {
@@ -602,11 +609,17 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
         number,
         { id: string; aim_lat: number | null; aim_lng: number | null }
       >()
-      const { data: remoteShots } = await supabase
+      let remote = await supabase
         .from('shots')
         .select('id, shot_number, aim_lat, aim_lng')
         .eq('hole_score_id', currentHoleScore.id)
-      for (const s of remoteShots ?? []) {
+      if (remote.error) {
+        remote = await supabase
+          .from('shots')
+          .select('id, shot_number, aim_lat, aim_lng')
+          .eq('hole_score_id', currentHoleScore.id)
+      }
+      for (const s of remote.data ?? []) {
         remoteByNum.set(s.shot_number, {
           id: s.id,
           aim_lat: s.aim_lat,
@@ -616,16 +629,28 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
 
       for (const row of rows) {
         const isPuttRow = isPuttEntry(row.lieType, row.club)
-        const local = localByNum.get(row.shotNumber)
-        const remote = remoteByNum.get(row.shotNumber)
-        // Preserve the live shot's id so the re-sync upserts (updates) it;
-        // fall back to a fresh id only for a shot that exists in neither
-        // store (shouldn't happen — the rows were built from these shots).
-        const id = local?.id ?? remote?.id ?? uuid.v4()
+        const existing =
+          localByNum.get(row.shotNumber) ?? remoteByNum.get(row.shotNumber)
+        // The reviewed rows were built from these very shots, so each MUST
+        // pair back to one. If both reads came up empty for this shot_number
+        // (both transiently failed above), fabricating a fresh id would queue
+        // a row that collides with the existing shot on unique(hole_score_id,
+        // shot_number) — a novel id isn't arbitrated by the sync upsert's
+        // onConflict:'id', so it 23505s and gets silently quarantined, losing
+        // this shot's metadata. Abort loudly instead: the sheet stays open
+        // with the player's edits intact (hydration is gated), so Save simply
+        // retries once the read recovers. Never mint a colliding id.
+        if (!existing?.id) {
+          throw new Error(
+            "Couldn't reach this hole's shots — check your connection and save again.",
+          )
+        }
+        const id = existing.id
         // Keep the aim captured live (SET_AIM); the review sheet doesn't edit
-        // non-putt aim, so the live value is authoritative.
-        const aimLat = local?.aim_lat ?? remote?.aim_lat ?? null
-        const aimLng = local?.aim_lng ?? remote?.aim_lng ?? null
+        // non-putt aim, so the live value is authoritative. `existing` is a
+        // queued payload or the remote row — both carry aim_lat/aim_lng.
+        const aimLat = existing.aim_lat ?? null
+        const aimLng = existing.aim_lng ?? null
         const payload: ShotPayload = {
           id,
           hole_score_id: currentHoleScore.id,

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -2,18 +2,24 @@ import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { Alert } from 'react-native'
 import { useRouter } from 'expo-router'
 import type { User } from '@supabase/supabase-js'
+import { uuid } from 'expo-modules-core'
 import {
   combinedBreakDirection,
   combinedPuttResult,
+  inferHoleStats,
+  isPuttEntry,
   isPuttShot,
   type LieType,
+  type ReviewedShotRow,
 } from '@oga/core'
 import { deleteRound, getProfile } from '@oga/supabase'
 import { supabase } from '../../../lib/supabase'
 import {
+  allShotsForHoleScore,
   insertPendingShot,
   pendingCount,
   setPendingShotEnd,
+  upsertReviewedShot,
   type ShotPayload,
 } from '../../../lib/db'
 import { syncPendingShots } from '../../../lib/sync'
@@ -22,7 +28,7 @@ import { completeRound } from '../../../lib/completeRound'
 import type { LatLng } from '../HoleMap'
 import type { ShotLoggerValue } from '../ShotLogger'
 import type { PuttingValue } from '../PuttingSheet'
-import { PUTTING_RADIUS_YARDS, type ActiveDialog } from './types'
+import { type ActiveDialog } from './types'
 import type { UseHoleDataResult } from './useHoleData'
 import type { UseHoleStateResult } from './useHoleState'
 
@@ -69,6 +75,15 @@ export interface UseShotActionsResult {
   swapPuttingToShot: (lieType: LieType) => void
   navigateHole: (delta: number) => void
   finishHole: () => void
+  // End-of-hole review save: attach the confirmed metadata to every shot
+  // logged live on this hole, write the hole_scores tallies, then advance.
+  saveHoleSummary: (
+    rows: ReviewedShotRow[],
+    summary: { score: number; putts: number; penalties: number },
+  ) => Promise<void>
+  // Dismiss the summary back to the live map so the player can fix ball
+  // positions (add / re-place a shot) before reopening the review.
+  editHoleOnMap: () => void
   handleEndRound: () => Promise<void>
   handleDeleteRound: () => Promise<void>
   handleExitFromError: () => void
@@ -113,9 +128,13 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     roundPin,
     remotePuttCount,
     localPuttCount,
+    previousShots,
     shotNumber,
     holeCount,
   } = data
+  // Guards a double-fire of the end-of-hole save the same way persistShot
+  // guards its own — the `saving` state setter commits a tick late.
+  const saveSummaryInFlightRef = useRef(false)
   const {
     ball,
     setBall,
@@ -131,10 +150,17 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     setAppendEngaged,
   } = state
 
-  function buildPayload(meta: ShotLoggerValue | null): ShotPayload | null {
+  function buildPayload(
+    meta: ShotLoggerValue | null,
+    opts?: { forceAim?: boolean },
+  ): ShotPayload | null {
     if (!user || !currentHoleScore || !ball) return null
     const isPutt = isPuttShot(meta?.lieType)
     const pinTarget = roundPin ?? storedPin ?? null
+    // Confirm-aim forces persist (the player accepted even an unadjusted
+    // auto-spawn); skip-aim forces drop; anything else falls back to the
+    // touched flag. `false ?? x === false`, so an explicit false wins.
+    const persistAim = opts?.forceAim ?? aimTouched
     return {
       hole_score_id: currentHoleScore.id,
       user_id: user.id,
@@ -147,10 +173,11 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       // "distance to target" is putt_distance_ft, not this column.
       distance_to_target:
         !isPutt && pinTarget ? Math.round(distanceYards(ball, pinTarget)) : null,
-      // Persist aim only if the player set/dragged it; an untouched auto-spawn
-      // suggestion is dropped so it can't enter the dispersion dataset.
-      aim_lat: aimTouched ? aim?.lat ?? null : null,
-      aim_lng: aimTouched ? aim?.lng ?? null : null,
+      // Persist aim only if the player set/dragged it (or explicitly confirmed);
+      // an untouched auto-spawn suggestion is dropped so it can't enter the
+      // dispersion dataset.
+      aim_lat: persistAim ? aim?.lat ?? null : null,
+      aim_lng: persistAim ? aim?.lng ?? null : null,
       club: meta?.club ?? null,
       lie_type: meta?.lieType ?? null,
       lie_slope: null,
@@ -187,9 +214,12 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     }
   }
 
-  async function persistShot(meta: ShotLoggerValue | null) {
+  async function persistShot(
+    meta: ShotLoggerValue | null,
+    opts?: { forceAim?: boolean },
+  ) {
     if (persistShotInFlightRef.current) return
-    const payload = buildPayload(meta)
+    const payload = buildPayload(meta, opts)
     if (!payload) return
     persistShotInFlightRef.current = true
     setSaving(true)
@@ -411,15 +441,13 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     }
     setBall(ballSnapshot)
     setAim(null)
-    const pinTarget = roundPin ?? storedPin ?? null
-    if (pinTarget && distanceYards(ballSnapshot, pinTarget) <= PUTTING_RADIUS_YARDS) {
-      setActiveDialog('onGreen')
-      return
-    }
-    // Go straight into aiming — no "Set aim point?" prompt. The aim line
-    // auto-spawns to the pin (useHoleState) with a draggable midpoint; "Skip
-    // aim" stays available in the SET_AIM bottom chrome. (The on-green prompt
-    // above is kept.)
+    // Every shot goes straight into aiming — the on-green "are you putting?"
+    // prompt was dropped (#791). During play a putt is just another location;
+    // whether it WAS a putt is decided at the end-of-hole review from the
+    // ball's position (green lie → putter), where the break / speed / aimer
+    // now live. The aim line auto-spawns to the pin (useHoleState) with a
+    // draggable midpoint; "Skip aim" stays in the SET_AIM chrome for a tap-in
+    // the player won't bother aiming.
     setRoundState('SET_AIM')
   }
 
@@ -449,18 +477,20 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   }
 
   function confirmAim() {
-    // Confirming is an explicit acceptance of the aim — even the unadjusted
-    // auto-suggestion — so mark it touched and persist it. ('Skip aim' clears
-    // the aim instead, so that path stays unpersisted.)
-    setAimTouched(true)
-    setRoundState('SHOT_DETAIL')
-    setLoggerOpen(true)
+    // Location-now, details-at-EOH (#791): confirming the aim saves the shot
+    // as a location (+ this accepted aim) and loops straight back to placing
+    // the next ball — no ShotLogger. forceAim:true persists even an unadjusted
+    // auto-spawn, since the player explicitly accepted it. persistShot clears
+    // the aim and returns to PLACE_BALL. Club / lie / result are captured in
+    // the end-of-hole review.
+    void persistShot(null, { forceAim: true })
   }
 
   function skipAim() {
-    setAim(null)
-    setRoundState('SHOT_DETAIL')
-    setLoggerOpen(true)
+    // Same location-only save, minus the aim — a tap-in or a shot the player
+    // won't bother aiming. forceAim:false drops the auto-spawn suggestion so it
+    // can't enter the dispersion dataset.
+    void persistShot(null, { forceAim: false })
   }
 
   function handleAimPromptConfirm() {
@@ -504,6 +534,19 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   }
 
   function finishHole() {
+    // Nothing placed on this hole → nothing to review; advance straight on
+    // (a skipped / walked hole). Otherwise open the end-of-hole review so the
+    // player confirms each shot's details before moving on (#791).
+    if (previousShots.length === 0) {
+      advanceAfterHole()
+      return
+    }
+    setRoundState('SUMMARY')
+  }
+
+  // Post-hole navigation, shared by finishHole (empty hole) and
+  // saveHoleSummary (after the review saves).
+  function advanceAfterHole() {
     if (holeNumber < holeCount) {
       onHoleChange(holeNumber + 1)
     } else {
@@ -512,6 +555,179 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       // round stays unfinished (blank total, reappears as resumable). Same
       // path as "End round early". (#639)
       void handleEndRound()
+    }
+  }
+
+  // Back out of the review to the live map so the player can add or re-place a
+  // ball, then reopen the summary. Mobile has no drag-existing-marker mode, so
+  // "edit on map" drops to PLACE_BALL — the append flow, which can add / re-mark
+  // a shot before finishing again.
+  function editHoleOnMap() {
+    setRoundState('PLACE_BALL')
+  }
+
+  // End-of-hole save. Mirrors the web review sheet's replace-all write, but
+  // attaches metadata to the shots the player already logged live rather than
+  // recreating them: each reviewed row is paired back to its live shot by
+  // shot_number so the shot's client id (and its live-captured aim) carry
+  // through, and the merged payload is re-queued via upsertReviewedShot →
+  // idempotent re-sync updates the same server row (no delete, no duplicates
+  // offline). Then the hole_scores tallies are written and the hole advances.
+  async function saveHoleSummary(
+    rows: ReviewedShotRow[],
+    summary: { score: number; putts: number; penalties: number },
+  ) {
+    if (!user || !currentHoleScore || !currentHole) return
+    if (saveSummaryInFlightRef.current) return
+    saveSummaryInFlightRef.current = true
+    setSaving(true)
+    try {
+      // Pair reviewed rows to the live shots by shot_number. Local queue
+      // (pending + synced) is the primary source for id + live aim; the
+      // remote table is the fallback for a shot whose local row was purged
+      // after a prior session's sync (restart mid-hole).
+      const localRows = await allShotsForHoleScore(currentHoleScore.id).catch(
+        () => [] as Awaited<ReturnType<typeof allShotsForHoleScore>>,
+      )
+      const localByNum = new Map<number, ShotPayload>()
+      for (const r of localRows) {
+        try {
+          const p = JSON.parse(r.payload) as ShotPayload
+          if (p.id && p.shot_number != null) localByNum.set(p.shot_number, p)
+        } catch {
+          // skip malformed pending payload
+        }
+      }
+      const remoteByNum = new Map<
+        number,
+        { id: string; aim_lat: number | null; aim_lng: number | null }
+      >()
+      const { data: remoteShots } = await supabase
+        .from('shots')
+        .select('id, shot_number, aim_lat, aim_lng')
+        .eq('hole_score_id', currentHoleScore.id)
+      for (const s of remoteShots ?? []) {
+        remoteByNum.set(s.shot_number, {
+          id: s.id,
+          aim_lat: s.aim_lat,
+          aim_lng: s.aim_lng,
+        })
+      }
+
+      for (const row of rows) {
+        const isPuttRow = isPuttEntry(row.lieType, row.club)
+        const local = localByNum.get(row.shotNumber)
+        const remote = remoteByNum.get(row.shotNumber)
+        // Preserve the live shot's id so the re-sync upserts (updates) it;
+        // fall back to a fresh id only for a shot that exists in neither
+        // store (shouldn't happen — the rows were built from these shots).
+        const id = local?.id ?? remote?.id ?? uuid.v4()
+        // Keep the aim captured live (SET_AIM); the review sheet doesn't edit
+        // non-putt aim, so the live value is authoritative.
+        const aimLat = local?.aim_lat ?? remote?.aim_lat ?? null
+        const aimLng = local?.aim_lng ?? remote?.aim_lng ?? null
+        const payload: ShotPayload = {
+          id,
+          hole_score_id: currentHoleScore.id,
+          user_id: user.id,
+          shot_number: row.shotNumber,
+          start_lat: row.startLat,
+          start_lng: row.startLng,
+          end_lat: row.endLat,
+          end_lng: row.endLng,
+          aim_lat: aimLat,
+          aim_lng: aimLng,
+          distance_to_target: isPuttRow ? null : Math.round(row.distanceToPin),
+          club: row.club,
+          lie_type: row.lieType,
+          lie_slope: null,
+          lie_slope_forward: isPuttRow ? null : row.lieSlopeForward ?? null,
+          lie_slope_side: isPuttRow ? null : row.lieSlopeSide ?? null,
+          shot_result: isPuttRow ? null : row.shotResult ?? null,
+          penalty: false,
+          ob: false,
+          // Putt tap-to-tap distance is in yards; * 3 = feet (US convention),
+          // and putt_distance_ft is what the rest of the app reads.
+          putt_distance_ft: isPuttRow ? Math.round(row.distanceYards * 3) : null,
+          putt_result: !isPuttRow
+            ? null
+            : combinedPuttResult({
+                made: row.puttMade,
+                distance: row.puttDistanceResult ?? null,
+                direction: row.puttDirectionResult ?? null,
+              }),
+          putt_distance_result:
+            !isPuttRow || row.puttMade ? null : row.puttDistanceResult ?? null,
+          putt_direction_result:
+            !isPuttRow || row.puttMade ? null : row.puttDirectionResult ?? null,
+          putt_slope_pct: isPuttRow ? row.puttSlopePct ?? null : null,
+          green_speed: isPuttRow ? row.greenSpeed ?? null : null,
+          break_direction: isPuttRow
+            ? combinedBreakDirection({
+                vertical: row.breakDirectionVertical,
+                horizontal: row.breakDirectionHorizontal,
+              })
+            : null,
+          break_direction_vertical: isPuttRow
+            ? row.breakDirectionVertical ?? null
+            : null,
+          break_direction_horizontal: isPuttRow
+            ? row.breakDirectionHorizontal ?? null
+            : null,
+          aim_offset_yards:
+            isPuttRow && row.aimOffsetInches != null
+              ? Math.round((row.aimOffsetInches / 36) * 10) / 10
+              : null,
+          notes: row.notes ?? null,
+        }
+        await upsertReviewedShot(payload)
+      }
+      // Background sync — the re-queued rows carry their metadata now.
+      syncPendingShots().catch(() => undefined)
+
+      // Authoritative hole_scores tallies from the review. fairway/gir are
+      // inferred from the placed lies; holedOut=true because this flow ends at
+      // the pin by construction (matches web's saveReviewedHole). An explicit
+      // scorecard toggle is never overwritten (?? guards).
+      const inferred = inferHoleStats(
+        rows.map((r) => ({ shot_number: r.shotNumber, lie_type: r.lieType })),
+        currentHole.par,
+        true,
+      )
+      setHoleScores((prev) =>
+        prev.map((hs) =>
+          hs.id === currentHoleScore.id
+            ? {
+                ...hs,
+                score: summary.score,
+                putts: summary.putts,
+                penalties: summary.penalties,
+              }
+            : hs,
+        ),
+      )
+      const { error: hsErr } = await supabase
+        .from('hole_scores')
+        .update({
+          score: summary.score,
+          putts: summary.putts,
+          penalties: summary.penalties,
+          fairway_hit: currentHoleScore.fairway_hit ?? inferred.fairway,
+          gir: currentHoleScore.gir ?? inferred.gir,
+        })
+        .eq('id', currentHoleScore.id)
+      if (hsErr) {
+        // eslint-disable-next-line no-console
+        console.warn('[hole/summary-score-update]', hsErr.message)
+      }
+
+      setRoundState('PLACE_BALL')
+      advanceAfterHole()
+    } catch (err) {
+      Alert.alert('Save failed', (err as Error).message)
+    } finally {
+      saveSummaryInFlightRef.current = false
+      setSaving(false)
     }
   }
 
@@ -634,6 +850,8 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     swapPuttingToShot,
     navigateHole,
     finishHole,
+    saveHoleSummary,
+    editHoleOnMap,
     handleEndRound,
     handleDeleteRound,
     handleExitFromError,

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -253,8 +253,13 @@ export async function allShotsForHoleScore(holeScoreId: string): Promise<Pending
 export async function upsertReviewedShot(payload: ShotPayload): Promise<void> {
   const db = await getDb()
   const withId: ShotPayload = payload.id ? payload : { ...payload, id: uuid.v4() }
+  // Exclude 'broken' rows: a quarantined shot's id must not be reactivated
+  // into 'pending' here (it would just re-poison on the next sync). Matching
+  // only pending/synced means a poisoned id falls through to a fresh insert.
   const existing = await db.getFirstAsync<{ local_id: number }>(
-    `SELECT local_id FROM pending_shots WHERE json_extract(payload, '$.id') = ?`,
+    `SELECT local_id FROM pending_shots
+     WHERE json_extract(payload, '$.id') = ?
+       AND status IN ('pending', 'synced')`,
     withId.id!,
   )
   if (existing) {

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -223,3 +223,51 @@ export async function pendingShotsForHoleScore(holeScoreId: string): Promise<Pen
     holeScoreId,
   )
 }
+
+// Like pendingShotsForHoleScore but includes already-synced rows. The
+// end-of-hole review pairs each reviewed row back to the shot the player
+// placed live so it can attach metadata by the shot's client id — and by
+// EOH most shots have synced (status='synced', still in the table this
+// session; purge only runs at next getDb() init). 'broken' rows stay
+// excluded — they carry corrupt data with nothing to attach to.
+export async function allShotsForHoleScore(holeScoreId: string): Promise<PendingShot[]> {
+  const db = await getDb()
+  return db.getAllAsync<PendingShot>(
+    `SELECT * FROM pending_shots
+     WHERE status IN ('pending', 'synced')
+       AND json_extract(payload, '$.hole_score_id') = ?
+     ORDER BY created_at ASC`,
+    holeScoreId,
+  )
+}
+
+// Attach end-of-hole metadata to a shot the player logged live. Keyed on the
+// client-generated payload.id: an existing local row (pending OR synced) is
+// rewritten in place and flipped back to 'pending' so the next sync re-upserts
+// it (idempotent on id — the server row updates, never duplicates, #652); a
+// shot whose local row was purged after an earlier session's sync is
+// re-inserted carrying the same id, which likewise updates the server row on
+// sync. This is the mobile equivalent of the web review sheet's replace-all
+// save, minus the delete — a delete-then-reinsert would strand duplicate
+// server rows whenever the save happens offline (there's no delete queue).
+export async function upsertReviewedShot(payload: ShotPayload): Promise<void> {
+  const db = await getDb()
+  const withId: ShotPayload = payload.id ? payload : { ...payload, id: uuid.v4() }
+  const existing = await db.getFirstAsync<{ local_id: number }>(
+    `SELECT local_id FROM pending_shots WHERE json_extract(payload, '$.id') = ?`,
+    withId.id!,
+  )
+  if (existing) {
+    await db.runAsync(
+      `UPDATE pending_shots SET payload = ?, status = 'pending' WHERE local_id = ?`,
+      JSON.stringify(withId),
+      existing.local_id,
+    )
+  } else {
+    await db.runAsync(
+      `INSERT INTO pending_shots (status, payload, created_at) VALUES ('pending', ?, ?)`,
+      JSON.stringify(withId),
+      Date.now(),
+    )
+  }
+}

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -13,6 +13,7 @@ import {
   haversineYards,
   horizontalBreakFromAim,
   isPuttEntry,
+  isPuttShot,
   type BreakDirectionHorizontal,
   type BreakDirectionVertical,
   type Club,
@@ -190,7 +191,11 @@ export function HoleReviewSheet({
       })
     setRows(merged)
     setScore(merged.length)
-    setPutts(merged.filter((r) => isPuttEntry(r.lieType, r.club)).length)
+    // Putt TALLY counts any green-lie shot (isPuttShot), matching the SG
+    // putting engine + putt-count readers — a bladed wedge on the green still
+    // counts as a putt here even though its row shows normal-shot UI (the
+    // per-row isPutt gate below stays isPuttEntry). User-overridable ticker.
+    setPutts(merged.filter((r) => isPuttShot(r.lieType)).length)
     setPenalties(0)
   }, [open, holeNumber, par, pinLat, pinLng])
 

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -11,6 +11,7 @@ import {
   haversineYards,
   inferHoleStats,
   isPuttEntry,
+  isPuttShot,
 } from '@oga/core'
 import type { PlacedPoint } from '../../../components/round/RoundMap'
 import type { ReviewedShotRow } from '../../../components/round/HoleReviewSheet'
@@ -571,7 +572,11 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         // Match HoleReviewSheet's isPutt — putt-ness is the green lie (set
         // when a putt is placed), never club or raw distance (a near-green
         // chip isn't a putt; unmapped rows read 0).
-        const puttCount = rows.filter((r) => isPuttEntry(r.lieType, r.club)).length
+        // Putt tally matches the SG putting engine + putt-count readers
+        // (isPuttShot = green lie), so hole_scores.putts stays consistent with
+        // stats. The per-row column gate below stays isPuttEntry. This is only
+        // a fallback — the review sheet always passes summary.putts.
+        const puttCount = rows.filter((r) => isPuttShot(r.lieType)).length
         // Materialize the synthetic hole if needed before upserting the
         // hole_score (FK to holes.id). The RPC inserts only (course_id,
         // number, par, stroke_index) — per-round tee/pin overrides


### PR DESCRIPTION
Mobile port of the web "how'd it go?" hole summary (#791), in lock-step with #795. **Stacked on #795** (base = `feature/web-hole-summary-v2`) — merge that first.

## What changes for the player
During a live round, each shot is now logged **location-only** — mark ball → set/skip aim → it saves and loops straight to the next ball. No per-shot detail modal, no on-green "are you putting?" prompt. At **Finish hole**, the ported `HoleReviewSheet` opens: confirm every shot's club / lie / result + putt read (break / speed / on-demand aimer), edit score/putts/penalties, save → advance. Details are captured once, at the end, instead of interrupting pace of play.

## How the save reconciles (the careful part)
Shots are already durably queued per-shot (`pending_shots`, client-generated id, idempotent sync upsert on `id`). The EOH save **attaches metadata to those existing shots** rather than recreating them: each reviewed row pairs back to its live shot by `shot_number`, so the client id + live-captured aim carry through, and the merged payload is re-queued → the next sync **updates the same server row**.

This deliberately differs from web's delete-then-reinsert: on mobile there's no offline delete queue, so delete-then-reinsert would strand **duplicate server rows** whenever the save happens offline. The id-preserving upsert is the offline-safe equivalent. Field-for-field the `shots`/`hole_scores` writes are identical to web's for the same input (verified by a parity audit).

## Review
Ran a 3-agent review (parity / defects+silent-failures / cross-feature seams) + a falsify pass that tried to disprove each finding. Of 11 consolidated claims: 5 phantom (existing guards defeat them), 4 narrowed, 1 real. Fixes shipped in `056d278`:

- **Never fabricate a colliding shot id** — if a reviewed row can't pair to an existing shot (both reads came up empty), the save **aborts loudly and retries** instead of minting a fresh uuid that would 23505 past the sync's `onConflict:'id'` and get silently quarantined. The sheet stays open with edits intact.
- **One-retry on both pairing reads** (mirrors `useHoleData`) so a transient blip doesn't strand a shot on the abort path.
- **`upsertReviewedShot` excludes `broken` rows** from its id lookup.
- **Putt tally counts green-lie shots** (`isPuttShot`) to match the SG putting engine + putt-count readers — web + mobile sheets + web save fallback. The per-row putt-UI gate stays `isPuttEntry` (green + putter), so a bladed-wedge-on-green shows normal-shot UI but still counts as a putt on the scorecard.

## Known limitation (accepted — #226)
The `hole_scores` tally write (incl. **penalties**) is not offline-queued — an offline review save's penalties don't reach the server. Same pre-existing gap as score/putts (score self-repairs at round finalize; penalties don't). Tracked in #226.

## Follow-up (not in this PR)
`ShotLogger` / `PuttingSheet` / the on-green handlers are now unreached in the live flow but left **inert** (minimal, low-risk diff). Removing them is a clean follow-up once this is validated on-device.

## Verification
- mobile typecheck ✓, web typecheck ✓, core 596 tests ✓.
- The sheet's visuals were rendered/screenshotted previously; this PR is state-machine wiring + a native SQLite save path. **Not device-tested** — needs on-device QA.

## On-device QA checklist
- [ ] Play a hole, finish → summary opens with the right shots in order
- [ ] Confirm club/lie/result + a putt's break/speed/aimer → save → advances
- [ ] Reopen the round: stored shots carry the metadata; score/putts/penalties correct
- [ ] Green-lie shot logged with a wedge → shows normal-shot UI, still counts as a putt in the tally
- [ ] Flaky/offline finish → save either succeeds or fails loudly + retries (no silent loss, no duplicate shots)
- [ ] Last hole finish → round finalizes with correct totals/SG (metadata synced before completeRound)
- [ ] "Edit on map" from the summary → returns to the live map, GPS re-arms