### PR TITLE
feat: live OB / stroke-and-distance (#839)

### DIFF
--- a/apps/mobile/components/round/HoleMap.tsx
+++ b/apps/mobile/components/round/HoleMap.tsx
@@ -83,6 +83,11 @@ interface HoleMapProps {
    * current position. Pass an empty array (or omit) on shot 1.
    */
   previousShots?: LatLng[]
+  /**
+   * Out-of-bounds flag per shot, index-aligned with `previousShots` (#839).
+   * Undefined/short arrays are treated as "not OB" — see BreadcrumbLayers.
+   */
+  previousShotObs?: boolean[]
   phase?: HoleMapPhase
   /**
    * Latest smoothed GPS position. Drives the recenter button (which
@@ -219,6 +224,7 @@ export function HoleMap({
   ball,
   handicap,
   previousShots,
+  previousShotObs,
   phase = 'PLACE_BALL',
   aimCommitted = false,
   gpsPosition,
@@ -684,6 +690,7 @@ export function HoleMap({
             styleLoaded={styleLoaded}
             isPinMode={isPinMode}
             toDisplay={toDisplay}
+            obs={previousShotObs}
           />
 
           <AimGhostLayers

--- a/apps/mobile/components/round/HoleReviewSheet.tsx
+++ b/apps/mobile/components/round/HoleReviewSheet.tsx
@@ -16,6 +16,7 @@ import {
   horizontalBreakFromAim,
   isPuttEntry,
   isPuttShot,
+  obCount,
   type BreakDirectionHorizontal,
   type BreakDirectionVertical,
   type Club,
@@ -150,7 +151,12 @@ export function HoleReviewSheet({
     const next = initialRowsRef.current
     const ids = shotIdsRef.current
     setRows(next.map((r, i) => ({ ...r, _shotId: ids[i] })))
-    setScore(next.length)
+    // Score seeds from the rows: struck rows + penalty strokes. A
+    // stroke-and-distance OB has no row of its own, and the caller marks it on
+    // the row it belongs to (shotResult 'ob') — without that term the ticker
+    // would re-seed to the struck count and Save would persist it back over
+    // the live chip's bump (#839).
+    setScore(next.length + obCount(next))
     // Putt TALLY counts any green-lie shot (isPuttShot), matching the SG
     // putting engine + putt-count readers — a bladed wedge on the green still
     // counts as a putt here even though its row shows normal-shot UI (the
@@ -198,8 +204,11 @@ export function HoleReviewSheet({
                 ),
             )
             // Keep the tickers honest: one fewer shot, and one fewer putt if it
-            // was a green-lie shot (matches the RPC's re-tally).
-            setScore((s) => Math.max(0, s - 1))
+            // was a green-lie shot (matches the RPC's re-tally). An OB row is
+            // worth TWO strokes — the shot plus its stroke-and-distance
+            // penalty, which has no row of its own — so deleting it drops 2,
+            // matching what delete_shot re-tallies server-side.
+            setScore((s) => Math.max(0, s - (row.shotResult === 'ob' ? 2 : 1)))
             if (isPuttShot(row.lieType)) setPutts((p) => Math.max(0, p - 1))
           },
         },

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -322,29 +322,6 @@ export default function LiveRoundSession({
       ? data.remoteShotCount + data.localShotCount
       : 0
 
-  // End-of-hole review rows. Built from the shots placed live (their start
-  // coords, in order) via the shared @oga/core inference — same call the web
-  // review sheet uses. Only computed while the summary is open. The pin
-  // anchors the last shot's end + every shot's distance-to-pin; with no pin
-  // (unmapped hole, none placed) the last placed point stands in so distances
-  // degrade to ~0 rather than exploding off [0,0].
-  const summaryRows = useMemo(() => {
-    if (finalState.roundState !== 'SUMMARY') return []
-    const pts = data.previousShots
-    if (pts.length === 0) return []
-    const pin = data.roundPin ?? data.storedPin ?? pts[pts.length - 1]!
-    const par = data.resolvedHole?.par ?? data.currentHoleScore?.par ?? data.currentHole?.par ?? 4
-    return buildInitialRows(pts, par, pin.lat, pin.lng)
-  }, [
-    finalState.roundState,
-    data.previousShots,
-    data.roundPin,
-    data.storedPin,
-    data.resolvedHole?.par,
-    data.currentHoleScore?.par,
-    data.currentHole?.par,
-  ])
-
   // Manual ball placement: an explicit override of the GPS-tracked marker.
   // Freeze GPS updates for this PLACE_BALL cycle and re-anchor the Kalman
   // filter at the manual point with a low variance (1 m²) — strong prior so
@@ -394,6 +371,48 @@ export default function LiveRoundSession({
       syncHoleToUrl?.(next)
     },
   })
+
+  // End-of-hole review rows. Built from the shots placed live (their start
+  // coords, in order) via the shared @oga/core inference — same call the web
+  // review sheet uses. Only computed while the summary is open. The pin
+  // anchors the last shot's end + every shot's distance-to-pin; with no pin
+  // (unmapped hole, none placed) the last placed point stands in so distances
+  // degrade to ~0 rather than exploding off [0,0].
+  //
+  // Declared below `actions` (rather than with the other data derivations
+  // above) because the OB seeding needs actions.shotObs — see below.
+  const summaryRows = useMemo(() => {
+    if (finalState.roundState !== 'SUMMARY') return []
+    const pts = data.previousShots
+    if (pts.length === 0) return []
+    const pin = data.roundPin ?? data.storedPin ?? pts[pts.length - 1]!
+    const par = data.resolvedHole?.par ?? data.currentHoleScore?.par ?? data.currentHole?.par ?? 4
+    // Carry the OB flag onto the rows (#839). buildInitialRows is geometry
+    // only — it never sets shotResult — and ReviewedShotRow has no `ob` field
+    // at all, so this string is the ONLY way a penalty reaches the sheet.
+    // Without it the sheet is blind to an OB the player already marked: the
+    // score ticker re-seeds to the struck count and Save persists that back
+    // over the chip's bump, the row shows no OB chip, and saveHoleSummary
+    // (which sources shot_result from the reviewed row, never from the stored
+    // one) writes null over the 'ob' the chip wrote.
+    //
+    // Read off `actions.shotObs`, not data.previousShotObs, for the same
+    // reason the chip's label is (see the OB props below): the fetched flags
+    // lag our own write by a refetch, and finishing the hole inside that
+    // window would seed the sheet without the penalty.
+    return buildInitialRows(pts, par, pin.lat, pin.lng).map((r, i) =>
+      actions.shotObs[i] ? { ...r, shotResult: 'ob' as const } : r,
+    )
+  }, [
+    finalState.roundState,
+    data.previousShots,
+    actions.shotObs,
+    data.roundPin,
+    data.storedPin,
+    data.resolvedHole?.par,
+    data.currentHoleScore?.par,
+    data.currentHole?.par,
+  ])
 
   // Played-hole on-map EDIT mode (vs. live capture): true when the shown
   // hole is BEHIND the finish-advance frontier AND has ≥1 logged shot — i.e.

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -703,6 +703,14 @@ export default function LiveRoundSession({
           previousShots={
             editMode ? data.previousShots.slice(0, activeShotIdx) : data.previousShots
           }
+          // Read off `actions.shotObs`, not `data.previousShotObs`, for the
+          // same reason the chip/summary do (see summaryRows above) — our own
+          // last OB write outranks the fetched flags until the refetch lands.
+          // Sliced identically to previousShots so the two stay index-aligned
+          // in edit mode too (#839).
+          previousShotObs={
+            editMode ? actions.shotObs.slice(0, activeShotIdx) : actions.shotObs
+          }
           gpsPosition={finalState.gpsPosition}
           courseCenter={data.courseCenter}
           holeNumber={holeNumber}

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -345,6 +345,23 @@ export default function LiveRoundSession({
     data.currentHole?.par,
   ])
 
+  // Manual ball placement: an explicit override of the GPS-tracked marker.
+  // Freeze GPS updates for this PLACE_BALL cycle and re-anchor the Kalman
+  // filter at the manual point with a low variance (1 m²) — strong prior so
+  // any future un-freeze still resists snapping back to a noisy raw fix.
+  // Used by the map drag/tap AND by the OB chip's stroke-and-distance snap
+  // (#839), so both freeze GPS identically rather than through two paths.
+  const placeBallManually = (loc: LatLng) => {
+    finalState.manuallyPlacedRef.current = true
+    setBallMoved(true)
+    finalState.kalmanStateRef.current = {
+      lat: loc.lat,
+      lng: loc.lng,
+      variance: 1,
+    }
+    finalState.setBall(loc)
+  }
+
   const actions = useShotActions({
     id: roundId,
     user,
@@ -356,6 +373,7 @@ export default function LiveRoundSession({
     setLoggerInitial,
     setPinPlacementOpen,
     setActiveDialog,
+    placeBallManually,
     // URL sync fires here — only on user-driven navigation (Next /
     // Prev / Finish), not on every render. A reactive useEffect that
     // depended on the parent's onHoleChange prop looped because the
@@ -703,25 +721,7 @@ export default function LiveRoundSession({
             finalState.setAim(loc)
             finalState.setAimTouched(true)
           }}
-          onSetBall={
-            editMode
-              ? handleEditModeMove
-              : (loc) => {
-                  // Manual drag/tap is an explicit override. Freeze GPS
-                  // updates for this PLACE_BALL cycle and re-anchor the
-                  // Kalman filter at the manual point with a low variance
-                  // (1 m²) — strong prior so any future un-freeze still
-                  // resists snapping back to a noisy raw fix.
-                  finalState.manuallyPlacedRef.current = true
-                  setBallMoved(true)
-                  finalState.kalmanStateRef.current = {
-                    lat: loc.lat,
-                    lng: loc.lng,
-                    variance: 1,
-                  }
-                  finalState.setBall(loc)
-                }
-          }
+          onSetBall={editMode ? handleEditModeMove : placeBallManually}
           onRecenterBall={(loc) => {
             // Deliberate recenter tap = "put the ball back on me": the
             // inverse of onSetBall above. Lift the manual freeze, restart
@@ -832,6 +832,13 @@ export default function LiveRoundSession({
             })
           }
           onNotOnGreen={actions.notOnGreen}
+          // Live OB (#839). State is DERIVED from the stored rows — a mid-hole
+          // reload must not offer to flag an already-OB shot again and charge
+          // the penalty twice.
+          onMarkLastShotOb={() => void actions.markLastShotOb()}
+          lastShotIsOb={
+            data.previousShotObs[data.previousShotObs.length - 1] ?? false
+          }
           onAddShot={() => {
             // Opt back into the live append flow on a revisited played hole:
             // re-arm the GPS ball + auto-aim and enter PLACE_BALL (#484).

--- a/apps/mobile/components/round/LiveRoundSession.tsx
+++ b/apps/mobile/components/round/LiveRoundSession.tsx
@@ -832,13 +832,14 @@ export default function LiveRoundSession({
             })
           }
           onNotOnGreen={actions.notOnGreen}
-          // Live OB (#839). State is DERIVED from the stored rows — a mid-hole
-          // reload must not offer to flag an already-OB shot again and charge
-          // the penalty twice.
+          // Live OB (#839). Both props come from useShotActions so the label
+          // and the toggle's direction share one source — the fetched flag,
+          // overridden by our own last write until the refetch catches up.
+          // Reading data.previousShotObs directly here would reintroduce the
+          // window where the chip still invites a tap that charges a second
+          // penalty stroke.
           onMarkLastShotOb={() => void actions.markLastShotOb()}
-          lastShotIsOb={
-            data.previousShotObs[data.previousShotObs.length - 1] ?? false
-          }
+          lastShotIsOb={actions.lastShotIsOb}
           onAddShot={() => {
             // Opt back into the live append flow on a revisited played hole:
             // re-arm the GPS ball + auto-aim and enter PLACE_BALL (#484).

--- a/apps/mobile/components/round/MapBottomChrome.tsx
+++ b/apps/mobile/components/round/MapBottomChrome.tsx
@@ -55,6 +55,13 @@ interface MapBottomChromeProps {
   /** Opt into the live append flow on a revisited played hole. Optional — its
    *  partner `isRevisitingPlayedHole` is the only path that reaches it. */
   onAddShot?: () => void
+  /** Live out-of-bounds: flag the hole's most recent shot as OB (or clear it),
+   *  charge the penalty stroke, and drop the ball back on that shot's origin
+   *  for the stroke-and-distance re-hit (#839). */
+  onMarkLastShotOb: () => void
+  /** True when that most recent shot is ALREADY flagged OB — flips the chip
+   *  into its undo label. Derived from the stored rows, not remembered. */
+  lastShotIsOb: boolean
   onFinishHole: () => void
   onPrev: () => void
   onNext: () => void
@@ -181,6 +188,20 @@ function ContextualActions(p: MapBottomChromeProps) {
         >
           {(p.ball != null || p.hasGps) && !p.saving && (
             <TextChip label="⛳ On the green" onPress={p.onOnGreen} />
+          )}
+          {/* Live OB (#839). Deliberately in the PLACE_BALL row and nowhere
+              else: every earlier branch above returns first, so the chip can
+              never appear during pin placement, played-hole edit mode, the
+              on-green Made/Missed overlay, aiming, or a played-hole revisit.
+              Gated on a shot existing this hole by the enclosing
+              totalShotsThisHole > 0 — there is no "last shot" before the
+              first one. */}
+          {!p.saving && (
+            <TextChip
+              label={p.lastShotIsOb ? '⚠ OB — tap to undo' : '⚠ Last shot went OB'}
+              onPress={p.onMarkLastShotOb}
+              danger
+            />
           )}
           <TextChip
             label={p.holeNumber < p.holeCount ? 'Finish hole · next →' : 'Finish round'}
@@ -371,10 +392,14 @@ function TextChip({
   label,
   onPress,
   strong,
+  danger,
 }: {
   label: string
   onPress: () => void
   strong?: boolean
+  /** Penalty action — caddie-neg (#A33A2A) border + tint, mirroring
+   *  SecondaryPill's own danger variant. */
+  danger?: boolean
 }) {
   return (
     <PressableTouch
@@ -387,7 +412,7 @@ function TextChip({
       // css-interop, so the chip background + border would silently drop.
       style={{
         backgroundColor: 'rgba(28,33,28,0.92)',
-        borderColor: 'rgba(242,238,229,0.45)',
+        borderColor: danger ? 'rgba(163,58,42,0.9)' : 'rgba(242,238,229,0.45)',
         borderWidth: 1,
         borderRadius: 16,
         paddingVertical: 10,
@@ -399,7 +424,17 @@ function TextChip({
         elevation: 3,
       }}
     >
-      <Text style={[TYPE.kicker, { ...KICKER, color: strong ? CREAM : 'rgba(242,238,229,0.85)' }]}>{label}</Text>
+      <Text
+        style={[
+          TYPE.kicker,
+          {
+            ...KICKER,
+            color: danger ? '#E6A99C' : strong ? CREAM : 'rgba(242,238,229,0.85)',
+          },
+        ]}
+      >
+        {label}
+      </Text>
     </PressableTouch>
   )
 }

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -85,6 +85,9 @@ interface PlacedShot {
   shotNumber: number
   start: LatLng | null
   aim: LatLng | null
+  /** Out-of-bounds flag (#839). Optional — fresh drafts (new/unplaced shots)
+   *  omit it and read as false; only the seed-from-`shots` site below sets it. */
+  ob?: boolean
 }
 
 type PlacementMode = Extract<HoleMapPhase, 'PLACE_BALL' | 'SET_AIM' | 'PIN'>
@@ -246,6 +249,7 @@ export function PastRoundMap({
               s.aim_lat != null && s.aim_lng != null
                 ? { lat: s.aim_lat, lng: s.aim_lng }
                 : null,
+            ob: s.ob === true,
           }))
       : []
     if (seededForRef.current === key) {
@@ -312,6 +316,19 @@ export function PastRoundMap({
         .slice(0, activeIdx)
         .map((s) => s.start)
         .filter((p): p is LatLng => p != null),
+    [placed, activeIdx],
+  )
+
+  // OB flag per breadcrumb waypoint (#839), index-aligned with
+  // `previousStarts` — built with the identical slice(0, activeIdx) +
+  // "has a start" filter so a dropped entry drops from both arrays at the
+  // same index, never just one.
+  const previousShotObs = useMemo(
+    () =>
+      placed
+        .slice(0, activeIdx)
+        .filter((s) => s.start != null)
+        .map((s) => s.ob === true),
     [placed, activeIdx],
   )
 
@@ -689,6 +706,7 @@ export function PastRoundMap({
           aim={active?.aim ?? null}
           ball={active?.start ?? null}
           previousShots={previousStarts}
+          previousShotObs={previousShotObs}
           // REVIEW is always flat top-down (PLACE_BALL) so the selected marker
           // drags; LOGGING follows the BALL/AIM/PIN mode chips.
           phase={completed ? 'PLACE_BALL' : mode}

--- a/apps/mobile/components/round/PastRoundMap.tsx
+++ b/apps/mobile/components/round/PastRoundMap.tsx
@@ -8,6 +8,7 @@ import {
   destinationYards,
   formatClubLabel,
   isPuttShot,
+  obCount,
   projectShotMove,
   resolveHole,
   summarizePuttParts,
@@ -337,13 +338,19 @@ export function PastRoundMap({
   }, [placed, tee, effectivePin])
 
   // Keep hole_scores.score honest with the placed-shot count (a placed shot
-  // IS a stroke). Pure score-only entry on the scorecard is untouched —
-  // this only fires when the map owns shot creation for the hole.
+  // IS a stroke) plus this hole's penalty strokes — a stroke-and-distance OB
+  // has no row of its own, so a raw row count would silently revert it
+  // (#839). Scoped to this hole_score_id, never round-wide. Pure score-only
+  // entry on the scorecard is untouched — this only fires when the map owns
+  // shot creation for the hole.
   async function syncScore(count: number) {
     if (!currentHoleScore) return
+    const obStrokes = obCount(
+      shots.filter((s) => s.hole_score_id === currentHoleScore.id),
+    )
     const { data, error } = await supabase
       .from('hole_scores')
-      .update({ score: count })
+      .update({ score: count + obStrokes })
       .eq('id', currentHoleScore.id)
       .eq('round_id', roundId)
       .select()

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -49,6 +49,12 @@ export interface UseHoleDataResult {
   setPendingForHole: React.Dispatch<React.SetStateAction<PendingShot[]>>
   previousShots: LatLng[]
   previousShotIds: string[]
+  /** Out-of-bounds flag per shot, aligned 1:1 with `previousShotIds` (same
+   *  order, same length, same filters). Drives the live OB chip's
+   *  set-vs-undo state so it is DERIVED from the stored rows rather than
+   *  remembered in component state — a mid-hole reload must not offer to
+   *  mark an already-OB shot again and double-charge the penalty (#839). */
+  previousShotObs: boolean[]
   refreshShots: () => void
   localShotCount: number
   localPuttCount: number
@@ -72,6 +78,7 @@ export function useHoleData(
   const [pendingForHole, setPendingForHole] = useState<PendingShot[]>([])
   const [remoteShotStarts, setRemoteShotStarts] = useState<LatLng[]>([])
   const [remoteShotIds, setRemoteShotIds] = useState<string[]>([])
+  const [remoteShotObs, setRemoteShotObs] = useState<boolean[]>([])
   const [shotsRefreshNonce, setShotsRefreshNonce] = useState(0)
   const refreshShots = useCallback(() => setShotsRefreshNonce((n) => n + 1), [])
 
@@ -268,6 +275,7 @@ export function useHoleData(
       setRemotePuttCount(0)
       setRemoteShotStarts([])
       setRemoteShotIds([])
+      setRemoteShotObs([])
       setPendingForHole([])
     }
     if (!currentHoleScore) return
@@ -277,7 +285,7 @@ export function useHoleData(
         const fetchShots = () =>
           supabase
             .from('shots')
-            .select('id, club, lie_type, shot_number, start_lat, start_lng')
+            .select('id, club, lie_type, shot_number, start_lat, start_lng, ob')
             .eq('hole_score_id', currentHoleScore.id)
             .order('shot_number')
         const [shotsResInitial, localInitial] = await Promise.all([
@@ -342,14 +350,17 @@ export function useHoleData(
         setRemotePuttCount(shots.filter((s) => isPuttShot(s.lie_type)).length)
         const starts: LatLng[] = []
         const ids: string[] = []
+        const obs: boolean[] = []
         for (const r of shots) {
           if (r.start_lat != null && r.start_lng != null) {
             starts.push({ lat: r.start_lat, lng: r.start_lng })
             ids.push(r.id)
+            obs.push(r.ob === true)
           }
         }
         setRemoteShotStarts(starts)
         setRemoteShotIds(ids)
+        setRemoteShotObs(obs)
         setPendingForHole(dedupedLocal)
       } catch (err) {
         if (myNonce !== fetchNonceRef.current) return
@@ -405,6 +416,26 @@ export function useHoleData(
     return out
   }, [remoteShotIds, pendingForHole])
 
+  // OB flag per shot, built with the SAME filters as previousShotIds above so
+  // the two stay index-aligned (a shot's id and its OB state must never drift
+  // apart). Pending payloads carry `ob` themselves — buildPayload writes it,
+  // and the live OB chip patches it back into SQLite so this stays true for a
+  // shot flagged after it was queued (#839).
+  const previousShotObs = useMemo(() => {
+    const out: boolean[] = [...remoteShotObs]
+    for (const r of pendingForHole) {
+      try {
+        const p = JSON.parse(r.payload) as ShotPayload
+        if (p.start_lat != null && p.start_lng != null && p.id) {
+          out.push(p.ob === true)
+        }
+      } catch {
+        // skip malformed pending payload (matches previousShotIds)
+      }
+    }
+    return out
+  }, [remoteShotObs, pendingForHole])
+
   // Live tee anchor: the player's first shot's start IS the tee. Falls back to
   // the stored course tee before the first shot (camera + pre-shot distances).
   // useHoleData is live-round-only (past rounds use PastRoundMap), so this is
@@ -453,6 +484,7 @@ export function useHoleData(
     setPendingForHole,
     previousShots,
     previousShotIds,
+    previousShotObs,
     refreshShots,
     localShotCount,
     localPuttCount,

--- a/apps/mobile/components/round/hole/useHoleData.ts
+++ b/apps/mobile/components/round/hole/useHoleData.ts
@@ -383,12 +383,21 @@ export function useHoleData(
   // pending shot starts (in pending insertion order). The current ball
   // is intentionally excluded — HoleMap appends it as the line's final
   // segment so the ball can move while the breadcrumb stays.
+  //
+  // INVARIANT: this filter and those of `previousShotIds` / `previousShotObs`
+  // below must stay IDENTICAL — the three arrays are consumed by index, and a
+  // payload admitted by one but not another shifts every later index. That
+  // alignment now decides which shot markLastShotOb writes `ob: true` to,
+  // which waypoint wears the OB badge, and which row summaryRows stamps —
+  // the row that then sets the hole score (#839). `p.id` is redundant today
+  // (insertPendingShot always stamps one) but is kept here so the invariant
+  // is structural rather than a coincidence of three call sites.
   const previousShots = useMemo(() => {
     const out: LatLng[] = [...remoteShotStarts]
     for (const r of pendingForHole) {
       try {
         const p = JSON.parse(r.payload) as ShotPayload
-        if (p.start_lat != null && p.start_lng != null) {
+        if (p.start_lat != null && p.start_lng != null && p.id) {
           out.push({ lat: p.start_lat, lng: p.start_lng })
         }
       } catch {
@@ -401,6 +410,7 @@ export function useHoleData(
   // Shot client-ids aligned 1:1 with `previousShots` (same order + length), so
   // the summary can map a row to its shot for delete_shot. Remote ids come from
   // the server rows; pending ids from payload.id (always set on insert, db.ts).
+  // Same filter as `previousShots` above — see the invariant note there.
   const previousShotIds = useMemo(() => {
     const out: string[] = [...remoteShotIds]
     for (const r of pendingForHole) {
@@ -416,9 +426,10 @@ export function useHoleData(
     return out
   }, [remoteShotIds, pendingForHole])
 
-  // OB flag per shot, built with the SAME filters as previousShotIds above so
-  // the two stay index-aligned (a shot's id and its OB state must never drift
-  // apart). Pending payloads carry `ob` themselves — buildPayload writes it,
+  // OB flag per shot, built with the SAME filters as previousShots /
+  // previousShotIds above so all three stay index-aligned (a shot's position,
+  // id and OB state must never drift apart — see the invariant note on
+  // previousShots). Pending payloads carry `ob` themselves — buildPayload writes it,
   // and the live OB chip patches it back into SQLite so this stays true for a
   // shot flagged after it was queued (#839).
   const previousShotObs = useMemo(() => {

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -127,6 +127,11 @@ export interface UseShotActionsResult {
   // its stroke-and-distance bookkeeping (#839). See the implementation for
   // why it writes two representations of the same fact.
   markLastShotOb: () => Promise<void>
+  // Whether that most recent shot is currently flagged OB — the chip's
+  // set-vs-undo label. Exposed from here rather than read off the fetched
+  // data directly so the label and the toggle's direction can never disagree
+  // (they share one source, including the just-written optimistic value).
+  lastShotIsOb: boolean
 }
 
 export function useShotActions(input: UseShotActionsInput): UseShotActionsResult {
@@ -156,11 +161,31 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   // late, so a fast double-tap of Finish (18th hole) or End round could fire
   // completeRound twice. The ref flips synchronously and blocks the second.
   const endInFlightRef = useRef(false)
-  // Same synchronous double-tap gate for the OB chip. It has no `saving`
-  // flag of its own, and its state (`previousShotObs`) only refreshes after
-  // the refetch lands — so two quick taps would both read "not OB yet",
-  // write ob=true twice and charge the penalty stroke twice.
+  // Serializes OB toggles: blocks a tap that arrives while one is in flight,
+  // and (because the hole_scores write below is awaited inside the same
+  // window) guarantees a set→undo pair reaches the server in the order it was
+  // issued rather than in whatever order two unordered writes happen to land.
   const obInFlightRef = useRef(false)
+  // The OB flag we last WROTE for a shot, which outranks the fetched value
+  // until the refetch catches up. `previousShotObs` only refreshes when the
+  // post-write `refreshShots` round-trip lands — a whole extra RTT after the
+  // write resolved and the in-flight gate released. Reading the fetched value
+  // in that window is what made the penalty chargeable twice: a second tap
+  // recomputed `next = true` against stale data, the update matched its (still
+  // ob=true) row so the 0-row guard passed, and the score took a second +1.
+  // Ref = the synchronous truth the next toggle's direction is computed from
+  // (a state setter commits a tick late, which is the whole double-tap
+  // problem); state = the render-visible mirror, so the chip's label flips the
+  // instant the write succeeds instead of an RTT later. Same ref-for-decisions
+  // / state-for-render split as persistShotInFlightRef vs `saving` above.
+  // Keyed on the shot id, so it simply stops applying once a newer shot is
+  // logged, and needs no explicit invalidation: by the time the refetch lands
+  // it agrees with the fetched value anyway.
+  const obOverrideRef = useRef<{ shotId: string; ob: boolean } | null>(null)
+  const [obOverride, setObOverride] = useState<{
+    shotId: string
+    ob: boolean
+  } | null>(null)
   const [ending, setEnding] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [shotEntrySeq, setShotEntrySeq] = useState(0)
@@ -1156,7 +1181,13 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     const shotId = previousShotIds[idx]
     if (!shotId) return
     const start = previousShots[idx] ?? null
-    const next = !(previousShotObs[idx] ?? false)
+    // Direction comes from the last value WE WROTE when there is one for this
+    // shot, never from the possibly-stale fetched value — see obOverrideRef.
+    const currentlyOb =
+      obOverrideRef.current?.shotId === shotId
+        ? obOverrideRef.current.ob
+        : previousShotObs[idx] ?? false
+    const next = !currentlyOb
     obInFlightRef.current = true
     try {
       // Flush first (mirrors moveShot): the client id is stable, so once the
@@ -1192,30 +1223,39 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
         )
         return
       }
+      // The write landed — record it as the authoritative flag for this shot
+      // BEFORE anything can be tapped again, so the next toggle reverses it
+      // instead of repeating it. The ref is what the decision above reads; the
+      // state mirror is what re-renders the chip's label.
+      obOverrideRef.current = { shotId, ob: next }
+      setObOverride({ shotId, ob: next })
       // Patch the local queue copy too. saveHoleSummary pairs each reviewed
       // row back to its LOCAL payload first and only falls back to the remote
       // row — so without this the stale local `ob: false` would erase the flag
       // at the very next end-of-hole save.
       await setPendingShotOb(shotId, next).catch(() => undefined)
-      // Score ±1 for the penalty stroke, written and mirrored the way
-      // persistShot does both (background write + warn, optimistic mirror) —
-      // the shot flag above is the authoritative record.
+      // Score ±1 for the penalty stroke, mirrored optimistically the way
+      // persistShot does — but AWAITED, unlike persistShot's fire-and-forget.
+      // Two score writes issued back to back (set then undo) are unordered
+      // otherwise, and the last to ARRIVE wins, which need not be the last
+      // issued. Awaiting it inside the in-flight window makes the next tap
+      // wait, so the server sees them in the order the player tapped them.
+      // A failure still only warns: the shot flag above is the authoritative
+      // record and the tally is re-derived downstream.
       const nextScore = Math.max(0, currentHoleScore.score + (next ? 1 : -1))
-      supabase
-        .from('hole_scores')
-        .update({ score: nextScore })
-        .eq('id', currentHoleScore.id)
-        .then(({ error: scoreErr }) => {
-          if (scoreErr) {
-            // eslint-disable-next-line no-console
-            console.warn('[hole/ob-score-update]', scoreErr.message)
-          }
-        })
       setHoleScores((prev) =>
         prev.map((hs) =>
           hs.id === currentHoleScore.id ? { ...hs, score: nextScore } : hs,
         ),
       )
+      const { error: scoreErr } = await supabase
+        .from('hole_scores')
+        .update({ score: nextScore })
+        .eq('id', currentHoleScore.id)
+      if (scoreErr) {
+        // eslint-disable-next-line no-console
+        console.warn('[hole/ob-score-update]', scoreErr.message)
+      }
       data.refreshShots()
       // Stroke and distance: the re-hit starts where the OB shot started, so
       // drop the ball back there and freeze GPS on it (the same manual-
@@ -1233,6 +1273,17 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       obInFlightRef.current = false
     }
   }
+
+  // The chip's label, resolved the SAME way markLastShotOb resolves the
+  // toggle's direction: our own last write for this shot wins over the fetched
+  // value until the refetch catches up. Sharing one rule is the point — a
+  // label saying "Last shot went OB" while the handler would treat it as an
+  // undo (or vice versa) is exactly how a second tap became a second penalty.
+  const lastShotIdForOb = previousShotIds[previousShotIds.length - 1] ?? null
+  const lastShotIsOb =
+    lastShotIdForOb != null && obOverride?.shotId === lastShotIdForOb
+      ? obOverride.ob
+      : previousShotObs[previousShotObs.length - 1] ?? false
 
   function handleExitFromError() {
     // Leave to home WITHOUT deleting. A load error (network blip on a
@@ -1276,5 +1327,6 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     deleteShot,
     moveShot,
     markLastShotOb,
+    lastShotIsOb,
   }
 }

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -873,15 +873,25 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
           lie_slope_forward: isPuttRow ? null : row.lieSlopeForward ?? null,
           lie_slope_side: isPuttRow ? null : row.lieSlopeSide ?? null,
           shot_result: isPuttRow ? null : row.shotResult ?? null,
-          // The review sheet has no OB control, so the live value is
-          // authoritative (same reasoning as aim, above). `shotResult === 'ob'`
-          // additionally lets the retrospective result picker set it — that
-          // path wrote the string but not the boolean, which is why prod has
-          // shot_result='ob' on exactly the rows that already had ob=true.
-          // Known limitation: the sheet cannot UNSET ob; the live chip's
-          // second tap is the undo (Task 4).
+          // The reviewed ROW is authoritative for OB — no `existing.ob ||`
+          // fallback. The sheet renders SHOT_RESULTS as a single-select
+          // picker, so a fallback would let one tap ("it was a pull") write
+          // shot_result='pull' while ob stayed true, leaving a row that SG
+          // charges −2 and the map badges red but whose label says pull, with
+          // no path from the sheet to clear it.
+          //
+          // Safe because the row genuinely arrives carrying the flag:
+          // useHoleData's remoteShotObs/previousShotObs read the fetched
+          // `shots.ob` (so it survives a mid-hole reload) → useShotActions'
+          // `shotObs` (obOverride wins over a lagging refetch) →
+          // LiveRoundSession's `summaryRows` stamps `shotResult: 'ob'` →
+          // HoleReviewSheet hydrates `rows` from those `initialRows` →
+          // back here as `rows`. saveHoleSummary has exactly one caller (that
+          // sheet, for the live hole), so the seed always fires. If that seed
+          // path is ever broken, this line silently drops every OB flag —
+          // keep the two in step (#839).
           penalty: existing.penalty ?? false,
-          ob: (existing.ob ?? false) || row.shotResult === 'ob',
+          ob: row.shotResult === 'ob',
           // Putt tap-to-tap distance is in yards; * 3 = feet (US convention),
           // and putt_distance_ft is what the rest of the app reads.
           putt_distance_ft: isPuttRow ? Math.round(row.distanceYards * 3) : null,

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -1,4 +1,4 @@
-import { useRef, useState, type Dispatch, type SetStateAction } from 'react'
+import { useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react'
 import { Alert } from 'react-native'
 import { useRouter } from 'expo-router'
 import { uuid } from 'expo-modules-core'
@@ -132,6 +132,12 @@ export interface UseShotActionsResult {
   // data directly so the label and the toggle's direction can never disagree
   // (they share one source, including the just-written optimistic value).
   lastShotIsOb: boolean
+  // The same OB truth for EVERY shot on the hole, index-aligned with
+  // data.previousShots / previousShotIds. Exposed for the same reason
+  // lastShotIsOb is: the end-of-hole summary seeds its rows from this, and
+  // reading the fetched flags directly would let it re-seed the score ticker
+  // to the struck count during the window before a just-written OB refetches.
+  shotObs: boolean[]
 }
 
 export function useShotActions(input: UseShotActionsInput): UseShotActionsResult {
@@ -208,6 +214,24 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     shotNumber,
     holeCount,
   } = data
+  // Effective OB flag per shot on this hole, index-aligned with
+  // previousShotIds: our own last write for a shot outranks the fetched value
+  // until the refetch catches up (see obOverrideRef above). One array so the
+  // chip's label and every score term below read the same truth.
+  // Memoized so consumers can use it as a dependency (the end-of-hole
+  // summary rebuilds its rows off it) without recomputing every render.
+  const shotObs = useMemo(
+    () =>
+      previousShotIds.map((shotId, i) =>
+        obOverride?.shotId === shotId ? obOverride.ob : previousShotObs[i] ?? false,
+      ),
+    [previousShotIds, previousShotObs, obOverride],
+  )
+  // Penalty strokes already recorded on THIS hole (scoped to one
+  // hole_score_id — never round-wide). A stroke-and-distance OB has no shot
+  // row of its own, so anywhere a struck-row count becomes hole_scores.score
+  // has to add these back or the OB chip's bump is silently reverted (#839).
+  const holeObStrokes = shotObs.filter(Boolean).length
   // Guards a double-fire of the end-of-hole save the same way persistShot
   // guards its own — the `saving` state setter commits a tick late.
   const saveSummaryInFlightRef = useRef(false)
@@ -332,9 +356,16 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       // Background sync — don't await.
       syncPendingShots().catch(() => undefined)
       const newPutts = remotePuttCount + localPuttCount + (isPutt ? 1 : 0)
+      // score = struck rows + penalty strokes. `shotNumber` IS the struck
+      // count once this row lands, so without the OB term the very next shot
+      // overwrites the chip's bump with the raw count. `payload.ob` covers
+      // this row itself being saved OB — it isn't in shotObs yet, which is
+      // built from the already-stored rows. Applied exactly once per save:
+      // the score is written absolutely, never incremented.
+      const newScore = shotNumber + holeObStrokes + (payload.ob ? 1 : 0)
       supabase
         .from('hole_scores')
-        .update({ score: shotNumber, putts: newPutts })
+        .update({ score: newScore, putts: newPutts })
         .eq('id', payload.hole_score_id)
         .then(({ error }) => {
           if (error) {
@@ -345,7 +376,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       setHoleScores((prev) =>
         prev.map((hs) =>
           hs.id === payload.hole_score_id
-            ? { ...hs, score: shotNumber, putts: newPutts }
+            ? { ...hs, score: newScore, putts: newPutts }
             : hs,
         ),
       )
@@ -1274,16 +1305,13 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     }
   }
 
-  // The chip's label, resolved the SAME way markLastShotOb resolves the
-  // toggle's direction: our own last write for this shot wins over the fetched
-  // value until the refetch catches up. Sharing one rule is the point — a
-  // label saying "Last shot went OB" while the handler would treat it as an
-  // undo (or vice versa) is exactly how a second tap became a second penalty.
-  const lastShotIdForOb = previousShotIds[previousShotIds.length - 1] ?? null
-  const lastShotIsOb =
-    lastShotIdForOb != null && obOverride?.shotId === lastShotIdForOb
-      ? obOverride.ob
-      : previousShotObs[previousShotObs.length - 1] ?? false
+  // The chip's label, read off the SAME shotObs array markLastShotOb resolves
+  // the toggle's direction from: our own last write for this shot wins over
+  // the fetched value until the refetch catches up. Sharing one rule is the
+  // point — a label saying "Last shot went OB" while the handler would treat
+  // it as an undo (or vice versa) is exactly how a second tap became a second
+  // penalty.
+  const lastShotIsOb = shotObs[shotObs.length - 1] ?? false
 
   function handleExitFromError() {
     // Leave to home WITHOUT deleting. A load error (network blip on a
@@ -1328,5 +1356,6 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     moveShot,
     markLastShotOb,
     lastShotIsOb,
+    shotObs,
   }
 }

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -926,7 +926,13 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       // the pin by construction (matches web's saveReviewedHole). An explicit
       // scorecard toggle is never overwritten (?? guards).
       const inferred = inferHoleStats(
-        rows.map((r) => ({ shot_number: r.shotNumber, lie_type: r.lieType })),
+        rows.map((r) => ({
+          shot_number: r.shotNumber,
+          lie_type: r.lieType,
+          // Required: shot_number is not the stroke number on an OB hole, so
+          // inferGir needs the penalty strokes to size its thresholds (#839).
+          shotResult: r.shotResult,
+        })),
         currentHole.par,
         true,
       )

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -22,6 +22,7 @@ import {
   insertPendingShot,
   pendingCount,
   setPendingShotEnd,
+  setPendingShotOb,
   upsertReviewedShot,
   type ShotPayload,
 } from '../../../lib/db'
@@ -50,6 +51,13 @@ interface UseShotActionsInput {
   setLoggerInitial: Dispatch<SetStateAction<ShotLoggerValue>>
   setPinPlacementOpen: Dispatch<SetStateAction<boolean>>
   setActiveDialog: Dispatch<SetStateAction<ActiveDialog>>
+  // The component's manual ball-placement path — the very handler a map
+  // drag/tap goes through (freezes GPS tracking for this PLACE_BALL cycle,
+  // re-anchors the Kalman filter, flips the CTA off its "at my GPS"
+  // labelling). Passed in rather than reimplemented here because part of
+  // that state (ballMoved) lives in LiveRoundSession. markLastShotOb uses
+  // it to drop the ball back on the OB shot's origin.
+  placeBallManually: (loc: LatLng) => void
   // Hole navigation is callback-driven so the parent (LiveRoundSession)
   // can keep the MapView resident across hole changes. Direct router.replace
   // would fully unmount + remount the screen — see #264.
@@ -115,6 +123,10 @@ export interface UseShotActionsResult {
     shotId: string,
     newStart: { lat: number; lng: number },
   ) => Promise<boolean>
+  // Online-first toggle of the OB flag on this hole's most recent shot, plus
+  // its stroke-and-distance bookkeeping (#839). See the implementation for
+  // why it writes two representations of the same fact.
+  markLastShotOb: () => Promise<void>
 }
 
 export function useShotActions(input: UseShotActionsInput): UseShotActionsResult {
@@ -129,6 +141,7 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     setLoggerInitial,
     setPinPlacementOpen,
     setActiveDialog,
+    placeBallManually,
     onHoleChange,
     onAdvanceHole,
   } = input
@@ -143,6 +156,11 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
   // late, so a fast double-tap of Finish (18th hole) or End round could fire
   // completeRound twice. The ref flips synchronously and blocks the second.
   const endInFlightRef = useRef(false)
+  // Same synchronous double-tap gate for the OB chip. It has no `saving`
+  // flag of its own, and its state (`previousShotObs`) only refreshes after
+  // the refetch lands — so two quick taps would both read "not OB yet",
+  // write ob=true twice and charge the penalty stroke twice.
+  const obInFlightRef = useRef(false)
   const [ending, setEnding] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [shotEntrySeq, setShotEntrySeq] = useState(0)
@@ -160,6 +178,8 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     remotePuttCount,
     localPuttCount,
     previousShots,
+    previousShotIds,
+    previousShotObs,
     shotNumber,
     holeCount,
   } = data
@@ -1113,6 +1133,107 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     }
   }
 
+  // Live out-of-bounds (#839). The affordance can exist at all because
+  // persistShot writes the shot row on confirmAim/skipAim — BEFORE the ball
+  // is struck — with `start` = the ball the player just marked. So when a
+  // shot flies OB the player is still standing at that shot's origin, and
+  // stroke-and-distance is nothing more than "flag it, charge the stroke,
+  // put the ball back where it was".
+  //
+  // Online-first, exactly like its siblings deleteShot / moveShot: flush the
+  // pending queue so the target has a server row, write it directly, and fail
+  // visibly on a 0-row response rather than pretending it worked. Second tap
+  // undoes.
+  async function markLastShotOb() {
+    if (!user || !currentHoleScore) return
+    if (obInFlightRef.current) return
+    // The hole's most recent shot. previousShotIds/previousShotObs/previousShots
+    // are built index-aligned in useHoleData, and #852's up-front id stamp is
+    // what puts a just-saved (still pending) shot in them at all — its payload
+    // carries the client id from the moment it is queued, so the shot the
+    // player is standing at IS the last entry here. No id is derived or minted.
+    const idx = previousShotIds.length - 1
+    const shotId = previousShotIds[idx]
+    if (!shotId) return
+    const start = previousShots[idx] ?? null
+    const next = !(previousShotObs[idx] ?? false)
+    obInFlightRef.current = true
+    try {
+      // Flush first (mirrors moveShot): the client id is stable, so once the
+      // shot has synced the update below hits the real row instead of 0 rows.
+      await syncPendingShots()
+      const { data: updatedRows, error } = await supabase
+        .from('shots')
+        // BOTH representations of the same fact, deliberately:
+        //   `ob`          — what the SG engine reads (sg-calculator charges
+        //                   an OB shot exactly −2, stroke and distance).
+        //   `shot_result` — what round-trips through ReviewedShotRow, the row
+        //                   type the end-of-hole review sheet is built from,
+        //                   which has NO `ob` field at all. The score ticker
+        //                   can only see the penalty through this string.
+        // buildPayload derives the boolean from the string on the way in, so
+        // writing both keeps one consistent fact rather than two sources of
+        // truth. Clearing restores shot_result to null: SHOT_RESULTS is
+        // single-select, so 'ob' had already displaced any ball-flight result
+        // and there is nothing to restore it from — undo is lossy that way.
+        .update({ ob: next, shot_result: next ? 'ob' : null })
+        .eq('id', shotId)
+        .eq('user_id', user.id)
+        .select('id')
+      if (error) throw error
+      // Matched 0 rows: error === null with empty data (same silent-success
+      // shape moveShot guards against, #710). Surface it instead of leaving
+      // the player believing the penalty was recorded.
+      if (!updatedRows || updatedRows.length === 0) {
+        if (__DEV__) console.warn('[hole/markLastShotOb] update matched 0 rows', shotId)
+        Alert.alert(
+          "Couldn't record that penalty",
+          'Marking a shot OB needs a connection. Try again when you’re back online.',
+        )
+        return
+      }
+      // Patch the local queue copy too. saveHoleSummary pairs each reviewed
+      // row back to its LOCAL payload first and only falls back to the remote
+      // row — so without this the stale local `ob: false` would erase the flag
+      // at the very next end-of-hole save.
+      await setPendingShotOb(shotId, next).catch(() => undefined)
+      // Score ±1 for the penalty stroke, written and mirrored the way
+      // persistShot does both (background write + warn, optimistic mirror) —
+      // the shot flag above is the authoritative record.
+      const nextScore = Math.max(0, currentHoleScore.score + (next ? 1 : -1))
+      supabase
+        .from('hole_scores')
+        .update({ score: nextScore })
+        .eq('id', currentHoleScore.id)
+        .then(({ error: scoreErr }) => {
+          if (scoreErr) {
+            // eslint-disable-next-line no-console
+            console.warn('[hole/ob-score-update]', scoreErr.message)
+          }
+        })
+      setHoleScores((prev) =>
+        prev.map((hs) =>
+          hs.id === currentHoleScore.id ? { ...hs, score: nextScore } : hs,
+        ),
+      )
+      data.refreshShots()
+      // Stroke and distance: the re-hit starts where the OB shot started, so
+      // drop the ball back there and freeze GPS on it (the same manual-
+      // placement path a drag uses) or the next fix would drag it away. On
+      // UNDO the ball is left exactly where it is — reversing the flag and
+      // the stroke is the undo; moving the player's map is not.
+      if (next && start) placeBallManually(start)
+    } catch (e) {
+      if (__DEV__) console.warn('[hole/markLastShotOb]', (e as Error)?.message)
+      Alert.alert(
+        "Couldn't record that penalty",
+        'Marking a shot OB needs a connection. Try again when you’re back online.',
+      )
+    } finally {
+      obInFlightRef.current = false
+    }
+  }
+
   function handleExitFromError() {
     // Leave to home WITHOUT deleting. A load error (network blip on a
     // rounds-deep resume) or a missing hole means the round is still
@@ -1154,5 +1275,6 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
     handleExitFromError,
     deleteShot,
     moveShot,
+    markLastShotOb,
   }
 }

--- a/apps/mobile/components/round/hole/useShotActions.ts
+++ b/apps/mobile/components/round/hole/useShotActions.ts
@@ -727,16 +727,22 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
       }
       const remoteByNum = new Map<
         number,
-        { id: string; aim_lat: number | null; aim_lng: number | null }
+        {
+          id: string
+          aim_lat: number | null
+          aim_lng: number | null
+          ob: boolean
+          penalty: boolean
+        }
       >()
       let remote = await supabase
         .from('shots')
-        .select('id, shot_number, aim_lat, aim_lng')
+        .select('id, shot_number, aim_lat, aim_lng, ob, penalty')
         .eq('hole_score_id', currentHoleScore.id)
       if (remote.error) {
         remote = await supabase
           .from('shots')
-          .select('id, shot_number, aim_lat, aim_lng')
+          .select('id, shot_number, aim_lat, aim_lng, ob, penalty')
           .eq('hole_score_id', currentHoleScore.id)
       }
       for (const s of remote.data ?? []) {
@@ -744,6 +750,8 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
           id: s.id,
           aim_lat: s.aim_lat,
           aim_lng: s.aim_lng,
+          ob: s.ob,
+          penalty: s.penalty,
         })
       }
 
@@ -789,8 +797,15 @@ export function useShotActions(input: UseShotActionsInput): UseShotActionsResult
           lie_slope_forward: isPuttRow ? null : row.lieSlopeForward ?? null,
           lie_slope_side: isPuttRow ? null : row.lieSlopeSide ?? null,
           shot_result: isPuttRow ? null : row.shotResult ?? null,
-          penalty: false,
-          ob: false,
+          // The review sheet has no OB control, so the live value is
+          // authoritative (same reasoning as aim, above). `shotResult === 'ob'`
+          // additionally lets the retrospective result picker set it — that
+          // path wrote the string but not the boolean, which is why prod has
+          // shot_result='ob' on exactly the rows that already had ob=true.
+          // Known limitation: the sheet cannot UNSET ob; the live chip's
+          // second tap is the undo (Task 4).
+          penalty: existing.penalty ?? false,
+          ob: (existing.ob ?? false) || row.shotResult === 'ob',
           // Putt tap-to-tap distance is in yards; * 3 = feet (US convention),
           // and putt_distance_ft is what the rest of the app reads.
           putt_distance_ft: isPuttRow ? Math.round(row.distanceYards * 3) : null,

--- a/apps/mobile/components/round/markers/BreadcrumbLayers.tsx
+++ b/apps/mobile/components/round/markers/BreadcrumbLayers.tsx
@@ -13,6 +13,13 @@ interface BreadcrumbLayersProps {
   styleLoaded: boolean
   isPinMode: boolean
   toDisplay: (yards: number) => string
+  /**
+   * Out-of-bounds flag per shot, index-aligned with `previousShots` (#839).
+   * Optional/undefined-safe so callers that haven't threaded OB data yet
+   * (there are none left, but keep this defensive) still render plain
+   * waypoints.
+   */
+  obs?: boolean[]
 }
 
 // Renders the orange breadcrumb line through prior shot starts, numbered
@@ -28,17 +35,18 @@ export function BreadcrumbLayers({
   styleLoaded,
   isPinMode,
   toDisplay,
+  obs,
 }: BreadcrumbLayersProps) {
   const waypointFeatures = useMemo<GeoJSON.FeatureCollection<GeoJSON.Point>>(
     () => ({
       type: 'FeatureCollection',
       features: previousShots.map((p, i) => ({
         type: 'Feature',
-        properties: { n: i + 1 },
+        properties: { n: i + 1, ob: obs?.[i] === true },
         geometry: { type: 'Point', coordinates: toCoord(p) },
       })),
     }),
-    [previousShots],
+    [previousShots, obs],
   )
 
   const segmentFeatures = useMemo<GeoJSON.FeatureCollection<GeoJSON.Point>>(
@@ -76,11 +84,35 @@ export function BreadcrumbLayers({
       </Mapbox.ShapeSource>
 
       <Mapbox.ShapeSource id="prevShotsWaypoints" shape={waypointFeatures}>
+        {/* OB badge ring (#839). An OB shot's re-hit starts from the exact
+            same coordinates (stroke-and-distance — no renumbering, the
+            re-hit is just the next struck-shot number), so its waypoint
+            disc lands directly on top of the OB shot's disc below. A same-
+            radius recolor alone would just have one circle silently win the
+            stacking order and look like a rendering glitch. This wider
+            stroked ring is declared BELOW the disc/number layers (rendered
+            first = underneath) and sized past the disc's radius, so its red
+            edge always peeks out around whichever disc ends up on top —
+            reading as an intentional "penalty happened here" badge rather
+            than a double-render. Renders only for the OB shot's own
+            feature; the covering re-hit disc has ob=false and gets no ring. */}
+        <Mapbox.CircleLayer
+          id="prevShotsObRing"
+          filter={['==', ['get', 'ob'], true]}
+          style={{
+            circleRadius: 15,
+            circleColor: 'rgba(0,0,0,0)',
+            circleStrokeColor: '#A33A2A',
+            circleStrokeWidth: 3,
+          }}
+        />
         <Mapbox.CircleLayer
           id="prevShotsWaypointDisc"
           style={{
             circleRadius: 10,
-            circleColor: '#A66A1F',
+            // caddie-neg (#A33A2A) for the shot that went OB, matching the
+            // live chip / scorecard penalty color; amber for everything else.
+            circleColor: ['case', ['==', ['get', 'ob'], true], '#A33A2A', '#A66A1F'],
             circleStrokeColor: '#FBF8F1',
             circleStrokeWidth: 2,
           }}

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -6,6 +6,7 @@ import {
   computeRoundSG,
   inferHoleCount,
   inferHoleStats,
+  obCount,
   playedRowsForDifferential,
   resolveCourseTee,
 } from '@oga/core'
@@ -107,8 +108,12 @@ export async function completeRound({
   // sees the repaired value; the SG/infer upserts below persist it.
   for (const hs of holeScores) {
     if (hs.score !== 0) continue
-    const shotCount = shots.filter((s) => s.hole_score_id === hs.id).length
-    if (shotCount > 0) hs.score = shotCount
+    const holeShots = shots.filter((s) => s.hole_score_id === hs.id)
+    // Live stamping defines score = struck rows + penalty strokes, so the
+    // repair has to include the OB term too — a stroke-and-distance penalty
+    // has no shot row of its own, and rebuilding from the raw count alone
+    // would drop it (#839). obCount is per-hole: only this hole's rows.
+    if (holeShots.length > 0) hs.score = holeShots.length + obCount(holeShots)
   }
 
   // Infer fairway_hit + gir for any hole where the player didn't set
@@ -129,11 +134,14 @@ export async function completeRound({
     const hole = holesById.get(hs.hole_id)
     if (!hole) continue
     const holeShots = shots.filter((s) => s.hole_score_id === hs.id)
-    // holedOut when the shot log fully accounts for the score: length === score
-    // means every stroke was logged, so the last one holed. Incomplete logs
-    // (length < score) stay conservative — never a false positive. This lets
-    // off-green hole-outs (ace, holed approach, chip-in) count GIR (#669).
-    const holedOut = holeShots.length === hs.score
+    // holedOut when the shot log fully accounts for the score: every stroke
+    // was logged, so the last one holed. Incomplete logs (fewer strokes
+    // accounted for than the score) stay conservative — never a false
+    // positive. This lets off-green hole-outs (ace, holed approach, chip-in)
+    // count GIR (#669). A penalty stroke has no shot row, so it has to be
+    // added back or an OB hole could never read as holed out — permanently
+    // false, silently degrading GIR and fairway inference (#839).
+    const holedOut = holeShots.length + obCount(holeShots) === hs.score
     const inferred = inferHoleStats(
       holeShots.map((s) => ({
         shot_number: s.shot_number,

--- a/apps/mobile/lib/completeRound.ts
+++ b/apps/mobile/lib/completeRound.ts
@@ -146,6 +146,9 @@ export async function completeRound({
       holeShots.map((s) => ({
         shot_number: s.shot_number,
         lie_type: s.lie_type,
+        // Required: shot_number is not the stroke number on an OB hole, so
+        // inferGir needs the penalty strokes to size its thresholds (#839).
+        ob: s.ob,
       })),
       hole.par,
       holedOut,

--- a/apps/mobile/lib/db.ts
+++ b/apps/mobile/lib/db.ts
@@ -175,6 +175,56 @@ export async function setPendingShotEnd(
   return { status: row.status, remote_id: row.remote_id }
 }
 
+/**
+ * Rewrites BOTH out-of-bounds representations on a locally-queued shot —
+ * pending OR already synced — keyed on the client-generated payload id.
+ *
+ * The live OB chip (#839) writes the server row directly, but that write is
+ * not the last word: `saveHoleSummary` pairs each reviewed row back to its
+ * LOCAL payload first (`allShotsForHoleScore`, which includes synced rows)
+ * and only falls back to the remote row. A server-only write would therefore
+ * be overwritten by the stale local `ob: false` at the very next end-of-hole
+ * save. Status is deliberately left untouched: the server already has the
+ * value, so there is nothing to re-sync — flipping back to 'pending' would
+ * queue a pointless re-upsert.
+ */
+export async function setPendingShotOb(
+  clientId: string,
+  ob: boolean,
+): Promise<void> {
+  const db = await getDb()
+  const row = await db.getFirstAsync<{ local_id: number; payload: string }>(
+    `SELECT local_id, payload FROM pending_shots
+     WHERE json_extract(payload, '$.id') = ?
+       AND status IN ('pending', 'synced')`,
+    clientId,
+  )
+  if (!row) return
+  let payload: ShotPayload
+  try {
+    payload = JSON.parse(row.payload) as ShotPayload
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(
+      '[db/payload-corrupt] local_id=%d msg=%s',
+      row.local_id,
+      (e as Error).message,
+    )
+    await markShotBroken(row.local_id)
+    return
+  }
+  payload.ob = ob
+  // Clearing restores shot_result to null rather than to whatever ball-flight
+  // result was there before — SHOT_RESULTS is single-select, so 'ob' had
+  // already replaced any prior value and there is nothing to restore it from.
+  payload.shot_result = ob ? 'ob' : null
+  await db.runAsync(
+    `UPDATE pending_shots SET payload = ? WHERE local_id = ?`,
+    JSON.stringify(payload),
+    row.local_id,
+  )
+}
+
 // Flush WAL frames to the main DB file when the app moves to the
 // background. expo-sqlite 14 keeps writes in -wal until checkpointed,
 // and a long-running session can grow the WAL file unbounded — frames

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -14,6 +14,7 @@ import {
   horizontalBreakFromAim,
   isPuttEntry,
   isPuttShot,
+  obCount,
   tourMakePercent,
   type BreakDirectionHorizontal,
   type BreakDirectionVertical,
@@ -191,7 +192,13 @@ export function HoleReviewSheet({
         }
       })
     setRows(merged)
-    setScore(merged.length)
+    // Score seeds from the rows: struck rows + penalty strokes. A
+    // stroke-and-distance OB has no row of its own — the result picker
+    // marks it on the row it belongs to (shotResult 'ob') — so without this
+    // term the ticker would re-seed to the struck count and Save would
+    // persist that under-count over whatever the player already knows about
+    // the hole (#839).
+    setScore(merged.length + obCount(merged))
     // Putt TALLY counts any green-lie shot (isPuttShot), matching the SG
     // putting engine + putt-count readers — a bladed wedge on the green still
     // counts as a putt here even though its row shows normal-shot UI (the

--- a/apps/web/src/components/round/HoleReviewSheet.tsx
+++ b/apps/web/src/components/round/HoleReviewSheet.tsx
@@ -192,12 +192,17 @@ export function HoleReviewSheet({
         }
       })
     setRows(merged)
-    // Score seeds from the rows: struck rows + penalty strokes. A
-    // stroke-and-distance OB has no row of its own — the result picker
-    // marks it on the row it belongs to (shotResult 'ob') — so without this
-    // term the ticker would re-seed to the struck count and Save would
-    // persist that under-count over whatever the player already knows about
-    // the hole (#839).
+    // Score seeds from the rows: struck rows + obCount(merged). On THIS
+    // platform obCount(merged) is always 0 here — web has no live capture,
+    // so at hydration time no row has shotResult set yet (buildInitialRows /
+    // the no-pin fallback / the putt merge above never set it; only the
+    // result-picker chip does, and that only fires after this effect has
+    // already run). The term is kept for the same reason mobile's is: it's
+    // the correct general formula, and it stops being a no-op the moment a
+    // row IS pre-populated with a result (e.g. a future re-open-same-hole
+    // path). What actually keeps the ticker accurate for THIS platform is
+    // downstream — the ±1 bump in the result-picker's onChange below, fired
+    // every time a row's shotResult flips to/from 'ob' (#839).
     setScore(merged.length + obCount(merged))
     // Putt TALLY counts any green-lie shot (isPuttShot), matching the SG
     // putting engine + putt-count readers — a bladed wedge on the green still
@@ -322,7 +327,30 @@ export function HoleReviewSheet({
               key={row.shotNumber}
               row={row}
               onOpenAimer={() => setAimingShot(row.shotNumber)}
-              onChange={(next) =>
+              onChange={(next) => {
+                // The score ticker starts at struck-count (obCount is always
+                // 0 at seed time — see the hydration effect above) and stays
+                // accurate from here on by bumping ±1 every time THIS row's
+                // shotResult flips to/from 'ob'. This is the only place
+                // shotResult can become 'ob' on web (the result-picker chip
+                // in ShotRow), so a flip here is the complete signal — no
+                // other write path needs to feed this counter (#839).
+                // Compared here against `row` (this render's rows[idx]) in
+                // the plain event-handler body, deliberately NOT inside the
+                // setRows updater below — a setState call as a side effect
+                // of another state's updater function would double-fire
+                // under dev Strict Mode's intentional double-invocation of
+                // updaters, actually incrementing the score twice.
+                if (next.shotResult !== row.shotResult) {
+                  if (next.shotResult === 'ob' && row.shotResult !== 'ob') {
+                    setScore((s) => s + 1)
+                  } else if (
+                    row.shotResult === 'ob' &&
+                    next.shotResult !== 'ob'
+                  ) {
+                    setScore((s) => Math.max(0, s - 1))
+                  }
+                }
                 setRows((prev) => {
                   const copy = prev.slice()
                   copy[idx] = next
@@ -357,7 +385,7 @@ export function HoleReviewSheet({
                   }
                   return copy
                 })
-              }
+              }}
             />
           ))}
           </>

--- a/apps/web/src/components/round/RoundMap.tsx
+++ b/apps/web/src/components/round/RoundMap.tsx
@@ -42,6 +42,12 @@ export interface ExistingShot {
   aimLat?: number | null
   aimLng?: number | null
   category?: ShotMarkerCategory | null
+  /** Out-of-bounds flag (#839) — recolors the map marker + draws the badge
+   *  ring in useMapLayers. */
+  ob?: boolean | null
+  /** Penalty-stroke flag. Read (not re-derived) so saveReviewedHole's
+   *  replace-all rewrite can preserve it — see useRoundActions. */
+  penalty?: boolean | null
 }
 
 export interface PlacedPoint {

--- a/apps/web/src/components/round/map/markerFactories.ts
+++ b/apps/web/src/components/round/map/markerFactories.ts
@@ -7,6 +7,9 @@ export const MARKER_COLORS = {
   putt: '#1F3D2C',
   ball: '#1F3D2C',
   pin: '#A33A2A',
+  // caddie-neg — the shot that went OB (#839). Same hex as `pin`, kept as
+  // its own key for readability at call sites that mean "OB", not "pin".
+  ob: '#A33A2A',
 } as const
 
 // ---------------------------------------------------------------------------
@@ -177,6 +180,30 @@ export function makeFlagMarker(color: string): FlagParts {
   content.appendChild(base)
   outer.appendChild(content)
   return { outer, content, flag }
+}
+
+// OB badge ring (#839, mirrors mobile's BreadcrumbLayers `prevShotsObRing`).
+// A stroke-and-distance OB's re-hit starts from the exact same coordinates
+// as the OB shot itself (no renumbering — the re-hit is just the next
+// struck-shot number), so the re-hit's numbered marker lands directly on
+// top of the OB shot's own marker. A same-radius recolor alone would just
+// have whichever marker got added to the map last silently win the DOM
+// stacking order and read as a rendering glitch. This wider transparent-
+// fill ring is added to the map BEFORE any numbered-marker discs for the
+// hole (Mapbox markers paint in DOM-insertion order, so earlier-added
+// elements render underneath), sized past a disc's radius, so its red edge
+// always peeks out around whichever disc ends up on top.
+export function makeObRingMarker(): HTMLElement {
+  const ring = document.createElement('div')
+  ring.style.cssText = [
+    'width:34px',
+    'height:34px',
+    'border-radius:999px',
+    'background:transparent',
+    `border:3px solid ${MARKER_COLORS.ob}`,
+    'pointer-events:none',
+  ].join(';')
+  return ring
 }
 
 export function attachDragFx(opts: {

--- a/apps/web/src/components/round/map/useMapLayers.ts
+++ b/apps/web/src/components/round/map/useMapLayers.ts
@@ -19,6 +19,7 @@ import {
   makeDistancePill,
   makeFlagMarker,
   makeNumberedMarker,
+  makeObRingMarker,
   makeTeeDotMarker,
   MARKER_COLORS,
 } from './markerFactories'
@@ -199,15 +200,36 @@ export function useMapLayers({
         (s.startLat != null && s.startLng != null) ||
         (s.endLat != null && s.endLng != null),
     )
+
+    // OB badge rings (#839) — added to the map BEFORE the numbered-marker
+    // loop below so they paint underneath (see makeObRingMarker). Rendered
+    // as a separate pass rather than inline in the main loop so every ring
+    // for the hole lands ahead of every disc, even though an OB shot's
+    // covering re-hit disc is a LATER entry in `existingValid`.
     for (const s of existingValid) {
+      if (s.ob !== true) continue
+      const lng = s.startLng ?? s.endLng!
+      const lat = s.startLat ?? s.endLat!
+      const ring = new mapboxgl.Marker({ element: makeObRingMarker() })
+        .setLngLat([lng, lat])
+        .addTo(map)
+      markerRefs.current.push(ring)
+    }
+
+    for (const s of existingValid) {
+      // caddie-neg overrides the category color for the shot that went OB —
+      // matches the live chip / scorecard penalty color (mirrors mobile's
+      // BreadcrumbLayers disc recolor).
       const color =
-        s.category === 'tee'
-          ? MARKER_COLORS.tee
-          : s.category === 'approach'
-            ? MARKER_COLORS.approach
-            : s.category === 'around-green'
+        s.ob === true
+          ? MARKER_COLORS.ob
+          : s.category === 'tee'
+            ? MARKER_COLORS.tee
+            : s.category === 'approach'
               ? MARKER_COLORS.approach
-              : MARKER_COLORS.green
+              : s.category === 'around-green'
+                ? MARKER_COLORS.approach
+                : MARKER_COLORS.green
       const parts = makeNumberedMarker(s.shotNumber, color, '#FBF8F1')
       const lng = s.startLng ?? s.endLng!
       const lat = s.startLat ?? s.endLat!

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -12,6 +12,7 @@ import {
   inferHoleStats,
   isPuttEntry,
   isPuttShot,
+  obCount,
   type CaptureMode,
 } from '@oga/core'
 import type { PlacedPoint } from '../../../components/round/RoundMap'
@@ -600,9 +601,9 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         // the map review never silently overwrites a value the player
         // explicitly toggled on the scorecard.
         // holedOut=true: this flow is holed-out by construction — the final
-        // marker's end is the pin and `score: rows.length` below asserts the
-        // placed shots ARE the whole hole. Lets aces / holed approaches count
-        // as GIR (#669).
+        // marker's end is the pin and the score term below asserts the
+        // placed shots (+ any OB penalty strokes) ARE the whole hole. Lets
+        // aces / holed approaches count as GIR (#669).
         const inferred = inferHoleStats(
           rows.map((r) => ({
             shot_number: r.shotNumber,
@@ -615,7 +616,14 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
           id: existing?.id,
           round_id: round.data.id,
           hole_id: realHoleId,
-          score: summary?.score ?? rows.length,
+          // A stroke-and-distance OB has no shot row of its own (the re-hit
+          // is just the next struck shot number), so the struck-row count
+          // alone undercounts the hole by one stroke per OB. `summary.score`
+          // is the ticker the player edited on the review sheet — left alone
+          // here because HoleReviewSheet now seeds that ticker OB-aware
+          // itself (#839; it has no per-row delete to keep in sync). This
+          // fallback only fires when the sheet didn't pass a summary at all.
+          score: summary?.score ?? rows.length + obCount(rows),
           putts: summary?.putts ?? puttCount,
           penalties: summary?.penalties ?? 0,
           fairway_hit: existing?.fairway_hit ?? inferred.fairway,
@@ -630,6 +638,21 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         })
         const hs = hsResult ?? existing
         if (!hs) throw new Error('hole_score upsert returned no row')
+
+        // Snapshot the ob/penalty flags of the shots about to be replaced,
+        // keyed by shot_number, BEFORE the delete-all below wipes them. The
+        // review sheet has no OB control of its own — `shotResult === 'ob'`
+        // only reflects the retrospective result-picker path (ShotEntryModal
+        // sets both `ob` and `shot_result` together; this row shape only
+        // carries `shotResult`) — so without this snapshot a re-save of an
+        // already-reviewed hole would silently drop a flag set some other
+        // way (e.g. mobile) (#797, #839).
+        const existingByShotNumber = new Map(
+          activeHoleShots.map((s) => [
+            s.shotNumber,
+            { ob: s.ob ?? false, penalty: s.penalty ?? false },
+          ]),
+        )
 
         // Replace-all save: drop any shots already attached to this
         // hole_score before inserting the freshly reviewed rows. Without
@@ -666,8 +689,16 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
             lie_slope_forward: isPuttRow ? null : row.lieSlopeForward ?? null,
             lie_slope_side: isPuttRow ? null : row.lieSlopeSide ?? null,
             shot_result: isPuttRow ? null : row.shotResult ?? null,
-            penalty: false,
-            ob: false,
+            // The review sheet has no OB control, so the previously stored
+            // value is authoritative unless this save's own result picker
+            // set it (mirrors mobile's useShotActions fix, #797/#839). A
+            // hole with no prior shots at this number (new hole, or the
+            // shot count changed) reads as not-ob/not-penalty, matching a
+            // fresh row's real state.
+            penalty: existingByShotNumber.get(row.shotNumber)?.penalty ?? false,
+            ob:
+              (existingByShotNumber.get(row.shotNumber)?.ob ?? false) ||
+              row.shotResult === 'ob',
             // Putt-specific fields. distanceYards on a putt row is the
             // tap-to-tap distance in yards; * 3 = feet (US convention),
             // and putt_distance_ft is what the rest of the app reads.
@@ -727,6 +758,7 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
     [
       user,
       activeHole,
+      activeHoleShots,
       round.data,
       scoresByHoleId,
       ensureRealHole,

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -608,6 +608,9 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
           rows.map((r) => ({
             shot_number: r.shotNumber,
             lie_type: r.lieType,
+            // Required: shot_number is not the stroke number on an OB hole, so
+            // inferGir needs the penalty strokes to size its thresholds (#839).
+            shotResult: r.shotResult,
           })),
           resolvedPar ?? activeHole.par,
           true,

--- a/apps/web/src/pages/rounds/hooks/useRoundActions.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundActions.ts
@@ -620,9 +620,14 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
           // is just the next struck shot number), so the struck-row count
           // alone undercounts the hole by one stroke per OB. `summary.score`
           // is the ticker the player edited on the review sheet — left alone
-          // here because HoleReviewSheet now seeds that ticker OB-aware
-          // itself (#839; it has no per-row delete to keep in sync). This
-          // fallback only fires when the sheet didn't pass a summary at all.
+          // here NOT because it's re-seeded OB-aware (it isn't: web has no
+          // live capture, so obCount is always 0 at the sheet's hydration
+          // time), but because the sheet bumps that ticker ±1 itself the
+          // moment a row's result flips to/from 'ob' via the chip — the only
+          // path that can set shotResult 'ob' on web (see HoleReviewSheet's
+          // ShotRow onChange). This fallback term (rows.length +
+          // obCount(rows)) only fires when the sheet didn't pass a summary
+          // at all.
           score: summary?.score ?? rows.length + obCount(rows),
           putts: summary?.putts ?? puttCount,
           penalties: summary?.penalties ?? 0,
@@ -640,19 +645,33 @@ export function useRoundActions(input: UseRoundActionsInput): UseRoundActionsRes
         if (!hs) throw new Error('hole_score upsert returned no row')
 
         // Snapshot the ob/penalty flags of the shots about to be replaced,
-        // keyed by shot_number, BEFORE the delete-all below wipes them. The
-        // review sheet has no OB control of its own — `shotResult === 'ob'`
-        // only reflects the retrospective result-picker path (ShotEntryModal
-        // sets both `ob` and `shot_result` together; this row shape only
-        // carries `shotResult`) — so without this snapshot a re-save of an
-        // already-reviewed hole would silently drop a flag set some other
-        // way (e.g. mobile) (#797, #839).
-        const existingByShotNumber = new Map(
-          activeHoleShots.map((s) => [
-            s.shotNumber,
-            { ob: s.ob ?? false, penalty: s.penalty ?? false },
-          ]),
-        )
+        // keyed by shot_number, BEFORE the delete-all below wipes them —
+        // ONLY when the shot count hasn't changed. `rows` (this save's
+        // placements) are numbered 1..M purely from THIS session's own
+        // taps: placedPoints is never seeded from stored shots
+        // (holeViewReducer resets it to [] on SWITCH_HOLE/AFTER_SAVE and
+        // only ever appends/moves/pops), so a re-placement that adds or
+        // drops even one tap re-numbers every later shot with zero
+        // positional correspondence to the stored 1..N it's replacing —
+        // keying by shot_number in that case would attach a stored OB flag
+        // to a physically different, clean shot (silent SG corruption,
+        // worse than the flag-loss bug this fix exists to prevent). Equal
+        // counts don't strictly guarantee the same shots in the same order,
+        // but "re-review without adding/dropping a tap" is the overwhelming
+        // real case, and it's strictly better than the prior always-erase
+        // behavior. A count mismatch falls back to the empty map, so every
+        // row's `ob`/`penalty` below reads as unset except what THIS save's
+        // own result picker set via `shotResult === 'ob'` — never carrying a
+        // stored flag across a renumbering (#797, #839).
+        const existingByShotNumber =
+          activeHoleShots.length === rows.length
+            ? new Map(
+                activeHoleShots.map((s) => [
+                  s.shotNumber,
+                  { ob: s.ob ?? false, penalty: s.penalty ?? false },
+                ]),
+              )
+            : new Map<number, { ob: boolean; penalty: boolean }>()
 
         // Replace-all save: drop any shots already attached to this
         // hole_score before inserting the freshly reviewed rows. Without

--- a/apps/web/src/pages/rounds/hooks/useRoundData.ts
+++ b/apps/web/src/pages/rounds/hooks/useRoundData.ts
@@ -328,6 +328,8 @@ export function useRoundData({
         startLng: s.start_lng,
         aimLat: s.aim_lat,
         aimLng: s.aim_lng,
+        ob: s.ob,
+        penalty: s.penalty,
         category: getShotMarkerCategory(
           {
             lieType: (s.lie_type ?? undefined) as LieType | undefined,

--- a/packages/core/src/__tests__/holeInference.test.ts
+++ b/packages/core/src/__tests__/holeInference.test.ts
@@ -4,6 +4,8 @@ import { inferHoleStats } from '../holeInference'
 interface S {
   shot_number: number
   lie_type: string | null
+  ob?: boolean | null
+  shotResult?: string | null
 }
 
 const tee = (n: number): S => ({ shot_number: n, lie_type: 'tee' })
@@ -138,5 +140,51 @@ describe('inferHoleStats — gir', () => {
 
   it('empty shots → gir: null', () => {
     expect(inferHoleStats([], 4).gir).toBeNull()
+  })
+
+  // Struck-shot numbering is preserved across an OB (#839), so shot_number
+  // undercounts strokes by one per stroke-and-distance penalty.
+  it('par 4, tee OB then re-tee then green-start shot 3 → gir: FALSE (arrived on stroke 3)', () => {
+    const shots: S[] = [
+      { shot_number: 1, lie_type: 'tee', ob: true },
+      lie(2, 'tee'),
+      lie(3, 'green'),
+    ]
+    expect(inferHoleStats(shots, 4).gir).toBe(false)
+  })
+
+  // `shotResult: 'ob'` is the review-row representation; obCount reads either.
+  it('par 3, tee OB then a green-start shot 2 → gir: FALSE (was 2 <= par-1)', () => {
+    const shots: S[] = [
+      { shot_number: 1, lie_type: 'tee', shotResult: 'ob' },
+      lie(2, 'green'),
+    ]
+    expect(inferHoleStats(shots, 3).gir).toBe(false)
+  })
+
+  it('par 3, tee OB then re-tee then green-start shot 3 → gir: FALSE', () => {
+    const shots: S[] = [
+      { shot_number: 1, lie_type: 'tee', ob: true },
+      lie(2, 'tee'),
+      lie(3, 'green'),
+    ]
+    expect(inferHoleStats(shots, 3).gir).toBe(false)
+  })
+
+  it('par 5, tee OB then green-start shot 3 → gir: true (arrived on stroke 3 = par-2)', () => {
+    const shots: S[] = [
+      { shot_number: 1, lie_type: 'tee', ob: true },
+      lie(2, 'tee'),
+      lie(3, 'green'),
+    ]
+    expect(inferHoleStats(shots, 5).gir).toBe(true)
+  })
+
+  it('par 4, tee OB then holed re-tee approach → gir: FALSE (holedOut branch)', () => {
+    const shots: S[] = [
+      { shot_number: 1, lie_type: 'tee', ob: true },
+      lie(2, 'tee'),
+    ]
+    expect(inferHoleStats(shots, 4, true).gir).toBe(false)
   })
 })

--- a/packages/core/src/__tests__/round.test.ts
+++ b/packages/core/src/__tests__/round.test.ts
@@ -5,6 +5,7 @@ import {
   isPuttShot,
   isPuttEntry,
   legacySlopeToAxes,
+  obCount,
   playedRowsForDifferential,
   summarizePuttParts,
   summarizeShotParts,
@@ -383,5 +384,23 @@ describe('playedRowsForDifferential', () => {
     expect(playedRowsForDifferential(rows([4, 5, 3, 0]), 3)).toEqual(
       rows([4, 5, 3]),
     )
+  })
+})
+
+describe('obCount', () => {
+  it('counts rows, not booleans — two OBs on a hole is 2', () => {
+    expect(obCount([{ ob: true }, { ob: false }, { ob: true }])).toBe(2)
+  })
+  it('counts a ReviewedShotRow-shaped row, which has no ob field', () => {
+    expect(obCount([{ shotResult: 'ob' }, { shotResult: 'solid' }])).toBe(1)
+  })
+  it('does not double-count a row carrying both representations', () => {
+    expect(obCount([{ ob: true, shotResult: 'ob' }])).toBe(1)
+  })
+  it('treats null and undefined as not-OB', () => {
+    expect(obCount([{ ob: null }, { ob: undefined }, {}])).toBe(0)
+  })
+  it('is 0 for an empty hole', () => {
+    expect(obCount([])).toBe(0)
   })
 })

--- a/packages/core/src/__tests__/sg.test.ts
+++ b/packages/core/src/__tests__/sg.test.ts
@@ -341,32 +341,32 @@ describe('calculateRoundSG — penalty / OB attribution', () => {
     expect(b.approach).toBeCloseTo(a.approach, 6)
   })
 
-  it('OB stroke subtracts 1 from the affected category SG', () => {
-    // OB is graded the same as a one-stroke penalty in the SG impl
-    // (penaltyAdjust = penalty || ob). Stroke-and-distance is not
-    // separately modeled — the dropped re-tee just becomes the next
-    // shot in the array. This pin makes sure the OB branch stays
-    // wired up and doesn't silently zero out.
+  it('OB stroke is exactly -2, independent of the next shot', () => {
+    // Stroke-and-distance: the OB shot's endExpected is defined as its own
+    // startExpected (they cancel), so the category SG contribution is a flat
+    // -1, then penaltyAdjust (penalty || ob) subtracts the second stroke —
+    // exactly -2, regardless of where the next logged shot (if any) sits.
     const withOB: ShotWithContext[] = [
       shot({ shotNumber: 1, par: 4, isLastShot: false, lieType: 'tee', distanceToTarget: 380, ob: true }),
       shot({ shotNumber: 2, par: 4, isLastShot: true, lieType: 'fairway', distanceToTarget: 50 }),
     ]
-    const a = calculateRoundSG(buildClean(), 15)
     const b = calculateRoundSG(withOB, 15)
-    expect(b.offTee).toBeCloseTo(a.offTee - 1, 6)
+    expect(b.offTee).toBeCloseTo(-2, 6)
+    // The next shot (not itself OB) is unaffected — still scored on its own terms.
+    const a = calculateRoundSG(buildClean(), 15)
     expect(b.approach).toBeCloseTo(a.approach, 6)
   })
 
-  it('OB and penalty stack — both flags subtract together', () => {
+  it('OB and penalty stack — both flags subtract together, not double', () => {
     // The impl uses `penalty || ob`, so a shot flagged with both still
-    // takes only ONE -1 adjustment, not two. Lock this in so a future
-    // refactor that splits them doesn't accidentally double-count.
+    // takes only ONE -1 penaltyAdjust on top of the cancelled -1 endExpected
+    // term — exactly -2, not -3. Lock this in so a future refactor that
+    // splits them doesn't accidentally double-count.
     const both: ShotWithContext[] = [
       shot({ shotNumber: 1, par: 4, isLastShot: false, lieType: 'tee', distanceToTarget: 380, penalty: true, ob: true }),
       shot({ shotNumber: 2, par: 4, isLastShot: true, lieType: 'fairway', distanceToTarget: 50 }),
     ]
-    const a = calculateRoundSG(buildClean(), 15)
     const b = calculateRoundSG(both, 15)
-    expect(b.offTee).toBeCloseTo(a.offTee - 1, 6)
+    expect(b.offTee).toBeCloseTo(-2, 6)
   })
 })

--- a/packages/core/src/__tests__/stats.test.ts
+++ b/packages/core/src/__tests__/stats.test.ts
@@ -585,6 +585,44 @@ describe('approachByDistance', () => {
     expect(band.shots).toBe(1)
     expect(band.avgSg).toBeCloseTo(start - end - 1, 5)
   })
+
+  // OB is stroke-and-distance: endExpected = startExpected, so the terms
+  // cancel and penaltyAdjust supplies the second stroke — exactly −2,
+  // independent of the baseline tables, matching calculateRoundSG (#839).
+  it('books an OB approach with NO logged recovery at exactly −2', () => {
+    const rounds = [
+      roundWithShots([
+        makeShot({ shot_number: 1, lie_type: 'tee', distance_to_target: 380 }),
+        makeShot({
+          shot_number: 2,
+          lie_type: 'fairway',
+          distance_to_target: 150,
+          ob: true,
+        }),
+      ]),
+    ]
+    const band = band150(approachByDistance(rounds, HCP))
+    expect(band.shots).toBe(1)
+    expect(band.avgSg).toBeCloseTo(-2, 5)
+  })
+
+  it('books an OB approach at −2 even when the next row has no position', () => {
+    const rounds = [
+      roundWithShots([
+        makeShot({ shot_number: 1, lie_type: 'tee', distance_to_target: 380 }),
+        makeShot({
+          shot_number: 2,
+          lie_type: 'fairway',
+          distance_to_target: 150,
+          ob: true,
+        }),
+        makeShot({ shot_number: 3, lie_type: 'fairway', distance_to_target: null }),
+      ]),
+    ]
+    const band = band150(approachByDistance(rounds, HCP))
+    expect(band.shots).toBe(1)
+    expect(band.avgSg).toBeCloseTo(-2, 5)
+  })
 })
 
 describe('ballStrikingStats — girPct', () => {

--- a/packages/core/src/holeInference.ts
+++ b/packages/core/src/holeInference.ts
@@ -1,3 +1,5 @@
+import { obCount } from './round'
+
 // Per-hole stat inference from shot rows. Currently feeds
 // hole_scores.fairway_hit / hole_scores.gir at save time so the
 // scorecard and round-level totals reflect what the player actually
@@ -16,6 +18,14 @@ export interface HoleInferred {
 interface ShotLike {
   shot_number: number
   lie_type: string | null
+  /** OB flag, in either of the two row shapes `obCount` accepts. Optional
+   *  only because two of the four callers pass one representation and two
+   *  pass the other — every caller MUST supply one of them, or the GIR
+   *  thresholds below silently revert to the pre-#839 (inflated) behaviour
+   *  with a clean typecheck. Raw `shots` rows carry `ob`; the review flows'
+   *  `ReviewedShotRow`s carry `shotResult`. */
+  ob?: boolean | null
+  shotResult?: string | null
 }
 
 /**
@@ -59,13 +69,22 @@ function inferGir(
   holedOut: boolean,
 ): boolean | null {
   if (shots.length === 0) return null
+  // Struck-shot numbering is PRESERVED across an OB (markers stay 1,2,3,4 and
+  // the OB shot just wears a badge — a deliberate product decision, #839), so
+  // shot_number is NOT the stroke number on a hole with an OB: it undercounts
+  // by one per stroke-and-distance penalty. Every threshold below compares a
+  // shot_number against a stroke budget, so each needs the penalty strokes
+  // added back — without it a par-4 tee-OB + re-tee + green-start shot 3 reads
+  // as a GIR when the ball actually arrived on stroke 3 against a budget of 2.
+  const obs = obCount(shots)
   // lie_type is the start lie, so shot N starting on the green means the
-  // ball reached the green on stroke N-1. GIR = on green in (par-2)
-  // strokes → the first green-start shot must be number <= par-1.
+  // ball reached the green on stroke N-1 (+ obs penalty strokes). GIR = on
+  // green in (par-2) strokes → the first green-start shot must be number
+  // <= par-1-obs.
   const greenNumbers = shots
     .filter((s) => s.lie_type === 'green')
     .map((s) => s.shot_number)
-  if (greenNumbers.length > 0) return Math.min(...greenNumbers) <= par - 1
+  if (greenNumbers.length > 0) return Math.min(...greenNumbers) <= par - 1 - obs
   // No shot ever STARTED on the green — the ball still reached it only by
   // holing out from off the green (ace, chip-in, holed approach). The cup
   // is on the green, so the ball got there ON the holing stroke itself:
@@ -73,7 +92,7 @@ function inferGir(
   // than the green-start branch — a chip-in for par (stroke par-1) is NOT
   // a GIR, which the old dead `shot_result === 'holed'` branch got wrong.
   if (holedOut) {
-    return Math.max(...shots.map((s) => s.shot_number)) <= par - 2
+    return Math.max(...shots.map((s) => s.shot_number)) <= par - 2 - obs
   }
   return false
 }

--- a/packages/core/src/round.ts
+++ b/packages/core/src/round.ts
@@ -88,6 +88,21 @@ export function inferHoleCount(holeNumbers: number[]): 9 | 18 {
   return Math.max(...holeNumbers) <= 9 ? 9 : 18
 }
 
+// Penalty strokes on a hole, derived from the rows themselves — a stroke-
+// and-distance OB has no shot row of its own, so a hole's score is
+// "struck rows + obCount(rows)". Counts ROWS, not a boolean test: a hole
+// with two OBs adds two strokes. Reads two fields because callers pass two
+// row shapes and neither has both — raw `shots` rows carry the `ob`
+// boolean but no camelCase `shotResult`, while `ReviewedShotRow` carries
+// `shotResult` and has no `ob` field at all. A row carrying both (once a
+// later task writes both representations on the same row) must still
+// count once, hence `||` not addition.
+export function obCount(
+  rows: ReadonlyArray<{ ob?: boolean | null; shotResult?: string | null }>,
+): number {
+  return rows.reduce((n, r) => (r.ob || r.shotResult === 'ob' ? n + 1 : n), 0)
+}
+
 // Gate for computing a WHS-style score differential: only a fully-played
 // round qualifies. Returns the played (score > 0) rows when they cover every
 // hole of the round, else null — a partial round must produce NO differential,

--- a/packages/core/src/sg-calculator.test.ts
+++ b/packages/core/src/sg-calculator.test.ts
@@ -181,3 +181,75 @@ describe('calculateRoundSG', () => {
   })
 })
 
+describe('OB / stroke and distance', () => {
+  // startExpected cancels against endExpected by construction, so -2 is exact
+  // and independent of every baseline value. Do not hardcode baselines here.
+  it('yields exactly -2 when the recovery shot IS logged', () => {
+    const sg = calculateRoundSG(
+      [
+        shotCtx({ shotNumber: 1, par: 4, isLastShot: false, distanceToTarget: 400, lieType: 'tee' }),
+        shotCtx({ shotNumber: 2, par: 4, isLastShot: false, distanceToTarget: 150, lieType: 'fairway', ob: true }),
+        shotCtx({ shotNumber: 3, par: 4, isLastShot: false, distanceToTarget: 150, lieType: 'fairway' }),
+        shotCtx({ shotNumber: 4, par: 4, isLastShot: true, distanceToTarget: 10, lieType: 'green', puttResult: 'made' }),
+      ],
+      15,
+    )
+    const clean = calculateRoundSG(
+      [
+        shotCtx({ shotNumber: 1, par: 4, isLastShot: false, distanceToTarget: 400, lieType: 'tee' }),
+        shotCtx({ shotNumber: 2, par: 4, isLastShot: false, distanceToTarget: 150, lieType: 'fairway' }),
+        shotCtx({ shotNumber: 3, par: 4, isLastShot: true, distanceToTarget: 10, lieType: 'green', puttResult: 'made' }),
+      ],
+      15,
+    )
+    expect(sg.total).toBeCloseTo(clean.total - 2, 5)
+  })
+
+  // THE REGRESSION THAT MOTIVATED THIS RULE. Positionally last => the old code
+  // took endExpected = 0 and returned a large POSITIVE number.
+  it('yields exactly -2 when the OB shot is the last logged row', () => {
+    const sg = calculateRoundSG(
+      [
+        shotCtx({ shotNumber: 1, par: 4, isLastShot: false, distanceToTarget: 400, lieType: 'tee' }),
+        shotCtx({ shotNumber: 2, par: 4, isLastShot: true, distanceToTarget: 150, lieType: 'fairway', ob: true }),
+      ],
+      15,
+    )
+    expect(sg.approach).toBeCloseTo(-2, 5)
+    expect(sg.approach).toBeLessThan(0)
+  })
+
+  it('yields exactly -2 for a par-3 tee shot going OB', () => {
+    const sg = calculateRoundSG(
+      [shotCtx({ shotNumber: 1, par: 3, isLastShot: true, distanceToTarget: 165, lieType: 'tee', ob: true })],
+      15,
+    )
+    expect(sg.approach).toBeCloseTo(-2, 5)
+  })
+
+  it('charges two OBs on one hole as -4', () => {
+    const sg = calculateRoundSG(
+      [
+        shotCtx({ shotNumber: 1, par: 4, isLastShot: false, distanceToTarget: 400, lieType: 'tee', ob: true }),
+        shotCtx({ shotNumber: 2, par: 4, isLastShot: true, distanceToTarget: 400, lieType: 'tee', ob: true }),
+      ],
+      15,
+    )
+    // The re-tee (shotNumber 2) is categorized 'approach', not 'off_tee' —
+    // getShotCategory keys off_tee on shotNumber === 1 only (pre-existing,
+    // out of scope here). Assert the combined total: -2 per OB shot holds
+    // regardless of which SG bucket absorbs it.
+    expect(sg.total).toBeCloseTo(-4, 5)
+  })
+
+  it('leaves a non-OB penalty shot on the existing path', () => {
+    const sg = calculateRoundSG(
+      [shotCtx({ shotNumber: 1, par: 4, isLastShot: true, distanceToTarget: 400, lieType: 'tee', penalty: true })],
+      15,
+    )
+    // isLastShot => endExpected 0 => startExpected - 1, then penaltyAdjust -1.
+    // Asserting only that the existing penalty path is untouched by this change.
+    expect(sg.offTee).toBeGreaterThan(-2)
+  })
+})
+

--- a/packages/core/src/sg-calculator.ts
+++ b/packages/core/src/sg-calculator.ts
@@ -106,7 +106,17 @@ export function calculateRoundSG(
     if (startExpected === null) continue
 
     let endExpected: number
-    if (shot.isLastShot || holedOut(shot)) {
+    // Out of bounds / lost ball is stroke-and-distance: the ball returns to
+    // where it was played from, so the end position IS the start position.
+    // Stated as a rule rather than read off the next row, because (a) the next
+    // row often does not exist — "Skip all, just track location" is always
+    // visible, so a player who drops without logging the recovery is normal
+    // use, and the positional isLastShot below would then zero endExpected and
+    // return a large POSITIVE sg; and (b) on web the two positions are
+    // independent taps that never match to the yard.
+    if (shot.ob) {
+      endExpected = startExpected
+    } else if (shot.isLastShot || holedOut(shot)) {
       endExpected = 0
     } else {
       const next = shots[i + 1]

--- a/packages/core/src/stats.ts
+++ b/packages/core/src/stats.ts
@@ -311,9 +311,25 @@ export function approachByDistance(
 
       // endExpected 0 = holed out — legitimate only when there is NO next
       // shot (the hole's last shot ends at the cup in both save flows).
+      //
+      // This inner loop is a DELIBERATE DUPLICATE of calculateRoundSG's
+      // (sg-calculator.ts): both walk a hole's shots and book
+      // calculateShotSG(start, end) + penaltyAdjust. The two must be kept in
+      // step — when they drift, the Stats page's approach chart silently
+      // disagrees with the round SG engine on identical data (#668, #839).
       let endExpected = 0
       const next = shots[i + 1]
-      if (next) {
+      // OB is stroke-and-distance: the ball returns to where it was played
+      // from, so end position IS start position. Stated as a rule, not read
+      // off the next row, because the recovery shot often isn't logged
+      // ("Skip all, just track location" is always visible) — the next-shot
+      // branch below would then leave endExpected at 0 and book a large
+      // POSITIVE sg for a shot the player marked out of bounds. With this
+      // rule the terms cancel and penaltyAdjust makes it exactly −2, matching
+      // calculateRoundSG (#839).
+      if (s.ob) {
+        endExpected = startExpected
+      } else if (next) {
         const nextCat = getShotCategory(
           {
             lieType: (next.lie_type as LieType | null) ?? undefined,

--- a/supabase/migrations/0054_delete_shot_ob.sql
+++ b/supabase/migrations/0054_delete_shot_ob.sql
@@ -1,0 +1,86 @@
+-- 0054: delete_shot drops TWO strokes for an OB row, not one.
+--
+-- A stroke-and-distance penalty (tee/fairway shot goes OB, replay from the
+-- original spot) costs two strokes but the replay swing has no shot row of
+-- its own — see #839. The struck shot that went OB is the ONE row in
+-- `shots`; the penalty stroke it incurs is invisible to the schema. So a
+-- hole's score is `struck rows + (count of OB rows)`: every row contributes
+-- its own stroke, and an `ob = true` row additionally contributes the
+-- rowless penalty stroke. Deleting an OB row must therefore remove BOTH —
+-- its own stroke and the penalty stroke that rode along with it — or the
+-- hole score is left one stroke too high forever.
+--
+-- This does NOT extend to the separate `penalty` flag (a non-OB penalty,
+-- e.g. a lateral/unplayable drop where the recovery swing is its own
+-- logged row): that flag only affects the strokes-gained baseline
+-- (`penalty || ob` in @oga/core's sg-calculator/stats), never the score
+-- count. A `penalty = true, ob = false` row still represents exactly one
+-- physical stroke, so its deletion still drops the score by one. Widening
+-- the 2-stroke drop to `penalty or ob` here would double-decrement a
+-- penalty shot whose stroke was never double-counted going in.
+--
+-- Everything else about the function is unchanged from 0046: same auth
+-- guard, same ownership check, same idempotent not-found return, same
+-- delete + renumber under the deferrable composite unique constraint, same
+-- putts/fairway_hit/gir re-tally, same security definer + grants. The only
+-- edit is computing the score decrement from `ob` alone instead of the
+-- hardcoded `- 1`.
+create or replace function public.delete_shot(p_shot_id uuid)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_uid uuid;
+  v_owner uuid;
+  v_hs uuid;
+  v_num int;
+  v_is_putt boolean;
+  v_penal boolean;
+  v_is_ob boolean;
+  v_remaining int;
+begin
+  v_uid := auth.uid();
+  if v_uid is null then
+    raise exception 'not authenticated';
+  end if;
+
+  select user_id, hole_score_id, shot_number,
+         (lie_type = 'green'), (penalty or ob), coalesce(ob, false)
+    into v_owner, v_hs, v_num, v_is_putt, v_penal, v_is_ob
+    from public.shots
+    where id = p_shot_id;
+  if not found then
+    return false; -- already gone; idempotent
+  end if;
+  if v_owner <> v_uid then
+    raise exception 'forbidden';
+  end if;
+
+  delete from public.shots where id = p_shot_id;
+
+  update public.shots
+    set shot_number = shot_number - 1
+    where hole_score_id = v_hs and shot_number > v_num;
+
+  select count(*) into v_remaining
+    from public.shots where hole_score_id = v_hs;
+
+  -- An OB row is worth two strokes (the swing + its rowless
+  -- stroke-and-distance penalty); every other row, including a plain
+  -- `penalty` row, is worth one. See house comment above.
+  update public.hole_scores set
+      score       = greatest(0, coalesce(score, 0) - (case when v_is_ob then 2 else 1 end)),
+      putts       = greatest(0, coalesce(putts, 0) - (case when v_is_putt then 1 else 0 end)),
+      penalties   = greatest(0, coalesce(penalties, 0) - (case when v_penal then 1 else 0 end)),
+      fairway_hit = case when v_remaining = 0 then null else fairway_hit end,
+      gir         = case when v_remaining = 0 then null else gir end
+    where id = v_hs;
+
+  return true;
+end;
+$$;
+
+revoke execute on function public.delete_shot(uuid) from public, anon;
+grant  execute on function public.delete_shot(uuid) to authenticated;


### PR DESCRIPTION
Closes #839. Also fixes #797.

Makes out-of-bounds work as a **live** action. Before this, `shots.ob` was true on **2 rows out of 886** in production — not because players didn't hit it OB, but because there was no way to say so: the only control lived in the end-of-hole review sheet behind a "+ result" chip, and `saveHoleSummary` hardcoded the flag back to `false` on every save (#797). The flag wasn't merely unset — it was actively erased.

## The live affordance

A chip in the `PLACE_BALL` chrome, beside "⛳ On the green":

```
⚠ Last shot went OB          →  tap again to undo
```

**One tap.** It sets `ob` on the last logged shot, snaps the ball back to that shot's origin, and adds the penalty stroke.

This is cheap because of a property of the existing capture flow: `persistShot` writes the shot row on `confirmAim`/`skipAim` — *before* the ball is struck — so when a shot flies OB the player is **still standing at that shot's origin**. Stroke-and-distance placement costs nothing. It also stays correct for a lost ball: walk up, fail to find it, walk back, and the chip is still valid because no new shot was logged in between.

Online-first, like its siblings (`delete_shot`, `projectShotMove`): flush pending → `shots.update` → fail visibly on a 0-row response.

## Strokes gained: the rule, not an inference

```ts
if (shot.ob) endExpected = startExpected   // stroke and distance: replay from here
```

Two earlier designs derived the −2 from the *next* row happening to share coordinates with the OB shot's origin. That's a coincidence, not a rule, and it produced a **sign-inverted** result: with no following row, `isLastShot` is positional, `endExpected` fell to 0, and an OB booked a large **positive** SG. Reachable by normal use — "Skip all, just track location" is always on screen, so a player who drops without logging the recovery hits exactly that shape.

Stating the rule makes the terms cancel, so `−2` is **exact and table-independent**, and it closes three things at once: the sign flip, web's inexact −2 (two taps never match to the yard), and a silent coupling on `off_tee`/`approach` sharing a baseline table.

## Numbering: struck shots + a badge

Markers stay `1, 2, 3, 4`. The OB shot wears a red badge; the re-hit is the next number from the same origin; the scorecard shows 5.

The issue asks for the re-hit "marked as 4th" — **this deliberately differs.** Two reasons. A marker in this app is a shot's START, and a penalty stroke has no start→end vector, so numbering it is a category error in our own model. And renumbering would render `1, 2, 4` with a visible gap unless a penalty pip filled it — which is the abandoned design's visual, reintroduced. The stroke *count* is right everywhere it matters; only the marker label differs.

## Score: `struck rows + OB rows`

One `obCount` helper in `@oga/core`, applied at every site where a row count becomes a score — **8 on mobile, 2 on web**. One of the mobile sites was missed by the plan and found only because the implementer searched by *derivation* shape (`hs.score = shotCount`) rather than write shape (`score:`).

**Why this isn't the trap that killed the first design.** That one added a phantom row ~10 consumers had to include in some pipelines and exclude from others; getting it wrong deleted the wrong shot or erased SG silently. This adds one additive term from a boolean every row already carries — every consumer still sees exactly the struck rows it always saw, and the failure mode is a visible off-by-one on a score, not silent structural corruption.

Rejected: a DB trigger recomputing score from rows. It would own the invariant in one place but destroy the end-of-hole ticker's manual override and break the 767 production holes that carry a score with no shot rows at all.

## Also fixed

- **`hole_scores.gir` was inflated by the hole's OB count.** `inferGir` reads `shot_number` as a stroke count, and preserving struck-shot numbering makes those differ. This is persisted from three sites, so it was corrupting GIR, not just displaying it wrong.
- **A second SG loop.** `approachByDistance` in `stats.ts` is a hand-rolled duplicate of the SG inner loop powering the Stats approach chart. It had `penaltyAdjust` for `ob` but not the stroke-and-distance rule, so a no-recovery OB booked **≈ +1 there while `calculateRoundSG` reported −2** — two surfaces disagreeing by ~3 strokes, the wrong one positive. Caught only by the whole-branch review; no task-scoped reviewer had reason to open that file.
- **Web could silently destroy a mobile-set flag.** `saveReviewedHole` hardcoded `ob: false`, so editing a round on the web wiped it. Web's save is delete-then-recreate, so preservation uses a snapshot guarded on `activeHoleShots.length === rows.length` — positional keying is only sound when the position space is unchanged, and on a mismatch it deliberately drops the flag rather than moving it to a different shot.

## Migration

`0054_delete_shot_ob.sql` — deleting an `ob` row drops **2** strokes, not 1, since the penalty has no row of its own. A faithful `create or replace` of `0046`: three deltas total, every auth/ownership guard, the re-tally, and the deferrable-constraint renumbering preserved verbatim.

**Sequencing:** `0053` belongs to open PR #868 and is not on this branch. Production is still at `0046`, and `0047`–`0052` are on `dev` awaiting the next release — apply in order.

**Unapplied and unexecuted.** No local Postgres and `oga-dev` is paused, so this SQL has never been parsed by a Postgres. Apply to dev first.

## Known follow-ups (not fixed here)

- Mobile's review sheet doesn't move the Score ticker when a row is flipped OB→non-OB, where web does. The stale value sits in a user-editable ticker on the same screen.
- `getShotCategory` gates `off_tee` on `shotNumber === 1`, so an OB **re-tee** is categorized `approach`. Pre-existing, but this feature is what makes it reachable.
- Web's `ShotEntryModal` sets/clears `ob` without touching `hole_scores.score`, so "score = struck + OB" is not an invariant on the web scorecard path.
- Web's review sheet never seeds rows from stored shot data, so re-opening a saved hole shows no OB chip.
- Single-slot OB override protects only the most recent OB on a hole.

## Verification

`pnpm test` 658 core (+7 new) · web 27 · supabase 7 — all green. `pnpm typecheck`, `pnpm --filter @oga/web build`, `apps/mobile npm run typecheck` clean.

Every task got an independent spec + quality review; the branch then got a whole-branch review that returned one Critical and three Important, all fixed and re-verified. **Migration `0054` is the one file whose task-scoped reviewer died mid-run** — it was checked by hand and then given a genuine pass in the whole-branch review.

**Behaviour is device/browser-only and unverified.** Nothing here has run on a phone. The load-bearing QA checks: the ball snapping and staying put under GPS, double-tap charging exactly one stroke, delete dropping 2 through the RPC, GIR on an OB hole, and a mobile→web round-trip preserving the flag.
