### PR TITLE
fix(mobile): intro-tour card 3 describes the pre-#791 capture flow

### DIFF
--- a/apps/mobile/components/onboarding/IntroTour.tsx
+++ b/apps/mobile/components/onboarding/IntroTour.tsx
@@ -29,7 +29,7 @@ const CARDS = [
   },
   {
     title: 'On the course, keep it light',
-    body: 'Before the shot: set your aim and drop your ball. After (while walking): club, lie, slope — or skip it. Metadata is always optional.',
+    body: 'Before the shot: aim, then drop your ball. Details like club and lie come later, in a quick end-of-hole summary — always optional.',
   },
   {
     title: "Then see where you're losing strokes",


### PR DESCRIPTION
QA (SDK 54 internal track) caught stale copy in intro-tour card 3: "After (while walking): club, lie, slope — or skip it" describes the pre-#791 flow. Since #791 Steps 1-2, during play it's aim + ball only; club/lie/slope live in the end-of-hole summary.

New copy (user-approved wording):
> "Before the shot: aim, then drop your ball. Details like club and lie come later, in a quick end-of-hole summary — always optional."

One line, `IntroTour.tsx`. Typecheck clean.

⚠️ OTA freeze (#827): ships inside the 1.2.0 release, NOT as an OTA.