### PR TITLE
fix(db): grant table access to anon/authenticated/service_role

### DIFF
--- a/supabase/migrations/0047_postgrest_role_default_grants.sql
+++ b/supabase/migrations/0047_postgrest_role_default_grants.sql
@@ -1,0 +1,29 @@
+-- `supabase db reset` applies these migrations as the `postgres` role, so
+-- every table here is owned by `postgres`. The Supabase local image's own
+-- bootstrap sets default privileges so future tables owned by
+-- `supabase_admin` auto-grant full CRUD to anon/authenticated/service_role,
+-- but nothing in this repo's migration history ever did the same for the
+-- `postgres` role — so on a from-scratch reset, PostgREST (which runs
+-- queries as anon/authenticated/service_role) gets "permission denied" on
+-- the first table it touches. RLS policies are the real access boundary
+-- throughout this schema; these grants are just the base plumbing PostgREST
+-- needs to attempt a query at all.
+--
+-- Two parts: backfill grants on tables this migration history already
+-- created, and set default privileges so tables created by later
+-- migrations get them automatically.
+--
+-- `anon` only gets `select` (defense-in-depth beyond RLS: a table that ships
+-- with RLS disabled, or created before its own `enable row level security`
+-- runs, stays anon-readable but not anon-writable). `authenticated` and
+-- `service_role` keep full DML since RLS is expected to scope their writes.
+grant select on all tables in schema public to anon;
+grant select, insert, update, delete on all tables in schema public to authenticated, service_role;
+grant usage, select on all sequences in schema public to anon, authenticated, service_role;
+
+alter default privileges for role postgres in schema public
+  grant select on tables to anon;
+alter default privileges for role postgres in schema public
+  grant select, insert, update, delete on tables to authenticated, service_role;
+alter default privileges for role postgres in schema public
+  grant usage, select on sequences to anon, authenticated, service_role;


### PR DESCRIPTION
Split out of #841 per review feedback — this is the standalone grants
migration, carried over from `feature/round-import` (identical filename/
content, same rationale) since `main`/`dev` are both missing it. No app
code changes.

None of the existing migrations grant table-level SELECT/INSERT/UPDATE/
DELETE to anon/authenticated/service_role on public-schema tables —
Supabase's local bootstrap only auto-grants for tables owned by
supabase_admin, not the postgres role our migrations run as. A
from-scratch `supabase db reset` hits "permission denied" on the first
table PostgREST touches.

First of 4 PRs replacing #841 (see #841 for the full split rationale):
1. **this PR** — grants migration
2. course-address-fields — website/address/country columns
3. hole-tees-resolver — hole_tees schema + resolver + production wiring
4. course-editor-ui — dev-only Course Editor UI + backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)