### PR TITLE
feat(db): add website/address/country columns to courses and facilities

### DIFF
--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -113,7 +113,9 @@ export type Database = {
       }
       courses: {
         Row: {
+          address: string | null
           city: string | null
+          country: string | null
           created_at: string
           created_by: string | null
           external_id: string | null
@@ -129,9 +131,12 @@ export type Database = {
           total_yards: number | null
           unit_name: string | null
           unit_order: number | null
+          website: string | null
         }
         Insert: {
+          address?: string | null
           city?: string | null
+          country?: string | null
           created_at?: string
           created_by?: string | null
           external_id?: string | null
@@ -147,9 +152,12 @@ export type Database = {
           total_yards?: number | null
           unit_name?: string | null
           unit_order?: number | null
+          website?: string | null
         }
         Update: {
+          address?: string | null
           city?: string | null
+          country?: string | null
           created_at?: string
           created_by?: string | null
           external_id?: string | null
@@ -165,6 +173,7 @@ export type Database = {
           total_yards?: number | null
           unit_name?: string | null
           unit_order?: number | null
+          website?: string | null
         }
         Relationships: [
           {
@@ -272,31 +281,40 @@ export type Database = {
       }
       facilities: {
         Row: {
+          address: string | null
           city: string | null
+          country: string | null
           created_at: string
           id: string
           lat: number | null
           lng: number | null
           name: string
           state: string | null
+          website: string | null
         }
         Insert: {
+          address?: string | null
           city?: string | null
+          country?: string | null
           created_at?: string
           id?: string
           lat?: number | null
           lng?: number | null
           name: string
           state?: string | null
+          website?: string | null
         }
         Update: {
+          address?: string | null
           city?: string | null
+          country?: string | null
           created_at?: string
           id?: string
           lat?: number | null
           lng?: number | null
           name?: string
           state?: string | null
+          website?: string | null
         }
         Relationships: []
       }

--- a/supabase/migrations/0047_postgrest_role_default_grants.sql
+++ b/supabase/migrations/0047_postgrest_role_default_grants.sql
@@ -1,0 +1,29 @@
+-- `supabase db reset` applies these migrations as the `postgres` role, so
+-- every table here is owned by `postgres`. The Supabase local image's own
+-- bootstrap sets default privileges so future tables owned by
+-- `supabase_admin` auto-grant full CRUD to anon/authenticated/service_role,
+-- but nothing in this repo's migration history ever did the same for the
+-- `postgres` role — so on a from-scratch reset, PostgREST (which runs
+-- queries as anon/authenticated/service_role) gets "permission denied" on
+-- the first table it touches. RLS policies are the real access boundary
+-- throughout this schema; these grants are just the base plumbing PostgREST
+-- needs to attempt a query at all.
+--
+-- Two parts: backfill grants on tables this migration history already
+-- created, and set default privileges so tables created by later
+-- migrations get them automatically.
+--
+-- `anon` only gets `select` (defense-in-depth beyond RLS: a table that ships
+-- with RLS disabled, or created before its own `enable row level security`
+-- runs, stays anon-readable but not anon-writable). `authenticated` and
+-- `service_role` keep full DML since RLS is expected to scope their writes.
+grant select on all tables in schema public to anon;
+grant select, insert, update, delete on all tables in schema public to authenticated, service_role;
+grant usage, select on all sequences in schema public to anon, authenticated, service_role;
+
+alter default privileges for role postgres in schema public
+  grant select on tables to anon;
+alter default privileges for role postgres in schema public
+  grant select, insert, update, delete on tables to authenticated, service_role;
+alter default privileges for role postgres in schema public
+  grant usage, select on sequences to anon, authenticated, service_role;

--- a/supabase/migrations/0048_course_website_address.sql
+++ b/supabase/migrations/0048_course_website_address.sql
@@ -1,0 +1,9 @@
+-- Dev-only Course Editor needs somewhere to store address/website. Nullable,
+-- no format validation — developer-entered data, not user-facing input.
+alter table public.courses
+  add column website text,
+  add column address text;
+
+alter table public.facilities
+  add column website text,
+  add column address text;

--- a/supabase/migrations/0049_course_country.sql
+++ b/supabase/migrations/0049_course_country.sql
@@ -1,0 +1,8 @@
+-- Courses outside the US (e.g. Merchants of Edinburgh) have no meaningful
+-- `state`, and address/website alone don't disambiguate country. Nullable,
+-- dev-entered via the Course Editor same as website/address.
+alter table public.courses
+  add column country text;
+
+alter table public.facilities
+  add column country text;


### PR DESCRIPTION
Split out of #841 per review feedback — schema-only, no app code
references these columns yet (that comes in course-editor-ui, PR 4/4).

Dev-entered metadata for the upcoming Course Editor. Nullable, no format
validation.

**Depends on #842** (grants migration) — no push access to upstream to
stack branch bases across forks, so this PR's diff currently also
includes #842's commit; it'll shrink to just this PR's change once #842
merges. Please merge #842 first.

2nd of 4 PRs replacing #841:
1. #842 — grants migration
2. **this PR** — website/address/country columns
3. hole-tees-resolver — hole_tees schema + resolver + production wiring
4. course-editor-ui — dev-only Course Editor UI + backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)