### PR TITLE
feature(course-data): course summary columns + needs_remap flag (migration 0043)

### DIFF
--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -117,33 +117,45 @@ export type Database = {
           created_at: string
           created_by: string | null
           external_id: string | null
+          hole_count: number | null
           id: string
           lat: number | null
           lng: number | null
           name: string
+          needs_remap: boolean
           state: string | null
+          total_par: number | null
+          total_yards: number | null
         }
         Insert: {
           city?: string | null
           created_at?: string
           created_by?: string | null
           external_id?: string | null
+          hole_count?: number | null
           id?: string
           lat?: number | null
           lng?: number | null
           name: string
+          needs_remap?: boolean
           state?: string | null
+          total_par?: number | null
+          total_yards?: number | null
         }
         Update: {
           city?: string | null
           created_at?: string
           created_by?: string | null
           external_id?: string | null
+          hole_count?: number | null
           id?: string
           lat?: number | null
           lng?: number | null
           name?: string
+          needs_remap?: boolean
           state?: string | null
+          total_par?: number | null
+          total_yards?: number | null
         }
         Relationships: [
           {
@@ -249,9 +261,9 @@ export type Database = {
           hole_id: string
           id: string
           par: number | null
+          penalties: number
           pin_lat: number | null
           pin_lng: number | null
-          penalties: number
           putts: number | null
           round_id: string
           score: number
@@ -266,9 +278,9 @@ export type Database = {
           hole_id: string
           id?: string
           par?: number | null
+          penalties?: number
           pin_lat?: number | null
           pin_lng?: number | null
-          penalties?: number
           putts?: number | null
           round_id: string
           score: number
@@ -283,9 +295,9 @@ export type Database = {
           hole_id?: string
           id?: string
           par?: number | null
+          penalties?: number
           pin_lat?: number | null
           pin_lng?: number | null
-          penalties?: number
           putts?: number | null
           round_id?: string
           score?: number
@@ -732,11 +744,15 @@ export type Database = {
           created_at: string
           created_by: string | null
           external_id: string | null
+          hole_count: number | null
           id: string
           lat: number | null
           lng: number | null
           name: string
+          needs_remap: boolean
           state: string | null
+          total_par: number | null
+          total_yards: number | null
         }[]
         SetofOptions: {
           from: "*"

--- a/supabase/migrations/0043_course_summary_columns.sql
+++ b/supabase/migrations/0043_course_summary_columns.sql
@@ -1,0 +1,27 @@
+-- Course summary columns: derived hole_count / total_par / total_yards, plus a
+-- needs_remap flag for under-mapped courses. The three summaries are derived
+-- deterministically from holes here; needs_remap is set by a separate one-off
+-- backfill against validated hole counts (external data, not reproducible here).
+
+alter table public.courses
+  add column if not exists hole_count  integer,
+  add column if not exists total_par   integer,
+  add column if not exists total_yards integer,
+  add column if not exists needs_remap boolean not null default false;
+
+-- Deterministic backfill from holes. total_yards is only meaningful when every
+-- hole carries a yardage, so leave it null if any hole is missing one.
+update public.courses c
+set hole_count  = h.cnt,
+    total_par   = h.par_sum,
+    total_yards = case when h.yards_missing = 0 then h.yards_sum else null end
+from (
+  select course_id,
+         count(*)                              as cnt,
+         sum(par)                              as par_sum,
+         sum(yards)                            as yards_sum,
+         count(*) filter (where yards is null) as yards_missing
+  from public.holes
+  group by course_id
+) h
+where c.id = h.course_id;


### PR DESCRIPTION
## What

Migration `0043` adds four derived/status columns to `courses`:

- `hole_count`, `total_par`, `total_yards` — derived from `holes` (total_yards null when any hole lacks a yardage)
- `needs_remap boolean` — flags courses whose stored hole count is below their validated real hole count

## Backfill

- **Deterministic summaries** run inside the migration: 9,801 courses got hole_count/total_par, 8,715 got total_yards.
- **needs_remap** set out-of-band from the course-validation dataset (stored hole_count < validated actual_holes, only for courses ≤18 holes so multi-nine facilities are left for their own design): **1,554 flagged** (531 unmapped, 1,023 partial). None are user-round courses.

## State

Already applied to **prod** via `supabase db push` (ledger at 0043; db push is ledger-idempotent so re-pushing is a no-op). This PR lands the migration file + regenerated `packages/supabase/src/types.ts` in the repo so dev/CI carry it too. Types diff is scoped to the four new columns (plus a benign field reorder).