### PR TITLE
fix(mobile): Stats header '?' inline with the web link (header grew a row)

### DIFF
--- a/apps/mobile/app/(app)/stats.tsx
+++ b/apps/mobile/app/(app)/stats.tsx
@@ -186,6 +186,9 @@ export default function Stats() {
         title="Strokes Gained"
         right={
           <View style={{ alignItems: 'flex-end', gap: 10 }}>
+            {/* "?" sits inline with the web link so the header keeps its
+                two-row height (QA 2026-08 — a third stacked row grew the bar). */}
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
             <HelpButton topicId="stats" />
             <Pressable
               accessibilityRole="link"
@@ -204,6 +207,7 @@ export default function Stats() {
                 Full dashboard → oga.golf ↗
               </Text>
             </Pressable>
+            </View>
             <View
               style={{
                 flexDirection: 'row',


### PR DESCRIPTION
QA (SDK 54 internal track): the #825 "?" pill stacked as a third row in the Stats AppBar right column, growing the header. This was #825's noted optional polish ("AppBar right is column-layout — flexDirection: row"); now user-requested.

Fix: "?" + "Full dashboard → oga.golf" share one row (`flexDirection: 'row'`, centered, gap 10); the L5/L10/L20 selector row is unchanged. Header returns to its pre-#825 two-row height. 4 insertions, stats.tsx only.

No conflict with #827 (its stats.tsx changes are the chart block + imports; this is the AppBar region).

⚠️ OTA freeze (#827): ships inside the 1.2.0 release, NOT as an OTA.