### PR TITLE
chore(mobile): document version-stream policy (#862)

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -6,6 +6,20 @@ const config: ExpoConfig = {
   name: 'OGA',
   slug: 'oga',
   scheme: 'oga',
+  // This is the MOBILE STORE version and it is load-bearing: runtimeVersion
+  // derives from it (policy 'appVersion' below), so OTA updates only reach
+  // installs whose native binary shipped this exact `version`. It must equal
+  // the version currently live on the App Store / Play — bump it ONLY when you
+  // submit a new native build, never to match a repo tag.
+  //
+  // Two independent version streams, by design (#862):
+  //   • GitHub / release-please tags (v1.x) — the REPO + web stream. Auto-bumps
+  //     from conventional commits on every merge to main; drives the changelog
+  //     and the continuously-deployed web app. Currently ahead (v1.4.x).
+  //   • This `version` — the MOBILE store stream. Only moves on a native submit.
+  //     Currently 1.2.0; everything since launch shipped as OTA on runtime 1.2.0.
+  // They reconverge naturally: at the NEXT native build, set this `version` to
+  // the then-current release-please number, and the store == GitHub tag again.
   version: '1.2.0',
   // EAS Update (OTA). Ships JS/asset-only fixes to installed builds WITHOUT an
   // App Store / Play review — Apple/Google permit interpreted-code updates that


### PR DESCRIPTION
## What

Documents the version-drift policy decided for #862, colocated with the load-bearing `version` field in `app.config.ts`.

## The decision (option a — document + converge at next build)

There are **two independent version streams**, and that's fine:

- **GitHub / release-please tags** (`v1.x`, currently ahead at v1.4.x) — the repo + web stream. Auto-bumps from conventional commits on every merge to main; drives the changelog and the continuously-deployed web app.
- **`app.config.ts` version** (currently `1.2.0`) — the mobile store stream. Only moves on a native submit. Everything since launch shipped as OTA on runtime 1.2.0.

They **reconverge at the next native build**: set `version` to the then-current release-please number and store == GitHub tag again. No version edits now — bumping `version` to 1.4.x today (with no matching native binary on the stores) would point runtimeVersion at a runtime no install has and **silently break OTA delivery**. The comment spells that out where someone would be tempted to do it.

## Scope

Comment-only, one file. No config value changed, no behavior change.

Closes #862.
