### PR TITLE
feature(#791): pre-round capture-mode picker — just-track vs track-patterns (step 3)

### DIFF
--- a/apps/mobile/app/(app)/round/[id]/index.tsx
+++ b/apps/mobile/app/(app)/round/[id]/index.tsx
@@ -18,6 +18,7 @@ import {
   pickRoundFocus,
   roundFocusHeadline,
   selectNudgeDrills,
+  type CaptureMode,
   type RoundFocus,
 } from '@oga/core'
 import {
@@ -364,6 +365,7 @@ export default function RoundIndex() {
         // The LiveRoundSession `mode`/isPastMode plumbing is now dead and can
         // be removed in a follow-up cleanup.
         mode="live"
+        captureMode={(round?.capture_mode ?? 'track_patterns') as CaptureMode}
         onHoleChange={syncHoleToUrl}
       />
     )

--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -12,11 +12,14 @@ import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import * as Location from 'expo-location'
 import {
+  CAPTURE_MODES,
+  CAPTURE_MODE_LABELS,
   formatLocation,
   getOpenGolfApiCourse,
   inferHoleCount,
   searchOpenGolfApi,
   todayLocalDate,
+  type CaptureMode,
   type OpenGolfApiSearchResult,
 } from '@oga/core'
 import {
@@ -182,6 +185,7 @@ export default function NewRound() {
   async function startWith(
     courseId: string,
     tee?: { courseTeeId: string | null; teeColor: string | null },
+    captureMode?: CaptureMode,
   ) {
     if (!user) return
     if (startInFlightRef.current) return
@@ -205,6 +209,9 @@ export default function NewRound() {
         ...(tee?.courseTeeId
           ? { course_tee_id: tee.courseTeeId, tee_color: tee.teeColor }
           : {}),
+        // Capture mode steers the live flow only; past entry keeps the
+        // 'track_patterns' column default.
+        ...(mode === 'live' && captureMode ? { capture_mode: captureMode } : {}),
       })
       if (roundError || !round) throw roundError ?? new Error('Round insert failed')
       createdRoundId = round.id
@@ -423,8 +430,8 @@ export default function NewRound() {
         mode={mode}
         busy={busy}
         onBack={() => setPendingCourse(null)}
-        onStart={(courseTeeId, teeColor) =>
-          startWith(pendingCourse.id, { courseTeeId, teeColor })
+        onStart={(courseTeeId, teeColor, captureMode) =>
+          startWith(pendingCourse.id, { courseTeeId, teeColor }, captureMode)
         }
       />
     )
@@ -609,11 +616,16 @@ function RoundSetupStep({
   mode: 'live' | 'past'
   busy: boolean
   onBack: () => void
-  onStart: (courseTeeId: string | null, teeColor: string | null) => void
+  onStart: (
+    courseTeeId: string | null,
+    teeColor: string | null,
+    captureMode: CaptureMode,
+  ) => void
 }) {
   const insets = useSafeAreaInsets()
   const [teeId, setTeeId] = useState<string | null>(null)
   const [teeColor, setTeeColor] = useState<string | null>(null)
+  const [captureMode, setCaptureMode] = useState<CaptureMode>('track_patterns')
 
   return (
     <View
@@ -637,13 +649,57 @@ function RoundSetupStep({
         {courseName}
       </Text>
 
-      <Text style={{ ...KICKER, marginBottom: 4 }}>Tee played</Text>
-      <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 12, marginBottom: 12 }]}>
-        Optional — add the tee's rating and slope for a handicap differential.
-        You can set it later from the scorecard.
-      </Text>
-
       <ScrollView keyboardShouldPersistTaps="handled" style={{ flex: 1 }}>
+        {mode === 'live' && (
+          <View style={{ marginBottom: 22 }}>
+            <Text style={{ ...KICKER, marginBottom: 8 }}>
+              How do you want to track it?
+            </Text>
+            {CAPTURE_MODES.map((cm) => {
+              const active = captureMode === cm
+              return (
+                <Pressable
+                  key={cm}
+                  onPress={() => setCaptureMode(cm)}
+                  style={{
+                    borderWidth: 1,
+                    borderColor: active ? '#1F3D2C' : '#D9D2BF',
+                    backgroundColor: active ? '#1F3D2C' : '#FBF8F1',
+                    borderRadius: 2,
+                    padding: 14,
+                    marginBottom: 8,
+                  }}
+                >
+                  <Text
+                    style={[TYPE.bodyBold, {
+                      color: active ? '#F2EEE5' : '#1C211C',
+                      fontSize: 15,
+                      fontWeight: '600',
+                      marginBottom: 2,
+                    }]}
+                  >
+                    {CAPTURE_MODE_LABELS[cm].title}
+                  </Text>
+                  <Text
+                    style={[TYPE.body, {
+                      color: active ? '#C7D3C0' : '#8A8B7E',
+                      fontSize: 12,
+                    }]}
+                  >
+                    {CAPTURE_MODE_LABELS[cm].subtitle}
+                  </Text>
+                </Pressable>
+              )
+            })}
+          </View>
+        )}
+
+        <Text style={{ ...KICKER, marginBottom: 4 }}>Tee played</Text>
+        <Text style={[TYPE.body, { color: '#8A8B7E', fontSize: 12, marginBottom: 12 }]}>
+          Optional — add the tee's rating and slope for a handicap differential.
+          You can set it later from the scorecard.
+        </Text>
+
         <TeePicker
           courseId={courseId}
           selectedTeeId={teeId}
@@ -679,7 +735,7 @@ function RoundSetupStep({
           <Text style={[TYPE.body, { color: '#5C6356', fontSize: 13 }]}>Back</Text>
         </Pressable>
         <Pressable
-          onPress={() => onStart(teeId, teeColor)}
+          onPress={() => onStart(teeId, teeColor, captureMode)}
           disabled={busy}
           style={{
             flex: 2,

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -16,6 +16,7 @@ import {
   bearingDegrees,
   buildInitialRows,
   destinationYards,
+  type CaptureMode,
 } from '@oga/core'
 import { getProfile } from '@oga/supabase'
 import { supabase } from '../../lib/supabase'
@@ -55,6 +56,10 @@ interface LiveRoundSessionProps {
   roundId: string | undefined
   initialHoleNumber: number
   mode: 'live' | 'past'
+  // Live capture mode (rounds.capture_mode). 'just_track' saves ball
+  // locations only; 'track_patterns' captures an aim per shot. Defaults to
+  // 'track_patterns' at the call site.
+  captureMode: CaptureMode
   // Called whenever the player navigates to a new hole. The parent uses
   // this to keep the URL in sync (router.setParams) — but never to
   // remount the screen, which is the whole point of this component.
@@ -70,6 +75,7 @@ export default function LiveRoundSession({
   roundId,
   initialHoleNumber,
   mode,
+  captureMode,
   onHoleChange: syncHoleToUrl,
 }: LiveRoundSessionProps) {
   const isPastMode = mode === 'past'
@@ -313,6 +319,7 @@ export default function LiveRoundSession({
     id: roundId,
     user,
     holeNumber,
+    captureMode,
     data,
     state: finalState,
     setLoggerOpen,

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -8,6 +8,7 @@ import {
   inferHoleStats,
   isPuttEntry,
   isPuttShot,
+  type CaptureMode,
   type LieType,
   type ReviewedShotRow,
 } from '@oga/core'
@@ -35,6 +36,10 @@ interface UseShotActionsInput {
   id: string | undefined
   user: User | null
   holeNumber: number
+  // Live capture mode (rounds.capture_mode). In 'just_track', markBallHere
+  // saves the location immediately and never enters SET_AIM; 'track_patterns'
+  // keeps the aim step.
+  captureMode: CaptureMode
   data: UseHoleDataResult
   state: UseHoleStateResult
   // Component-level UI state setters.
@@ -93,6 +98,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     id,
     user,
     holeNumber,
+    captureMode,
     data,
     state,
     setLoggerOpen,
@@ -151,9 +157,13 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
 
   function buildPayload(
     meta: ShotLoggerValue | null,
-    opts?: { forceAim?: boolean },
+    opts?: { forceAim?: boolean; ball?: LatLng },
   ): ShotPayload | null {
-    if (!user || !currentHoleScore || !ball) return null
+    // `ball` state is set async, so a caller that just placed the ball (e.g.
+    // markBallHere in just-track mode) passes it explicitly to avoid reading
+    // the pre-update value out of the closure.
+    const effectiveBall = opts?.ball ?? ball
+    if (!user || !currentHoleScore || !effectiveBall) return null
     const isPutt = isPuttShot(meta?.lieType)
     const pinTarget = roundPin ?? storedPin ?? null
     // Confirm-aim forces persist (the player accepted even an unadjusted
@@ -164,14 +174,16 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       hole_score_id: currentHoleScore.id,
       user_id: user.id,
       shot_number: shotNumber,
-      start_lat: ball.lat,
-      start_lng: ball.lng,
+      start_lat: effectiveBall.lat,
+      start_lng: effectiveBall.lng,
       end_lat: null,
       end_lng: null,
       // Putts leave this null to match the web save path — a putt's
       // "distance to target" is putt_distance_ft, not this column.
       distance_to_target:
-        !isPutt && pinTarget ? Math.round(distanceYards(ball, pinTarget)) : null,
+        !isPutt && pinTarget
+          ? Math.round(distanceYards(effectiveBall, pinTarget))
+          : null,
       // Persist aim only if the player set/dragged it (or explicitly confirmed);
       // an untouched auto-spawn suggestion is dropped so it can't enter the
       // dispersion dataset.
@@ -215,7 +227,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
 
   async function persistShot(
     meta: ShotLoggerValue | null,
-    opts?: { forceAim?: boolean },
+    opts?: { forceAim?: boolean; ball?: LatLng },
   ) {
     if (persistShotInFlightRef.current) return
     const payload = buildPayload(meta, opts)
@@ -440,10 +452,18 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     }
     setBall(ballSnapshot)
     setAim(null)
-    // Every shot goes straight into aiming — the on-green "are you putting?"
-    // prompt was dropped (#791). During play a putt is just another location;
-    // whether it WAS a putt is decided at the end-of-hole review from the
-    // ball's position (green lie → putter), where the break / speed / aimer
+    // Just-track mode (#791 step 3): no aim step. Save the location right away
+    // — passing the fresh ball since setBall hasn't committed — and persistShot
+    // loops back to PLACE_BALL for the next ball. Putt-ness / club / lie are
+    // still decided at the end-of-hole review.
+    if (captureMode === 'just_track') {
+      await persistShot(null, { forceAim: false, ball: ballSnapshot })
+      return
+    }
+    // Track-patterns mode: every shot goes into aiming — the on-green "are you
+    // putting?" prompt was dropped (#791). During play a putt is just another
+    // location; whether it WAS a putt is decided at the end-of-hole review from
+    // the ball's position (green lie → putter), where the break / speed / aimer
     // now live. The aim line auto-spawns to the pin (useHoleState) with a
     // draggable midpoint; "Skip aim" stays in the SET_AIM chrome for a tap-in
     // the player won't bother aiming.

--- a/apps/web/src/pages/rounds/NewRoundPage.tsx
+++ b/apps/web/src/pages/rounds/NewRoundPage.tsx
@@ -262,6 +262,9 @@ function ModeChip({
       }
       style={{
         flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'flex-start',
         textAlign: 'left',
         border: active ? '0.5px solid transparent' : '0.5px solid #E4E4E0',
         borderRadius: 10,

--- a/apps/web/src/pages/rounds/NewRoundPage.tsx
+++ b/apps/web/src/pages/rounds/NewRoundPage.tsx
@@ -1,6 +1,11 @@
 import { useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { todayLocalDate } from '@oga/core'
+import {
+  CAPTURE_MODES,
+  CAPTURE_MODE_LABELS,
+  todayLocalDate,
+  type CaptureMode,
+} from '@oga/core'
 import { CourseSearch } from '../../components/courses/CourseSearch'
 import { TeeSelector } from '../../components/courses/TeeSelector'
 import { useCreateRound } from '../../hooks/useRounds'
@@ -22,6 +27,7 @@ export function NewRoundPage() {
   const [teeColor, setTeeColor] = useState<string>('white')
   const [courseTeeId, setCourseTeeId] = useState<string | null>(null)
   const [mode, setMode] = useState<RoundMode>('past')
+  const [captureMode, setCaptureMode] = useState<CaptureMode>('track_patterns')
   const [error, setError] = useState<string | null>(null)
 
   async function handleSubmit(e: FormEvent) {
@@ -61,6 +67,9 @@ export function NewRoundPage() {
         played_at: playedAt,
         tee_color: teeColor,
         course_tee_id: courseTeeId,
+        // Capture mode only steers the live flow; past-round entry leaves the
+        // column at its 'track_patterns' default.
+        ...(mode === 'live' ? { capture_mode: captureMode } : {}),
       })
       if (!round) throw new Error('Round insert returned no row')
       // Live rounds open the map view directly so the user can start
@@ -108,6 +117,23 @@ export function NewRoundPage() {
             />
           </div>
         </section>
+
+        {mode === 'live' && (
+          <section>
+            <FieldLabel>How do you want to track it?</FieldLabel>
+            <div style={{ display: 'flex', gap: 8 }}>
+              {CAPTURE_MODES.map((cm) => (
+                <ModeChip
+                  key={cm}
+                  active={captureMode === cm}
+                  onClick={() => setCaptureMode(cm)}
+                  title={CAPTURE_MODE_LABELS[cm].title}
+                  subtitle={CAPTURE_MODE_LABELS[cm].subtitle}
+                />
+              ))}
+            </div>
+          </section>
+        )}
 
         <section>
           <FieldLabel>Course</FieldLabel>

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -11,7 +11,12 @@ import { ShareableScorecardCard } from '../../components/round/ShareableScorecar
 import { HoleReviewSheet } from '../../components/round/HoleReviewSheet'
 import { WebPuttingSheet } from '../../components/round/WebPuttingSheet'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
-import { DEFAULT_HANDICAP, haversineYards, inferHoleCount } from '@oga/core'
+import {
+  DEFAULT_HANDICAP,
+  haversineYards,
+  inferHoleCount,
+  type CaptureMode,
+} from '@oga/core'
 import { useAuth } from '../../hooks/useAuth'
 import { useProfile } from '../../hooks/useProfile'
 import { toUserMessage } from '../../lib/errors'
@@ -147,6 +152,7 @@ export function RoundDetailPage() {
     profile,
     data,
     isLiveEntry,
+    captureMode: (round.data?.capture_mode ?? 'track_patterns') as CaptureMode,
     pinOverride,
     teeOverride,
     placedAims,

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -12,6 +12,7 @@ import {
   inferHoleStats,
   isPuttEntry,
   isPuttShot,
+  type CaptureMode,
 } from '@oga/core'
 import type { PlacedPoint } from '../../../components/round/RoundMap'
 import type { ReviewedShotRow } from '../../../components/round/HoleReviewSheet'
@@ -59,6 +60,9 @@ interface UseRoundActionsInput {
    *  map view). Live entry auto-spawns the aim point; past-round review
    *  keeps the explicit aim prompt. Captured once at mount by the page. */
   isLiveEntry: boolean
+  /** Live capture mode (rounds.capture_mode). 'track_patterns' auto-spawns an
+   *  aim per shot; 'just_track' records location only — no aim. */
+  captureMode: CaptureMode
   pinOverride: PlacedPoint | null
   teeOverride: PlacedPoint | null
   placedAims: (PlacedPoint | null)[]
@@ -120,6 +124,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
     profile,
     data,
     isLiveEntry,
+    captureMode,
     pinOverride,
     teeOverride,
     placedAims,
@@ -235,7 +240,11 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
   const pushShotWithAim = useCallback(
     (p: PlacedPoint) => {
       dispatchHoleView({ type: 'PUSH_POINT', point: p, openPuttSheet: false })
-      if (isLiveEntry && effectivePin) {
+      if (isLiveEntry && captureMode === 'just_track') {
+        // Just-track mode records the location only — no aim capture. The
+        // end-of-hole review still infers putts and lets the player fill
+        // club/lie/result; aim is simply never prompted or spawned.
+      } else if (isLiveEntry && effectivePin) {
         dispatchHoleView({
           type: 'SET_AIM',
           index: placedAims.length,
@@ -251,7 +260,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         setAimPromptOpen(true)
       }
     },
-    [isLiveEntry, effectivePin, placedAims.length, dispatchHoleView, setAimPromptOpen],
+    [isLiveEntry, captureMode, effectivePin, placedAims.length, dispatchHoleView, setAimPromptOpen],
   )
 
   const placeHandlers = {

--- a/packages/core/src/__tests__/barrel.test.ts
+++ b/packages/core/src/__tests__/barrel.test.ts
@@ -38,4 +38,16 @@ describe('@oga/core barrel', () => {
     expect(Array.isArray(OgaCore.DEFAULT_BAG)).toBe(true)
     expect(OgaCore.DEFAULT_BAG.length).toBeGreaterThan(0)
   })
+
+  it('exports CAPTURE_MODES as a non-empty array', () => {
+    expect(Array.isArray(OgaCore.CAPTURE_MODES)).toBe(true)
+    expect(OgaCore.CAPTURE_MODES.length).toBeGreaterThan(0)
+  })
+
+  it('exports CAPTURE_MODE_LABELS with a title + subtitle per mode', () => {
+    for (const mode of OgaCore.CAPTURE_MODES) {
+      expect(typeof OgaCore.CAPTURE_MODE_LABELS[mode].title).toBe('string')
+      expect(typeof OgaCore.CAPTURE_MODE_LABELS[mode].subtitle).toBe('string')
+    }
+  })
 })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -211,6 +211,11 @@ export const FACILITIES = ['range', 'short_game', 'putting', 'sim'] as const
 
 export const SHOT_CATEGORIES = ['off_tee', 'approach', 'around_green', 'putting'] as const
 
+// Live-round capture mode (#791 step 3). 'track_patterns' prompts for an
+// explicit aim per shot (dispersion data); 'just_track' records ball
+// locations only — score + GPS distances, no aim. Column: rounds.capture_mode.
+export const CAPTURE_MODES = ['just_track', 'track_patterns'] as const
+
 // ---------------------------------------------------------------------------
 // Display label maps. Stored values stay snake_case + lowercase so the DB
 // constraints don't break; render code looks the labels up here so the UI
@@ -229,6 +234,18 @@ export type SkillLevel = (typeof SKILL_LEVELS)[number]
 export type Goal = (typeof GOALS)[number]
 export type Facility = (typeof FACILITIES)[number]
 export type ShotCategory = (typeof SHOT_CATEGORIES)[number]
+export type CaptureMode = (typeof CAPTURE_MODES)[number]
+
+export const CAPTURE_MODE_LABELS: Record<CaptureMode, { title: string; subtitle: string }> = {
+  just_track: {
+    title: 'Just track my round',
+    subtitle: 'Score + GPS distances. Fastest — tap where the ball is, keep moving.',
+  },
+  track_patterns: {
+    title: 'Track shot patterns',
+    subtitle: 'Set an aim per shot to build your dispersion data.',
+  },
+}
 
 // LegacyPuttResultKey mirrors LegacyPuttResult in types.ts (which can't
 // import from this file without a cycle); the union duplication locks

--- a/packages/supabase/src/queries/rounds.ts
+++ b/packages/supabase/src/queries/rounds.ts
@@ -11,7 +11,7 @@ type RoundUpdate = Database['public']['Tables']['rounds']['Update']
 // no longer ships every audit column for every shot in every round.
 // Single literal so supabase-js's select-type inference doesn't collapse
 // to GenericStringError.
-const ROUND_COLUMNS = 'id, user_id, course_id, played_at, tee_color, total_score, total_putts, fairways_hit, fairways_total, gir, sg_off_tee, sg_approach, sg_around_green, sg_putting, sg_total, course_tee_id, score_differential' as const
+const ROUND_COLUMNS = 'id, user_id, course_id, played_at, tee_color, total_score, total_putts, fairways_hit, fairways_total, gir, sg_off_tee, sg_approach, sg_around_green, sg_putting, sg_total, course_tee_id, score_differential, capture_mode' as const
 
 export function getRounds(client: OgaSupabaseClient, userId: string, limit = 20) {
   return client

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -461,6 +461,7 @@ export type Database = {
       }
       rounds: {
         Row: {
+          capture_mode: string
           completed_at: string | null
           course_id: string
           course_tee_id: string | null
@@ -484,6 +485,7 @@ export type Database = {
           user_id: string
         }
         Insert: {
+          capture_mode?: string
           completed_at?: string | null
           course_id: string
           course_tee_id?: string | null
@@ -507,6 +509,7 @@ export type Database = {
           user_id: string
         }
         Update: {
+          capture_mode?: string
           completed_at?: string | null
           course_id?: string
           course_tee_id?: string | null

--- a/supabase/migrations/0042_round_capture_mode.sql
+++ b/supabase/migrations/0042_round_capture_mode.sql
@@ -1,0 +1,8 @@
+-- Per-round capture mode for the live-round flow (#791 step 3).
+-- 'track_patterns' captures an explicit aim per shot for the dispersion
+-- dataset; 'just_track' records ball locations only (score + GPS distances),
+-- no aim prompt. Default 'track_patterns' preserves the behavior every round
+-- created before the picker shipped.
+alter table public.rounds
+  add column capture_mode text not null default 'track_patterns'
+  check (capture_mode in ('just_track', 'track_patterns'));


### PR DESCRIPTION
**#791 live-round redesign — Step 3.** Pre-round capture-mode picker, web + mobile in lock-step.

> [!WARNING]
> **Blocks-prod: apply migration `0042` to prod BEFORE (or atomically with) the web deploy + mobile OTA.**
> `ROUND_COLUMNS` now selects `capture_mode`, so `getRounds` / `getRound` / `getRoundsWithDetails` (rounds list, round detail, stats) reference the column, and the live-round insert paths write it. Against a prod DB without `0042`: those reads 400 ("column does not exist") and live-round creation 400s (past rounds are unaffected — they omit the column). Mobile reads via `select('*')` degrade gracefully to the `track_patterns` fallback, but **writes and explicit-column reads hard-fail** — so the migration must land first. Dev is already consistent (0042 applied via MCP).

New per-round column `rounds.capture_mode` (`'just_track' | 'track_patterns'`, default `'track_patterns'`) gates aim capture in the live flow:

- **`track_patterns`** (default) — unchanged behavior: an aim is spawned/prompted per shot for the dispersion dataset.
- **`just_track`** — records ball locations only (score + GPS distances). No aim step. Putt-ness, club, lie, and result are still filled in at the end-of-hole review.

### Changes
- **DB:** migration `0042_round_capture_mode.sql` — applied to **dev** (MCP); prod push deferred to the dev→main release (see warning above). Column added to `ROUND_COLUMNS` + hand-added to generated types (matches the 0040 precedent).
- **Core:** `CAPTURE_MODES`, `CaptureMode`, `CAPTURE_MODE_LABELS` in `constants.ts`.
- **Web:** Live-only picker in `NewRoundPage` writes `capture_mode`; `RoundDetailPage` reads it and passes to `useRoundActions`, which skips the aim spawn/prompt in `just_track`. `ModeChip` content top-aligned so uneven-length chips line up.
- **Mobile:** Live-only picker in `RoundSetupStep` writes `capture_mode`; `LiveRoundSession` threads it to `useShotActions`, whose `markBallHere` saves the location immediately and skips `SET_AIM` in `just_track`. `persistShot`/`buildPayload` gained an explicit `ball` arg so the immediate save doesn't read the pre-update `ball` state out of the closure.

The picker shows only for **Live** rounds on both platforms; past-round entry leaves the column at its default.

### Seam audit (post-implementation)
Traced every seam the diff opened — all sound: web no-aim shot persists (aim null-coalesced at save), mobile immediate-persist numbers correctly (`persistShotInFlightRef` blocks double-fire), the dropped on-green/aim dialogs are inert so `markBallHere` is the sole SET_AIM entry (no double-persist), mobile reads `capture_mode` via `select('*')`, and both platforms share the `@oga/core` labels + default. Only material item = the release-ordering warning above.

### Verification
- `pnpm typecheck` (web + core + supabase) ✅
- `npm run typecheck` (mobile) ✅
- `pnpm test` — 596/596 ✅
- Web picker render verified (Playwright screenshot, dev fixture)

### Needs on-device / browser QA
- Web: New round → Live → picker renders, both modes; just_track live round places shots with no aim UI; track_patterns unchanged.
- Mobile: same, plus confirm just_track `markBallHere` persists each ball and loops back to PLACE_BALL (no SET_AIM), and the end-of-hole review still works. (No RN render path — needs an EAS build / simulator.)

Deferred to the release PR: prod `db push` of 0042 **first**, then the closing keyword.