### PR TITLE
feat(rounds): add provider-agnostic round import from JSON

### DIFF
--- a/apps/web/e2e/import-data.flow.spec.ts
+++ b/apps/web/e2e/import-data.flow.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
+
+const admin = createClient(
+  process.env.SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  { auth: { persistSession: false, autoRefreshToken: false } },
+)
+
+// Same seeded, fully-loaded course new-round-past.flow.spec.ts relies on.
+const COURSE_NAME = 'Pine Ridge Golf Club'
+
+function payload() {
+  return JSON.stringify({
+    course_name: COURSE_NAME,
+    played_at: '2026-06-01',
+    total_score: 9,
+    total_putts: 4,
+    holes: [
+      { number: 1, score: 4, putts: 2 },
+      { number: 2, score: 5, putts: 2 },
+    ],
+  })
+}
+
+let createdRoundId: string | null = null
+
+test.describe('Import from data (signed in, mutating)', () => {
+  test.afterEach(async () => {
+    if (createdRoundId) {
+      // Cascades through hole_scores + shots via FK.
+      await admin.from('rounds').delete().eq('id', createdRoundId)
+      createdRoundId = null
+    }
+  })
+
+  test('paste a valid payload → pick course → import → land on round detail', async ({
+    page,
+  }) => {
+    await page.goto('/rounds/import')
+    await expect(
+      page.getByRole('heading', { name: /Import from data/i }),
+    ).toBeVisible()
+
+    await page.getByPlaceholder('{"played_at"').fill(payload())
+    await expect(page.getByText(/Looks good/i)).toBeVisible()
+
+    await page.getByRole('button', { name: /Continue/i }).click()
+
+    // course_name hint pre-seeds CourseSearch verbatim (ImportDataPage
+    // passes initialQuery={payload.course_name}).
+    await expect(page.getByPlaceholder('Search courses')).toHaveValue(COURSE_NAME)
+    await page
+      .getByRole('button', { name: new RegExp(COURSE_NAME, 'i') })
+      .first()
+      .click()
+    await expect(
+      page.getByText(new RegExp(`Selected: ${COURSE_NAME}`, 'i')),
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: /^Import round$/i }).click()
+
+    await page.waitForURL(/\/rounds\/[0-9a-f-]{36}/i, { timeout: 15_000 })
+    const match = page.url().match(/\/rounds\/([0-9a-f-]{36})/i)
+    expect(match).toBeTruthy()
+    createdRoundId = match![1]
+  })
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "typecheck": "tsc -b --noEmit",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -24,7 +25,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.0",
-    "recharts": "^2.12.7"
+    "recharts": "^2.12.7",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",
@@ -36,6 +38,7 @@
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.7",
     "typescript": "^5.4.0",
-    "vite": "^6.4.2"
+    "vite": "^6.4.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/apps/web/src/components/courses/CourseSearch.tsx
+++ b/apps/web/src/components/courses/CourseSearch.tsx
@@ -20,6 +20,11 @@ interface CourseSearchProps {
    *  Only meaningful for live rounds; defaults to false so past-round
    *  entry doesn't trigger a permission prompt. */
   requestGps?: boolean
+  /** Pre-seeds the search box, e.g. with an imported payload's course_name
+   *  hint, so the user lands on likely matches immediately instead of an
+   *  empty field. Only used as the initial value — later prop changes
+   *  don't reset an in-progress search. */
+  initialQuery?: string
 }
 
 interface GpsState {
@@ -32,8 +37,9 @@ export function CourseSearch({
   selectedCourseId,
   onSelect,
   requestGps = false,
+  initialQuery = '',
 }: CourseSearchProps) {
-  const [query, setQuery] = useState('')
+  const [query, setQuery] = useState(initialQuery)
   const [creatingManual, setCreatingManual] = useState(false)
   const [gps, setGps] = useState<GpsState>({ status: 'idle' })
   const [facility, setFacility] = useState<FacilityRow | null>(null)

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -3,10 +3,27 @@
 // not fine in production. In dev we keep the raw message so failures
 // stay debuggable; in prod we collapse to a single neutral string and
 // rely on console.error for the detail.
+// postgrest-js only wraps a query error in a real Error when you call
+// `.throwOnError()` — every query in this app just awaits the {data, error}
+// tuple, so `error` here is normally the raw JSON error body PostgREST sent
+// back (message/details/hint/code), not an Error instance. Without this
+// check, `error instanceof Error` is false, `typeof error === 'string'` is
+// false, and it falls through to `String(error)` → "[object Object]" for
+// every single DB error in the app.
+function isMessageBearing(error: unknown): error is { message: string } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  )
+}
+
 export function toUserMessage(error: unknown): string {
   if (import.meta.env.DEV) {
     if (error instanceof Error) return error.message
     if (typeof error === 'string') return error
+    if (isMessageBearing(error)) return error.message
     return String(error)
   }
   return 'Something went wrong. Please try again.'

--- a/apps/web/src/lib/import.test.ts
+++ b/apps/web/src/lib/import.test.ts
@@ -1,0 +1,297 @@
+import { describe, expect, it } from 'vitest'
+import { summarizeImportDataQuality, validateImportPayload } from './import'
+
+function validPayload() {
+  return {
+    import_id: 'garmin:98765432',
+    course_name: 'Lakeside National',
+    played_at: '2026-08-01',
+    tee_color: 'white',
+    total_score: 92,
+    total_putts: 31,
+    holes: [
+      {
+        number: 1,
+        score: 5,
+        putts: 2,
+        penalties: 0,
+        shots: [
+          {
+            shot_number: 1,
+            club: 'driver',
+            lie_type: 'tee',
+            start_lat: 40.0,
+            start_lng: -105.0,
+            end_lat: 40.001,
+            end_lng: -105.001,
+            distance_to_target: 365,
+          },
+          {
+            shot_number: 2,
+            club: 'putter',
+            lie_type: 'green',
+            putt_distance_ft: 5.5,
+          },
+        ],
+      },
+    ],
+  }
+}
+
+describe('validateImportPayload', () => {
+  it('accepts a well-formed payload', () => {
+    const result = validateImportPayload(validPayload())
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.holes).toHaveLength(1)
+      expect(result.data.holes[0]!.shots).toHaveLength(2)
+    }
+  })
+
+  it('rounds a fractional distance_to_target to the nearest yard', () => {
+    // shots.distance_to_target is an integer column — a GPS-derived
+    // fractional yardage (Garmin et al.) would otherwise fail the insert
+    // with a Postgres "invalid input syntax for type integer" error.
+    const payload = validPayload()
+    payload.holes[0]!.shots[0]!.distance_to_target = 235.7
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.holes[0]!.shots[0]!.distance_to_target).toBe(236)
+    }
+  })
+
+  it('accepts a payload with no shots (score-only import)', () => {
+    const payload = validPayload()
+    payload.holes[0]!.shots = []
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a JSON string, not just a parsed object', () => {
+    const result = validateImportPayload(JSON.stringify(validPayload()))
+    expect(result.success).toBe(true)
+  })
+
+  it('reports invalid JSON without throwing', () => {
+    const result = validateImportPayload('{ not valid json')
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors[0]!.message).toMatch(/invalid JSON/)
+    }
+  })
+
+  it('rejects a missing required field with a field-level error', () => {
+    const payload = validPayload() as Record<string, unknown>
+    delete payload.played_at
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors.some((e) => e.path === 'played_at')).toBe(true)
+    }
+  })
+
+  it('rejects an out-of-vocabulary enum value with a path pointing at the exact shot', () => {
+    const payload = validPayload()
+    payload.holes[0]!.shots[0]!.lie_type = 'bunker'
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors.some((e) => e.path === 'holes[0].shots[0].lie_type')).toBe(true)
+    }
+  })
+
+  it('rejects an out-of-range latitude', () => {
+    const payload = validPayload()
+    payload.holes[0]!.shots[0]!.start_lat = 200
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors.some((e) => e.path === 'holes[0].shots[0].start_lat')).toBe(true)
+    }
+  })
+
+  it('requires at least one hole', () => {
+    const payload = validPayload()
+    payload.holes = []
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors.some((e) => e.path === 'holes')).toBe(true)
+    }
+  })
+
+  it('rejects a malformed played_at date string', () => {
+    const payload = validPayload()
+    payload.played_at = '08/01/2026'
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects Infinity for distance_to_target', () => {
+    const payload = validPayload()
+    payload.holes[0]!.shots[0]!.distance_to_target = Infinity
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects Infinity for putt_distance_ft', () => {
+    const payload = validPayload()
+    payload.holes[0]!.shots[1]!.putt_distance_ft = Infinity
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects Infinity for aim_offset_yards', () => {
+    const payload = validPayload() as Record<string, unknown>
+    ;(
+      (payload.holes as Record<string, unknown>[])[0]!.shots as Record<string, unknown>[]
+    )[0]!.aim_offset_yards = -Infinity
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects more than 20 shots on a single hole', () => {
+    const payload = validPayload() as Record<string, unknown>
+    ;(payload.holes as Record<string, unknown>[])[0]!.shots = Array.from(
+      { length: 21 },
+      (_, i) => ({ shot_number: i + 1 }),
+    )
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors.some((e) => e.path === 'holes[0].shots')).toBe(true)
+    }
+  })
+
+  it('rejects more than 18 holes', () => {
+    // Capped at 18 (not the schema's per-hole number range extended for a
+    // double round) because the write path upserts hole_scores on
+    // (round_id, hole_id) — a second nine would silently overwrite the
+    // first instead of creating a second round.
+    const payload = validPayload() as Record<string, unknown>
+    payload.holes = Array.from({ length: 19 }, (_, i) => ({
+      number: i + 1,
+      score: 4,
+      shots: [],
+    }))
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors.some((e) => e.path === 'holes')).toBe(true)
+    }
+  })
+
+  it('rejects a duplicate shot_number on the same hole', () => {
+    // shots has a DB unique constraint on (hole_score_id, shot_number) —
+    // this should fail validation up front instead of passing review and
+    // tripping the constraint mid-insert.
+    const payload = validPayload()
+    payload.holes[0]!.shots[1]!.shot_number = 1
+    const result = validateImportPayload(payload)
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.errors.some((e) => e.path === 'holes[0].shots[1].shot_number')).toBe(true)
+    }
+  })
+})
+
+function summarize(payload: unknown) {
+  const result = validateImportPayload(payload)
+  if (!result.success) throw new Error('expected payload to validate')
+  return summarizeImportDataQuality(result.data)
+}
+
+describe('summarizeImportDataQuality', () => {
+  it('reports no warnings for a fully-complete payload', () => {
+    // validPayload()'s shot 1 has club/lie_type/distance_to_target; shot 2
+    // is a putt (lie_type: 'green') with putt_distance_ft set correctly.
+    expect(summarize(validPayload())).toEqual({
+      missingClub: [],
+      missingLieType: [],
+      missingDistanceToTarget: [],
+      misplacedPuttDistance: [],
+    })
+  })
+
+  it('locates a shot missing club by hole and shot number', () => {
+    const payload = validPayload()
+    delete (payload.holes[0]!.shots[0] as Record<string, unknown>).club
+    expect(summarize(payload).missingClub).toEqual([{ holeNumber: 1, shotNumber: 1 }])
+  })
+
+  it('locates a shot missing lie_type by hole and shot number', () => {
+    const payload = validPayload()
+    delete (payload.holes[0]!.shots[0] as Record<string, unknown>).lie_type
+    expect(summarize(payload).missingLieType).toEqual([{ holeNumber: 1, shotNumber: 1 }])
+  })
+
+  it('does not flag a putt (lie_type "green") missing distance_to_target', () => {
+    const payload = validPayload()
+    const putt = payload.holes[0]!.shots[1] as Record<string, unknown>
+    delete putt.club
+    // lie_type stays 'green', no distance_to_target.
+    expect(summarize(payload).missingDistanceToTarget).toEqual([])
+  })
+
+  it('does not flag a putt identified via club "putter" alone missing distance_to_target', () => {
+    const payload = validPayload()
+    const putt = payload.holes[0]!.shots[1] as Record<string, unknown>
+    delete putt.lie_type
+    // club stays 'putter', no distance_to_target.
+    expect(summarize(payload).missingDistanceToTarget).toEqual([])
+  })
+
+  it('locates a non-putt shot missing distance_to_target', () => {
+    const payload = validPayload()
+    delete (payload.holes[0]!.shots[0] as Record<string, unknown>).distance_to_target
+    expect(summarize(payload).missingDistanceToTarget).toEqual([{ holeNumber: 1, shotNumber: 1 }])
+  })
+
+  it('returns empty lists for a payload with no shots', () => {
+    const payload = validPayload()
+    payload.holes[0]!.shots = []
+    expect(summarize(payload)).toEqual({
+      missingClub: [],
+      missingLieType: [],
+      missingDistanceToTarget: [],
+      misplacedPuttDistance: [],
+    })
+  })
+
+  it('locates a putt whose distance landed in distance_to_target instead of putt_distance_ft', () => {
+    const payload = validPayload()
+    const putt = payload.holes[0]!.shots[1] as Record<string, unknown>
+    delete putt.putt_distance_ft
+    putt.distance_to_target = 5.5
+    expect(summarize(payload).misplacedPuttDistance).toEqual([{ holeNumber: 1, shotNumber: 2 }])
+  })
+
+  it('does not flag a putt with putt_distance_ft correctly set, even if distance_to_target is also present', () => {
+    const payload = validPayload()
+    const putt = payload.holes[0]!.shots[1] as Record<string, unknown>
+    putt.distance_to_target = 5.5 // stray extra value alongside a correct putt_distance_ft
+    expect(summarize(payload).misplacedPuttDistance).toEqual([])
+  })
+
+  it('does not flag a putt with neither distance field set (no data at all, not a misplacement)', () => {
+    const payload = validPayload()
+    const putt = payload.holes[0]!.shots[1] as Record<string, unknown>
+    delete putt.putt_distance_ft
+    // distance_to_target already absent on this shot.
+    expect(summarize(payload).misplacedPuttDistance).toEqual([])
+  })
+
+  it('aggregates issues across multiple holes', () => {
+    const payload = validPayload()
+    delete (payload.holes[0]!.shots[0] as Record<string, unknown>).club
+    ;(payload.holes as Record<string, unknown>[]).push({
+      number: 2,
+      score: 4,
+      shots: [{ shot_number: 1, club: 'driver' }], // missing lie_type
+    })
+    const result = summarize(payload)
+    expect(result.missingClub).toEqual([{ holeNumber: 1, shotNumber: 1 }])
+    expect(result.missingLieType).toEqual([{ holeNumber: 2, shotNumber: 1 }])
+  })
+})

--- a/apps/web/src/lib/import.ts
+++ b/apps/web/src/lib/import.ts
@@ -1,0 +1,232 @@
+import { z } from 'zod'
+import { LIE_SLOPES_FORWARD, LIE_SLOPES_SIDE, LIE_TYPES, SHOT_RESULTS } from '@oga/core'
+
+// Schema for the "Import from data" feature (apps/web ImportDataPage). Field
+// names are the actual snake_case DB column names on shots/hole_scores/rounds
+// (not the app's camelCase TS conventions) — the payload is meant to be
+// produced by an external script (e.g. a Garmin-to-OGA converter someone
+// writes themselves) that maps a third-party data source straight onto this
+// app's schema, so it doubles as a preview of what will actually be
+// inserted. Fields the review/commit step resolves interactively — user_id,
+// course_id, hole_id, round_id, hole_score_id — are deliberately absent;
+// `course_name` is a hint for pre-seeding the course search, not a stored
+// value, and `holes[].number` is what gets matched against the chosen
+// course's real holes.
+//
+// break_direction_vertical/horizontal and green_speed/putt distance-result
+// unions are hand-written (not sourced from constants.ts) because they're
+// plain string-literal types in ./types, not exported const arrays — keep
+// these in sync with BreakDirectionVertical/BreakDirectionHorizontal/
+// GreenSpeed/PuttDistanceResult/PuttDirectionResult there.
+
+const latitude = z.number().min(-90).max(90)
+const longitude = z.number().min(-180).max(180)
+
+export const importShotSchema = z.object({
+  shot_number: z.number().int().min(1),
+  club: z.string().min(1).nullish(),
+  lie_type: z.enum(LIE_TYPES).nullish(),
+  lie_slope_forward: z.enum(LIE_SLOPES_FORWARD).nullish(),
+  lie_slope_side: z.enum(LIE_SLOPES_SIDE).nullish(),
+  shot_result: z.enum(SHOT_RESULTS).nullish(),
+  start_lat: latitude.nullish(),
+  start_lng: longitude.nullish(),
+  end_lat: latitude.nullish(),
+  end_lng: longitude.nullish(),
+  aim_lat: latitude.nullish(),
+  aim_lng: longitude.nullish(),
+  // shots.distance_to_target is an integer column, and the rest of the app
+  // already rounds to whole yards before writing it (see
+  // useRoundActions.ts's live-capture path) — round here too so a
+  // GPS-derived fractional yardage (Garmin et al.) doesn't fail the insert
+  // with a Postgres "invalid input syntax for type integer" error.
+  // .finite() rejects Infinity/-Infinity, which plain z.number() lets
+  // through (only NaN is rejected by default) and Postgres would otherwise
+  // reject at insert time with the same class of numeric-syntax error.
+  distance_to_target: z
+    .number()
+    .min(0)
+    .finite()
+    .nullish()
+    .transform((v) => (v == null ? v : Math.round(v))),
+  penalty: z.boolean().nullish(),
+  ob: z.boolean().nullish(),
+  aim_offset_yards: z.number().finite().nullish(),
+  break_direction_vertical: z.enum(['uphill', 'downhill', 'flat']).nullish(),
+  break_direction_horizontal: z.enum(['left_to_right', 'right_to_left', 'straight']).nullish(),
+  putt_distance_ft: z.number().min(0).finite().nullish(),
+  putt_distance_result: z.enum(['short', 'long']).nullish(),
+  putt_direction_result: z.enum(['left', 'right']).nullish(),
+  putt_slope_pct: z.number().int().min(0).max(4).nullish(),
+  green_speed: z.enum(['slow', 'medium', 'fast']).nullish(),
+  notes: z.string().nullish(),
+})
+
+export const importHoleSchema = z
+  .object({
+    number: z.number().int().min(1).max(18),
+    score: z.number().int().min(1),
+    putts: z.number().int().min(0).nullish(),
+    penalties: z.number().int().min(0).nullish(),
+    fairway_hit: z.boolean().nullish(),
+    gir: z.boolean().nullish(),
+    pin_lat: latitude.nullish(),
+    pin_lng: longitude.nullish(),
+    // No real hole has anywhere near this many recorded shots — caps a
+    // malformed/malicious payload from queuing an unbounded number of
+    // sequential shot inserts on Import.
+    shots: z.array(importShotSchema).max(20, 'a single hole cannot have more than 20 shots').default([]),
+  })
+  // shots has a DB unique constraint on (hole_score_id, shot_number) — catch
+  // a duplicate shot_number here so the payload fails validation up front
+  // instead of passing review and then tripping the constraint mid-insert
+  // (which leaves a partially-imported round for the rollback path to undo).
+  .superRefine((hole, ctx) => {
+    const seen = new Set<number>()
+    hole.shots.forEach((shot, i) => {
+      if (seen.has(shot.shot_number)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['shots', i, 'shot_number'],
+          message: `duplicate shot_number ${shot.shot_number} on hole ${hole.number}`,
+        })
+      }
+      seen.add(shot.shot_number)
+    })
+  })
+
+export const importRoundSchema = z.object({
+  // Provider-agnostic external reference for dedup, e.g. "garmin:98765432"
+  // — stored as rounds.import_id (see migration 0052). Optional: a payload
+  // with no external source (hand-built, or a provider without stable ids)
+  // can still be imported, just without duplicate-import protection.
+  import_id: z.string().min(1).nullish(),
+  // Hint only, not persisted — pre-seeds CourseSearch in the review step.
+  course_name: z.string().min(1).nullish(),
+  played_at: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'expected YYYY-MM-DD'),
+  tee_color: z.string().min(1).nullish(),
+  total_score: z.number().int().nullish(),
+  total_putts: z.number().int().min(0).nullish(),
+  // Capped at 18 (real courses top out there) — the write path upserts
+  // hole_scores on (round_id, hole_id), so a payload with a second nine
+  // (holes 19-36 for a double round) would silently overwrite the first
+  // instead of creating a second round. Double-round import needs its own
+  // design, not a bigger cap here.
+  holes: z
+    .array(importHoleSchema)
+    .min(1, 'at least one hole is required')
+    .max(18, 'a single payload cannot have more than 18 holes'),
+})
+
+export type ImportShotPayload = z.infer<typeof importShotSchema>
+export type ImportHolePayload = z.infer<typeof importHoleSchema>
+export type ImportRoundPayload = z.infer<typeof importRoundSchema>
+
+export interface ImportValidationError {
+  /** Dot/bracket path into the payload, e.g. "holes[2].shots[0].lie_type". */
+  path: string
+  message: string
+}
+
+export type ImportValidationResult =
+  | { success: true; data: ImportRoundPayload }
+  | { success: false; errors: ImportValidationError[] }
+
+function formatPath(path: (string | number)[]): string {
+  let out = ''
+  for (const segment of path) {
+    if (typeof segment === 'number') {
+      out += `[${segment}]`
+    } else {
+      out += out ? `.${segment}` : segment
+    }
+  }
+  return out || '(root)'
+}
+
+/**
+ * Parses + validates a raw import payload (already-parsed JSON, or a string
+ * to JSON.parse first). Never throws — malformed JSON and schema violations
+ * both come back as a flat, UI-friendly error list so the import screen can
+ * show every problem at once instead of stopping at the first one.
+ */
+export function validateImportPayload(raw: unknown): ImportValidationResult {
+  let value: unknown = raw
+  if (typeof raw === 'string') {
+    try {
+      value = JSON.parse(raw)
+    } catch (err) {
+      return {
+        success: false,
+        errors: [{ path: '(root)', message: `invalid JSON: ${(err as Error).message}` }],
+      }
+    }
+  }
+
+  const result = importRoundSchema.safeParse(value)
+  if (result.success) {
+    return { success: true, data: result.data }
+  }
+  return {
+    success: false,
+    errors: result.error.issues.map((issue) => ({
+      path: formatPath(issue.path),
+      message: issue.message,
+    })),
+  }
+}
+
+/** Pinpoints a single flagged shot so the UI can say exactly where to look. */
+export interface ImportDataQualityIssue {
+  holeNumber: number
+  shotNumber: number
+}
+
+export interface ImportDataQualitySummary {
+  missingClub: ImportDataQualityIssue[]
+  missingLieType: ImportDataQualityIssue[]
+  missingDistanceToTarget: ImportDataQualityIssue[]
+  misplacedPuttDistance: ImportDataQualityIssue[]
+}
+
+function isPutt(shot: ImportShotPayload): boolean {
+  return shot.lie_type === 'green' || shot.club === 'putter'
+}
+
+/**
+ * Non-blocking, advisory scan of an already-valid payload for optional
+ * fields worth backfilling (club, lie_type, distance_to_target on full
+ * swings) and one specific footgun (putt distance landing in
+ * distance_to_target instead of putt_distance_ft). Every field checked
+ * here is optional in the schema, so this never affects
+ * validateImportPayload's success/failure — purely a list of where to
+ * look for the caller to surface however it likes.
+ */
+export function summarizeImportDataQuality(payload: ImportRoundPayload): ImportDataQualitySummary {
+  const missingClub: ImportDataQualityIssue[] = []
+  const missingLieType: ImportDataQualityIssue[] = []
+  const missingDistanceToTarget: ImportDataQualityIssue[] = []
+  const misplacedPuttDistance: ImportDataQualityIssue[] = []
+
+  for (const hole of payload.holes) {
+    for (const shot of hole.shots) {
+      const at = { holeNumber: hole.number, shotNumber: shot.shot_number }
+      if (shot.club == null) missingClub.push(at)
+      if (shot.lie_type == null) missingLieType.push(at)
+      // Putts legitimately have no distance_to_target (they use
+      // putt_distance_ft instead) — flagging them here would light up
+      // every single round.
+      if (shot.distance_to_target == null && !isPutt(shot)) missingDistanceToTarget.push(at)
+      // The putting SG calc reads only putt_distance_ft, with no fallback
+      // to distance_to_target (sg-calculator.ts's startDistanceFt) — a
+      // putt carrying its distance in distance_to_target instead silently
+      // contributes zero to putting SG for the whole round, which looks
+      // like broken data rather than a mapping mistake.
+      if (isPutt(shot) && shot.putt_distance_ft == null && shot.distance_to_target != null) {
+        misplacedPuttDistance.push(at)
+      }
+    }
+  }
+
+  return { missingClub, missingLieType, missingDistanceToTarget, misplacedPuttDistance }
+}

--- a/apps/web/src/pages/rounds/ImportDataPage.tsx
+++ b/apps/web/src/pages/rounds/ImportDataPage.tsx
@@ -1,0 +1,511 @@
+import { useMemo, useRef, useState, type ChangeEvent } from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+  summarizeImportDataQuality,
+  validateImportPayload,
+  type ImportDataQualityIssue,
+  type ImportRoundPayload,
+} from '../../lib/import'
+import { CourseSearch } from '../../components/courses/CourseSearch'
+import { TeeSelector } from '../../components/courses/TeeSelector'
+import { useAuth } from '../../hooks/useAuth'
+import { useCreateRound, useDeleteRound } from '../../hooks/useRounds'
+import { useUpsertHoleScore } from '../../hooks/useHoleScores'
+import { useCreateShot } from '../../hooks/useShots'
+import { useHolesForCourse } from '../../hooks/useCourses'
+import { supabase } from '../../lib/supabase'
+import { toUserMessage } from '../../lib/errors'
+
+type Step = 'input' | 'review'
+
+// "Import from data" lets you pre-populate a round from a JSON payload you
+// produce yourself — e.g. a Garmin-to-OGA converter script you write and
+// run outside this app. Field names in the payload are this app's actual
+// snake_case DB columns (see ../../lib/import.ts), so the payload
+// is both the input format and a preview of what gets inserted. Fields no
+// external source can know (shot shape, lie slope, break direction, green
+// speed, ...) are simply absent from the payload and get filled in on the
+// normal scorecard/shot-entry screens after import.
+export function ImportDataPage() {
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const createRound = useCreateRound()
+  const deleteRound = useDeleteRound()
+  const upsertHoleScore = useUpsertHoleScore(undefined)
+  const createShot = useCreateShot(undefined)
+
+  const [step, setStep] = useState<Step>('input')
+  const [rawText, setRawText] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [progress, setProgress] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [payload, setPayload] = useState<ImportRoundPayload | null>(null)
+  const [alreadyImported, setAlreadyImported] = useState(false)
+
+  const [courseId, setCourseId] = useState<string | null>(null)
+  const [courseName, setCourseName] = useState('')
+  const [courseTeeId, setCourseTeeId] = useState<string | null>(null)
+  const [teeColor, setTeeColor] = useState('white')
+
+  const holesQuery = useHolesForCourse(courseId ?? undefined)
+
+  // Live validation on every keystroke/paste — zod parsing a round-sized
+  // payload is well under a millisecond, no debounce needed.
+  const validation = useMemo(() => {
+    if (!rawText.trim()) return null
+    return validateImportPayload(rawText)
+  }, [rawText])
+
+  // Advisory only — every field it checks is optional in the schema, so
+  // this never gates Continue. Lets someone iterating on a converter
+  // script (Garmin, etc.) notice dropped fields immediately instead of
+  // discovering degraded stats much later.
+  const dataQuality = useMemo(() => {
+    if (!validation?.success) return null
+    return summarizeImportDataQuality(validation.data)
+  }, [validation])
+
+  function handleFile(e: ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => setRawText(String(reader.result ?? ''))
+    reader.readAsText(file)
+    e.target.value = '' // allow re-selecting the same file after a fix
+  }
+
+  async function handleContinue() {
+    if (!validation?.success || !user) return
+    setError(null)
+    setBusy(true)
+    try {
+      if (validation.data.import_id) {
+        const { data: existing } = await supabase
+          .from('rounds')
+          .select('id')
+          .eq('user_id', user.id)
+          .eq('import_id', validation.data.import_id)
+          .maybeSingle()
+        setAlreadyImported(!!existing)
+      } else {
+        setAlreadyImported(false)
+      }
+      setPayload(validation.data)
+      setCourseId(null)
+      setCourseName(validation.data.course_name ?? '')
+      setCourseTeeId(null)
+      setStep('review')
+    } catch (err) {
+      setError(toUserMessage(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // Most crawler-imported courses have no `holes` rows at all — only the
+  // ones OSM actually mapped. hole_scores.hole_id has an FK to holes.id, so
+  // without materializing a real row first, every hole on a typical course
+  // would get silently skipped and this would create an empty round.
+  // Mirrors the insert_synthetic_hole RPC call in useRoundActions.ts's
+  // ensureRealHole (migration 0026) — that version lives inside a hook tied
+  // to an already-loaded round's state, so it's re-inlined here rather than
+  // reused directly.
+  async function resolveHoleId(
+    roundId: string,
+    holesByNumber: Map<number, { id: string }>,
+    number: number,
+  ): Promise<string> {
+    const holeRow = holesByNumber.get(number)
+    if (holeRow) return holeRow.id
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rpc = (supabase as any).rpc.bind(supabase) as (
+      fn: 'insert_synthetic_hole',
+      args: { p_course_id: string; p_number: number; p_par: number; p_round_id: string },
+    ) => Promise<{ data: string | null; error: { message: string } | null }>
+    const { data: holeId, error } = await rpc('insert_synthetic_hole', {
+      p_course_id: courseId!,
+      p_number: number,
+      p_par: 4,
+      p_round_id: roundId,
+    })
+    if (error || !holeId) {
+      throw new Error(error?.message ?? 'insert_synthetic_hole returned no id')
+    }
+    return holeId
+  }
+
+  async function handleImport() {
+    if (!user || !payload || !courseId) return
+    setBusy(true)
+    setError(null)
+
+    let roundRow: { id: string } | null = null
+    try {
+      setProgress('Creating round…')
+      roundRow = await createRound.mutateAsync({
+        user_id: user.id,
+        course_id: courseId,
+        course_tee_id: courseTeeId,
+        played_at: payload.played_at,
+        tee_color: payload.tee_color ?? teeColor,
+        total_score: payload.total_score ?? null,
+        total_putts: payload.total_putts ?? null,
+        import_id: payload.import_id ?? null,
+      })
+      if (!roundRow) throw new Error('Round insert returned no row')
+
+      const holesByNumber = new Map((holesQuery.data ?? []).map((h) => [h.number, h]))
+
+      for (const hole of payload.holes) {
+        setProgress(`Saving hole ${hole.number} of ${payload.holes.length}…`)
+        const holeId = await resolveHoleId(roundRow.id, holesByNumber, hole.number)
+        const savedHoleScore = await upsertHoleScore.mutateAsync({
+          round_id: roundRow.id,
+          hole_id: holeId,
+          score: hole.score,
+          putts: hole.putts ?? null,
+          penalties: hole.penalties ?? 0,
+          fairway_hit: hole.fairway_hit ?? null,
+          gir: hole.gir ?? null,
+          pin_lat: hole.pin_lat ?? null,
+          pin_lng: hole.pin_lng ?? null,
+        })
+        if (!savedHoleScore) continue
+        for (const shot of hole.shots) {
+          await createShot.mutateAsync({
+            hole_score_id: savedHoleScore.id,
+            user_id: user.id,
+            shot_number: shot.shot_number,
+            club: shot.club ?? null,
+            lie_type: shot.lie_type ?? null,
+            lie_slope_forward: shot.lie_slope_forward ?? null,
+            lie_slope_side: shot.lie_slope_side ?? null,
+            shot_result: shot.shot_result ?? null,
+            start_lat: shot.start_lat ?? null,
+            start_lng: shot.start_lng ?? null,
+            end_lat: shot.end_lat ?? null,
+            end_lng: shot.end_lng ?? null,
+            aim_lat: shot.aim_lat ?? null,
+            aim_lng: shot.aim_lng ?? null,
+            distance_to_target: shot.distance_to_target ?? null,
+            penalty: shot.penalty ?? false,
+            ob: shot.ob ?? false,
+            aim_offset_yards: shot.aim_offset_yards ?? null,
+            break_direction_vertical: shot.break_direction_vertical ?? null,
+            break_direction_horizontal: shot.break_direction_horizontal ?? null,
+            putt_distance_ft: shot.putt_distance_ft ?? null,
+            putt_distance_result: shot.putt_distance_result ?? null,
+            putt_direction_result: shot.putt_direction_result ?? null,
+            putt_slope_pct: shot.putt_slope_pct ?? null,
+            green_speed: shot.green_speed ?? null,
+            notes: shot.notes ?? null,
+          })
+        }
+      }
+
+      navigate(`/rounds/${roundRow.id}`)
+    } catch (err) {
+      // Partial imports leave an orphaned round (and consume import_id) —
+      // delete it so a retry after fixing the payload isn't blocked by a
+      // half-written round from this attempt. Best-effort: if the rollback
+      // itself fails, at least log it rather than swallowing it — the
+      // import_id is already consumed at that point, so a silent failure
+      // here means a retry would just say "already imported" with no way
+      // back short of manual cleanup.
+      if (roundRow) {
+        try {
+          await deleteRound.mutateAsync(roundRow.id)
+        } catch (rollbackErr) {
+          console.error('Failed to roll back partially-imported round', roundRow.id, rollbackErr)
+        }
+      }
+      setError(toUserMessage(err))
+      setBusy(false)
+      setProgress('')
+    }
+  }
+
+  const shotCount = payload?.holes.reduce((n, h) => n + h.shots.length, 0) ?? 0
+
+  return (
+    <div className="mx-auto max-w-2xl">
+      <div style={{ marginBottom: 18 }}>
+        <h1 className="text-caddie-ink" style={{ fontSize: 22, fontWeight: 600, lineHeight: 1.3 }}>
+          Import from data
+        </h1>
+        <div className="text-caddie-ink-dim" style={{ fontSize: 13, marginTop: 2 }}>
+          Paste or upload a JSON payload to pre-populate a round — fill in shot shape, lie
+          slope, and other detail your data source doesn't track once it lands on the
+          scorecard.
+        </div>
+      </div>
+
+      <div
+        className="bg-caddie-surface flex flex-col gap-5"
+        style={{ border: '0.5px solid #E4E4E0', borderRadius: 10, padding: 20 }}
+      >
+        {step === 'input' && (
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+              <FieldLabel>JSON payload</FieldLabel>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="text-caddie-accent"
+                style={{ background: 'transparent', border: 'none', fontSize: 12, fontWeight: 600 }}
+              >
+                Upload file…
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json,.json"
+                onChange={handleFile}
+                style={{ display: 'none' }}
+              />
+            </div>
+            <textarea
+              value={rawText}
+              onChange={(e) => setRawText(e.target.value)}
+              placeholder='{"played_at": "2026-08-01", "holes": [...]}'
+              spellCheck={false}
+              className="w-full bg-caddie-surface-2 text-caddie-ink"
+              style={{
+                border: '0.5px solid #E4E4E0',
+                borderRadius: 7,
+                padding: '10px 12px',
+                fontSize: 12,
+                fontFamily: 'monospace',
+                minHeight: 260,
+                resize: 'vertical',
+              }}
+            />
+
+            {rawText.trim().length === 0 && (
+              <div className="text-caddie-ink-mute" style={{ fontSize: 12 }}>
+                Waiting for a payload — see apps/web/src/lib/import.ts for the expected shape.
+              </div>
+            )}
+
+            {validation && !validation.success && (
+              <div
+                className="text-caddie-neg"
+                style={{
+                  fontSize: 12,
+                  border: '1px solid #E4A0A0',
+                  borderRadius: 7,
+                  padding: 10,
+                  maxHeight: 200,
+                  overflowY: 'auto',
+                }}
+              >
+                <div style={{ fontWeight: 600, marginBottom: 6 }}>
+                  {validation.errors.length} problem{validation.errors.length === 1 ? '' : 's'}
+                </div>
+                {validation.errors.map((err, idx) => (
+                  <div key={idx} style={{ marginBottom: 4 }}>
+                    <span style={{ fontFamily: 'monospace' }}>{err.path}</span>: {err.message}
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {validation && validation.success && (
+              <div className="text-caddie-accent" style={{ fontSize: 13 }}>
+                Looks good — {validation.data.holes.length} hole
+                {validation.data.holes.length === 1 ? '' : 's'},{' '}
+                {validation.data.holes.reduce((n, h) => n + h.shots.length, 0)} shot(s).
+              </div>
+            )}
+
+            {dataQuality &&
+              (dataQuality.missingClub.length > 0 ||
+                dataQuality.missingLieType.length > 0 ||
+                dataQuality.missingDistanceToTarget.length > 0 ||
+                dataQuality.misplacedPuttDistance.length > 0) && (
+                <div className="text-caddie-warn" style={{ fontSize: 12 }}>
+                  <div style={{ fontWeight: 600, marginBottom: 6 }}>
+                    Watch out — some shot details are missing:
+                  </div>
+                  {dataQuality.missingClub.length > 0 && (
+                    <div style={{ marginBottom: 4 }}>
+                      {dataQuality.missingClub.length} shot
+                      {dataQuality.missingClub.length === 1 ? '' : 's'} missing club:{' '}
+                      {formatIssueLocations(dataQuality.missingClub)}.
+                    </div>
+                  )}
+                  {dataQuality.missingLieType.length > 0 && (
+                    <div style={{ marginBottom: 4 }}>
+                      {dataQuality.missingLieType.length} shot
+                      {dataQuality.missingLieType.length === 1 ? '' : 's'} missing lie_type:{' '}
+                      {formatIssueLocations(dataQuality.missingLieType)}.
+                    </div>
+                  )}
+                  {dataQuality.missingDistanceToTarget.length > 0 && (
+                    <div style={{ marginBottom: 4 }}>
+                      {dataQuality.missingDistanceToTarget.length} non-putt shot
+                      {dataQuality.missingDistanceToTarget.length === 1 ? '' : 's'} missing
+                      distance_to_target: {formatIssueLocations(dataQuality.missingDistanceToTarget)}.
+                    </div>
+                  )}
+                  {dataQuality.misplacedPuttDistance.length > 0 && (
+                    <div>
+                      {dataQuality.misplacedPuttDistance.length} putt
+                      {dataQuality.misplacedPuttDistance.length === 1 ? '' : 's'} carry their distance
+                      in distance_to_target instead of putt_distance_ft — putting Strokes Gained will
+                      read as 0 for these: {formatIssueLocations(dataQuality.misplacedPuttDistance)}.
+                    </div>
+                  )}
+                </div>
+              )}
+
+            {error && (
+              <div className="text-caddie-neg" style={{ fontSize: 13 }}>
+                {error}
+              </div>
+            )}
+
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={handleContinue}
+                disabled={busy || !validation?.success}
+                className="bg-caddie-accent text-caddie-accent-ink disabled:opacity-50"
+                style={buttonStyle}
+              >
+                {busy ? 'Checking…' : 'Continue'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === 'review' && payload && (
+          <div className="flex flex-col gap-5">
+            {alreadyImported && (
+              <div
+                className="text-caddie-neg"
+                style={{ fontSize: 13, border: '1px solid #E4A0A0', borderRadius: 7, padding: 10 }}
+              >
+                A round with import_id "{payload.import_id}" already exists. Importing again will
+                create a duplicate round — go back and remove/change import_id if that's not what
+                you want.
+              </div>
+            )}
+
+            <div>
+              <FieldLabel>
+                Course{payload.course_name ? ` (payload says "${payload.course_name}")` : ''}
+              </FieldLabel>
+              <CourseSearch
+                selectedCourseId={courseId}
+                initialQuery={payload.course_name ?? ''}
+                onSelect={(id, name) => {
+                  setCourseId(id)
+                  setCourseName(name)
+                  setCourseTeeId(null)
+                }}
+              />
+              {courseName && courseId && (
+                <p className="text-caddie-accent" style={{ fontSize: 13, marginTop: 8 }}>
+                  Selected: {courseName}
+                </p>
+              )}
+            </div>
+
+            {courseId && (
+              <div>
+                <FieldLabel>Tee</FieldLabel>
+                <TeeSelector
+                  courseId={courseId}
+                  selectedTeeId={courseTeeId}
+                  onSelect={(id, color) => {
+                    setCourseTeeId(id)
+                    setTeeColor(color)
+                  }}
+                />
+              </div>
+            )}
+
+            <div>
+              <FieldLabel>What's coming in</FieldLabel>
+              <div className="text-caddie-ink-dim" style={{ fontSize: 13 }}>
+                {payload.played_at} · {payload.total_score ?? '?'} strokes over{' '}
+                {payload.holes.length} holes, {shotCount} shots.
+              </div>
+            </div>
+
+            {error && (
+              <div className="text-caddie-neg" style={{ fontSize: 13 }}>
+                {error}
+              </div>
+            )}
+
+            {busy && progress && (
+              <div className="text-caddie-ink-dim" style={{ fontSize: 13 }}>
+                {progress}
+              </div>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setStep('input')}
+                disabled={busy}
+                className="bg-caddie-surface text-caddie-ink transition-colors hover:bg-caddie-surface-2 disabled:opacity-50"
+                style={{ ...buttonStyle, background: 'transparent', border: '0.5px solid #E4E4E0' }}
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                onClick={handleImport}
+                disabled={busy || !courseId || holesQuery.isLoading}
+                className="bg-caddie-accent text-caddie-accent-ink disabled:opacity-50"
+                style={buttonStyle}
+              >
+                {busy ? 'Importing…' : 'Import round'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// Groups flat (holeNumber, shotNumber) issues by hole for a compact,
+// scannable location list, e.g. "hole 3 (shots 2, 3), hole 11 (shot 2)".
+function formatIssueLocations(issues: ImportDataQualityIssue[]): string {
+  const shotsByHole = new Map<number, number[]>()
+  for (const { holeNumber, shotNumber } of issues) {
+    const shots = shotsByHole.get(holeNumber) ?? []
+    shots.push(shotNumber)
+    shotsByHole.set(holeNumber, shots)
+  }
+  return [...shotsByHole.entries()]
+    .map(
+      ([holeNumber, shotNumbers]) =>
+        `hole ${holeNumber} (shot${shotNumbers.length === 1 ? '' : 's'} ${shotNumbers.join(', ')})`,
+    )
+    .join(', ')
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="text-caddie-ink-dim uppercase"
+      style={{ fontSize: 11, fontWeight: 500, letterSpacing: 0.4, marginBottom: 6 }}
+    >
+      {children}
+    </div>
+  )
+}
+
+const buttonStyle: React.CSSProperties = {
+  borderRadius: 10,
+  padding: '10px 16px',
+  fontSize: 13,
+  fontWeight: 500,
+}

--- a/apps/web/src/pages/rounds/RoundsPage.tsx
+++ b/apps/web/src/pages/rounds/RoundsPage.tsx
@@ -37,22 +37,38 @@ export function RoundsPage() {
             </div>
           )}
         </div>
-        <Link
-          to="/rounds/new"
-          className="bg-caddie-accent text-caddie-accent-ink hover:opacity-90"
-          style={{
-            padding: '12px 16px',
-            fontSize: 14,
-            fontWeight: 600,
-            letterSpacing: '0.02em',
-            borderRadius: 2,
-          }}
-        >
-          New round{' '}
-          <span className="font-serif" style={{ fontStyle: 'italic' }}>
-            →
-          </span>
-        </Link>
+        <div className="flex" style={{ gap: 8 }}>
+          <Link
+            to="/rounds/import"
+            className="bg-caddie-surface text-caddie-ink hover:bg-caddie-surface-2"
+            style={{
+              padding: '12px 16px',
+              fontSize: 14,
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+              borderRadius: 2,
+              border: '0.5px solid #E4E4E0',
+            }}
+          >
+            Import from data
+          </Link>
+          <Link
+            to="/rounds/new"
+            className="bg-caddie-accent text-caddie-accent-ink hover:opacity-90"
+            style={{
+              padding: '12px 16px',
+              fontSize: 14,
+              fontWeight: 600,
+              letterSpacing: '0.02em',
+              borderRadius: 2,
+            }}
+          >
+            New round{' '}
+            <span className="font-serif" style={{ fontStyle: 'italic' }}>
+              →
+            </span>
+          </Link>
+        </div>
       </div>
 
       {isLoading && (

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -34,6 +34,9 @@ const ShotPatternsPage = lazy(() =>
 const RoundDetailPage = lazy(() =>
   import('./pages/rounds/RoundDetailPage').then((m) => ({ default: m.RoundDetailPage })),
 )
+const ImportDataPage = lazy(() =>
+  import('./pages/rounds/ImportDataPage').then((m) => ({ default: m.ImportDataPage })),
+)
 const LearnPage = lazy(() =>
   import('./pages/learn/LearnPage').then((m) => ({ default: m.LearnPage })),
 )
@@ -120,6 +123,7 @@ const routes: RouteObject[] = [
       { path: '/dashboard', element: <DashboardPage />, errorElement },
       { path: '/rounds', element: <RoundsPage />, errorElement },
       { path: '/rounds/new', element: <NewRoundPage />, errorElement },
+      { path: '/rounds/import', element: <ImportDataPage />, errorElement },
       { path: '/rounds/:id', element: <RoundDetailPage />, errorElement },
       { path: '/stats', element: <StrokesGainedPage />, errorElement },
       { path: '/patterns', element: <ShotPatternsPage />, errorElement },

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -597,6 +597,7 @@ export type Database = {
           fairways_total: number | null
           gir: number | null
           id: string
+          import_id: string | null
           notes: string | null
           played_at: string
           score_differential: number | null
@@ -621,6 +622,7 @@ export type Database = {
           fairways_total?: number | null
           gir?: number | null
           id?: string
+          import_id?: string | null
           notes?: string | null
           played_at: string
           score_differential?: number | null
@@ -645,6 +647,7 @@ export type Database = {
           fairways_total?: number | null
           gir?: number | null
           id?: string
+          import_id?: string | null
           notes?: string | null
           played_at?: string
           score_differential?: number | null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       recharts:
         specifier: ^2.12.7
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -124,6 +127,9 @@ importers:
       vite:
         specifier: ^6.4.2
         version: 6.4.2(@types/node@25.6.0)(jiti@1.21.7)(lightningcss@1.27.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@25.6.0)(lightningcss@1.27.0)(terser@5.46.2)
 
   packages/core:
     dependencies:
@@ -2524,6 +2530,9 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -4689,3 +4698,5 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  zod@3.25.76: {}

--- a/supabase/migrations/0052_rounds_import_id.sql
+++ b/supabase/migrations/0052_rounds_import_id.sql
@@ -1,0 +1,15 @@
+-- Provider-agnostic external-import reference for rounds, mirroring the
+-- courses.external_id pattern (0004/0019). Format "<provider>:<id>", e.g.
+-- "garmin:98765432". Lets the "Import from data" feature detect/block
+-- re-importing a round it's already brought in without being tied to any
+-- one provider.
+alter table public.rounds add column import_id text;
+
+-- Scoped to (user_id, import_id), not import_id alone: nothing guarantees
+-- a provider's id is unique *across* accounts (and a source with no
+-- stable ids at all might reuse a caller-chosen string like "manual:1"),
+-- so a global unique index would let one user's import block another
+-- user's.
+create unique index if not exists rounds_import_id_unique
+  on public.rounds(user_id, import_id)
+  where import_id is not null;


### PR DESCRIPTION
Lets a user paste/upload a JSON payload (e.g. from a hand-written Garmin-to-OGA converter) to pre-populate a round, matching provider data straight onto this app's own schema so the payload doubles as a preview of what gets inserted.

- packages/core/src/import.ts: zod schema + validateImportPayload, plus summarizeImportDataQuality — a non-blocking advisory scan that flags shots missing club/lie_type/distance_to_target and putts whose distance landed in distance_to_target instead of putt_distance_ft (the latter silently zeroes out putting Strokes Gained with no error).
- ImportDataPage.tsx: paste/upload -> validate -> pick course/tee ->
  import, with rollback on partial failure and a warning when holes can't be matched to the selected course instead of silently dropping them.
- Migration 0046: rounds.import_id (scoped per-user) for duplicate-import detection.
- Migration 0047: fixes a from-scratch `supabase db reset` gap where PostgREST roles never got table grants on anything created by the `postgres` role, breaking local dev for every table, not just this feature's.
- Hardening: capped payload array sizes, rejected non-finite numbers, and fixed toUserMessage silently showing "[object Object]" for every Postgres error app-wide (postgrest-js errors aren't real Error instances unless .throwOnError() is used).
- vite.config.ts: dev-only CSP relaxation so local Supabase is reachable under `vite dev` (production CSP is untouched).

## What this PR does
<!-- Brief description of the change -->

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Design/UI change
- [ ] Refactor
- [ ] Docs

## Testing
- [x] pnpm typecheck passes (3/3 workspace packages)
- [x] pnpm test passes (all)
- [x] pnpm --filter web build passes
- [x] Tested in browser at localhost:5173
- [ ] Mobile typecheck passes

## Notes for reviewer
I've got a private repo for the garmin JSON creator - I'm not sure how Garmin feel about me getting _my own data_ but I didn't want to link it whatsoever to this project. Happy to share if you need it, but it didn't take long to generate. Only oddity that caught me was the different measurements between yards and feet for putting, but I can see why we need that for SG. 

Only other thing is - you can access the Import from the "Rounds" page but actually, I wasn't sure if you wanted to adjust the "New Round+" page instead? Not too fussed, open to changing it. 

<img width="739" height="727" alt="image" src="https://github.com/user-attachments/assets/9ef10f35-b1f8-4abb-8b58-58d753aeb463" />
