### PR TITLE
fix(learn): add missing review footer to Strokes Gained + Benchmarks (both platforms)

### DIFF
--- a/apps/mobile/components/learn/articles/Benchmarks.tsx
+++ b/apps/mobile/components/learn/articles/Benchmarks.tsx
@@ -7,7 +7,7 @@ import {
   type DetailedStats,
 } from '@oga/core'
 import { getProfile, getRoundsWithDetails } from '@oga/supabase'
-import { ArticleHeader, C, Link, P, Sources, Subhead } from '../primitives'
+import { ArticleFooter, ArticleHeader, C, Link, P, Sources, Subhead } from '../primitives'
 import { FONT } from '../../../lib/typography'
 import { supabase } from '../../../lib/supabase'
 import { useAuth } from '../../../hooks/useAuth'
@@ -278,6 +278,8 @@ export function BenchmarksArticle() {
           },
         ]}
       />
+
+      <ArticleFooter>Last reviewed July 2026</ArticleFooter>
     </View>
   )
 }

--- a/apps/mobile/components/learn/articles/StrokesGained.tsx
+++ b/apps/mobile/components/learn/articles/StrokesGained.tsx
@@ -1,6 +1,7 @@
 import { Text, View } from 'react-native'
 import { FONT } from '../../../lib/typography'
 import {
+  ArticleFooter,
   ArticleHeader,
   C,
   DefRow,
@@ -88,6 +89,8 @@ export function StrokesGainedArticle() {
           },
         ]}
       />
+
+      <ArticleFooter>Last reviewed July 2026</ArticleFooter>
     </View>
   )
 }

--- a/apps/web/src/pages/learn/articles/ReadingStatsArticle.tsx
+++ b/apps/web/src/pages/learn/articles/ReadingStatsArticle.tsx
@@ -53,7 +53,26 @@ export function ReadingStatsArticle() {
       </h2>
       <BenchmarkBody me={me} />
       <Sources />
+      <Footer />
     </article>
+  )
+}
+
+function Footer() {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 1.6,
+      }}
+    >
+      Last reviewed July 2026
+    </div>
   )
 }
 

--- a/apps/web/src/pages/learn/articles/StrokesGainedArticle.tsx
+++ b/apps/web/src/pages/learn/articles/StrokesGainedArticle.tsx
@@ -92,7 +92,26 @@ export function StrokesGainedArticle() {
       <SGCategoriesTable />
 
       <Sources />
+      <Footer />
     </article>
+  )
+}
+
+function Footer() {
+  return (
+    <div
+      className="font-mono uppercase text-caddie-ink-mute"
+      style={{
+        fontSize: 10,
+        letterSpacing: '0.14em',
+        borderTop: '1px solid #D9D2BF',
+        paddingTop: 18,
+        marginTop: 22,
+        lineHeight: 1.6,
+      }}
+    >
+      Last reviewed July 2026
+    </div>
   )
 }
 


### PR DESCRIPTION
Surfaced during on-device QA of the preview build: the **Strokes Gained** and **Benchmarks / Stats** Learn articles lacked the `Last reviewed July 2026` footer that the other 18 articles carry — on both platforms.

- **Web:** `StrokesGainedArticle`, `ReadingStatsArticle` (id=`benchmarks`) → local `Footer()` matching peers.
- **Mobile:** `StrokesGained`, `Benchmarks` → shared `<ArticleFooter>` from primitives.
- **Docs mirrors** already carry `last_reviewed: 2026-07` frontmatter — no change.

Additive/static; typecheck green both platforms. Ships with the dev→main release.