### PR TITLE
fix(facilities): lock curated course columns + guard drill-down race (#821 review)

### DIFF
--- a/apps/mobile/app/(app)/round/new.tsx
+++ b/apps/mobile/app/(app)/round/new.tsx
@@ -80,6 +80,10 @@ export default function NewRound() {
   // until the query changes or the user taps Back. Mirrors web CourseSearch.
   const [facility, setFacility] = useState<FacilityRow | null>(null)
   const [units, setUnits] = useState<CourseRow[]>([])
+  const [facilityError, setFacilityError] = useState(false)
+  // Monotonic token so a slow getFacilityUnits response from an earlier
+  // facility tap can't overwrite the units of a facility tapped later.
+  const facilityReqRef = useRef(0)
   const [searching, setSearching] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -110,8 +114,12 @@ export default function NewRound() {
   // query could strand the picker inside a stale facility whose units no
   // longer match what was typed. Mirrors web CourseSearch.
   useEffect(() => {
+    // Invalidate any in-flight openFacility so a late response can't re-open
+    // a facility the user has navigated away from.
+    facilityReqRef.current++
     setFacility(null)
     setUnits([])
+    setFacilityError(false)
   }, [query])
 
   // Capture GPS once (best-effort) so manual / API course creation can
@@ -232,13 +240,21 @@ export default function NewRound() {
   const showAddNew = !searching && debouncedQuery.trim().length > 0
 
   async function openFacility(f: FacilityRow) {
+    const reqId = ++facilityReqRef.current
     const { data, error } = await getFacilityUnits(supabase, f.id)
+    // A newer facility tap bumped the counter — drop this stale response.
+    if (facilityReqRef.current !== reqId) return
+    setFacility(f)
     if (error) {
+      // Surface fetch failure as an error state instead of an empty facility.
       // eslint-disable-next-line no-console
       console.warn('[round/new getFacilityUnits]', error.message)
+      setUnits([])
+      setFacilityError(true)
+      return
     }
+    setFacilityError(false)
     setUnits((data ?? []) as unknown as CourseRow[])
-    setFacility(f)
   }
 
   async function startWith(
@@ -540,7 +556,14 @@ export default function NewRound() {
         {facility ? (
           <View style={{ marginBottom: 14 }}>
             <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-              <PressableTouch onPress={() => setFacility(null)}>
+              <PressableTouch
+                onPress={() => {
+                  facilityReqRef.current++
+                  setFacility(null)
+                  setUnits([])
+                  setFacilityError(false)
+                }}
+              >
                 <Text style={{ ...KICKER, color: '#1F3D2C' }}>‹ Back</Text>
               </PressableTouch>
               <Text style={KICKER}>{facility.name}</Text>
@@ -573,6 +596,19 @@ export default function NewRound() {
                 </Text>
               </PressableTouch>
             ))}
+            {units.length === 0 && (
+              <Text
+                style={[TYPE.body, {
+                  color: facilityError ? '#A33A2A' : '#8A8B7E',
+                  fontSize: 13,
+                  paddingVertical: 14,
+                }]}
+              >
+                {facilityError
+                  ? "Couldn't load courses — go back and try again."
+                  : 'No courses listed.'}
+              </Text>
+            )}
           </View>
         ) : (
           <>

--- a/apps/web/src/components/courses/CourseSearch.tsx
+++ b/apps/web/src/components/courses/CourseSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { formatLocation } from '@oga/core'
 import { getFacilityUnits } from '@oga/supabase'
 import type { Database } from '@oga/supabase'
@@ -38,6 +38,10 @@ export function CourseSearch({
   const [gps, setGps] = useState<GpsState>({ status: 'idle' })
   const [facility, setFacility] = useState<FacilityRow | null>(null)
   const [units, setUnits] = useState<CourseRow[]>([])
+  const [facilityError, setFacilityError] = useState(false)
+  // Monotonic token so a slow getFacilityUnits response from an earlier
+  // facility tap can't overwrite the units of a facility tapped later.
+  const facilityReqRef = useRef(0)
   const search = useCourseSearch(query)
   const importApi = useImportApiCourse()
 
@@ -56,17 +60,28 @@ export function CourseSearch({
   // otherwise a fresh query could strand the picker inside a stale facility
   // whose units no longer match what was typed.
   useEffect(() => {
+    // Invalidate any in-flight openFacility so a late response can't re-open
+    // a facility the user has navigated away from.
+    facilityReqRef.current++
     setFacility(null)
     setUnits([])
+    setFacilityError(false)
   }, [query])
 
   async function openFacility(f: FacilityRow) {
+    const reqId = ++facilityReqRef.current
     const { data, error } = await getFacilityUnits(supabase, f.id)
+    // A newer facility tap bumped the counter — drop this stale response.
+    if (facilityReqRef.current !== reqId) return
+    setFacility(f)
     if (error) {
       console.warn('[CourseSearch getFacilityUnits]', error.message)
+      setUnits([])
+      setFacilityError(true)
+      return
     }
+    setFacilityError(false)
     setUnits((data ?? []) as unknown as CourseRow[])
-    setFacility(f)
   }
 
   // Capture GPS once when the parent has opted in (live-round mode) so
@@ -144,8 +159,10 @@ export function CourseSearch({
             <SearchGroup
               label={facility.name}
               onBack={() => {
+                facilityReqRef.current++
                 setFacility(null)
                 setUnits([])
+                setFacilityError(false)
               }}
             >
               {units.map((unit) => (
@@ -159,6 +176,16 @@ export function CourseSearch({
                   }}
                 />
               ))}
+              {units.length === 0 && (
+                <div
+                  className="text-caddie-ink-mute"
+                  style={{ padding: 14, fontSize: 13 }}
+                >
+                  {facilityError
+                    ? "Couldn't load courses — go back and try again."
+                    : 'No courses listed.'}
+                </div>
+              )}
             </SearchGroup>
           ) : (
             <>

--- a/supabase/migrations/0045_lock_facility_columns.sql
+++ b/supabase/migrations/0045_lock_facility_columns.sql
@@ -1,0 +1,105 @@
+-- Lock down courses.facility_id / unit_name / unit_order — facilities-feature
+-- security review (0044 follow-up).
+--
+-- THE HOLE: 0044 added facility_id/unit_name/unit_order to `courses` but the
+-- courses INSERT policy from 0001 is still just
+--   with check (auth.uid() is not null)
+-- with no column restriction, and 0044's `facilities` table is publicly
+-- readable (`facilities_read using (true)`), so every facility's id is
+-- discoverable. Any authenticated user can therefore INSERT a `courses` row
+-- carrying a real facility_id + an arbitrary unit_name (or unit_order), and
+-- it renders inside that facility's card for every user — spoofing /
+-- defacement of a curated grouping. There is currently no UPDATE policy on
+-- `courses` at all (no policy = no client UPDATE access under RLS), so the
+-- live exposure is INSERT-only today; this migration still closes UPDATE in
+-- case a future courses-UPDATE policy is added without re-deriving this
+-- guard from scratch.
+--
+-- unit_name also had no length/charset constraint — same "publicly-readable,
+-- user-writable text" class of exposure 0014 closed for courses.name.
+--
+-- MECHANISM CHOICE: a BEFORE INSERT OR UPDATE trigger on `courses`, not a
+-- revised RLS WITH CHECK. Reasons:
+--   1. Single point of enforcement. An RLS fix would mean tightening the
+--      INSERT policy's WITH CHECK *and* remembering to repeat the same
+--      predicate in any UPDATE policy added later (none exists today — see
+--      above). A trigger enforces the invariant independent of how many
+--      policies eventually govern writes to this table, so a future
+--      "users can update own courses" policy can't silently reopen this.
+--   2. Precedent on this exact table: 0027's `rate_limit_course_inserts`
+--      trigger already guards `courses` INSERT this way, using the same
+--      `auth.role() = 'service_role'` bypass idiom for the crawler /
+--      backfill scripts. This keeps the two guards consistent and
+--      reviewable side by side.
+-- Tradeoff accepted: a trigger fires on every row regardless of which
+-- policy let the statement through, and (unlike RLS) doesn't silently
+-- filter — a blocked write raises a hard Postgres error. That's the
+-- desired behavior here (fail loud on a spoofing attempt) but is a
+-- slightly bigger footprint than a narrow WITH CHECK tweak.
+--
+-- BYPASS: `auth.role() = 'service_role'` (Edge Functions / any future
+-- service-role script going through PostgREST — same as the crawler) OR
+-- `auth.role() is null` (a direct Postgres connection with no PostgREST
+-- request context, e.g. `supabase db push` migrations or the SQL editor —
+-- inherently a higher trust level than the anon/authenticated roles this
+-- guard targets). The facilities backfill script
+-- (scripts/facilities/backfill-facilities.cjs) connects via supabase-js
+-- with SUPABASE_SERVICE_ROLE_KEY, so it satisfies the service_role branch.
+--
+-- unit_order is included alongside facility_id/unit_name even though the
+-- prompt driving this migration only named the latter two: it's the same
+-- curated-only column added in the same 0044 ALTER TABLE, controls display
+-- order *within* a spoofed facility card, and costs nothing extra to guard.
+
+create or replace function public.guard_courses_facility_columns()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  -- service_role (Edge Functions, backfill/crawler scripts via PostgREST)
+  -- and direct Postgres connections (migrations, SQL editor — no JWT
+  -- request context at all) are trusted; everyone else goes through the
+  -- checks below.
+  if auth.role() = 'service_role' or auth.role() is null then
+    return new;
+  end if;
+
+  if tg_op = 'INSERT' then
+    if new.facility_id is not null or new.unit_name is not null or new.unit_order is not null then
+      raise exception
+        'facility_id/unit_name/unit_order are curated fields and cannot be set on insert'
+        using errcode = '42501';
+    end if;
+  elsif tg_op = 'UPDATE' then
+    if new.facility_id is distinct from old.facility_id
+      or new.unit_name is distinct from old.unit_name
+      or new.unit_order is distinct from old.unit_order
+    then
+      raise exception
+        'facility_id/unit_name/unit_order are curated fields and cannot be changed'
+        using errcode = '42501';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists courses_guard_facility_columns on public.courses;
+
+create trigger courses_guard_facility_columns
+  before insert or update on public.courses
+  for each row
+  execute function public.guard_courses_facility_columns();
+
+-- unit_name is publicly readable (rendered on every facility card) and, pre
+-- this migration's trigger, was directly user-writable — same exposure
+-- class 0014 closed for courses.name. Mirror that pattern: allow NULL
+-- (most courses aren't part of a facility), bound length, and block
+-- HTML/template-shaped strings.
+alter table public.courses
+  add constraint courses_unit_name_length
+    check (unit_name is null or char_length(unit_name) between 1 and 100),
+  add constraint courses_unit_name_chars
+    check (unit_name is null or unit_name ~ '^[^<>{}]*$');


### PR DESCRIPTION
Two pre-merge hardening fixes surfaced by the #821 release review. Both independently reviewed (security agent on the migration, TypeScript agent on the race fix).

## 1. Migration 0045 — facility write lock (security)

**Hole:** 0044 added `facility_id` / `unit_name` / `unit_order` to `courses`, but the INSERT policy is still `with check (auth.uid() is not null)` with no column restriction, and `facilities` is world-readable — so any authenticated user could insert a `courses` row carrying a real `facility_id` + arbitrary `unit_name` and deface that facility's card app-wide.

**Fix:** `BEFORE INSERT OR UPDATE` trigger blocking non-service-role writes to those three curated columns (mirrors 0027's trigger + service-role bypass), plus `unit_name` length (1–100) and charset (`^[^<>{}]*$`) CHECKs mirroring 0014.

- Client `createCourse` (manual-add + OpenGolfAPI import) never sets these columns → unaffected.
- Backfill script uses service-role → bypass works.
- Forward-only; existing 3 curated facility rows pass the new CHECKs.
- Security review: **GO** dev + prod, no exploitable bypass found.

**Applied to dev + prod after merge, per the migration-channel rule.**

## 2. `openFacility` drill-down race (web + mobile)

`getFacilityUnits` was awaited with no ordering guard — rapid taps between two facility cards could let a stale response overwrite the newer facility's units, and a fetch error looked identical to a facility with zero units.

**Fix:** monotonic `facilityReqRef` token drops stale responses (incl. after Back / query-change, so a late response can't re-open a facility you left); fetch errors now show a message. Web + mobile at parity. Dual typecheck clean.

Closes the concerns raised in the #821 review.