### PR TITLE
feat(mobile): delete a shot from the end-of-hole summary (online)

### DIFF
--- a/apps/mobile/components/round/HoleReviewSheet.tsx
+++ b/apps/mobile/components/round/HoleReviewSheet.tsx
@@ -183,7 +183,20 @@ export function HoleReviewSheet({
           onPress: async () => {
             const ok = await onDeleteShot(row._shotId!)
             if (!ok) return // handler already showed the connection alert; keep the row
-            setRows((prev) => prev.filter((r) => r._shotId !== row._shotId))
+            // Filter + renumber in one atomic update: the server RPC renumbers
+            // survivors to stay contiguous (delete #2 of [1,2,3,4] -> [1,2,3]),
+            // and this sheet's hydration is gated once per (hole, visible) — a
+            // delete changes neither, so without this the sheet would keep
+            // stale numbers and saveHoleSummary would re-persist the gap.
+            setRows((prev) =>
+              prev
+                .filter((r) => r._shotId !== row._shotId)
+                .map((r) =>
+                  r.shotNumber > row.shotNumber
+                    ? { ...r, shotNumber: r.shotNumber - 1 }
+                    : r,
+                ),
+            )
             // Keep the tickers honest: one fewer shot, and one fewer putt if it
             // was a green-lie shot (matches the RPC's re-tally).
             setScore((s) => Math.max(0, s - 1))

--- a/apps/mobile/components/round/HoleReviewSheet.tsx
+++ b/apps/mobile/components/round/HoleReviewSheet.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useRef, useState, type JSX } from 'react'
-import { ScrollView, Text, View, type TextStyle } from 'react-native'
+import { Alert, ScrollView, Text, View, type TextStyle } from 'react-native'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { MaterialCommunityIcons } from '@expo/vector-icons'
 import {
   DEFAULT_BAG,
   LIE_TYPES,
@@ -47,7 +48,13 @@ export interface HoleReviewSheetProps {
   ) => void
   /** Dismiss to let the user drag markers on the map. */
   onEditOnMap: () => void
+  /** Shot client-ids aligned 1:1 with initialRows (same order). */
+  shotIds: string[]
+  /** Delete a shot by id; resolves true on success, false on failure. */
+  onDeleteShot: (shotId: string) => Promise<boolean>
 }
+
+type EditableRow = ReviewedShotRow & { _shotId: string | undefined }
 
 // Palette — mirrors the web review sheet hexes exactly. Static objects only;
 // NativeWind css-interop drops function styles on iOS (#303).
@@ -107,9 +114,11 @@ export function HoleReviewSheet({
   saving,
   onSave,
   onEditOnMap,
+  shotIds,
+  onDeleteShot,
 }: HoleReviewSheetProps): JSX.Element | null {
   const insets = useSafeAreaInsets()
-  const [rows, setRows] = useState<ReviewedShotRow[]>([])
+  const [rows, setRows] = useState<EditableRow[]>([])
   // Score / putts / penalties are editable tickers. Score and putts pre-fill
   // from the placed shots (shot count, green-lie shots); penalties is the one
   // number no marker implies. All three become the hole_scores values on save.
@@ -125,6 +134,8 @@ export function HoleReviewSheet({
   // a new array reference.
   const initialRowsRef = useRef(initialRows)
   initialRowsRef.current = initialRows
+  const shotIdsRef = useRef(shotIds)
+  shotIdsRef.current = shotIds
 
   // Hydrate rows once per (hole, visible). After hydration the user's edits
   // are the source of truth — the sheet re-hydrates fresh on next open.
@@ -137,7 +148,8 @@ export function HoleReviewSheet({
     if (hydratedHoleRef.current === holeNumber) return
     hydratedHoleRef.current = holeNumber
     const next = initialRowsRef.current
-    setRows(next)
+    const ids = shotIdsRef.current
+    setRows(next.map((r, i) => ({ ...r, _shotId: ids[i] })))
     setScore(next.length)
     // Putt TALLY counts any green-lie shot (isPuttShot), matching the SG
     // putting engine + putt-count readers — a bladed wedge on the green still
@@ -154,9 +166,33 @@ export function HoleReviewSheet({
   const setRow = (idx: number, nextRow: ReviewedShotRow) =>
     setRows((prev) => {
       const copy = prev.slice()
-      copy[idx] = nextRow
+      copy[idx] = { ...nextRow, _shotId: prev[idx]?._shotId }
       return copy
     })
+
+  const confirmDelete = (row: EditableRow) => {
+    if (!row._shotId || saving) return
+    Alert.alert(
+      'Delete this shot?',
+      'This removes the shot and renumbers the rest of the hole.',
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Delete',
+          style: 'destructive',
+          onPress: async () => {
+            const ok = await onDeleteShot(row._shotId!)
+            if (!ok) return // handler already showed the connection alert; keep the row
+            setRows((prev) => prev.filter((r) => r._shotId !== row._shotId))
+            // Keep the tickers honest: one fewer shot, and one fewer putt if it
+            // was a green-lie shot (matches the RPC's re-tally).
+            setScore((s) => Math.max(0, s - 1))
+            if (isPuttShot(row.lieType)) setPutts((p) => Math.max(0, p - 1))
+          },
+        },
+      ],
+    )
+  }
 
   return (
     // RN <Modal> is intentionally NOT used — the web sheet is an absolute-fill
@@ -236,6 +272,8 @@ export function HoleReviewSheet({
                   row={row}
                   onOpenAimer={() => setAimingShot(row.shotNumber)}
                   onChange={(nextRow) => setRow(idx, nextRow)}
+                  onDelete={() => confirmDelete(row)}
+                  deleteDisabled={saving || !row._shotId}
                 />
               ))}
             </>
@@ -414,11 +452,16 @@ function ShotRow({
   row,
   onChange,
   onOpenAimer,
+  onDelete,
+  deleteDisabled,
 }: {
   row: ReviewedShotRow
   onChange: (next: ReviewedShotRow) => void
   /** Open the full-screen green aimer for this putt row. */
   onOpenAimer: () => void
+  /** Delete this shot (confirm dialog owned by the parent). */
+  onDelete: () => void
+  deleteDisabled: boolean
 }) {
   // Putt-ness is the green lie only (set when a putt is placed). Raw distance
   // must NOT classify — a chip/bunker inside 30 yd is not a putt (#660).
@@ -498,6 +541,16 @@ function ShotRow({
         <Text style={[TYPE.body, { color: C.mute, fontSize: 12, marginLeft: 'auto' }]}>
           {toDisplay(row.distanceToPin)} to pin
         </Text>
+        <PressableTouch
+          accessibilityRole="button"
+          accessibilityLabel={`Delete shot ${row.shotNumber}`}
+          disabled={deleteDisabled}
+          onPress={onDelete}
+          hitSlop={8}
+          style={{ padding: 6, alignSelf: 'center', opacity: deleteDisabled ? 0.4 : 1 }}
+        >
+          <MaterialCommunityIcons name="trash-can-outline" size={18} color={C.brick} />
+        </PressableTouch>
       </View>
 
       {isPutt ? (

--- a/apps/mobile/components/round/HoleReviewSheet.tsx
+++ b/apps/mobile/components/round/HoleReviewSheet.tsx
@@ -281,7 +281,11 @@ export function HoleReviewSheet({
               </Text>
               {rows.map((row, idx) => (
                 <ShotRow
-                  key={row.shotNumber}
+                  // Key on the stable shot id, not shotNumber: confirmDelete
+                  // renumbers survivors, so a shotNumber key would shift every
+                  // row below a deletion and reattach each ShotRow's local
+                  // picker-open state to the wrong shot.
+                  key={row._shotId ?? `shot-${row.shotNumber}`}
                   row={row}
                   onOpenAimer={() => setAimingShot(row.shotNumber)}
                   onChange={(nextRow) => setRow(idx, nextRow)}

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -801,6 +801,8 @@ export default function LiveRoundSession({
         saving={actions.saving}
         onSave={actions.saveHoleSummary}
         onEditOnMap={actions.editHoleOnMap}
+        shotIds={data.previousShotIds}
+        onDeleteShot={actions.deleteShot}
       />
 
       {/* Round-options popover. Full-screen transparent backdrop catches the

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -37,6 +37,8 @@ export interface UseHoleDataResult {
   pendingForHole: PendingShot[]
   setPendingForHole: React.Dispatch<React.SetStateAction<PendingShot[]>>
   previousShots: LatLng[]
+  previousShotIds: string[]
+  refreshShots: () => void
   localShotCount: number
   localPuttCount: number
   shotNumber: number
@@ -56,6 +58,9 @@ export function useHoleData(
   const [remotePuttCount, setRemotePuttCount] = useState(0)
   const [pendingForHole, setPendingForHole] = useState<PendingShot[]>([])
   const [remoteShotStarts, setRemoteShotStarts] = useState<LatLng[]>([])
+  const [remoteShotIds, setRemoteShotIds] = useState<string[]>([])
+  const [shotsRefreshNonce, setShotsRefreshNonce] = useState(0)
+  const refreshShots = useCallback(() => setShotsRefreshNonce((n) => n + 1), [])
 
   // How many holes this round plays. course_tees.par is unpopulated in
   // our crawled data, so infer from the mapped hole numbers — a genuine
@@ -187,6 +192,7 @@ export function useHoleData(
     setRemoteShotCount(0)
     setRemotePuttCount(0)
     setRemoteShotStarts([])
+    setRemoteShotIds([])
     setPendingForHole([])
     if (!currentHoleScore) return
     const myNonce = ++fetchNonceRef.current
@@ -259,12 +265,15 @@ export function useHoleData(
         setRemoteShotCount(shots.length)
         setRemotePuttCount(shots.filter((s) => isPuttShot(s.lie_type)).length)
         const starts: LatLng[] = []
+        const ids: string[] = []
         for (const r of shots) {
           if (r.start_lat != null && r.start_lng != null) {
             starts.push({ lat: r.start_lat, lng: r.start_lng })
+            ids.push(r.id)
           }
         }
         setRemoteShotStarts(starts)
+        setRemoteShotIds(ids)
         setPendingForHole(dedupedLocal)
       } catch (err) {
         if (myNonce !== fetchNonceRef.current) return
@@ -276,7 +285,7 @@ export function useHoleData(
         }
       }
     })()
-  }, [currentHoleScore?.id])
+  }, [currentHoleScore?.id, shotsRefreshNonce])
 
   // Derive local shot/putt counts from the pending array — single source
   // of truth, never out of sync with the underlying queue. Putts are
@@ -301,6 +310,24 @@ export function useHoleData(
     }
     return out
   }, [remoteShotStarts, pendingForHole])
+
+  // Shot client-ids aligned 1:1 with `previousShots` (same order + length), so
+  // the summary can map a row to its shot for delete_shot. Remote ids come from
+  // the server rows; pending ids from payload.id (always set on insert, db.ts).
+  const previousShotIds = useMemo(() => {
+    const out: string[] = [...remoteShotIds]
+    for (const r of pendingForHole) {
+      try {
+        const p = JSON.parse(r.payload) as ShotPayload
+        if (p.start_lat != null && p.start_lng != null && p.id) {
+          out.push(p.id)
+        }
+      } catch {
+        // skip malformed pending payload (matches previousShots)
+      }
+    }
+    return out
+  }, [remoteShotIds, pendingForHole])
 
   // Live tee anchor: the player's first shot's start IS the tee. Falls back to
   // the stored course tee before the first shot (camera + pre-shot distances).
@@ -347,6 +374,8 @@ export function useHoleData(
     pendingForHole,
     setPendingForHole,
     previousShots,
+    previousShotIds,
+    refreshShots,
     localShotCount,
     localPuttCount,
     shotNumber,

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -16,6 +16,7 @@ import { deleteRound, getProfile } from '@oga/supabase'
 import { supabase } from '../../../lib/supabase'
 import {
   allShotsForHoleScore,
+  deletePendingShotById,
   insertPendingShot,
   pendingCount,
   setPendingShotEnd,
@@ -92,6 +93,10 @@ export interface UseShotActionsResult {
   handleEndRound: () => Promise<void>
   handleDeleteRound: () => Promise<void>
   handleExitFromError: () => void
+  // Online-first single-shot delete: flush pending, call the delete_shot RPC,
+  // refresh the hole's shot state. Returns true on success, false (with an
+  // alert already shown) on network/error.
+  deleteShot: (shotId: string) => Promise<boolean>
 }
 
 export function useShotActions(input: UseShotActionsInput): UseShotActionsResult {
@@ -924,6 +929,29 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     }
   }
 
+  async function deleteShot(shotId: string): Promise<boolean> {
+    try {
+      // Flush any not-yet-synced shots so the target has a server row to delete.
+      await syncPendingShots()
+      const { data: deleted, error } = await supabase.rpc('delete_shot', {
+        p_shot_id: shotId,
+      })
+      if (error) throw error
+      // If the RPC found nothing on the server (false), the shot never synced —
+      // drop its local pending row so it actually disappears.
+      if (deleted === false) await deletePendingShotById(shotId)
+      data.refreshShots()
+      return true
+    } catch (e) {
+      if (__DEV__) console.warn('[hole/deleteShot]', (e as Error)?.message)
+      Alert.alert(
+        "Couldn't delete that shot",
+        'Deleting a shot needs a connection. Try again when you’re back online.',
+      )
+      return false
+    }
+  }
+
   function handleExitFromError() {
     // Leave to home WITHOUT deleting. A load error (network blip on a
     // rounds-deep resume) or a missing hole means the round is still
@@ -963,5 +991,6 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     handleEndRound,
     handleDeleteRound,
     handleExitFromError,
+    deleteShot,
   }
 }

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -241,15 +241,6 @@ export async function allShotsForHoleScore(holeScoreId: string): Promise<Pending
   )
 }
 
-// Attach end-of-hole metadata to a shot the player logged live. Keyed on the
-// client-generated payload.id: an existing local row (pending OR synced) is
-// rewritten in place and flipped back to 'pending' so the next sync re-upserts
-// it (idempotent on id — the server row updates, never duplicates, #652); a
-// shot whose local row was purged after an earlier session's sync is
-// re-inserted carrying the same id, which likewise updates the server row on
-// sync. This is the mobile equivalent of the web review sheet's replace-all
-// save, minus the delete — a delete-then-reinsert would strand duplicate
-// server rows whenever the save happens offline (there's no delete queue).
 // Drop a not-yet-synced local shot by its client id. Used by the online
 // delete path for a shot that never reached the server (the synced case goes
 // through the delete_shot RPC + refetch instead). This is the simple,
@@ -262,6 +253,15 @@ export async function deletePendingShotById(clientId: string): Promise<void> {
   )
 }
 
+// Attach end-of-hole metadata to a shot the player logged live. Keyed on the
+// client-generated payload.id: an existing local row (pending OR synced) is
+// rewritten in place and flipped back to 'pending' so the next sync re-upserts
+// it (idempotent on id — the server row updates, never duplicates, #652); a
+// shot whose local row was purged after an earlier session's sync is
+// re-inserted carrying the same id, which likewise updates the server row on
+// sync. This is the mobile equivalent of the web review sheet's replace-all
+// save, minus the delete — a delete-then-reinsert would strand duplicate
+// server rows whenever the save happens offline (there's no delete queue).
 export async function upsertReviewedShot(payload: ShotPayload): Promise<void> {
   const db = await getDb()
   const withId: ShotPayload = payload.id ? payload : { ...payload, id: uuid.v4() }

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -250,6 +250,18 @@ export async function allShotsForHoleScore(holeScoreId: string): Promise<Pending
 // sync. This is the mobile equivalent of the web review sheet's replace-all
 // save, minus the delete — a delete-then-reinsert would strand duplicate
 // server rows whenever the save happens offline (there's no delete queue).
+// Drop a not-yet-synced local shot by its client id. Used by the online
+// delete path for a shot that never reached the server (the synced case goes
+// through the delete_shot RPC + refetch instead). This is the simple,
+// non-tombstone local removal — offline delete of a SYNCED shot is Phase 1.5.
+export async function deletePendingShotById(clientId: string): Promise<void> {
+  const db = await getDb()
+  await db.runAsync(
+    `delete from pending_shots where json_extract(payload, '$.id') = ?`,
+    [clientId],
+  )
+}
+
 export async function upsertReviewedShot(payload: ShotPayload): Promise<void> {
   const db = await getDb()
   const withId: ShotPayload = payload.id ? payload : { ...payload, id: uuid.v4() }

--- a/packages/supabase/src/types.ts
+++ b/packages/supabase/src/types.ts
@@ -773,6 +773,7 @@ export type Database = {
     }
     Functions: {
       delete_my_account: { Args: never; Returns: undefined }
+      delete_shot: { Args: { p_shot_id: string }; Returns: boolean }
       insert_synthetic_hole: {
         Args: {
           p_course_id: string

--- a/scripts/test-delete-shot-rpc.ts
+++ b/scripts/test-delete-shot-rpc.ts
@@ -1,0 +1,101 @@
+import { createClient } from '@supabase/supabase-js'
+
+const URL = process.env.SUPABASE_URL ?? 'http://127.0.0.1:54321'
+const SERVICE = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '' // from `npx supabase status`
+const ANON = process.env.SUPABASE_ANON_KEY ?? '' // from `npx supabase status`
+if (!SERVICE || !ANON) throw new Error('Set SUPABASE_SERVICE_ROLE_KEY + SUPABASE_ANON_KEY (npx supabase status)')
+
+const admin = createClient(URL, SERVICE, { auth: { persistSession: false } })
+let failures = 0
+const check = (name: string, ok: boolean) => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}`)
+  if (!ok) failures++
+}
+
+async function makeUser(email: string) {
+  const { data, error } = await admin.auth.admin.createUser({
+    email, password: 'test-pw-123456', email_confirm: true,
+  })
+  if (error) throw error
+  return data.user!.id // handle_new_user() auto-creates the profiles row
+}
+
+async function signedInClient(email: string) {
+  const c = createClient(URL, ANON, { auth: { persistSession: false } })
+  const { error } = await c.auth.signInWithPassword({ email, password: 'test-pw-123456' })
+  if (error) throw error
+  return c
+}
+
+async function main() {
+  const emailA = `del-a-${Date.now()}@example.com`
+  const emailB = `del-b-${Date.now()}@example.com`
+  const uidA = await makeUser(emailA)
+  const uidB = await makeUser(emailB)
+
+  // Seed A's round + hole + 4 shots via service role (bypasses RLS).
+  // rounds.course_id is NOT NULL (FK to courses) — seed a minimal course first.
+  const { data: course } = await admin.from('courses')
+    .insert({ name: `Delete Shot RPC Test Course ${Date.now()}` })
+    .select('id').single()
+  const { data: round } = await admin.from('rounds')
+    .insert({ user_id: uidA, course_id: course!.id, played_at: new Date('2026-08-17').toISOString() })
+    .select('id').single()
+  // hole_scores.hole_id is NOT NULL (FK to holes) — seed a real hole row first.
+  const { data: hole } = await admin.from('holes')
+    .insert({ course_id: course!.id, number: 1, par: 4 })
+    .select('id').single()
+  const { data: hs } = await admin.from('hole_scores')
+    .insert({ round_id: round!.id, hole_id: hole!.id, par: 4, score: 4, putts: 1, penalties: 1 })
+    .select('id').single()
+  const mk = (n: number, lie: string, penalty = false) => ({
+    hole_score_id: hs!.id, user_id: uidA, shot_number: n, lie_type: lie, penalty,
+    start_lat: 35 + n * 0.001, start_lng: -97 + n * 0.001,
+  })
+  const { data: shots } = await admin.from('shots')
+    .insert([mk(1, 'tee'), mk(2, 'fairway', true), mk(3, 'fairway'), mk(4, 'green')])
+    .select('id, shot_number').order('shot_number')
+  const shot2 = shots!.find((s) => s.shot_number === 2)!
+
+  const A = await signedInClient(emailA)
+
+  // 1. Happy path: delete the middle penalty shot (#2).
+  const { data: deleted, error: delErr } = await A.rpc('delete_shot', { p_shot_id: shot2.id })
+  check('rpc returns true on delete', !delErr && deleted === true)
+
+  const { data: after } = await admin.from('shots')
+    .select('shot_number, lie_type').eq('hole_score_id', hs!.id).order('shot_number')
+  check('renumbered to 1,2,3', JSON.stringify(after!.map((s) => s.shot_number)) === '[1,2,3]')
+  check('deleted shot gone (3 remain)', after!.length === 3)
+
+  const { data: hsAfter } = await admin.from('hole_scores')
+    .select('score, putts, penalties').eq('id', hs!.id).single()
+  check('score 4->3', hsAfter!.score === 3)
+  check('putts unchanged (deleted was not a putt)', hsAfter!.putts === 1)
+  check('penalties 1->0 (deleted had penalty)', hsAfter!.penalties === 0)
+
+  // 2. Idempotent double-delete.
+  const { data: again, error: againErr } = await A.rpc('delete_shot', { p_shot_id: shot2.id })
+  check('idempotent double-delete returns false, no error', !againErr && again === false)
+
+  // 3. Ownership: B cannot delete A's shot.
+  const B = await signedInClient(emailB)
+  const { data: aShot } = await admin.from('shots')
+    .select('id').eq('hole_score_id', hs!.id).eq('shot_number', 1).single()
+  const { error: fbErr } = await B.rpc('delete_shot', { p_shot_id: aShot!.id })
+  check('non-owner rejected (forbidden)', !!fbErr && /forbidden/i.test(fbErr.message))
+
+  // 4. Anon / service-role (auth.uid() is null) rejected.
+  const { error: anonErr } = await admin.rpc('delete_shot', { p_shot_id: aShot!.id })
+  check('anon rejected (not authenticated)', !!anonErr && /not authenticated/i.test(anonErr.message))
+
+  // Cleanup: deleting the round cascades hole_scores + shots; delete the users + course.
+  await admin.from('rounds').delete().eq('id', round!.id)
+  await admin.from('courses').delete().eq('id', course!.id)
+  await admin.auth.admin.deleteUser(uidA)
+  await admin.auth.admin.deleteUser(uidB)
+
+  console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`)
+  process.exit(failures === 0 ? 0 : 1)
+}
+main().catch((e) => { console.error(e); process.exit(1) })

--- a/supabase/migrations/0046_delete_shot_rpc.sql
+++ b/supabase/migrations/0046_delete_shot_rpc.sql
@@ -1,0 +1,68 @@
+-- 0046: delete_shot RPC — atomic shot delete + renumber + hole_scores re-tally.
+-- The composite unique (hole_score_id, shot_number) is made DEFERRABLE so the
+-- renumber decrement can shift multiple rows in one statement without a
+-- transient duplicate tripping the constraint mid-statement (Postgres does not
+-- guarantee UPDATE row order). It cannot be ALTERed to DEFERRABLE in place, so
+-- drop + re-add. This does NOT affect any existing upsert: every shots upsert
+-- arbitrates onConflict:'id' (the PK), never this composite.
+alter table public.shots
+  drop constraint shots_hole_score_id_shot_number_key;
+alter table public.shots
+  add constraint shots_hole_score_id_shot_number_key
+  unique (hole_score_id, shot_number) deferrable initially deferred;
+
+create or replace function public.delete_shot(p_shot_id uuid)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid;
+  v_owner uuid;
+  v_hs uuid;
+  v_num int;
+  v_is_putt boolean;
+  v_penal boolean;
+  v_remaining int;
+begin
+  v_uid := auth.uid();
+  if v_uid is null then
+    raise exception 'not authenticated';
+  end if;
+
+  select user_id, hole_score_id, shot_number,
+         (lie_type = 'green'), (penalty or ob)
+    into v_owner, v_hs, v_num, v_is_putt, v_penal
+    from public.shots
+    where id = p_shot_id;
+  if not found then
+    return false; -- already gone; idempotent
+  end if;
+  if v_owner <> v_uid then
+    raise exception 'forbidden';
+  end if;
+
+  delete from public.shots where id = p_shot_id;
+
+  update public.shots
+    set shot_number = shot_number - 1
+    where hole_score_id = v_hs and shot_number > v_num;
+
+  select count(*) into v_remaining
+    from public.shots where hole_score_id = v_hs;
+
+  update public.hole_scores set
+      score       = greatest(0, coalesce(score, 0) - 1),
+      putts       = greatest(0, coalesce(putts, 0) - (case when v_is_putt then 1 else 0 end)),
+      penalties   = greatest(0, coalesce(penalties, 0) - (case when v_penal then 1 else 0 end)),
+      fairway_hit = case when v_remaining = 0 then null else fairway_hit end,
+      gir         = case when v_remaining = 0 then null else gir end
+    where id = v_hs;
+
+  return true;
+end;
+$$;
+
+revoke execute on function public.delete_shot(uuid) from public, anon;
+grant  execute on function public.delete_shot(uuid) to authenticated;


### PR DESCRIPTION
## What

Lets a player delete a shot from the end-of-hole summary. A `SECURITY DEFINER` Postgres RPC (`delete_shot`, migration 0046) atomically deletes the shot, renumbers survivors, and re-tallies the hole score in one transaction; the mobile summary sheet gets a per-row trash affordance that flushes pending shots, calls the RPC, refetches server truth, and optimistically updates the tickers.

Built subagent-driven from the reviewed plan (`docs/superpowers/plans/2026-08-17-live-round-shot-deletion.md`). **Online-only** by design — offline delete of a *synced* shot is an explicit later phase (a network error leaves the shot in place with a "needs a connection" message).

## Commits

- **0046 `delete_shot` RPC** — delete + renumber + re-tally (score, putts on green-lie, penalties on penalty/ob, clears fairway_hit/gir when the hole empties), all clamped `greatest(0,…)`. Composite unique `(hole_score_id, shot_number)` made `deferrable initially deferred` so the single-statement renumber decrement is safe. `auth.uid()` null-guard → `not authenticated`; ownership on `shots.user_id` → `forbidden`; missing id → `false` (idempotent). Follows the 0036/0040 precedent (`revoke ... from public, anon` / `grant ... to authenticated`). Covered by `scripts/test-delete-shot-rpc.ts` (9/9 against a local Supabase).
- **Client delete flow** — `deletePendingShotById` (db.ts), `previousShotIds` + `refreshShots` (useHoleData), `deleteShot` (useShotActions): flush pending → RPC → drop never-synced local row on `false` → refetch.
- **Summary UI** — per-row delete + confirm + optimistic removal that renumbers survivors so the display and the subsequent `saveHoleSummary` write stay contiguous with the server.

## Review

Each task passed spec + quality review; a whole-branch adversarial review (opus) caught one Critical (a stale-shotNumber gap that `saveHoleSummary` would re-persist) — fixed and re-review confirmed RESOLVED. `packages/supabase/src/types.ts` carries a hand-added `delete_shot` Functions entry so `supabase.rpc` typechecks; reconcile with a real `supabase gen types` once 0046 is applied.

## Before this ships to users

- Apply **0046** to dev (MCP) + prod (CLI `db push`) — **the client OTA must not ship before the migration is applied**, or `delete_shot` 404s.
- Device QA per the plan's Device QA section (delete middle/putt/last shot; airplane-mode guard; reopen-hole persistence).

Mobile is JS-only here → OTA-eligible after the migration lands.