### PR TITLE
fix(mobile): summary shot-delete disabled on first open (missing client id)

### DIFF
--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -1,6 +1,7 @@
 import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { Alert } from 'react-native'
 import { useRouter } from 'expo-router'
+import { uuid } from 'expo-modules-core'
 import type { User } from '@supabase/supabase-js'
 import {
   combinedBreakDirection,
@@ -236,8 +237,14 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     opts?: { forceAim?: boolean; ball?: LatLng },
   ) {
     if (persistShotInFlightRef.current) return
-    const payload = buildPayload(meta, opts)
-    if (!payload) return
+    const base = buildPayload(meta, opts)
+    if (!base) return
+    // Stamp the client id up front so the optimistic pending entry below carries
+    // the SAME id that insertPendingShot persists to SQLite. Without it, the
+    // in-memory payload has no `id`, so previousShotIds skips this shot (its
+    // `&& p.id` guard) while previousShots keeps it — misaligning the summary's
+    // row→shot map and leaving the delete affordance disabled until a refetch.
+    const payload = base.id ? base : { ...base, id: uuid.v4() }
     persistShotInFlightRef.current = true
     setSaving(true)
     try {


### PR DESCRIPTION
## Bug (device-repro'd)

On the **first** open of the end-of-hole summary in a live round, every shot row's trash affordance is disabled — tapping does nothing. It only starts working after leaving and re-entering the summary (Edit on map → Finish hole again).

## Root cause

`persistShot` (useShotActions) mints the shot's client `id` **inside** `insertPendingShot` (which stamps it onto the SQLite row) but then optimistically appends the **pre-mint** payload to the in-memory `pendingForHole` list. So the in-memory shot has coords but no `id`.

`useHoleData.previousShotIds` skips id-less pending shots (its `&& p.id` guard) while `previousShots` keeps them → the two arrays diverge in length → the summary's row→shot-id zip (`shotIds[i]`) lands `undefined` on the tail rows → `deleteDisabled = !row._shotId` disables the trash. A refetch rebuilds `pendingForHole` from SQLite (which has the id), which is why the round-trip "fixes" it.

## Fix

Stamp the client id once, up front, and use that stamped payload for **both** the DB insert and the optimistic in-memory append — so they always carry the same id (mirrors the `id ? … : uuid.v4()` idiom already in `db.ts`).

JS-only → OTA-eligible. No migration, no API change.