### PR TITLE
feature(web): start-round CTAs on the dashboard home

### DIFF
--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -1,5 +1,6 @@
-import { lazy, Suspense, useMemo } from 'react'
+import { lazy, Suspense, useMemo, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
+import { mdiPlay, mdiPlus } from '@mdi/js'
 import { formatSG } from '@oga/core'
 import { useRecentSG } from '../../hooks/useRounds'
 import { useProfile } from '../../hooks/useProfile'
@@ -91,6 +92,8 @@ export function DashboardPage() {
         }`}
       />
 
+      <StartRoundCTAs />
+
       <Lede strongest={strongest} weakest={weakest} />
 
       <Section kicker="By the numbers">
@@ -132,7 +135,18 @@ export function DashboardPage() {
         </div>
       </Section>
 
-      <Section kicker="Recent rounds">
+      <Section
+        kicker="Recent rounds"
+        action={
+          <Link
+            to="/rounds"
+            className="font-mono uppercase text-caddie-ink-mute hover:text-caddie-ink tabular"
+            style={{ fontSize: 10, letterSpacing: '0.14em' }}
+          >
+            See all →
+          </Link>
+        }
+      >
         <ul>
           {rounds.slice(0, 5).map((r, i) => (
             <li
@@ -247,14 +261,17 @@ function Lede({
 
 function Section({
   kicker,
+  action,
   children,
 }: {
   kicker: string
+  action?: ReactNode
   children: React.ReactNode
 }) {
   return (
     <section style={{ marginBottom: 28 }}>
       <div
+        className="flex items-center justify-between"
         style={{
           borderTop: '1px solid #D9D2BF',
           paddingTop: 14,
@@ -262,9 +279,62 @@ function Section({
         }}
       >
         <div className="kicker">{kicker}</div>
+        {action}
       </div>
       {children}
     </section>
+  )
+}
+
+// Mirrors the native Home CTAs (components/home/RoundCTAs.tsx): a filled
+// "Start live round" over an outline "Log past round". Both route to
+// /rounds/new with a mode param NewRoundPage reads to preselect the tab.
+function StartRoundCTAs() {
+  return (
+    <div style={{ marginBottom: 28 }}>
+      <Link
+        to="/rounds/new?mode=live"
+        className="bg-caddie-accent text-caddie-accent-ink hover:opacity-90 flex items-center justify-center"
+        style={{
+          gap: 8,
+          padding: '15px 16px',
+          borderRadius: 2,
+          fontSize: 16,
+          fontWeight: 700,
+          letterSpacing: '0.02em',
+        }}
+      >
+        <svg width={20} height={20} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d={mdiPlay} />
+        </svg>
+        Start live round
+      </Link>
+      <div
+        className="text-caddie-ink-dim text-center"
+        style={{ fontSize: 12, marginTop: 6, marginBottom: 12 }}
+      >
+        Track shots in real time with GPS
+      </div>
+      <Link
+        to="/rounds/new?mode=past"
+        className="hover:opacity-80 flex items-center justify-center"
+        style={{
+          gap: 8,
+          padding: '11px 16px',
+          borderRadius: 2,
+          border: '1px solid #1F3D2C',
+          color: '#1F3D2C',
+          fontSize: 14,
+          fontWeight: 600,
+          letterSpacing: '0.02em',
+        }}
+      >
+        <svg width={18} height={18} viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d={mdiPlus} />
+        </svg>
+        Log past round
+      </Link>
+    </div>
   )
 }
 

--- a/apps/web/src/pages/rounds/NewRoundPage.tsx
+++ b/apps/web/src/pages/rounds/NewRoundPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import {
   CAPTURE_MODES,
   CAPTURE_MODE_LABELS,
@@ -19,6 +19,7 @@ type RoundMode = 'live' | 'past'
 
 export function NewRoundPage() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const { user } = useAuth()
   const createRoundMutation = useCreateRound()
   const [courseId, setCourseId] = useState<string | null>(null)
@@ -26,7 +27,11 @@ export function NewRoundPage() {
   const [playedAt, setPlayedAt] = useState(() => todayLocalDate())
   const [teeColor, setTeeColor] = useState<string>('white')
   const [courseTeeId, setCourseTeeId] = useState<string | null>(null)
-  const [mode, setMode] = useState<RoundMode>('past')
+  // Seed from ?mode=live|past so the Home CTAs land on the right mode
+  // (defaults to past for a bare /rounds/new).
+  const [mode, setMode] = useState<RoundMode>(
+    searchParams.get('mode') === 'live' ? 'live' : 'past',
+  )
   const [captureMode, setCaptureMode] = useState<CaptureMode>('track_patterns')
   const [error, setError] = useState<string | null>(null)
 


### PR DESCRIPTION
Fixes a web↔mobile parity gap surfaced testing the mobile shell: the web **Home (`/dashboard`) had no start-round action for returning users** — it only appeared in the zero-rounds empty state, so the only path was the drawer → Rounds → New round. Native Home leads with a prominent CTA pair; this brings web to match.

## What changed
- **Dashboard CTA pair** (`DashboardPage.tsx`), mirroring native `RoundCTAs`: filled forest **"Start live round"** (play icon → `/rounds/new?mode=live`) over an outline **"Log past round"** (plus icon → `/rounds/new?mode=past`), placed right under the masthead. Icons via `@mdi/js` (same glyphs as native).
- **"See all →"** on the Recent rounds section header → `/rounds`, so round history is reachable from Home without opening the menu.
- **`NewRoundPage`** now reads `?mode=live|past` from the URL to seed its initial tab (was hardcoded `past`), so the live CTA actually lands on live.

## Scope notes
- **Resume-round banner deferred:** native shows a resume banner for an in-progress round, but web has no active/in-progress-round query (only `useRecentSG`/`useRounds`). Building that query is out of scope here — filed as a follow-up rather than plumbed for a nice-to-have.
- The **top-bar menu stays for now** — it's still the only home for Learn / My Bag. Removing it belongs to the Phase-2 nav reflow (give those routes native homes first). These CTAs remove the main reason to open it.

## Verification
- `pnpm typecheck` + `pnpm --filter @oga/web build` green.
- **Visual QA = this PR's Vercel preview** (mobile + desktop): CTA pair under the masthead, live CTA opens New Round on the *live* tab, "See all" → /rounds.

Separate from #818 (capture chrome). Do not merge until previewed.