### PR TITLE
fix(mobile): scorecard score stale after live edit-mode shot delete

### DIFF
--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -978,6 +978,23 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       // drop its local pending row so it actually disappears.
       if (deleted === false) await deletePendingShotById(shotId)
       data.refreshShots()
+      // refreshShots only refetches SHOTS; the RPC also re-tallied hole_scores
+      // (score/putts/penalties/fairway_hit/gir) server-side, and that row is
+      // fetched by a separate effect refreshShots doesn't trigger. Refetch it so
+      // the scorecard score updates instead of staying stale after the delete.
+      const hsId = data.currentHoleScore?.id
+      if (hsId) {
+        const { data: updatedHs } = await supabase
+          .from('hole_scores')
+          .select('*')
+          .eq('id', hsId)
+          .single()
+        if (updatedHs) {
+          setHoleScores((prev) =>
+            prev.map((hs) => (hs.id === hsId ? { ...hs, ...updatedHs } : hs)),
+          )
+        }
+      }
       return true
     } catch (e) {
       if (__DEV__) console.warn('[hole/deleteShot]', (e as Error)?.message)


### PR DESCRIPTION
## Bug (device QA, Phase 2A)

Deleting a shot from a played hole in the live-round edit mode correctly removes it from the shot list, but the **saved scorecard score doesn't update**.

## Cause

`deleteShot` calls the `delete_shot` RPC (which re-tallies `hole_scores` server-side) then `data.refreshShots()`. But `refreshShots` only re-runs the **shots** fetch (`useHoleData` `shotsRefreshNonce` effect); the `holeScores` state that drives the scorecard is fetched by a **separate** effect it doesn't trigger. So the shot leaves the list while the shown score stays stale. (This is the live-round twin of the past-round `PastRoundMap` fix in #855.)

## Fix

After the RPC, refetch the current hole's `hole_scores` row and merge it into `holeScores` via the existing `setHoleScores`, so the scorecard reflects the re-tallied score/putts. No overwrite of the server's values; online-first (a failed refetch just leaves the score to self-correct on next load).

JS-only → OTA-eligible.