### PR TITLE
chore(mobile): bump version 1.0.1 → 1.1.0

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -8,7 +8,7 @@ const config: ExpoConfig = {
   name: 'OGA',
   slug: 'oga',
   scheme: 'oga',
-  version: '1.0.1',
+  version: '1.1.0',
   // EAS Update (OTA). Ships JS/asset-only fixes to installed builds WITHOUT an
   // App Store / Play review — Apple/Google permit interpreted-code updates that
   // don't add native code or change the app's purpose. Native changes (SDK/RN


### PR DESCRIPTION
App Store won't let us re-release `1.0.1`, so this feature release (#791 Steps 3–4 — capture-mode picker + green rework) needs a new version.

- `app.config.ts` version → `1.1.0`.
- `appVersion` runtimeVersion policy moves the OTA runtime to `1.1.0` too — correct for a new user-facing release; rebuilding **both** platforms keeps their runtimes aligned.
- Build numbers (versionCode/buildNumber) stay EAS-`autoIncrement`-managed.

Supersedes the two 1.0.1 prod builds cut earlier (don't submit those).