### PR TITLE
fix(mobile): re-mint Turnstile widget after failed auth (login + signup form)

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -22,6 +22,11 @@ export default function Login() {
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
+  // Turnstile tokens are single-use; a failed sign-in consumes the token, so
+  // the widget must be remounted (key bump) to mint a fresh one — otherwise
+  // the submit button stays disabled until the screen remounts. Same pattern
+  // as signup.tsx (#738).
+  const [captchaNonce, setCaptchaNonce] = useState(0)
 
   const captchaEnabled = Boolean(TURNSTILE_SITE_KEY)
   const canSubmit = !loading && (!captchaEnabled || captchaToken !== null)
@@ -40,6 +45,7 @@ export default function Login() {
     if (signInError) {
       setError(signInError.message)
       setCaptchaToken(null)
+      setCaptchaNonce((n) => n + 1)
       return
     }
     // Route through the brand splash (plays on every login), which then
@@ -97,6 +103,7 @@ export default function Login() {
         />
         {captchaEnabled && (
           <WebView
+            key={captchaNonce}
             source={{ uri: `https://oga.golf/captcha.html?siteKey=${encodeURIComponent(TURNSTILE_SITE_KEY ?? '')}` }}
             // about:blank + about:srcdoc required for the Turnstile challenge
             // iframe to load inside iOS WKWebView — without them iOS filters the

--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -25,7 +25,7 @@ export default function Login() {
   // Turnstile tokens are single-use; a failed sign-in consumes the token, so
   // the widget must be remounted (key bump) to mint a fresh one — otherwise
   // the submit button stays disabled until the screen remounts. Same pattern
-  // as signup.tsx (#738).
+  // as signup's check-email screen introduced in #738.
   const [captchaNonce, setCaptchaNonce] = useState(0)
 
   const captchaEnabled = Boolean(TURNSTILE_SITE_KEY)

--- a/apps/mobile/app/(auth)/signup.tsx
+++ b/apps/mobile/app/(auth)/signup.tsx
@@ -150,6 +150,10 @@ export default function Signup() {
       setError(signUpError.message)
       captchaTokenRef.current = null
       setCaptchaToken(null)
+      // Token was consumed by the failed attempt — remount the widget so a
+      // fresh one can mint; otherwise Create account stays disabled (same
+      // single-use mechanism as the check-email screen + login).
+      setCaptchaNonce((n) => n + 1)
       return
     }
     // Email confirmation is required, so signUp returns no session yet. Show a
@@ -295,6 +299,7 @@ export default function Signup() {
         />
         {captchaEnabled && (
           <WebView
+            key={captchaNonce}
             source={{ uri: `https://oga.golf/captcha.html?siteKey=${encodeURIComponent(TURNSTILE_SITE_KEY ?? '')}` }}
             // about:blank + about:srcdoc required for the Turnstile challenge
             // iframe to load inside iOS WKWebView — without them iOS filters the


### PR DESCRIPTION
## Bug
On the login screen with captcha enabled (production env), a failed sign-in (e.g. wrong password) permanently disables the Sign in button (faded, no retry). Workaround was navigating to Sign up and back.

Found during SDK 54 internal-track QA, but **pre-existing** — live in production 1.1.0 (preview builds run captcha-OFF, which is why it never showed in earlier QA).

## Mechanism
Turnstile tokens are single-use: GoTrue consumes the token even when auth fails. The error path did `setCaptchaToken(null)` but never re-minted the widget — the mounted WebView keeps showing its already-solved challenge and never emits a new token, so `canSubmit` stays false forever.

## Fix
Mirror of signup.tsx's #738 pattern: `key={captchaNonce}` on the captcha WebView + nonce bump on the error path → widget remounts → fresh challenge → new token re-enables the button. 7 lines, login.tsx only.

## Repro / verify
Captcha-enabled build (internal-track AAB or prod): enter a wrong password → error shows → captcha widget reloads → solve → Sign in re-enabled → correct password signs in. Not reproducible on preview builds (captcha off).

## Ship note
⚠️ OTA freeze is in effect for the SDK 54 window (#827) — this ships **inside the 1.2.0 release**, NOT as an OTA.