### PR TITLE
release: live-round on-course fixes (green-slope button, first-hole framing, GPS recenter)

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -244,17 +244,39 @@ export function HoleMap({
     courseCenter,
   })
 
-  const recenterOnGps = useCallback(() => {
-    if (!gpsPosition || !cameraRef.current) return
+  const recenterOnGps = useCallback(async () => {
+    if (!cameraRef.current) return
+    // Recenter on the FRESHEST fix, not the state gpsPosition. That value is
+    // throttled by the listener's 5 m displacement filter (useHoleState), so
+    // "center on me" could land the camera up to ~5 m off the live native
+    // LocationPuck — the puck ended up off-centre and it read as "the camera
+    // moved but the dot didn't." getLastKnownLocation reads the same native
+    // engine the puck renders from. Falls back to the state value if it's
+    // null / throws.
+    let target = gpsPosition
+    try {
+      const last = await Mapbox.locationManager.getLastKnownLocation()
+      if (
+        last &&
+        Number.isFinite(last.coords.latitude) &&
+        Number.isFinite(last.coords.longitude)
+      ) {
+        target = { lat: last.coords.latitude, lng: last.coords.longitude }
+      }
+    } catch {
+      // fall back to gpsPosition
+    }
+    // Re-check the ref: the await gives the component a window to unmount.
+    if (!target || !cameraRef.current) return
     cameraRef.current.setCamera({
-      centerCoordinate: toCoord(gpsPosition),
+      centerCoordinate: toCoord(target),
       zoomLevel: 17,
       pitch: 0,
       animationDuration: 600,
     })
-    // During ball placement the tap also snaps the ball back onto the
-    // player — the only way to resume GPS tracking after a manual drag.
-    if (isPlaceBallPhase) onRecenterBall?.(gpsPosition)
+    // During ball placement the tap also snaps the ball onto the player —
+    // the way to resume GPS tracking after a manual drag.
+    if (isPlaceBallPhase) onRecenterBall?.(target)
   }, [gpsPosition, cameraRef, isPlaceBallPhase, onRecenterBall])
 
   const { aimGhosts, aimGhostFeatures } = useAimGhosts({

--- a/apps/mobile/components/round/HoleMapOverlays.tsx
+++ b/apps/mobile/components/round/HoleMapOverlays.tsx
@@ -189,8 +189,7 @@ type IconName = ComponentProps<typeof MaterialCommunityIcons>['name']
 // centered; the full-height wrapper is box-none so only the strip itself
 // catches touches — map pan/long-press underneath stay live.
 //
-// green-map (slope heatmap) is a dimmed v1.1 stub. The dispersion button
-// toggles the single-color historical-shot dots (render lands in T4).
+// The dispersion button toggles the single-color historical-shot dots.
 interface LeftToolbarProps {
   dotsVisible: boolean
   onToggleDots: () => void
@@ -225,11 +224,6 @@ export function LeftToolbar({
           alignItems: 'center',
         }}
       >
-        <ToolbarButton
-          icon="terrain"
-          label="Green slope heatmap (coming soon)"
-          disabled
-        />
         <ToolbarButton
           icon="grain"
           label={dotsVisible ? 'Hide shot pattern' : 'Show shot pattern'}

--- a/apps/mobile/components/round/hooks/useHoleCamera.ts
+++ b/apps/mobile/components/round/hooks/useHoleCamera.ts
@@ -157,7 +157,15 @@ export function useHoleCamera({
   // Keyed on the pin coords so it fires once per hole, not on every GPS tick.
   useEffect(() => {
     if (!styleLoaded) return
-    if (!cameraInitialized.current) return
+    // NB: do NOT gate on cameraInitialized here. When the pin resolves
+    // BEFORE the first-frame init runs (its deps are style+center, not pin),
+    // an early bail on !cameraInitialized left this effect never re-firing —
+    // its own deps hadn't changed — so the map stayed stuck north-up. That's
+    // the "first hole opens with the pin not at the top" bug. The init effect
+    // is defined first, so on the common path it still frames first; this is
+    // the safety net that guarantees the up-the-hole heading lands once the
+    // pin is known, whatever the load order. (A redundant re-frame to the same
+    // heading is a visual no-op — the camera is already there.)
     if (phase !== 'PLACE_BALL') return
     if (!cameraRef.current) return
     const target = roundPin ?? pin ?? null


### PR DESCRIPTION
Mobile on-course fixes from device testing. All mobile JS — ships to existing installs via OTA after this merge.

- Remove green-slope toolbar stub.
- First hole opens pin-at-top (framing race fix).
- GPS recenter targets the freshest fix (camera + ball land on the live puck).