### PR TITLE
feature(web): live-capture onto the mobile map surface

### DIFF
--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -4,9 +4,9 @@ import { MAPBOX_TOKEN_PRESENT } from '../../lib/mapbox'
 import { useMapSetup } from './map/useMapSetup'
 import { useMapLayers, type ClubPick } from './map/useMapLayers'
 
-// Re-export the instruction strip so existing imports
-// (`{ RoundMapInstructionStrip } from '.../RoundMap'`) keep working.
-export { RoundMapInstructionStrip } from './map/RoundMapInstructionStrip'
+// Re-export the map bottom chrome so existing imports
+// (`{ MapBottomChrome } from '.../RoundMap'`) keep working.
+export { MapBottomChrome } from './map/MapBottomChrome'
 
 // Stable no-op default for the optional `selectClub` prop. A module constant so
 // the identity never changes — an inline `() => null` default would be a fresh

--- a/apps/web/src/components/round/map/MapBottomChrome.tsx
+++ b/apps/web/src/components/round/map/MapBottomChrome.tsx
@@ -42,10 +42,106 @@ interface MapBottomChromeProps {
   onDoneEditing?: () => void
 }
 
-// Strip used to live inside the map as an absolute overlay, but the
-// "Done" button kept colliding with Mapbox's zoom controls. It now
-// renders as a separate full-width bar above the map. See MapView in
-// RoundDetailPage for the layout.
+// Map-only dark chrome (see DESIGN.md "Map surface / on-course HUD"). Renders
+// as an absolute, bottom-anchored overlay INSIDE the map box (see MapView) —
+// not a full-width bar above it. The instruction card is pointer-events:none
+// (text only) so taps reach the Mapbox canvas listener underneath; only the
+// button row (and only when a button actually matters) is pointer-events:auto.
+const MAP_DARK = 'rgba(28,33,28,0.82)'
+const MAP_CREAM = '#FBF8F1'
+const FOREST = 'var(--caddie-accent)'
+
+const wrapperStyle = {
+  position: 'absolute' as const,
+  left: 12,
+  right: 12,
+  bottom: 12,
+  display: 'flex' as const,
+  flexDirection: 'column' as const,
+  gap: 9,
+  alignItems: 'center' as const,
+  pointerEvents: 'none' as const,
+  zIndex: 5,
+}
+
+const cardStyle = {
+  pointerEvents: 'none' as const,
+  maxWidth: '92%',
+  background: MAP_DARK,
+  borderRadius: 12,
+  padding: '8px 13px',
+  textAlign: 'center' as const,
+}
+
+const kickerStyle = { color: '#C9C7B8', marginBottom: 2 }
+const bodyStyle = { color: MAP_CREAM, fontSize: 13 }
+const bodyDimStyle = { color: 'rgba(251,248,241,0.68)', fontSize: 12 }
+
+const buttonRowStyle = {
+  pointerEvents: 'auto' as const,
+  display: 'flex' as const,
+  gap: 9,
+  justifyContent: 'center' as const,
+  flexWrap: 'wrap' as const,
+}
+
+const primaryStyle = {
+  pointerEvents: 'auto' as const,
+  background: MAP_CREAM,
+  color: FOREST,
+  border: `1px solid ${FOREST}`,
+  borderRadius: 26,
+  padding: '11px 20px',
+  fontWeight: 700,
+  fontSize: 14,
+  boxShadow: '0 6px 16px rgba(28,33,28,0.25)',
+}
+
+function primaryDisabledStyle(disabled: boolean) {
+  return { ...primaryStyle, opacity: disabled ? 0.5 : 1 }
+}
+
+const secondaryStyle = {
+  pointerEvents: 'auto' as const,
+  background: 'rgba(251,248,241,0.92)',
+  color: 'var(--caddie-ink)',
+  border: '1px solid var(--caddie-line)',
+  borderRadius: 22,
+  padding: '9px 13px',
+  fontSize: 12,
+  fontWeight: 600,
+}
+
+function secondaryDisabledStyle(disabled: boolean) {
+  return { ...secondaryStyle, opacity: disabled ? 0.4 : 1 }
+}
+
+function amberStyle(active: boolean) {
+  return {
+    pointerEvents: 'auto' as const,
+    border: '1px solid var(--caddie-warn)',
+    borderRadius: 22,
+    padding: '9px 13px',
+    fontSize: 12,
+    background: active ? 'var(--caddie-warn)' : 'transparent',
+    color: active ? MAP_CREAM : 'var(--caddie-warn)',
+    fontWeight: 600,
+    letterSpacing: '0.02em',
+  }
+}
+
+const brickStyle = {
+  pointerEvents: 'auto' as const,
+  border: '1px solid var(--caddie-neg)',
+  borderRadius: 22,
+  padding: '9px 13px',
+  fontSize: 12,
+  background: 'transparent',
+  color: 'var(--caddie-neg)',
+  fontWeight: 600,
+  letterSpacing: '0.02em',
+}
+
 export function MapBottomChrome({
   hasExistingShots,
   editing,
@@ -77,42 +173,25 @@ export function MapBottomChrome({
     const targetLabel =
       placementMode === 'tee' ? 'tee box' : 'pin'
     return (
-      <div
-        style={{
-          background: '#FBF8F1',
-          border: '1px solid #D9D2BF',
-          borderRadius: 2,
-          padding: '10px 14px',
-          display: 'flex',
-          gap: 14,
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          flexWrap: 'wrap',
-        }}
-      >
-        <div style={{ minWidth: 200 }}>
-          <div className="kicker" style={{ marginBottom: 2 }}>
+      <div style={wrapperStyle}>
+        <div style={cardStyle}>
+          <div className="kicker" style={kickerStyle}>
             Place {targetLabel}
           </div>
-          <div className="text-caddie-ink" style={{ fontSize: 13 }}>
+          <div style={bodyStyle}>
             Tap to place the {targetLabel}{holeLabel}.
           </div>
         </div>
         {onCancelPlacement && (
-          <button
-            type="button"
-            onClick={onCancelPlacement}
-            className="text-caddie-ink-dim"
-            style={{
-              border: '1px solid #D9D2BF',
-              borderRadius: 2,
-              padding: '6px 10px',
-              fontSize: 12,
-              background: 'transparent',
-            }}
-          >
-            Cancel
-          </button>
+          <div style={buttonRowStyle}>
+            <button
+              type="button"
+              onClick={onCancelPlacement}
+              style={secondaryStyle}
+            >
+              Cancel
+            </button>
+          </div>
         )}
       </div>
     )
@@ -121,55 +200,30 @@ export function MapBottomChrome({
     showPinButton && onStartPlacePin ? (
       <>
         {showPinButton && onStartPlacePin && (
-          <button
-            type="button"
-            onClick={onStartPlacePin}
-            style={{
-              border: '1px solid #A33A2A',
-              borderRadius: 2,
-              padding: '6px 10px',
-              fontSize: 12,
-              background: 'transparent',
-              color: '#A33A2A',
-              fontWeight: 600,
-              letterSpacing: '0.02em',
-            }}
-          >
+          <button type="button" onClick={onStartPlacePin} style={brickStyle}>
             Set pin
           </button>
         )}
       </>
     ) : null
   return (
-    <div
-      style={{
-        background: '#FBF8F1',
-        border: '1px solid #D9D2BF',
-        borderRadius: 2,
-        padding: '10px 14px',
-        display: 'flex',
-        gap: 14,
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        flexWrap: 'wrap',
-      }}
-    >
-      <div style={{ minWidth: 200 }}>
+    <div style={wrapperStyle}>
+      <div style={cardStyle}>
         {editing ? (
           <>
-            <div className="kicker" style={{ marginBottom: 2 }}>
+            <div className="kicker" style={kickerStyle}>
               Edit on map
             </div>
-            <div className="text-caddie-ink" style={{ fontSize: 13 }}>
+            <div style={bodyStyle}>
               Drag any marker to adjust where the shot was hit from.
             </div>
           </>
         ) : hasExistingShots ? (
           <>
-            <div className="kicker" style={{ marginBottom: 2 }}>
+            <div className="kicker" style={kickerStyle}>
               Logged hole
             </div>
-            <div className="text-caddie-ink" style={{ fontSize: 13 }}>
+            <div style={bodyStyle}>
               {shotDragUndoLabel
                 ? `${shotDragUndoLabel} updated.`
                 : 'Drag any marker to adjust its position.'}
@@ -177,23 +231,20 @@ export function MapBottomChrome({
           </>
         ) : aimMode ? (
           <>
-            <div className="kicker" style={{ marginBottom: 2 }}>
+            <div className="kicker" style={kickerStyle}>
               Aim line — shot {shotsPlaced}
             </div>
-            <div className="text-caddie-ink" style={{ fontSize: 13 }}>
+            <div style={bodyStyle}>
               Tap your aim line — where you started shot {shotsPlaced}, not
               where it finished.
             </div>
           </>
         ) : (
           <>
-            <div className="kicker" style={{ marginBottom: 2 }}>
+            <div className="kicker" style={kickerStyle}>
               Tap where you hit shot {placingNumber} from
             </div>
-            <div
-              className="text-caddie-ink-dim"
-              style={{ fontSize: 12 }}
-            >
+            <div style={bodyDimStyle}>
               {shotsPlaced === 0
                 ? 'Start at the tee box.'
                 : `${shotsPlaced} shot${shotsPlaced === 1 ? '' : 's'} placed${
@@ -209,129 +260,75 @@ export function MapBottomChrome({
           </>
         )}
       </div>
-      {editing ? (
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          {placeButtons}
-          <button
-            type="button"
-            onClick={onDoneEditing}
-            className="bg-caddie-accent text-caddie-accent-ink"
-            style={{
-              borderRadius: 2,
-              padding: '6px 12px',
-              fontSize: 13,
-              fontWeight: 600,
-              letterSpacing: '0.02em',
-            }}
-          >
-            Done editing →
-          </button>
-        </div>
-      ) : !hasExistingShots ? (
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          {placeButtons}
-          {onToggleAimMode && shotsPlaced > 0 && (
-            <button
-              type="button"
-              onClick={() => onToggleAimMode(!aimMode)}
-              aria-pressed={aimMode}
-              style={{
-                border: '1px solid #A66A1F',
-                borderRadius: 2,
-                padding: '6px 10px',
-                fontSize: 12,
-                background: aimMode ? '#A66A1F' : 'transparent',
-                color: aimMode ? '#F2EEE5' : '#A66A1F',
-                fontWeight: 600,
-                letterSpacing: '0.02em',
-              }}
-            >
-              {aimMode ? 'Cancel aim' : 'Set aim'}
-            </button>
-          )}
-          {onClearLastAim && aimsSet > 0 && !aimMode && (
-            <button
-              type="button"
-              onClick={onClearLastAim}
-              className="text-caddie-ink-dim"
-              style={{
-                border: '1px solid #D9D2BF',
-                borderRadius: 2,
-                padding: '6px 10px',
-                fontSize: 12,
-                background: 'transparent',
-              }}
-            >
-              Clear aim
-            </button>
-          )}
-          <button
-            type="button"
-            disabled={shotsPlaced === 0}
-            onClick={onUndo}
-            className="text-caddie-ink-dim disabled:opacity-40"
-            style={{
-              border: '1px solid #D9D2BF',
-              borderRadius: 2,
-              padding: '6px 10px',
-              fontSize: 12,
-              background: 'transparent',
-            }}
-          >
-            Undo
-          </button>
-          <button
-            type="button"
-            disabled={shotsPlaced === 0}
-            onClick={onClear}
-            className="text-caddie-ink-dim disabled:opacity-40"
-            style={{
-              border: '1px solid #D9D2BF',
-              borderRadius: 2,
-              padding: '6px 10px',
-              fontSize: 12,
-              background: 'transparent',
-            }}
-          >
-            Clear
-          </button>
-          <button
-            type="button"
-            disabled={shotsPlaced === 0}
-            onClick={onDone}
-            className="bg-caddie-accent text-caddie-accent-ink disabled:opacity-40"
-            style={{
-              borderRadius: 2,
-              padding: '6px 12px',
-              fontSize: 13,
-              fontWeight: 600,
-              letterSpacing: '0.02em',
-            }}
-          >
-            Done with hole →
-          </button>
-        </div>
-      ) : (placeButtons || (shotDragUndoLabel && onApplyShotDragUndo)) ? (
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          {placeButtons}
-          {shotDragUndoLabel && onApplyShotDragUndo && (
-            <button
-              type="button"
-              onClick={onApplyShotDragUndo}
-              className="text-caddie-ink-dim"
-              style={{
-                border: '1px solid #D9D2BF',
-                borderRadius: 2,
-                padding: '6px 10px',
-                fontSize: 12,
-                background: 'transparent',
-              }}
-            >
-              Undo
-            </button>
+      {(shotsPlaced > 0 || editing || placeButtons ||
+        (shotDragUndoLabel && onApplyShotDragUndo)) && (
+        <div style={buttonRowStyle}>
+          {editing ? (
+            <>
+              {placeButtons}
+              <button type="button" onClick={onDoneEditing} style={primaryStyle}>
+                Done editing →
+              </button>
+            </>
+          ) : !hasExistingShots ? (
+            <>
+              {placeButtons}
+              {onToggleAimMode && shotsPlaced > 0 && (
+                <button
+                  type="button"
+                  onClick={() => onToggleAimMode(!aimMode)}
+                  aria-pressed={aimMode}
+                  style={amberStyle(aimMode)}
+                >
+                  {aimMode ? 'Cancel aim' : 'Set aim'}
+                </button>
+              )}
+              {onClearLastAim && aimsSet > 0 && !aimMode && (
+                <button type="button" onClick={onClearLastAim} style={secondaryStyle}>
+                  Clear aim
+                </button>
+              )}
+              <button
+                type="button"
+                disabled={shotsPlaced === 0}
+                onClick={onUndo}
+                style={secondaryDisabledStyle(shotsPlaced === 0)}
+              >
+                Undo
+              </button>
+              <button
+                type="button"
+                disabled={shotsPlaced === 0}
+                onClick={onClear}
+                style={secondaryDisabledStyle(shotsPlaced === 0)}
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                disabled={shotsPlaced === 0}
+                onClick={onDone}
+                style={primaryDisabledStyle(shotsPlaced === 0)}
+              >
+                Done with hole →
+              </button>
+            </>
+          ) : (
+            <>
+              {placeButtons}
+              {shotDragUndoLabel && onApplyShotDragUndo && (
+                <button
+                  type="button"
+                  onClick={onApplyShotDragUndo}
+                  style={secondaryStyle}
+                >
+                  Undo
+                </button>
+              )}
+            </>
           )}
         </div>
-      ) : null}
+      )}
     </div>
   )
 }

--- a/apps/web/src/components/round/map/MapBottomChrome.tsx
+++ b/apps/web/src/components/round/map/MapBottomChrome.tsx
@@ -7,7 +7,7 @@ interface MapBottomChromeProps {
   shotsPlaced: number
   remainingToPin: number | null
   /** Label for the most recent saved-shot drag — when non-null, render
-   *  an Undo button on the logged-hole strip. The parent owns the 5s
+   *  an Undo button on the logged-hole chrome. The parent owns the 5s
    *  fade timer and clears the label by passing null. */
   shotDragUndoLabel?: string | null
   onApplyShotDragUndo?: () => void
@@ -28,7 +28,7 @@ interface MapBottomChromeProps {
    *  round on a geo-anchored hole — shown even when a pin coord already
    *  exists so the player can override a wrong crawled pin. */
   showPinButton?: boolean
-  /** Active manual-placement mode. When set, the strip switches to a
+  /** Active manual-placement mode. When set, the chrome switches to a
    *  "tap to place …" prompt with a Cancel button. */
   placementMode?: 'tee' | 'pin' | null
   onStartPlaceTee?: () => void
@@ -42,8 +42,9 @@ interface MapBottomChromeProps {
   onDoneEditing?: () => void
 }
 
-// Map-only dark chrome (see DESIGN.md "Map surface / on-course HUD"). Renders
-// as an absolute, bottom-anchored overlay INSIDE the map box (see MapView) —
+// Map-only dark chrome — the on-course HUD treatment for surfaces rendered over
+// Mapbox satellite imagery. Renders as an absolute, bottom-anchored overlay
+// INSIDE the map box (see MapView) —
 // not a full-width bar above it. The instruction card is pointer-events:none
 // (text only) so taps reach the Mapbox canvas listener underneath; only the
 // button row (and only when a button actually matters) is pointer-events:auto.

--- a/apps/web/src/components/round/map/MapBottomChrome.tsx
+++ b/apps/web/src/components/round/map/MapBottomChrome.tsx
@@ -1,6 +1,6 @@
 import { useUnits } from '../../../hooks/useUnits'
 
-interface RoundMapInstructionStripProps {
+interface MapBottomChromeProps {
   hasExistingShots: boolean
   /** True while the user is dragging-to-correct from the review sheet. */
   editing?: boolean
@@ -46,7 +46,7 @@ interface RoundMapInstructionStripProps {
 // "Done" button kept colliding with Mapbox's zoom controls. It now
 // renders as a separate full-width bar above the map. See MapView in
 // RoundDetailPage for the layout.
-export function RoundMapInstructionStrip({
+export function MapBottomChrome({
   hasExistingShots,
   editing,
   shotsPlaced,
@@ -69,7 +69,7 @@ export function RoundMapInstructionStrip({
   onClear,
   onDone,
   onDoneEditing,
-}: RoundMapInstructionStripProps) {
+}: MapBottomChromeProps) {
   const placingNumber = shotsPlaced + 1
   const { toDisplay } = useUnits()
   if (placementMode) {

--- a/apps/web/src/components/round/map/useMapSetup.ts
+++ b/apps/web/src/components/round/map/useMapSetup.ts
@@ -75,13 +75,12 @@ export function useMapSetup({
     })
     map.addControl(
       new mapboxgl.AttributionControl({ compact: true }),
-      'bottom-right',
+      'top-left',
     )
-    // Zoom + / – live in the bottom-right corner so they don't fight the
-    // instruction strip across the top of the map.
+    // Zoom +/– and attribution live top-left (top-right = ExpStrokesHud); the chrome owns the bottom.
     map.addControl(
       new mapboxgl.NavigationControl({ showCompass: false }),
-      'bottom-right',
+      'top-left',
     )
     map.on('load', () => setMapLoaded(true))
     mapRef.current = map

--- a/apps/web/src/components/round/map/useMapSetup.ts
+++ b/apps/web/src/components/round/map/useMapSetup.ts
@@ -158,7 +158,7 @@ export function useMapSetup({
     function onClick(e: mapboxgl.MapMouseEvent) {
       // Pin placement wins over every other click outcome — even when shots
       // already exist, the user explicitly entered placement mode from the
-      // strip and the next tap should land the marker. (The tee is no longer
+      // bottom chrome and the next tap should land the marker. (The tee is no longer
       // placed manually — it's derived from the first shot, mirroring mobile.)
       if (placementMode === 'pin' && onMovePin) {
         userPlacedRef.current = true

--- a/apps/web/src/pages/rounds/RoundDetailPage.tsx
+++ b/apps/web/src/pages/rounds/RoundDetailPage.tsx
@@ -42,7 +42,7 @@ export function RoundDetailPage() {
   const [confirmDelete, setConfirmDelete] = useState(false)
   // "Set an aim point?" prompt — opens after every non-putt PUSH_POINT
   // so the player decides explicitly whether this shot has aim data.
-  // Replaces the easy-to-miss "Set aim" button on the strip as the
+  // Replaces the easy-to-miss "Set aim" button on the bottom chrome as the
   // primary aim-collection moment. Putt placements skip it (putts
   // capture aim through the putting sheet's break/aim-offset fields).
   const [aimPromptOpen, setAimPromptOpen] = useState(false)

--- a/apps/web/src/pages/rounds/components/MapView.tsx
+++ b/apps/web/src/pages/rounds/components/MapView.tsx
@@ -7,7 +7,7 @@ import {
 } from '@oga/core'
 import type { Database } from '@oga/supabase'
 import {
-  RoundMapInstructionStrip,
+  MapBottomChrome,
   type ExistingShot,
   type HoleGeo,
   type PlacedPoint,
@@ -267,7 +267,7 @@ export function MapView({
         {/* Left column: controls + per-hole shot list. Below the map on
             narrow screens (map-first), left of it on desktop. */}
         <div className="lg:order-1">
-          <RoundMapInstructionStrip
+          <MapBottomChrome
             hasExistingShots={hasExistingShots}
           editing={editingOnMap}
           shotsPlaced={placedPoints.length}

--- a/apps/web/src/pages/rounds/components/MapView.tsx
+++ b/apps/web/src/pages/rounds/components/MapView.tsx
@@ -267,39 +267,10 @@ export function MapView({
         {/* Left column: controls + per-hole shot list. Below the map on
             narrow screens (map-first), left of it on desktop. */}
         <div className="lg:order-1">
-          <MapBottomChrome
-            hasExistingShots={hasExistingShots}
-          editing={editingOnMap}
-          shotsPlaced={placedPoints.length}
-          remainingToPin={remainingToPin}
-          pinAvailable={effectivePin != null}
-          aimMode={aimMode}
-          aimsSet={placedAims.filter((a) => a != null).length}
-          holeNumber={activeHoleNumber}
-          needsTee={needsTee}
-          showPinButton={showPinButton}
-          placementMode={placementMode}
-          shotDragUndoLabel={shotDragUndoLabel}
-          onApplyShotDragUndo={onApplyShotDragUndo}
-          onStartPlaceTee={handlers.onStartPlaceTee}
-          onStartPlacePin={handlers.onStartPlacePin}
-          onCancelPlacement={handlers.onCancelPlacement}
-          onToggleAimMode={handlers.onToggleAimMode}
-          onClearLastAim={() => {
-            const idx = placedAims.length - 1
-            if (idx >= 0) handlers.onSetAim(idx, null)
-          }}
-          onUndo={handlers.onUndoPoint}
-          onClear={handlers.onClearPoints}
-          onDone={handlers.onDoneWithHole}
-          onDoneEditing={handlers.onDoneEditing}
-          />
-          <div style={{ marginTop: 16 }}>
-            <div className="kicker" style={{ marginBottom: 6 }}>
-              Shots
-            </div>
-            <ShotList shots={existingShots} />
+          <div className="kicker" style={{ marginBottom: 6 }}>
+            Shots
           </div>
+          <ShotList shots={existingShots} />
         </div>
         {/* Right column: portrait up-the-hole map (leads on narrow). */}
         <div
@@ -358,6 +329,33 @@ export function MapView({
             onSelectRail={selectRail}
           />
         )}
+        <MapBottomChrome
+          hasExistingShots={hasExistingShots}
+          editing={editingOnMap}
+          shotsPlaced={placedPoints.length}
+          remainingToPin={remainingToPin}
+          pinAvailable={effectivePin != null}
+          aimMode={aimMode}
+          aimsSet={placedAims.filter((a) => a != null).length}
+          holeNumber={activeHoleNumber}
+          needsTee={needsTee}
+          showPinButton={showPinButton}
+          placementMode={placementMode}
+          shotDragUndoLabel={shotDragUndoLabel}
+          onApplyShotDragUndo={onApplyShotDragUndo}
+          onStartPlaceTee={handlers.onStartPlaceTee}
+          onStartPlacePin={handlers.onStartPlacePin}
+          onCancelPlacement={handlers.onCancelPlacement}
+          onToggleAimMode={handlers.onToggleAimMode}
+          onClearLastAim={() => {
+            const idx = placedAims.length - 1
+            if (idx >= 0) handlers.onSetAim(idx, null)
+          }}
+          onUndo={handlers.onUndoPoint}
+          onClear={handlers.onClearPoints}
+          onDone={handlers.onDoneWithHole}
+          onDoneEditing={handlers.onDoneEditing}
+        />
         </div>
       </div>
       {saveError && (

--- a/apps/web/src/pages/rounds/components/MapView.tsx
+++ b/apps/web/src/pages/rounds/components/MapView.tsx
@@ -91,7 +91,7 @@ interface MapViewProps {
   /** Drag-end on a saved shot's aim ghost. */
   onMoveExistingShotAim: (shotId: string, point: PlacedPoint) => void
   /** Label for the most recent saved-shot drag, or null when no recent
-   *  edit exists. Drives the Undo affordance on the logged-hole strip. */
+   *  edit exists. Drives the Undo affordance on the logged-hole chrome. */
   shotDragUndoLabel: string | null
   onApplyShotDragUndo: () => void
   reviewSheet?: ReactNode
@@ -179,7 +179,7 @@ export function MapView({
       ? { lat: activeHoleGeo.teeLat, lng: activeHoleGeo.teeLng }
       : null)
   // The tee is derived from the first shot (not placed manually); this flag
-  // is retained only for the existing strip plumbing.
+  // is retained only for the existing chrome plumbing.
   const needsTee = activeHoleGeo != null && effectiveTee == null
   // "Set pin" is available while logging or editing a PAST round on a
   // geo-anchored hole — shown even when a pin coord already exists so the
@@ -576,11 +576,11 @@ function OverlayRail({
   )
 }
 
-// Live expected-strokes HUD pill (Phase D), top-right of the map clear of the
-// bottom-right Mapbox controls and the vertically-centered rail. The To Hole /
-// remaining readouts already live in the instruction strip + aim pills on web
-// (Option 1 keeps the strip), so this surfaces the one new value — expected
-// strokes to hole out from the current ball. Best-case SG rides the carry pill.
+// Live expected-strokes HUD pill (Phase D), top-right of the map (the Mapbox
+// controls sit top-left and the rail is vertically centered, so it's clear of
+// both). The To Hole / remaining readouts already live in the bottom chrome +
+// aim pills on web, so this surfaces the one new value — expected strokes to
+// hole out from the current ball. Best-case SG rides the carry pill.
 function ExpStrokesHud({ value }: { value: number }) {
   return (
     <div

--- a/apps/web/src/pages/rounds/components/MapView.tsx
+++ b/apps/web/src/pages/rounds/components/MapView.tsx
@@ -541,7 +541,7 @@ function OverlayRail({
     flexDirection: 'column' as const,
     gap: 2,
     padding: 3,
-    borderRadius: 12,
+    borderRadius: 16,
     background: 'rgba(28,33,28,0.82)',
   }
   return (
@@ -590,7 +590,7 @@ function ExpStrokesHud({ value }: { value: number }) {
         right: 12,
         zIndex: 5,
         background: 'rgba(28,33,28,0.82)',
-        borderRadius: 6,
+        borderRadius: 20,
         padding: '6px 12px',
         textAlign: 'right',
         pointerEvents: 'none',
@@ -604,7 +604,7 @@ function ExpStrokesHud({ value }: { value: number }) {
       </div>
       <div
         className="tabular"
-        style={{ color: '#F2EEE5', fontSize: 18, fontWeight: 600, lineHeight: 1.2 }}
+        style={{ color: 'var(--caddie-accent-ink)', fontSize: 18, fontWeight: 600, lineHeight: 1.2 }}
       >
         {value.toFixed(1)}
       </div>
@@ -641,11 +641,11 @@ function DotsToggle({
         className="font-mono uppercase"
         style={{
           padding: '8px 12px',
-          borderRadius: 12,
+          borderRadius: 15,
           border: 'none',
           cursor: 'pointer',
           background: active ? '#FBF8F1' : 'rgba(28,33,28,0.82)',
-          color: active ? '#1C211C' : '#F2EEE5',
+          color: active ? 'var(--caddie-ink)' : 'var(--caddie-accent-ink)',
           fontSize: 10,
           fontWeight: active ? 700 : 500,
           letterSpacing: '0.12em',

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -35,7 +35,7 @@ type HoleRow = Database['public']['Tables']['holes']['Row']
 const AIM_AUTOSPAWN_FRACTION = 0.65
 
 // Last drag-edit on a saved shot. Surfaces the Undo button on the
-// logged-hole strip for 5s after every drag, then clears itself.
+// bottom chrome for 5s after every drag, then clears itself.
 // Holds the previous coords so the undo can restore them via the same
 // mutation path the drag took. `field` is the column the drag
 // touched ('start' = start_lat/lng + distance_to_target, 'aim' =


### PR DESCRIPTION
Brings the web live-round capture screen onto mobile's on-course **map surface** — one contextual instruction + CTA over the map, mobile HUD-pill radii — without regressing tap-to-place. Base editorial system untouched; the map treatment is codified as a documented per-surface exception in the project design system.

## What changed
- **Mapbox controls → top-left** (were bottom-right; top-right is the expected-strokes HUD) so the chrome can own the bottom.
- **`RoundMapInstructionStrip` → `MapBottomChrome`** (file + `RoundMap` barrel re-export + `MapView` caller).
- **Tap-safe over-map bottom chrome**: instruction card is `pointer-events:none` (taps reach the Mapbox canvas listener); the button row is `pointer-events:auto` and only renders when a button matters, so the live tee-shot tap (bottom-center) is never occluded. Every prior state branch + button preserved.
- **HUD pill radii** bumped to the mobile range (ExpStrokesHud, DotsToggle, OverlayRail container); token de-drift on touched lines.

## Hardening
Plan was put through **two adversarial falsification rounds (10 findings, all fixed)** before implementation — most importantly: tap-to-place is a Mapbox *canvas* click listener, so any `pointer-events:auto` element over it swallows the tap; the pointer-events discipline + gated button row is what keeps the tee tap clear.

## Known, by-design tradeoffs
- Past-round "Set pin" at 0 shots renders over the bottom (single small pill; live path unaffected).
- Once shots exist, the CTA row sits over the lower map — intended map-parity behavior.

## Verification
- `pnpm typecheck` + `pnpm --filter @oga/web build` green.
- Per-task reviews + a final whole-branch review (most-capable model): **READY TO MERGE**, no Critical/Important.
- **Visual QA = this PR's Vercel preview** — check: chrome floats bottom, tee-shot bottom-center tappable, top-left controls + bottom-left logo uncovered, HUD pills rounded, paper pages unchanged, **and at a few viewport heights confirm the wrapped button row doesn't overlap the vertically-centered DotsToggle / OverlayRail on short screens**.

Do not merge until reviewed on the preview.