### PR TITLE
Release: bump version to 1.1.0

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -8,7 +8,7 @@ const config: ExpoConfig = {
   name: 'OGA',
   slug: 'oga',
   scheme: 'oga',
-  version: '1.0.1',
+  version: '1.1.0',
   // EAS Update (OTA). Ships JS/asset-only fixes to installed builds WITHOUT an
   // App Store / Play review — Apple/Google permit interpreted-code updates that
   // don't add native code or change the app's purpose. Native changes (SDK/RN


### PR DESCRIPTION
Version bump only (`app.config.ts` 1.0.1 → 1.1.0) so the App Store accepts this feature release as a new version. Follows the #791 Steps 3–4 release (#810). Both prod builds re-cut at 1.1.0 after this merges.