### PR TITLE
feature(web): app-like mobile shell — bottom tab bar + top bar (phase 1)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@marsidev/react-turnstile": "^1.5.2",
+    "@mdi/js": "^7.4.47",
     "@oga/core": "workspace:*",
     "@oga/supabase": "workspace:*",
     "@supabase/supabase-js": "^2.45.0",

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useLocation } from 'react-router-dom'
 import { Sidebar } from './Sidebar'
+import { MobileTabBar } from './MobileTabBar'
 
 export function AppShell({ children }: { children: ReactNode }) {
   const [drawerOpen, setDrawerOpen] = useState(false)
@@ -43,9 +44,39 @@ export function AppShell({ children }: { children: ReactNode }) {
         <Sidebar />
       </div>
 
+      {/* Mobile top bar — brand + menu (opens the same drawer). Fixed so it
+          stays on scroll; hidden on md+ where the sidebar takes over. */}
+      <div
+        className="md:hidden fixed top-0 left-0 right-0 z-30 bg-caddie-surface flex items-center justify-between"
+        style={{ height: 52, borderBottom: '1px solid #D9D2BF', paddingInline: 16 }}
+      >
+        <div
+          className="font-serif text-caddie-ink"
+          style={{ fontSize: 20, fontWeight: 500, fontStyle: 'italic' }}
+        >
+          oga<span style={{ fontStyle: 'normal', color: '#1F3D2C' }}>.</span>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDrawerOpen(true)}
+          aria-label="Open menu"
+          className="font-mono uppercase text-caddie-ink"
+          style={{
+            border: '1px solid #D9D2BF',
+            borderRadius: 2,
+            padding: '7px 10px',
+            fontSize: 11,
+            letterSpacing: '0.14em',
+            fontWeight: 600,
+          }}
+        >
+          ☰ Menu
+        </button>
+      </div>
+
       <main
         ref={mainRef}
-        className="flex-1 overflow-y-auto"
+        className="flex-1 overflow-y-auto pt-[52px] md:pt-0"
         style={{ paddingInline: 'clamp(16px, 4vw, 32px)' }}
       >
         <div
@@ -58,25 +89,6 @@ export function AppShell({ children }: { children: ReactNode }) {
             paddingBlock: 'clamp(18px, 3vw, 28px)',
           }}
         >
-          <button
-            type="button"
-            onClick={() => setDrawerOpen(true)}
-            aria-label="Open menu"
-            className="md:hidden self-start"
-            style={{
-              background: 'transparent',
-              border: '1px solid #D9D2BF',
-              borderRadius: 2,
-              padding: '8px 10px',
-              fontSize: 12,
-              letterSpacing: '0.14em',
-              fontWeight: 600,
-              color: '#1C211C',
-              marginBottom: 16,
-            }}
-          >
-            ☰ MENU
-          </button>
           <div style={{ flex: 1 }}>{children}</div>
           <footer
             className="font-mono uppercase text-caddie-ink-mute"
@@ -117,8 +129,14 @@ export function AppShell({ children }: { children: ReactNode }) {
             </a>{' '}
             contributors (ODbL)
           </footer>
+          {/* Clears the fixed bottom tab bar (mobile only). */}
+          <div
+            className="md:hidden"
+            style={{ height: 'calc(56px + env(safe-area-inset-bottom, 0px))' }}
+          />
         </div>
       </main>
+      <MobileTabBar />
     </div>
   )
 }

--- a/apps/web/src/components/layout/MobileTabBar.tsx
+++ b/apps/web/src/components/layout/MobileTabBar.tsx
@@ -28,7 +28,9 @@ const svg = (children: React.ReactNode) => (
 const HomeIcon = (_: IconProps) => svg(<><path d="M3 10.5 12 3l9 7.5" /><path d="M5 9.5V21h14V9.5" /></>)
 const StatsIcon = (_: IconProps) => svg(<><path d="M4 5v14h16" /><path d="m7 14 3-4 3 3 4-6" /></>)
 const PatternsIcon = (_: IconProps) => svg(<><circle cx="12" cy="12" r="8" /><circle cx="12" cy="12" r="3.4" /><circle cx="12" cy="12" r="0.6" fill="currentColor" /></>)
-const PracticeIcon = (_: IconProps) => svg(<><path d="M6 21V3" /><path d="M6 4h11l-3 3 3 3H6" /></>)
+// Golf ball on a tee (matches the native app's MDI golf-tee tab icon): ball on
+// top, a cupped tee cradling it, tapering to a point.
+const PracticeIcon = (_: IconProps) => svg(<><circle cx="12" cy="6.5" r="3" /><path d="M9.2 10c.5 1.2 1.6 1.9 2.8 1.9s2.3-.7 2.8-1.9" /><path d="M10.8 12 12 20l1.2-8" /></>)
 const ProfileIcon = (_: IconProps) => svg(<><circle cx="12" cy="8" r="4" /><path d="M4.5 20.5c1-3.6 4-5.5 7.5-5.5s6.5 1.9 7.5 5.5" /></>)
 
 const tabs: { to: string; label: string; Icon: (p: IconProps) => React.ReactNode; end?: boolean }[] = [

--- a/apps/web/src/components/layout/MobileTabBar.tsx
+++ b/apps/web/src/components/layout/MobileTabBar.tsx
@@ -1,0 +1,85 @@
+import { NavLink } from 'react-router-dom'
+
+// Phase 1 of the mobile-web redesign: on phone viewports the desktop sidebar is
+// replaced by this fixed bottom tab bar, mirroring the native app's five tabs
+// (Home / Stats / Patterns / Practice / Profile). Secondary routes (Rounds,
+// Learn, My Bag, Settings) stay reachable via the top-bar menu until Phase 2
+// folds them into the Home + Profile pages. Hidden on md+ (desktop keeps the
+// sidebar).
+
+type IconProps = { active: boolean }
+
+const svg = (children: React.ReactNode) => (
+  <svg
+    width={22}
+    height={22}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.6}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    {children}
+  </svg>
+)
+
+const HomeIcon = (_: IconProps) => svg(<><path d="M3 10.5 12 3l9 7.5" /><path d="M5 9.5V21h14V9.5" /></>)
+const StatsIcon = (_: IconProps) => svg(<><path d="M4 5v14h16" /><path d="m7 14 3-4 3 3 4-6" /></>)
+const PatternsIcon = (_: IconProps) => svg(<><circle cx="12" cy="12" r="8" /><circle cx="12" cy="12" r="3.4" /><circle cx="12" cy="12" r="0.6" fill="currentColor" /></>)
+const PracticeIcon = (_: IconProps) => svg(<><path d="M6 21V3" /><path d="M6 4h11l-3 3 3 3H6" /></>)
+const ProfileIcon = (_: IconProps) => svg(<><circle cx="12" cy="8" r="4" /><path d="M4.5 20.5c1-3.6 4-5.5 7.5-5.5s6.5 1.9 7.5 5.5" /></>)
+
+const tabs: { to: string; label: string; Icon: (p: IconProps) => React.ReactNode; end?: boolean }[] = [
+  { to: '/dashboard', label: 'Home', Icon: HomeIcon, end: true },
+  { to: '/stats', label: 'Stats', Icon: StatsIcon },
+  { to: '/patterns', label: 'Patterns', Icon: PatternsIcon },
+  { to: '/practice', label: 'Practice', Icon: PracticeIcon },
+  // Profile maps to Settings (the native "Profile" tab is the account/settings
+  // area). No `end`, so /settings/bag also keeps Profile lit.
+  { to: '/settings', label: 'Profile', Icon: ProfileIcon },
+]
+
+export function MobileTabBar() {
+  return (
+    <nav
+      aria-label="Primary"
+      className="md:hidden fixed bottom-0 left-0 right-0 z-30 bg-caddie-surface"
+      style={{
+        borderTop: '1px solid #D9D2BF',
+        display: 'flex',
+        // Respect the iOS/Android home-indicator inset in mobile browsers.
+        paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+      }}
+    >
+      {tabs.map(({ to, label, Icon, end }) => (
+        <NavLink
+          key={to}
+          to={to}
+          end={end}
+          aria-label={label}
+          className={({ isActive }) =>
+            [
+              'flex flex-1 flex-col items-center justify-center transition-colors',
+              isActive ? 'text-caddie-accent' : 'text-caddie-ink-mute',
+            ].join(' ')
+          }
+          style={{ gap: 3, paddingTop: 8, paddingBottom: 8, minHeight: 56 }}
+        >
+          {({ isActive }) => (
+            <>
+              <Icon active={isActive} />
+              <span
+                className="font-mono uppercase"
+                style={{ fontSize: 9, letterSpacing: '0.1em', fontWeight: isActive ? 600 : 500 }}
+              >
+                {label}
+              </span>
+            </>
+          )}
+        </NavLink>
+      ))}
+    </nav>
+  )
+}

--- a/apps/web/src/components/layout/MobileTabBar.tsx
+++ b/apps/web/src/components/layout/MobileTabBar.tsx
@@ -1,46 +1,38 @@
 import { NavLink } from 'react-router-dom'
+import {
+  mdiHomeOutline,
+  mdiChartLine,
+  mdiTargetVariant,
+  mdiGolfTee,
+  mdiAccountCircleOutline,
+} from '@mdi/js'
 
 // Phase 1 of the mobile-web redesign: on phone viewports the desktop sidebar is
-// replaced by this fixed bottom tab bar, mirroring the native app's five tabs
-// (Home / Stats / Patterns / Practice / Profile). Secondary routes (Rounds,
+// replaced by this fixed bottom tab bar, mirroring the native app's five tabs.
+// Icons are the SAME Material Community Icons the native app renders via
+// @expo/vector-icons (home-outline / chart-line / target-variant / golf-tee /
+// account-circle-outline) — pulled here as SVG path data from @mdi/js so the
+// two platforms draw identical glyphs with no drift. Secondary routes (Rounds,
 // Learn, My Bag, Settings) stay reachable via the top-bar menu until Phase 2
 // folds them into the Home + Profile pages. Hidden on md+ (desktop keeps the
 // sidebar).
 
-type IconProps = { active: boolean }
+function MdiIcon({ path }: { path: string }) {
+  return (
+    <svg width={24} height={24} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d={path} />
+    </svg>
+  )
+}
 
-const svg = (children: React.ReactNode) => (
-  <svg
-    width={22}
-    height={22}
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.6}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    aria-hidden="true"
-  >
-    {children}
-  </svg>
-)
-
-const HomeIcon = (_: IconProps) => svg(<><path d="M3 10.5 12 3l9 7.5" /><path d="M5 9.5V21h14V9.5" /></>)
-const StatsIcon = (_: IconProps) => svg(<><path d="M4 5v14h16" /><path d="m7 14 3-4 3 3 4-6" /></>)
-const PatternsIcon = (_: IconProps) => svg(<><circle cx="12" cy="12" r="8" /><circle cx="12" cy="12" r="3.4" /><circle cx="12" cy="12" r="0.6" fill="currentColor" /></>)
-// Golf ball on a tee (matches the native app's MDI golf-tee tab icon): ball on
-// top, a cupped tee cradling it, tapering to a point.
-const PracticeIcon = (_: IconProps) => svg(<><circle cx="12" cy="6.5" r="3" /><path d="M9.2 10c.5 1.2 1.6 1.9 2.8 1.9s2.3-.7 2.8-1.9" /><path d="M10.8 12 12 20l1.2-8" /></>)
-const ProfileIcon = (_: IconProps) => svg(<><circle cx="12" cy="8" r="4" /><path d="M4.5 20.5c1-3.6 4-5.5 7.5-5.5s6.5 1.9 7.5 5.5" /></>)
-
-const tabs: { to: string; label: string; Icon: (p: IconProps) => React.ReactNode; end?: boolean }[] = [
-  { to: '/dashboard', label: 'Home', Icon: HomeIcon, end: true },
-  { to: '/stats', label: 'Stats', Icon: StatsIcon },
-  { to: '/patterns', label: 'Patterns', Icon: PatternsIcon },
-  { to: '/practice', label: 'Practice', Icon: PracticeIcon },
+const tabs: { to: string; label: string; icon: string; end?: boolean }[] = [
+  { to: '/dashboard', label: 'Home', icon: mdiHomeOutline, end: true },
+  { to: '/stats', label: 'Stats', icon: mdiChartLine },
+  { to: '/patterns', label: 'Patterns', icon: mdiTargetVariant },
+  { to: '/practice', label: 'Practice', icon: mdiGolfTee },
   // Profile maps to Settings (the native "Profile" tab is the account/settings
   // area). No `end`, so /settings/bag also keeps Profile lit.
-  { to: '/settings', label: 'Profile', Icon: ProfileIcon },
+  { to: '/settings', label: 'Profile', icon: mdiAccountCircleOutline },
 ]
 
 export function MobileTabBar() {
@@ -55,7 +47,7 @@ export function MobileTabBar() {
         paddingBottom: 'env(safe-area-inset-bottom, 0px)',
       }}
     >
-      {tabs.map(({ to, label, Icon, end }) => (
+      {tabs.map(({ to, label, icon, end }) => (
         <NavLink
           key={to}
           to={to}
@@ -71,7 +63,7 @@ export function MobileTabBar() {
         >
           {({ isActive }) => (
             <>
-              <Icon active={isActive} />
+              <MdiIcon path={icon} />
               <span
                 className="font-mono uppercase"
                 style={{ fontSize: 9, letterSpacing: '0.1em', fontWeight: isActive ? 600 : 500 }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@marsidev/react-turnstile':
         specifier: ^1.5.2
         version: 1.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mdi/js':
+        specifier: ^7.4.47
+        version: 7.4.47
       '@oga/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -780,6 +783,9 @@ packages:
     peerDependencies:
       react: ^17.0.2 || ^18.0.0 || ^19.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0
+
+  '@mdi/js@7.4.47':
+    resolution: {integrity: sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2961,6 +2967,8 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@mdi/js@7.4.47': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
**Phase 1** of the mobile-web redesign (app-like responsive web). On **phone viewports** (`md-`), the desktop sidebar is replaced by a native-style shell; **desktop is unchanged** (every new element is `md:hidden`-gated).

### Changes
- **New `MobileTabBar`** — fixed bottom tab bar mirroring the native app's five tabs: **Home** (`/dashboard`), **Stats** (`/stats`), **Patterns** (`/patterns`), **Practice** (`/practice`), **Profile** (`/settings`), with hand-authored inline-SVG icons (no icon-lib dependency) + labels + active state. Safe-area-inset aware.
- **`AppShell`** — adds a slim fixed **mobile top bar** (`oga.` brand + a menu button that opens the *existing* drawer), pads `main` for the two bars, removes the old in-content hamburger.
- Secondary routes (Rounds, Learn, My Bag, Settings) stay reachable via the top-bar menu → drawer for now; **Phase 2** folds them into the Home + Profile pages, **Phase 3** adds GPS to the mobile-web live round.

### Verification
- `pnpm --filter @oga/web typecheck` ✅
- Render-verified at a 390×844 mobile viewport (signed-in): top bar + 5-tab bottom bar, active state tracks route (Home→Stats). Screenshots in the PR thread.

Desktop sidebar untouched.