### PR TITLE
fix(mobile): green rework — on-green Made/Missed overlays + auto-detect, capture-mode aware

### DIFF
--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -248,6 +248,11 @@ export default function LiveRoundSession({
     data.storedPin?.lat,
     data.storedPin?.lng,
   ])
+  // Putt distance in feet, mirrored from HoleModals' ShotLogger puttDistanceFt
+  // calc (yards × 3 = feet). Feeds both the on-green make-% pill and the
+  // persisted putt_distance_ft on Made/Missed.
+  const puttDistanceFt =
+    ballToPinYards != null ? Math.round(ballToPinYards * 3) : null
   // Single-color dispersion dots for the selected club (left-toolbar toggle).
   // Computed only when the dots are shown; sparse clubs → null (no dots).
   const dispersionPoints = useMemo(() => {
@@ -682,8 +687,27 @@ export default function LiveRoundSession({
             finalState.setRoundState('PLACE_BALL')
           }}
           onSkipAim={actions.skipAim}
+          // Auto-detect on-green entry lives inside markBallHere itself
+          // (restored from pre-#791 — see useShotActions comment); this
+          // stays a plain pass-through. The chip below still forces toGreen
+          // explicitly as the fallback.
           onMarkBallHere={actions.markBallHere}
           onOnGreen={() => actions.markBallHere({ toGreen: true })}
+          onGreenActive={finalState.roundState === 'PUTTING'}
+          puttDistanceFt={puttDistanceFt}
+          onPuttMade={() =>
+            actions.persistPutt({
+              puttMade: true,
+              puttDistanceFt: puttDistanceFt ?? undefined,
+            })
+          }
+          onPuttMissed={() =>
+            actions.persistPutt({
+              puttMade: false,
+              puttDistanceFt: puttDistanceFt ?? undefined,
+            })
+          }
+          onNotOnGreen={actions.notOnGreen}
           onAddShot={() => {
             // Opt back into the live append flow on a revisited played hole:
             // re-arm the GPS ball + auto-aim and enter PLACE_BALL (#484).
@@ -710,7 +734,6 @@ export default function LiveRoundSession({
         ball={finalState.ball}
         roundPin={data.roundPin}
         storedPin={data.storedPin}
-        roundState={finalState.roundState}
         scorecardOpen={scorecardOpen}
         holes={data.holes}
         holeScores={data.holeScores}
@@ -750,10 +773,7 @@ export default function LiveRoundSession({
         deleting={actions.deleting}
         saving={actions.saving}
         onPersistShot={actions.persistShot}
-        onPersistPutt={actions.persistPutt}
         onCloseLogger={actions.closeLogger}
-        onClosePuttingSheet={actions.closePuttingSheet}
-        onSwapPuttingToShot={actions.swapPuttingToShot}
         onConfirmDelete={actions.handleDeleteRound}
         onCancelDelete={() => setActiveDialog(null)}
         onConfirmLeave={() => {

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -1,6 +1,7 @@
 import { Pressable, Text, View } from 'react-native'
 import { PressableTouch } from '../ui/PressableTouch'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { tourMakePercent } from '@oga/core'
 import { TYPE } from '../../lib/typography'
 import { KICKER, type RoundState } from './hole/types'
 
@@ -51,6 +52,17 @@ interface MapBottomChromeProps {
   onPrev: () => void
   onNext: () => void
   onOpenScorecard: () => void
+  /** On-green rework: true while `roundState === 'PUTTING'`. Swaps the whole
+   *  contextual-action block for the Made/Missed overlay — the detailed aim
+   *  line read moved to the end-of-hole summary (HoleReviewSheet), so there
+   *  is nothing else to show here. */
+  onGreenActive: boolean
+  /** Ball→pin distance in feet, for the make-% pill and as the persisted
+   *  putt distance. Null when there's no pin to measure against. */
+  puttDistanceFt: number | null
+  onPuttMade: () => void
+  onPuttMissed: () => void
+  onNotOnGreen: () => void
 }
 
 export function MapBottomChrome(props: MapBottomChromeProps) {
@@ -81,6 +93,13 @@ function ContextualActions(p: MapBottomChromeProps) {
         {p.roundPin && <SecondaryPill label="Clear flag" danger onPress={p.onClearRoundPin} />}
       </View>
     )
+  }
+  // On-green (#791 step 4 rework): Made/Missed replace the whole chrome for
+  // this state — no place/mark/on-green CTA while putting. Checked ahead of
+  // SET_AIM/isRevisitingPlayedHole since PUTTING is its own roundState, not a
+  // variant of either.
+  if (p.onGreenActive) {
+    return <OnGreenActions {...p} />
   }
   if (p.roundState === 'SET_AIM') {
     return (
@@ -158,6 +177,86 @@ function ContextualActions(p: MapBottomChromeProps) {
         />
       )}
     </>
+  )
+}
+
+// On-green overlay (#791 step 4 rework): make-% pill + Made/Missed + a quiet
+// escape. The detailed read (aim/break/speed) is gone from here — it now
+// lives in the end-of-hole summary (HoleReviewSheet's Read ▸ / AimerOverlay).
+function OnGreenActions(p: MapBottomChromeProps) {
+  const ft = p.puttDistanceFt
+  const tourPct = ft != null && ft > 0 ? tourMakePercent(ft) : null
+  return (
+    <>
+      {ft != null && ft > 0 && (
+        <View
+          style={{
+            backgroundColor: CHROME_BG,
+            borderRadius: 14,
+            paddingHorizontal: 14,
+            paddingVertical: 8,
+          }}
+        >
+          <Text style={[TYPE.body, { color: CREAM, fontSize: 13 }]}>
+            {Math.round(ft)} ft
+            {tourPct != null ? (
+              <Text style={[TYPE.bodyBold, { color: CREAM, fontWeight: '700' }]}>
+                {' '}· tour makes {tourPct}%
+              </Text>
+            ) : null}
+          </Text>
+        </View>
+      )}
+      <View style={{ flexDirection: 'row', gap: 10 }}>
+        <PuttResultButton label="Missed" onPress={p.onPuttMissed} />
+        <PuttResultButton label="Made" primary onPress={p.onPuttMade} />
+      </View>
+      <TextChip label="Not on the green" onPress={p.onNotOnGreen} />
+    </>
+  )
+}
+
+function PuttResultButton({
+  label,
+  primary,
+  onPress,
+}: {
+  label: string
+  primary?: boolean
+  onPress: () => void
+}) {
+  return (
+    <PressableTouch
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      onPress={onPress}
+      android_ripple={{ color: 'rgba(242,238,229,0.18)' }}
+      // Static style object (see PrimaryCta) — a function `style` is dropped
+      // by NativeWind/css-interop.
+      style={{
+        backgroundColor: primary ? '#1F3D2C' : CHROME_BG,
+        borderColor: primary ? '#1F3D2C' : 'rgba(242,238,229,0.4)',
+        borderWidth: 1,
+        borderRadius: 26,
+        paddingVertical: 15,
+        paddingHorizontal: 34,
+        alignItems: 'center',
+        shadowColor: '#000',
+        shadowOpacity: 0.3,
+        shadowRadius: 6,
+        shadowOffset: { width: 0, height: 2 },
+        elevation: 4,
+      }}
+    >
+      <Text
+        style={[
+          TYPE.bodyBold,
+          { color: CREAM, fontSize: 16, fontWeight: '700', letterSpacing: 0.3 },
+        ]}
+      >
+        {label}
+      </Text>
+    </PressableTouch>
   )
 }
 

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -208,8 +208,8 @@ function OnGreenActions(p: MapBottomChromeProps) {
         </View>
       )}
       <View style={{ flexDirection: 'row', gap: 10 }}>
-        <PuttResultButton label="Missed" onPress={p.onPuttMissed} />
-        <PuttResultButton label="Made" primary onPress={p.onPuttMade} />
+        <PuttResultButton label="Missed" onPress={p.onPuttMissed} disabled={p.saving} />
+        <PuttResultButton label="Made" primary onPress={p.onPuttMade} disabled={p.saving} />
       </View>
       <TextChip label="Not on the green" onPress={p.onNotOnGreen} />
     </>
@@ -220,15 +220,19 @@ function PuttResultButton({
   label,
   primary,
   onPress,
+  disabled,
 }: {
   label: string
   primary?: boolean
   onPress: () => void
+  disabled?: boolean
 }) {
   return (
     <PressableTouch
       accessibilityRole="button"
       accessibilityLabel={label}
+      accessibilityState={{ disabled: !!disabled }}
+      disabled={disabled}
       onPress={onPress}
       android_ripple={{ color: 'rgba(242,238,229,0.18)' }}
       // Static style object (see PrimaryCta) — a function `style` is dropped
@@ -241,6 +245,7 @@ function PuttResultButton({
         paddingVertical: 15,
         paddingHorizontal: 34,
         alignItems: 'center',
+        opacity: disabled ? 0.5 : 1,
         shadowColor: '#000',
         shadowOpacity: 0.3,
         shadowRadius: 6,

--- a/apps/mobile/components/round/hole/HoleModals.tsx
+++ b/apps/mobile/components/round/hole/HoleModals.tsx
@@ -1,20 +1,20 @@
 import { Modal, View } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import type { Database } from '@oga/supabase'
-import type { LieType } from '@oga/core'
 import {
+  // ShotLogger is mounted below but currently unreachable: its only entry
+  // point was PuttingSheet's "Not a putt?" escape (swapPuttingToShot), and
+  // PuttingSheet's live modal was retired in the #791 step-4 rework (Made/
+  // Missed bottom overlays replaced it). Left in place rather than removed
+  // to keep this diff focused — follow-up cleanup ticket, not this change.
   ShotLogger,
   type ShotLoggerValue,
 } from '../ShotLogger'
-import {
-  PuttingSheet,
-  type PuttingValue,
-} from '../PuttingSheet'
 import { ScorecardModal } from '../Scorecard'
 import { ConfirmDialog } from '../../ui/ConfirmDialog'
 import type { LatLng } from '../HoleMap'
 import { distanceYards } from '../../../lib/maps'
-import type { ActiveDialog, RoundState } from './types'
+import type { ActiveDialog } from './types'
 
 type HoleRow = Database['public']['Tables']['holes']['Row']
 type HoleScoreRow = Database['public']['Tables']['hole_scores']['Row']
@@ -32,7 +32,6 @@ interface HoleModalsProps {
   ball: LatLng | null
   roundPin: LatLng | null
   storedPin: LatLng | null
-  roundState: RoundState
   scorecardOpen: boolean
   holes: HoleRow[]
   holeScores: HoleScoreRow[]
@@ -49,10 +48,7 @@ interface HoleModalsProps {
   deleting: boolean
   saving: boolean
   onPersistShot: (v: ShotLoggerValue | null) => void
-  onPersistPutt: (v: PuttingValue) => Promise<void>
   onCloseLogger: () => void
-  onClosePuttingSheet: () => void
-  onSwapPuttingToShot: (lieType: LieType) => void
   onConfirmDelete: () => void
   onCancelDelete: () => void
   onConfirmLeave: () => void
@@ -74,7 +70,6 @@ export function HoleModals(props: HoleModalsProps) {
     ball,
     roundPin,
     storedPin,
-    roundState,
     scorecardOpen,
     holes,
     holeScores,
@@ -89,10 +84,7 @@ export function HoleModals(props: HoleModalsProps) {
     deleting,
     saving,
     onPersistShot,
-    onPersistPutt,
     onCloseLogger,
-    onClosePuttingSheet,
-    onSwapPuttingToShot,
     onConfirmDelete,
     onCancelDelete,
     onConfirmLeave,
@@ -123,35 +115,12 @@ export function HoleModals(props: HoleModalsProps) {
         onClose={onCloseLogger}
       />
 
-      <Modal
-        visible={roundState === 'PUTTING'}
-        transparent
-        animationType="slide"
-        onRequestClose={onClosePuttingSheet}
-      >
-        {/* React Native's <Modal> renders to a separate native window on
-            Android, so the app-root GestureHandlerRootView doesn't apply
-            inside. Wrap the modal contents in their own root to restore
-            the GreenDiagram aim-handle pan gesture. */}
-        <GestureHandlerRootView style={{ flex: 1 }}>
-          <View style={{ flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(0,0,0,0.4)' }}>
-            <PuttingSheet
-              key={shotEntryKey}
-              shotNumber={shotNumber}
-              initialDistanceFt={
-                ball && (roundPin ?? storedPin)
-                  ? Math.round(
-                      distanceYards(ball, (roundPin ?? storedPin) as LatLng) * 3,
-                    )
-                  : undefined
-              }
-              onSave={onPersistPutt}
-              onClose={onClosePuttingSheet}
-              onChangeLie={onSwapPuttingToShot}
-            />
-          </View>
-        </GestureHandlerRootView>
-      </Modal>
+      {/* PuttingSheet's live-round modal was retired here (#791 step-4
+          rework): on-green now uses the Made/Missed bottom overlays
+          (MapBottomChrome) instead of a full sheet. The detailed putt read
+          (aim/break/speed) moved to the end-of-hole summary, which has its
+          own AimerOverlay + Read ▸ (HoleReviewSheet.tsx) — a parallel
+          implementation, not a reuse of the PuttingSheet component. */}
 
       <ConfirmDialog
         visible={activeDialog === 'delete'}

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -467,7 +467,13 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     // The chip (opts?.toGreen) stays as the fallback for when there's no pin
     // yet or the auto-detect misses.
     const pinTarget = roundPin ?? storedPin ?? null
+    // Never auto-enter putting on the hole's FIRST shot — you can't putt a tee
+    // shot. A par-3 / drivable tee shot landing within PUTTING_RADIUS_YARDS
+    // would otherwise pop Made/Missed and let one tap record a phantom ace.
+    // Mirrors the "⛳ On the green" chip's own `totalShotsThisHole > 0` gate
+    // (MapBottomChrome); the explicit chip (opts.toGreen) is already gated there.
     const autoGreen =
+      previousShots.length > 0 &&
       pinTarget != null &&
       distanceYards(ballSnapshot, pinTarget) <= PUTTING_RADIUS_YARDS
     // On the green (#791 step 4 rework): the marked ball is the putt's start.

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -472,7 +472,12 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     // would otherwise pop Made/Missed and let one tap record a phantom ace.
     // Mirrors the "⛳ On the green" chip's own `totalShotsThisHole > 0` gate
     // (MapBottomChrome); the explicit chip (opts.toGreen) is already gated there.
+    // Only auto-force the overlay in track_patterns. just_track's contract is
+    // "save the location, never prompt" — auto-popping Made/Missed there breaks
+    // it. The explicit "⛳ On the green" chip (opts.toGreen) still works in
+    // either mode for a just_track player who wants to log the putt.
     const autoGreen =
+      captureMode === 'track_patterns' &&
       previousShots.length > 0 &&
       pinTarget != null &&
       distanceYards(ballSnapshot, pinTarget) <= PUTTING_RADIUS_YARDS
@@ -536,6 +541,14 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   // player overrides in ShotLogger — but there is no dialog to clear here
   // (the overlay isn't a Modal/ConfirmDialog, just bottom chrome).
   function notOnGreen() {
+    // just_track never enters aiming — mirror markBallHere's just_track path:
+    // save the already-marked ball's location and loop back to PLACE_BALL,
+    // rather than stranding the player in a SET_AIM chrome their mode never
+    // shows. track_patterns re-routes the ball into the normal aim flow.
+    if (captureMode === 'just_track') {
+      void persistShot(null, { forceAim: false })
+      return
+    }
     setLoggerInitial({ lieType: 'rough' })
     setRoundState('SET_AIM')
   }

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -28,7 +28,7 @@ import { completeRound } from '../../../lib/completeRound'
 import type { LatLng } from '../HoleMap'
 import type { ShotLoggerValue } from '../ShotLogger'
 import type { PuttingValue } from '../PuttingSheet'
-import { type ActiveDialog } from './types'
+import { PUTTING_RADIUS_YARDS, type ActiveDialog } from './types'
 import type { UseHoleDataResult } from './useHoleData'
 import type { UseHoleStateResult } from './useHoleState'
 
@@ -70,6 +70,7 @@ export interface UseShotActionsResult {
   markBallHere: (opts?: { toGreen?: boolean }) => Promise<void>
   handleOnGreenYes: () => void
   handleOnGreenNo: () => void
+  notOnGreen: () => void
   confirmAim: () => void
   skipAim: () => void
   handleAimPromptConfirm: () => void
@@ -459,11 +460,23 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     }
     setBall(ballSnapshot)
     setAim(null)
-    // On the green (#791 step 4): the marked ball is the putt's start. Skip
-    // aiming entirely — Made/Missed is the action. Seed lie=green/putter so
-    // persistPutt writes a putt; the make-% readout + read live in PuttingSheet.
-    // Overrides capture mode (a putt is a putt in either mode).
-    if (opts?.toGreen) {
+    // On-green auto-detect, restored from pre-#791 (b0f123b removed it when
+    // the on-green flow moved behind the explicit "⛳ On the green" chip):
+    // a ball marked within PUTTING_RADIUS_YARDS of the pin enters the
+    // putting flow on its own, same as if the player had tapped the chip.
+    // The chip (opts?.toGreen) stays as the fallback for when there's no pin
+    // yet or the auto-detect misses.
+    const pinTarget = roundPin ?? storedPin ?? null
+    const autoGreen =
+      pinTarget != null &&
+      distanceYards(ballSnapshot, pinTarget) <= PUTTING_RADIUS_YARDS
+    // On the green (#791 step 4 rework): the marked ball is the putt's start.
+    // Skip aiming entirely — Made/Missed is the action (bottom-chrome
+    // overlays, not a modal). Seed lie=green/putter so persistPutt writes a
+    // putt; the make-% pill lives in MapBottomChrome, the detailed read in
+    // the end-of-hole summary. Overrides capture mode (a putt is a putt in
+    // either mode).
+    if (opts?.toGreen || autoGreen) {
       setLoggerInitial({ lieType: 'green', club: 'putter' })
       setRoundState('PUTTING')
       return
@@ -508,6 +521,16 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     // Chips and pitches still benefit from explicit aim capture for the
     // shot-pattern dataset; the aim line auto-spawns and "Skip aim" stays
     // available in the SET_AIM chrome.
+    setRoundState('SET_AIM')
+  }
+
+  // Escape from the on-green Made/Missed overlays (#791 step 4 rework): the
+  // ball marked into PUTTING wasn't actually on the green after all. Same
+  // seed as handleOnGreenNo — 'rough' is the safest near-green default, the
+  // player overrides in ShotLogger — but there is no dialog to clear here
+  // (the overlay isn't a Modal/ConfirmDialog, just bottom chrome).
+  function notOnGreen() {
+    setLoggerInitial({ lieType: 'rough' })
     setRoundState('SET_AIM')
   }
 
@@ -906,6 +929,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     markBallHere,
     handleOnGreenYes,
     handleOnGreenNo,
+    notOnGreen,
     confirmAim,
     skipAim,
     handleAimPromptConfirm,


### PR DESCRIPTION
## Green rework (live round, mobile)

Reworks the on-green flow so putting is one-tap overlays instead of a blocking sheet:

- **38cfd37** — on-green Made/Missed + make-% as bottom overlays; "Not on the green" escape; `PuttingSheet` modal retired; putt read moves to the end-of-hole summary. Auto-detect restored inside `markBallHere` via `PUTTING_RADIUS_YARDS` (30yd — the real pre-#791 mechanism).
- **62722e5** — phantom-ace guard: never auto-enter putting on a hole's first shot (a par-3 tee shot near the pin no longer pops the overlay).
- **70a59da** — from the adversarial review pass:
  - auto-detect + the escape respect capture mode — `just_track` rounds no longer get Made/Missed forced on them; the escape places the ball instead of stranding the player in an aim flow.
  - Made/Missed disabled during the in-flight save (double-tap can't fire `finishHole` twice).

Review-verified: no double-persist (in-flight ref), make-% distance reads the marked ball, missed→loop→re-enter works, ball survives the escape into aiming, no dangling refs, `hole_scores` tally correct. `ShotLogger` + `swapPuttingToShot` + `closePuttingSheet` are now inert — follow-up cleanup ticket, not this PR.

JS-only → OTA-eligible after merge.

## QA needed before merge (no RN render path in CI; live-round behavior)
- Auto-detect feel at 30yd
- Made → summary / Missed → next shot
- "Not on the green" escape (ball placed, not stranded in aim)
- Par-3 tee shot near the pin does NOT pop the overlay
- `just_track` round: no Made/Missed forced