### PR TITLE
fix(mobile): consolidate live-round bottom chrome (5 stacked pills → 3 layers)

### DIFF
--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -149,14 +149,25 @@ function ContextualActions(p: MapBottomChromeProps) {
     <>
       <PrimaryCta label={ballLabel} disabled={ballDisabled} onPress={p.onMarkBallHere} />
       {/* One chip row for the secondary actions — stacking them one-per-line
-          read as clutter over the satellite (QA 2026-08). The GPS drag hint
-          that used to sit here was a duplicate of the top map banner; the
-          banner is the single home for that instruction now.
+          read as clutter over the satellite (QA 2026-08). flexWrap: at the
+          1.3x font cap on narrow devices the two chips can exceed the row
+          width; wrapping beats an untappable off-screen chip. The GPS drag
+          hint that used to sit here duplicated TopHint (HoleMapOverlays.tsx,
+          rendered unconditionally whenever !isAimPhase in HoleMap.tsx) —
+          TopHint covers every state the hint showed in, and the CTA label
+          ("Mark ball at my GPS") carries the GPS-tracking cue.
           On-green gate (#791 step 4): requires a prior shot this hole — as the
           FIRST tap it would skip persisting the stroke that reached the green
           (phantom ace) and finishHole would skip the review. */}
       {p.totalShotsThisHole > 0 && (
-        <View style={{ flexDirection: 'row', gap: 10 }}>
+        <View
+          style={{
+            flexDirection: 'row',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            gap: 10,
+          }}
+        >
           {(p.ball != null || p.hasGps) && !p.saving && (
             <TextChip label="⛳ On the green" onPress={p.onOnGreen} />
           )}

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -148,33 +148,24 @@ function ContextualActions(p: MapBottomChromeProps) {
   return (
     <>
       <PrimaryCta label={ballLabel} disabled={ballDisabled} onPress={p.onMarkBallHere} />
-      {/* Gated on a prior shot this hole (#791 step 4): as the FIRST tap it
-          would skip persisting the stroke that reached the green — the putt
-          would save as shot 1 (a phantom ace) and finishHole would skip the
-          review. A putt always follows the shot that got you there. */}
-      {p.totalShotsThisHole > 0 && (p.ball != null || p.hasGps) && !p.saving && (
-        <TextChip label="⛳ On the green" onPress={p.onOnGreen} />
-      )}
-      {p.ballFromGps && !p.saving && (
-        <View
-          style={{
-            backgroundColor: CHROME_BG,
-            borderRadius: 14,
-            paddingHorizontal: 12,
-            paddingVertical: 5,
-          }}
-        >
-          <Text style={[TYPE.body, { color: CREAM, fontSize: 11, opacity: 0.85 }]}>
-            The ball follows your GPS — drag to adjust.
-          </Text>
-        </View>
-      )}
+      {/* One chip row for the secondary actions — stacking them one-per-line
+          read as clutter over the satellite (QA 2026-08). The GPS drag hint
+          that used to sit here was a duplicate of the top map banner; the
+          banner is the single home for that instruction now.
+          On-green gate (#791 step 4): requires a prior shot this hole — as the
+          FIRST tap it would skip persisting the stroke that reached the green
+          (phantom ace) and finishHole would skip the review. */}
       {p.totalShotsThisHole > 0 && (
-        <TextChip
-          label={p.holeNumber < p.holeCount ? 'Finish hole · next →' : 'Finish round'}
-          onPress={p.onFinishHole}
-          strong
-        />
+        <View style={{ flexDirection: 'row', gap: 10 }}>
+          {(p.ball != null || p.hasGps) && !p.saving && (
+            <TextChip label="⛳ On the green" onPress={p.onOnGreen} />
+          )}
+          <TextChip
+            label={p.holeNumber < p.holeCount ? 'Finish hole · next →' : 'Finish round'}
+            onPress={p.onFinishHole}
+            strong
+          />
+        </View>
       )}
     </>
   )


### PR DESCRIPTION
QA (SDK 54 internal track): the live PLACE_BALL state stacked 5 elements over the map — primary CTA, "On the green" chip, a GPS drag hint, "Finish hole" chip, and the nav pill ([screenshot in QA thread]). Launch-blocking per user.

## Changes (ContextualActions PLACE_BALL block only)
- **Deleted the GPS drag-hint pill** — verbatim duplicate of the top map banner ("drag the ball to refine…"); the banner is now the single home for that instruction.
- **"⛳ On the green" + "Finish hole · next" merged into one horizontal chip row** (same row pattern the SET_AIM state already uses).

Result: CTA / chip row / nav pill — 3 layers. Behavior gates unchanged: on-green chip keeps its phantom-ace gate (prior shot + ball/GPS + not saving); finish chip keeps `totalShotsThisHole > 0`; both now render inside one row gated on the shared condition. On-green (PUTTING) state untouched.

**Stacked on `fix/green-putt-overlays` (#826)** — this file's future shape lives there. Merge #826 first, then this (do NOT delete the base branch before this merges).

Typecheck clean. Device QA: same pass as #826 (one live hole: mark ball, on-green chip works, finish hole works, no hint pill, chip row wraps nothing at 1.3x font cap).